### PR TITLE
fix error to create a wallet due to missing pick_random_server decl

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -3,7 +3,7 @@ from util import format_satoshis, print_msg, print_json, print_error, set_verbos
 from wallet import WalletSynchronizer, WalletStorage
 from wallet_factory import WalletFactory as Wallet
 from verifier import TxVerifier
-from network import Network, DEFAULT_SERVERS, DEFAULT_PORTS
+from network import Network, DEFAULT_SERVERS, DEFAULT_PORTS, pick_random_server
 from interface import Interface
 from simple_config import SimpleConfig
 import bitcoin

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -28,10 +28,6 @@ DEFAULT_TIMEOUT = 5
 proxy_modes = ['socks4', 'socks5', 'http']
 
 
-def pick_random_server():
-    return random.choice( filter_protocol(DEFAULT_SERVERS,'s') )
-
-
 class Interface(threading.Thread):
 
 

--- a/lib/network.py
+++ b/lib/network.py
@@ -33,6 +33,9 @@ def filter_protocol(servers, p):
     return l
     
 
+def pick_random_server():
+    return random.choice( filter_protocol(DEFAULT_SERVERS,'s') )
+
 
 class Network(threading.Thread):
 


### PR DESCRIPTION
when just pick_random_server was added to `__init__.py`, it failed later with filter_protocol, so i just moved it to network
the bug happened when creating a wallet on the command line
