### PR TITLE
Remove eval from run_hook

### DIFF
--- a/gui/gui_classic/main_window.py
+++ b/gui/gui_classic/main_window.py
@@ -472,7 +472,7 @@ class ElectrumWindow(QMainWindow):
                 return
 
             try:
-                apply(f, args)
+                f(*args)
             except:
                 print_error("Plugin error")
                 traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
small improvement to remove `eval` using builtin function `getattr`.
