### PR TITLE
Only add data files if user has permission

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if (len(sys.argv) > 1 and (sys.argv[1] == "sdist")) or (platform.system() != 'Wi
     for lang in os.listdir('locale'):
         if os.path.exists('locale/%s/LC_MESSAGES/electrum.mo'%lang):
             data_files.append(  ('/usr/share/locale/%s/LC_MESSAGES'%lang, ['locale/%s/LC_MESSAGES/electrum.mo'%lang]) )
+    data_files = [data for data in data_files if os.access(data[0], os.W_OK)]
 
 data_files += [
     (util.appdata_dir(), ["data/README"]),


### PR DESCRIPTION
pip requires setup.py to fail without errors. Attempting to install electrum in a virtualenv (as opposed to globally) will most likely mean the user doesn't have permission to install into /usr/share, causing installation to fail.

This change ignores data_files that can not be added due to lack of permissions to the directory they are going to be installed in.

References #177
