### PR TITLE
Retry password change dialog (fixes #53)

### DIFF
--- a/lib/gui_qt.py
+++ b/lib/gui_qt.py
@@ -1424,8 +1424,12 @@ class ElectrumWindow(QMainWindow):
 
         if new_password != new_password2:
             QMessageBox.warning(parent, _('Error'), _('Passwords do not match'), _('OK'))
-            return
+            return ElectrumWindow.change_password_dialog(wallet, parent) # Retry
 
+        if new_password == '':
+            QMessageBox.warning(parent, _('Error'), _('Password cannot be empty'), _('OK'))
+            return ElectrumWindow.change_password_dialog(wallet, parent) # Retry
+   
         wallet.update_password(seed, password, new_password)
 
     @staticmethod


### PR DESCRIPTION
Retry password dialog when passwords are different or password is blank. User can now skip encryption of the wallet only by pressing "Cancel" button.
