### PR TITLE
Changed Preferences to Settings on icons (apply before PR 107 to keep)

### DIFF
--- a/lib/gui_qt.py
+++ b/lib/gui_qt.py
@@ -1189,7 +1189,7 @@ class ElectrumWindow(QMainWindow):
              sb.addPermanentWidget( StatusBarButton( QIcon(":icons/switchgui.png"), "Switch to Lite Mode", self.go_lite ) )
         if self.wallet.seed:
             sb.addPermanentWidget( StatusBarButton( QIcon(":icons/lock.png"), "Password", lambda: self.change_password_dialog(self.wallet, self) ) )
-        sb.addPermanentWidget( StatusBarButton( QIcon(":icons/preferences.png"), "Preferences", self.settings_dialog ) )
+        sb.addPermanentWidget( StatusBarButton( QIcon(":icons/preferences.png"), "Settings", self.settings_dialog ) )
         if self.wallet.seed:
             sb.addPermanentWidget( StatusBarButton( QIcon(":icons/seed.png"), "Seed", lambda: self.show_seed_dialog(self.wallet, self) ) )
         self.status_button = StatusBarButton( QIcon(":icons/status_disconnected.png"), "Network", lambda: self.network_dialog(self.wallet, self) ) 


### PR DESCRIPTION
Changed "Preferences" to "Settings" to to maintain consistency, because it is called that way in the other parts of the application. Like: "Electrum Settings" title.

This PR need to be manually if my last one is already applied
