### PR TITLE
fixes #245: use alternate datafiles location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,23 @@ util = imp.load_source('version', 'lib/util.py')
 if sys.version_info[:3] < (2,6,0):
     sys.exit("Error: Electrum requires Python version >= 2.6.0...")
 
+usr_share = '/usr/share'
+if not os.access(usr_share, os.W_OK):
+    usr_share = os.getenv("XDG_DATA_HOME",
+                           os.path.join(os.getenv("HOME"), ".local", "share"))
+
 data_files = []
 if (len(sys.argv) > 1 and (sys.argv[1] == "sdist")) or (platform.system() != 'Windows' and platform.system() != 'Darwin'):
     print "Including all files"
     data_files += [
-        ('/usr/share/applications/',['electrum.desktop']),
-        ('/usr/share/app-install/icons/',['icons/electrum.png'])
+        (os.path.join(usr_share, 'applications/'),['electrum.desktop']),
+        (os.path.join(usr_share, 'app-install', 'icons/'),['icons/electrum.png'])
     ]
     if not os.path.exists('locale'):
         os.mkdir('locale')
     for lang in os.listdir('locale'):
         if os.path.exists('locale/%s/LC_MESSAGES/electrum.mo'%lang):
-            data_files.append(  ('/usr/share/locale/%s/LC_MESSAGES'%lang, ['locale/%s/LC_MESSAGES/electrum.mo'%lang]) )
+            data_files.append(  (os.path.join(usr_share, 'locale/%s/LC_MESSAGES'%lang), ['locale/%s/LC_MESSAGES/electrum.mo'%lang]) )
 
 data_files += [
     (util.appdata_dir(), ["data/README"]),


### PR DESCRIPTION
Hi,

This is proposed fix for #244, #245.

Looks like `$XDG_DATA_HOME` (or default to `~/.local/share`) works as an alternate data files location when installing within a virtualenv. I can confirm that both virtualenv and global installations work (along with dekstop entry, locales etc) with this changeset, atleast on ubuntu 13.04.

Cheers.
