### PR TITLE
make it possible to create wallet non-interactively

### DIFF
--- a/electrum
+++ b/electrum
@@ -84,6 +84,7 @@ def arg_parser():
     parser.add_option("-L", "--lang", dest="language", default=None, help="defaut language used in GUI")
     parser.add_option("-u", "--usb", dest="bitkey", action="store_true", help="Turn on support for hardware wallets (EXPERIMENTAL)")
     parser.add_option("-G", "--gap", dest="gap_limit", default=None, help="gap limit")
+    parser.add_option("-W", "--password", dest="password", default=None, help="set password for usage with commands (currently only implemented for create command, do not use it for longrunning gui session since the password is visible in /proc)")
     return parser
 
 def print_help(parser):
@@ -185,22 +186,22 @@ if __name__ == '__main__':
     if cmd in ['create', 'restore']:
         if wallet.storage.file_exists:
             sys.exit("Error: Remove the existing wallet first!")
-        password = prompt_password("Password (hit return if you do not wish to encrypt your wallet):")
+        if options.password != None:
+            password = options.password
+        else:
+            password = prompt_password("Password (hit return if you do not wish to encrypt your wallet):")
 
-        server = config.get('server')
-        if not server: server = pick_random_server()
-        w_host, w_port, w_protocol = server.split(':')
-        host = raw_input("server (default:%s):"%w_host)
-        port = raw_input("port (default:%s):"%w_port)
-        protocol = raw_input("protocol [t=tcp;h=http] (default:%s):"%w_protocol)
-        fee = raw_input("fee (default:%s):"%( str(Decimal(wallet.fee)/100000000)) )
-        gap = raw_input("gap limit (default 5):")
-        if host: w_host = host
-        if port: w_port = port
-        if protocol: w_protocol = protocol
-        config.set_key('server', w_host + ':' + w_port + ':' +w_protocol)
-        if fee: wallet.fee = float(fee)
-        if gap: wallet.gap_limit = int(gap)
+        # if config.server is set, the user either passed the server on command line
+        # or chose it previously already. if he didn't pass a server on the command line,
+        # we just pick up a random one.
+        if not config.get('server'):
+            config.set_key('server', pick_random_server())
+
+        fee = options.tx_fee if options.tx_fee else raw_input("fee (default:%s):"%( str(Decimal(wallet.fee)/100000000)) )
+        gap = options.gap_limit if options.gap_limit else raw_input("gap limit (default 5):")
+
+        if fee: wallet.set_fee(float(fee)*100000000)
+        if gap: wallet.change_gap_limit(int(gap))
 
         if cmd == 'restore':
             seed = raw_input("seed:")
@@ -225,7 +226,6 @@ if __name__ == '__main__':
             else:
                 print_msg("Warning: Found no history for this wallet")
 
-            print_msg("Wallet saved in '%s'"%config.path)
         else:
             wallet.init_seed(None)
             wallet.save_seed()
@@ -235,7 +235,8 @@ if __name__ == '__main__':
             print_msg("Please keep it in a safe place; if you lose it, you will not be able to restore your wallet.")
             print_msg("Equivalently, your wallet seed can be stored and recovered with the following mnemonic code:")
             print_msg("\""+' '.join(mnemonic_encode(wallet.seed))+"\"")
-            print_msg("Wallet saved in '%s'"%config.path)
+
+        print_msg("Wallet saved in '%s'"%wallet.storage.path)
             
         if password:
             wallet.update_password(wallet.seed, None, password)


### PR DESCRIPTION
add a --password option,
respect --server,--fee,--gap as passed on the command line,
and do not ask for them if they were specified.

so if all of them are passed, there are no interactive questions
asked and one can create wallets automatically via scripts.

closes #308

additionally it fixes the bug that the default fee and gap limit
were not stored in the new wallet, if entered manually.

additionally it fixes the bug that the wallet path was not displayed
correctly if a custom wallet path was used.
