### PR TITLE
Mac OS X 10.5 compatibility (minor)

### DIFF
--- a/setup-release.py
+++ b/setup-release.py
@@ -60,7 +60,7 @@ if sys.platform == 'darwin':
       qt_menu_location = "/opt/local/lib/Resources/qt_menu.nib"
     else:
       # No dice? Then let's try the brew version
-      qt_menu_location = os.popen("mdfind -name qt_menu.nib | grep Cellar | head").read()
+      qt_menu_location = os.popen("find /usr/local/Cellar -name qt_menu.nib | head").read()
       qt_menu_location = re.sub('\n','', qt_menu_location)
 
     if(len(qt_menu_location) == 0):


### PR DESCRIPTION
The build script for Mac OS X uses mdfind to locate the qt_menu.nib file.
In Mac OS X 10.5 Leopard, mdfind does not have the -name option.
This fix uses find instead of mdfind to locate qt_menu.nib.
With this fix, it becomes easier to build Electrum on Leopard, even if it is an old platform.
