### PR TITLE
command ``history`` fail -- if not transactions

### DIFF
--- a/electrum
+++ b/electrum
@@ -563,6 +563,7 @@ if __name__ == '__main__':
 
     if cmd == 'history':
         import datetime
+        balance = 0
         for item in wallet.get_tx_history():
             tx_hash, conf, is_mine, value, fee, balance, timestamp = item
             try:


### PR DESCRIPTION
we see that like this:

```
$ ./electrum history
Connected to electrum.bitcoin.cz:50001
Traceback (most recent call last):
  File "./electrum", line 578, in <module>
    print_msg("# balance: ", format_satoshis(balance))
```

thanks in advance!
