### PR TITLE
Remove an obsolete parameter.

### DIFF
--- a/electrum
+++ b/electrum
@@ -391,7 +391,7 @@ if __name__ == '__main__':
 
     elif cmd.name == 'password':
         new_password = prompt_password('New password:')
-        wallet.update_password(seed, password, new_password)
+        wallet.update_password(password, new_password)
 
     else:
         run_command(cmd.name, password, args)


### PR DESCRIPTION
`wallet.update_password` doesn't have the `seed` parameter anymore.

This was straight-up crashing before. Need more automated tests, I think. :/
