### PR TITLE
Split colon - separate - Clean wikia translation page

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -50,7 +50,7 @@ class NetworkDialog(QDialog):
                 status = _("Not connected")
 
             if network.is_connected():
-                status += "\n" + _("Server:") + " %s"%(network.interface.host) 
+                status += "\n" + _("Server") + ": %s"%(network.interface.host) 
             else:
                 status += "\n" + _("Disconnected from server")
                 

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -154,10 +154,10 @@ class TxDialog(QDialog):
             if is_mine:
                 if fee is not None: 
                     self.amount_label.setText(_("Amount sent:")+' %s'% self.parent.format_amount(v-fee) + ' ' + self.parent.base_unit())
-                    self.fee_label.setText(_("Transaction fee:")+' %s'% self.parent.format_amount(fee) + ' ' + self.parent.base_unit())
+                    self.fee_label.setText(_("Transaction fee")+': %s'% self.parent.format_amount(fee) + ' ' + self.parent.base_unit())
                 else:
                     self.amount_label.setText(_("Amount sent:")+' %s'% self.parent.format_amount(v) + ' ' + self.parent.base_unit())
-                    self.fee_label.setText(_("Transaction fee: unknown"))
+                    self.fee_label.setText(_("Transaction fee")+': ' _("unknown"))
             else:
                 self.amount_label.setText(_("Amount received:")+' %s'% self.parent.format_amount(v) + ' ' + self.parent.base_unit())
         else:
@@ -198,7 +198,7 @@ class TxDialog(QDialog):
     def broadcast(self):
         result, result_message = self.wallet.sendtx( self.tx )
         if result:
-            self.show_message(_("Transaction successfully sent:")+' %s' % (result_message))
+            self.show_message(_("Transaction successfully sent")+': %s' % (result_message))
             if dialog:
                 dialog.done(0)
         else:


### PR DESCRIPTION
Separate colon symbol for duplicated text strings

Cleaned wikia translation page, now it only have the text strings on 1.9 and fixed some minor errors. This latest version with legacy text strings, could be found in the branch `docs` in my fork
