### PR TITLE
Fix tray icon after close

### DIFF
--- a/gui/qt/lite_window.py
+++ b/gui/qt/lite_window.py
@@ -355,9 +355,7 @@ class MiniWindow(QDialog):
     def closeEvent(self, event):
         g = self.geometry()
         self.config.set_key("winpos-lite", [g.left(),g.top(),g.width(),g.height()],True)
-        
-        super(MiniWindow, self).closeEvent(event)
-        qApp.quit()
+        self.actuator.g.closeEvent(event)
 
     def set_payment_fields(self, dest_address, amount):
         self.address_input.setText(dest_address)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2137,6 +2137,7 @@ class ElectrumWindow(QMainWindow):
         NetworkDialog(self.wallet.network, self.config, self).do_exec()
 
     def closeEvent(self, event):
+        self.tray.hide()
         g = self.geometry()
         self.config.set_key("winpos-qt", [g.left(),g.top(),g.width(),g.height()], True)
         self.save_column_widths()


### PR DESCRIPTION
This broke the "Exit Electrum" menu option in the tray icon when lite mode was active.
