### PR TITLE
Use blockchain.info instead of intersango.com for exchange rates

### DIFF
--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -36,9 +36,8 @@ class Exchanger(threading.Thread):
         response = json.loads(response.read())
         quote_currencies = {}
         try:
-            quote_currencies["GBP"] = self._lookup_rate(response, "GBP")
-            quote_currencies["EUR"] = self._lookup_rate(response, "EUR")
-            quote_currencies["USD"] = self._lookup_rate(response, "USD")
+            for r in response:
+                quote_currencies[r] = self._lookup_rate(response, r)
             with self.lock:
                 self.quote_currencies = quote_currencies
             self.parent.emit(SIGNAL("refresh_balance()"))
@@ -46,9 +45,9 @@ class Exchanger(threading.Thread):
             pass
 
     def _lookup_rate(self, response, quote_id):
-        return decimal.Decimal(response[str(quote_id)]["24h"])
+        return decimal.Decimal(response[str(quote_id)]["15m"])
 
 if __name__ == "__main__":
-    exch = Exchanger(("EUR", "USD", "GBP"))
+    exch = Exchanger(("BRL", "CNY", "EUR", "GBP", "RUB", "USD"))
     print exch.exchange(1, "EUR")
 

--- a/lib/gui_lite.py
+++ b/lib/gui_lite.py
@@ -197,7 +197,7 @@ class MiniWindow(QDialog):
         self.actuator = actuator
         self.config = config
         self.btc_balance = None
-        self.quote_currencies = ["EUR", "USD", "GBP"]
+        self.quote_currencies = ["BRL", "CNY", "EUR", "GBP", "RUB", "USD"]
         self.actuator.set_configured_currency(self.set_quote_currency)
         self.exchanger = exchange_rate.Exchanger(self)
         # Needed because price discovery is done in a different thread


### PR DESCRIPTION
Replaced Intersango with Blockchain.info to display exchange rates (rather a quick hack then a clean rewrite to new API)
