### PR TITLE
Update lib/gui_qt.py

### DIFF
--- a/lib/gui_qt.py
+++ b/lib/gui_qt.py
@@ -1871,7 +1871,7 @@ class ElectrumWindow(QMainWindow):
         interface = wallet.interface
         if parent:
             if interface.is_connected:
-                status = _("Connected to")+" %s\n%d "+_("blocks")%(interface.host, wallet.verifier.height)
+                status = _("Connected to")+" %s\n%d blocks"%(interface.host, wallet.verifier.height)
             else:
                 status = _("Not connected")
             server = interface.server


### PR DESCRIPTION
The change I did to 'blocks' on line 1874 was not a valid syntax.

Tried to do this to be able to translate that word _("blocks"), someone who knows how to accomplish this may do it.

ACCEPT this pull request, because this syntax error broke the Network green button action.

Reseted the default blocks string text.
