### PR TITLE
BIP32Sequence::get_pubkey not using mpk parameter

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -521,7 +521,7 @@ class BIP32Sequence:
 
     def get_pubkey(self, sequence, mpk = None):
         if not mpk: mpk = self.mpk
-        master_public_key, master_chain = self.mpk
+        master_public_key, master_chain = mpk
         K = master_public_key.decode('hex')
         chain = master_chain.decode('hex')
         for i in sequence:


### PR DESCRIPTION
The get_pubkey function was not using the mpk parameter instead always use self.mpk
