### PR TITLE
FIX: make the curses text UI not crash when started in --offline mode

### DIFF
--- a/gui/text.py
+++ b/gui/text.py
@@ -22,8 +22,7 @@ class ElectrumGui:
             exit()
 
         self.wallet = Wallet(storage)
-        if self.network:
-            self.wallet.start_threads(network)
+        self.wallet.start_threads(self.network)
 
         locale.setlocale(locale.LC_ALL, '')
         self.encoding = locale.getpreferredencoding()


### PR DESCRIPTION
(matching ThomasV's recent changes to the other UIs)
