### PR TITLE
sendmany attempt

### DIFF
--- a/electrum
+++ b/electrum
@@ -326,7 +326,7 @@ if __name__ == '__main__':
         domain = [options.from_addr] if options.from_addr else None
         args = [ 'mktx', args[1], Decimal(args[2]), Decimal(options.tx_fee) if options.tx_fee else None, options.change_addr, domain ]
         
-    elif cmd == 'mksendmanytx':
+    elif cmd in ['paytomany', 'mksendmanytx']:
         domain = [options.from_addr] if options.from_addr else None
         outputs = []
         for i in range(1, len(args), 2):

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -59,8 +59,9 @@ register_command('importprivkey',        1, 1, True,  True,  'Import a private k
 register_command('listaddresses',        3, 3, False, True,  'Returns your list of addresses.', '', listaddr_options)
 register_command('listunspent',          0, 0, False, True,  'Returns a list of unspent inputs in your wallet.')
 register_command('mktx',                 5, 5, True,  True,  'Create a signed transaction', 'mktx <recipient> <amount> [label]', payto_options)
-register_command('mksendmanytx',         4, 4, True,  True,  'Create a signed transaction', 'mktx <recipient> <amount> [<recipient> <amount> ...]', payto_options)
+register_command('mksendmanytx',         4, 4, True,  True,  'Create a signed transaction', 'mksendmanytx <recipient> <amount> [<recipient> <amount> ...]', payto_options)
 register_command('payto',                5, 5, True,  False, 'Create and broadcast a transaction.', "payto <recipient> <amount> [label]\n<recipient> can be a bitcoin address or a label", payto_options)
+register_command('paytomany',            4, 4, True,  False, 'Create and broadcast a transaction.', "paytomany <recipient> <amount> [<recipient> <amount> ...]\n<recipient> can be a bitcoin address or a label", payto_options)
 register_command('password',             0, 0, True,  True,  'Change your password')
 register_command('prioritize',           1, 1, False, True,  'Coins at prioritized addresses are spent first.', 'prioritize <address>')
 register_command('restore',              0, 0, False, False, 'Restore a wallet')
@@ -257,6 +258,11 @@ class Commands:
 
     def payto(self, to_address, amount, fee = None, change_addr = None, domain = None):
         tx = self._mktx([(to_address, amount)], fee, change_addr, domain)
+        r, h = self.wallet.sendtx( tx )
+        return h
+
+    def paytomany(self, outputs, fee = None, change_addr = None, domain = None):
+        tx = self._mktx(outputs, fee, change_addr, domain)
         r, h = self.wallet.sendtx( tx )
         return h
 


### PR DESCRIPTION
I needed to have sendmany like in bitcoin-qt, but with change address and fee control. Of course electrum is always my go-to client for custom tailored transactions without the perils of creating them by hand, so I took a stab at it.

I have not tested actually submitting the tx, but I reviewed a bunch of them from mksendmanytx and it looks very sane, as it should as the change is minimal.

I thought about piggybacking on payto/mktx, as the optional 'label' described in the help text does not seem to be processed anywhere, but I only did a quick search for it and didn't want to change the existing command expected behaviour.
