### PR TITLE
Fixed fromaddr/changeaddr

### DIFF
--- a/electrum
+++ b/electrum
@@ -18,6 +18,7 @@
 
 import re
 import sys
+from time import sleep
 # import argparse
 import optparse
 
@@ -468,9 +469,15 @@ if __name__ == '__main__':
             
             wallet.interface.get_history(from_addr)
             print "Waiting for history (warning: this won't timeout)"
-            while not from_addr in wallet.history:
-                sleep(0.1)
-            wallet.update_tx_history()
+            try:
+                while not from_addr in wallet.history:
+                    sleep(0.1)
+                wallet.update_tx_history()
+            except:
+                # it seems the key may be saved when interrumpted
+                wallet.imported_keys.pop(from_addr)
+                del(wallet.history[from_addr])
+                raise
             change_addr = from_addr
 
         if options.change_addr:


### PR DESCRIPTION
I added a feature back in February for making transactions from command line
with key pairs not in the wallet and optionally use a change address. With
all the improvements made to the architecture, this no longer works, so I
fixed it.
