### PR TITLE
Fixes the QR code widget to include a 10px margin to offset the widget on dark theme background

### DIFF
--- a/gui/qrcodewidget.py
+++ b/gui/qrcodewidget.py
@@ -62,6 +62,11 @@ class QRCodeWidget(QWidget):
         left = (r.width() - size)/2
         top = (r.height() - size)/2         
 
+        # Make a white margin around the QR in case of dark theme use:
+        margin = 10
+        qp.setBrush(white)
+        qp.drawRect(left-margin, top-margin, size+(margin*2), size+(margin*2))
+
         for r in range(k):
             for c in range(k):
                 if self.qr.isDark(r, c):


### PR DESCRIPTION
On my screen, QR codes are not scannable because I use a dark green theme and there is not an adequate amount of white padding between the background and the QR code.

[QR code without margin (unscannable)](http://i.imgur.com/C1kKXx1.png)

[QR code with margin added (scannable)](http://i.imgur.com/HD5rTKn.png)

It looks like the upstream pyqrnative has a margin parameter, but the one included in electrum does not, so I simply drew a white square underneath the QR code that is 10 pixels bigger.
