### PR TITLE
Fix for the built-in raw_input not redirecting properly without readline loaded on Unix systems (http://bugs.python.org/issue1927)

### DIFF
--- a/electrum
+++ b/electrum
@@ -166,11 +166,6 @@ if __name__ == '__main__':
         time.sleep(0.1)
         sys.exit(0)
 
-    # Python bug (http://bugs.python.org/issue1927) causes raw_input
-    # to be redirected improperly between stdin/stderr on Unix systems
-    # if readline is not initialised first.
-    import readline
-    
     if cmd not in known_commands:
         cmd = 'help'
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -179,4 +179,12 @@ def parse_url(url):
     return address, amount, label, message, signature, identity, url
 
 
-
+# Python bug (http://bugs.python.org/issue1927) causes raw_input
+# to be redirected improperly between stdin/stderr on Unix systems
+def raw_input(prompt=None):
+    if prompt:
+        sys.stdout.write(prompt)
+    return builtin_raw_input()
+import __builtin__
+builtin_raw_input = __builtin__.raw_input
+__builtin__.raw_input = raw_input


### PR DESCRIPTION
Fix for the built-in raw_input not redirecting properly without readline loaded on Unix systems (http://bugs.python.org/issue1927)
