### PR TITLE
Bugfix/parsing error in csv transaction

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1882,7 +1882,7 @@ class ElectrumWindow(QMainWindow):
         try:
             for row in csvReader:
                 address = row[0]
-                amount = float(row[1])
+                amount = Decimal(row[1])
                 amount = int(100000000*amount)
                 outputs.append((address, amount))
         except (ValueError, IOError, os.error), reason:


### PR DESCRIPTION
There is a bug in the code that creates a transaction from a CSV file. Amounts which cannot be represented precisely in floating point are not correctly converted to an integer amount of satoshis. See the commit message of https://github.com/shunyata/electrum/commit/acec9c2b4313a65dca42ce106cfe442680a09201 for more information.

Note: I also removed a lot of trailing whitespace. The change which fixes the bug is in https://github.com/shunyata/electrum/commit/acec9c2b4313a65dca42ce106cfe442680a09201
