### PR TITLE
Changed electrum-desktop.com to electrum.org

### DIFF
--- a/lib/gui_lite.py
+++ b/lib/gui_lite.py
@@ -596,7 +596,7 @@ class MiniWindow(QDialog):
         self.actuator.acceptbit(self.quote_currencies[0])
 
     def the_website(self):
-        webbrowser.open("http://electrum-desktop.com")
+        webbrowser.open("http://electrum.org")
 
     def show_about(self):
         QMessageBox.about(self, "Electrum",


### PR DESCRIPTION
Changed the website link under the Help menu option from electrum-desktop.com to electrum.org
