### PR TITLE
Old addresses on receive tab grayed out

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1236,7 +1236,7 @@ class ElectrumWindow(QMainWindow):
                 is_red = False
                 gap = 0
 
-                for address in reversed(account.get_addresses(is_change)):
+                for address in account.get_addresses(is_change):
                     h = self.wallet.history.get(address,[])
             
                     if h == []:


### PR DESCRIPTION
For version 2, I suggest that the receive tab only contains empty addresses and that a 'wallet' or 'balance' is added with non-empty addresses.
Also, this graying out might not be perfect for those who want to reuse addresses which is not a felony or something.
