### PR TITLE
Separated the new line command from text strings

### DIFF
--- a/lib/gui_lite.py
+++ b/lib/gui_lite.py
@@ -340,7 +340,7 @@ class MiniWindow(QDialog):
 
 
         # Label
-        extra_layout.addWidget( QLabel(_('Selecting an address will copy it to the clipboard.\nDouble clicking the label will allow you to edit it.') ),0,0)
+        extra_layout.addWidget( QLabel(_('Selecting an address will copy it to the clipboard.') + '\n' + _('Double clicking the label will allow you to edit it.') ),0,0)
 
         extra_layout.addWidget(self.receiving, 1,0)
         extra_layout.addWidget(hide_used, 2,0)


### PR DESCRIPTION
Separated the new line command from text strings because it causes a bug when the text strings are pulled from the Translation wiki in multiple lines text strings.
