### PR TITLE
New temporary Electrum translation wiki page Wikia

### DIFF
--- a/mki18n.py
+++ b/mki18n.py
@@ -3,7 +3,8 @@
 import urllib2, os
 from lib.version import TRANSLATION_ID
 
-url = "https://en.bitcoin.it/w/index.php?title=Electrum/Translation&oldid=%d&action=raw"%TRANSLATION_ID
+#url = "https://en.bitcoin.it/w/index.php?title=Electrum/Translation&oldid=%d&action=raw"%TRANSLATION_ID
+url = "http://bitcoin.wikia.com/wiki/Electrum?oldid=%d&action=raw"%TRANSLATION_ID
 f = urllib2.urlopen(url)
 lines = f.readlines()
 dicts = {}


### PR DESCRIPTION
When editing the translation page use the "source" editing option instead of the WYSIWYG "Visual" editor.

Due to a permission change in the bitcoin.it/wiki the Electrum translation page can not be edited and it is slowing down the translation process.

Tested and working.
