### PR TITLE
Separated the text string from the github bug URL 

### DIFF
--- a/lib/gui_lite.py
+++ b/lib/gui_lite.py
@@ -603,7 +603,7 @@ class MiniWindow(QDialog):
 
     def show_report_bug(self):
         QMessageBox.information(self, "Electrum - " + _("Reporting Bugs"),
-            _("Please report any bugs as issues on github: <a href=\"https://github.com/spesmilo/electrum/issues\">https://github.com/spesmilo/electrum/issues</a>"))
+            _("Please report any bugs as issues on github:")+" <a href=\"https://github.com/spesmilo/electrum/issues\">https://github.com/spesmilo/electrum/issues</a>")
 
     def toggle_receiving_layout(self, toggle_state):
         if toggle_state:


### PR DESCRIPTION
Set the text and the link separated to be able to translate only the text part. If the bug report link ever change the text translated keep intact.
