### PR TITLE
Import WalletFactory instead of Wallet

### DIFF
--- a/electrum
+++ b/electrum
@@ -139,6 +139,7 @@ def arg_parser():
     parser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False, help="show debugging information")
     parser.add_option("-P", "--portable", action="store_true", dest="portable", default=False, help="portable wallet")
     parser.add_option("-L", "--lang", dest="language", default=None, help="defaut language used in GUI")
+    parser.add_option("-u", "--usb", dest="bitkey", action="store_true", help="Turn on support for hardware wallets (EXPERIMENTAL)")
     return parser
 
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,7 +1,8 @@
 from version import ELECTRUM_VERSION
 from util import format_satoshis, print_msg, print_error, set_verbosity
 from i18n import set_language
-from wallet import Wallet, WalletSynchronizer
+from wallet import WalletSynchronizer
+from wallet_factory import WalletFactory as Wallet
 from verifier import WalletVerifier
 from interface import Interface, pick_random_server, DEFAULT_SERVERS
 from simple_config import SimpleConfig

--- a/lib/wallet_bitkey.py
+++ b/lib/wallet_bitkey.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2011 thomasv@gitorious
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from wallet import Wallet
+#import bitkeylib.bitkey_pb2 as proto
+
+from version import ELECTRUM_VERSION
+SEED_VERSION = 4 # Version of bitkey algorithm
+
+class WalletBitkey(Wallet):
+    pass

--- a/lib/wallet_factory.py
+++ b/lib/wallet_factory.py
@@ -1,0 +1,11 @@
+class WalletFactory(object):
+    def __new__(cls, config):
+        if config.get('bitkey', False):
+            # if user requested support for Bitkey device,
+            # import Bitkey driver
+            from wallet_bitkey import WalletBitkey
+            return WalletBitkey(config)
+        
+        # Load standard wallet
+        from wallet import Wallet
+        return Wallet(config)


### PR DESCRIPTION
This is previous pull request reworked to one commit.

I'm working on Bitkey protocol support in my own branch, but I merge Electrum upstream with my branch quite often and merging it manually is a bit annoying. I'd appreciate if this stub of bitkey branch would be accepted to upstream, to make my life much easier. The change itself is backward compatible, it just introduces new command line switch (--usb) and if it is presented, it loads WalletBitkey class instead of default Wallet.
