### PR TITLE
pointofsale: generated bitcoin url might contain invalid characters

### DIFF
--- a/plugins/pointofsale.py
+++ b/plugins/pointofsale.py
@@ -1,6 +1,7 @@
 import re
 import platform
 from decimal import Decimal
+from urllib import quote
 
 from PyQt4.QtGui import *
 from PyQt4.QtCore import *
@@ -89,9 +90,11 @@ class QR_Window(QWidget):
         if self.amount is not None:
             msg += '?amount=%s'%(str( self.amount))
             if self.label is not None:
-                msg += '&label=%s'%(self.label)
+                encoded_label = quote(self.label)
+                msg += '&label=%s'%(encoded_label)
         elif self.label is not None:
-            msg += '?label=%s'%(self.label)
+            encoded_label = quote(self.label)
+            msg += '?label=%s'%(encoded_label)
             
         self.qrw.set_addr( msg )
 


### PR DESCRIPTION
The bitcoin invoice url generated for the QR code might contain illegal
characters because the labels can have any text. In default it already
contains spaces (ie. the naming convention "Invoice - 0001").

The invalid URL did confuse e.g. the Bitcoin Wallet Android app, that
couldn't read bitcoin addresses from the generated QR code.

This is fixed by escaping the label text before displaying it as a
QR code.
