### PR TITLE
Register as protocol handler for bitcoin: URIs

### DIFF
--- a/electrum.desktop
+++ b/electrum.desktop
@@ -3,7 +3,7 @@
 
 [Desktop Entry]
 Comment=Lightweight Bitcoin Client
-Exec=electrum
+Exec=electrum %u
 GenericName[en_US]=Electrum
 GenericName=Electrum
 Icon=/usr/share/app-install/icons/electrum.png
@@ -13,4 +13,5 @@ Categories=Network;
 StartupNotify=false
 Terminal=false
 Type=Application
+MimeType=x-scheme-handler/bitcoin
 


### PR DESCRIPTION
This adds an association for bitcoin: URIs to the desktop entry, so that clicking a bitcoin link in a browser automatically opens electrum under linux.
