### PR TITLE
Fixed indexing a function rather than calling it in WalletStorage.put

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -132,7 +132,7 @@ class WalletStorage:
             if value is not None:
                 self.data[key] = value
             else:
-                self.data.pop[key]
+                self.data.pop(key)
             if save: 
                 self.write()
 


### PR DESCRIPTION
Found a trivial error in WalletStorage when I updated to version 1.9 today.
