### PR TITLE
Fix for resetting options to default on program start when in portable mode

### DIFF
--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -30,8 +30,7 @@ a SimpleConfig instance then reads the wallet file.
 
         # user conf, writeable
         self.user_config = {}
-        if options.get('portable') == False:
-            self.read_user_config()
+        self.read_user_config()
 
 
 


### PR DESCRIPTION
Fixes bug: When in portable mode, config file is created and updated properly, but when Electrum is restarted it is wiped out and set to default values.
