### PR TITLE
Another file that was missing in app.fil

### DIFF
--- a/app.fil
+++ b/app.fil
@@ -1,3 +1,4 @@
 lib/gui_qt.py
 lib/gui.py
 lib/gui_lite.py
+lib/history_widget.py


### PR DESCRIPTION
Finishing the translation for Lite mode, the words that are not being translated are located in this file.

Tested and working, from source.
