### PR TITLE
Fix command line redirect error

### DIFF
--- a/electrum
+++ b/electrum
@@ -18,7 +18,7 @@
 
 import re
 import pkgutil
-import sys, os, time, json
+import sys, os, time, json, readline
 import optparse
 import platform
 from decimal import Decimal


### PR DESCRIPTION
Python bug (http://bugs.python.org/issue1927) causes raw_input to be redirected improperly between stdin/stderr on Unix systems if readline is not initialised first.
