### PR TITLE
Fix error when network.is_running() is called before the network is started.

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -50,6 +50,7 @@ class Network(threading.Thread):
         self.queue = Queue.Queue()
         self.callbacks = {}
         self.protocol = self.config.get('protocol','s')
+        self.running = False
 
         # Server for addresses and transactions
         self.default_server = self.config.get('server')


### PR DESCRIPTION
This was causing a AttributeError when network.is_running() was called before the network was started.
