### PR TITLE
allow to connect to one server only

### DIFF
--- a/electrum
+++ b/electrum
@@ -84,6 +84,7 @@ def arg_parser():
     parser.add_option("-u", "--usb", dest="bitkey", action="store_true", help="Turn on support for hardware wallets (EXPERIMENTAL)")
     parser.add_option("-G", "--gap", dest="gap_limit", default=None, help="gap limit")
     parser.add_option("-W", "--password", dest="password", default=None, help="set password for usage with commands (currently only implemented for create command, do not use it for longrunning gui session since the password is visible in /proc)")
+    parser.add_option("-1", "--oneserver", action="store_true", dest="oneserver", default=False, help="connect to one server only")
     return parser
 
 def print_help(parser):

--- a/lib/network.py
+++ b/lib/network.py
@@ -22,7 +22,6 @@ DEFAULT_SERVERS = {
 }
 
 
-NUM_SERVERS = 8
 
 
 def filter_protocol(servers, p):
@@ -45,6 +44,7 @@ class Network(threading.Thread):
         self.daemon = True
         self.config = SimpleConfig(config) if type(config) == type({}) else config
         self.lock = threading.Lock()
+        self.num_server = 8 if not self.config.get('oneserver') else 0
         self.blockchain = Blockchain(self.config, self)
         self.interfaces = {}
         self.queue = Queue.Queue()
@@ -154,7 +154,7 @@ class Network(threading.Thread):
         self.start_interface(self.default_server)
         self.interface = self.interfaces[self.default_server]
 
-        for i in range(NUM_SERVERS):
+        for i in range(self.num_server):
             self.start_random_interface()
             
         if not self.interface:
@@ -282,7 +282,7 @@ class Network(threading.Thread):
             try:
                 i = self.queue.get(timeout = 30 if self.interfaces else 3)
             except Queue.Empty:
-                if len(self.interfaces) < NUM_SERVERS:
+                if len(self.interfaces) < self.num_server:
                     self.start_random_interface()
                 continue
 


### PR DESCRIPTION
This changeset allow to disable block headers retrieval from multiple servers.

This feature is useful when you run an electrum server and you don't want your client to connect to other servers leaking your IP address.
