### PR TITLE
wallet.synchronizer should exist at construction.

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -186,6 +186,8 @@ class Wallet:
                 print msg
                 sys.exit(1)
 
+        # This attribute is set when wallet.start_threads is called.
+        self.synchronizer = None
 
         self.load_accounts()
 


### PR DESCRIPTION
The CLI command `electrum importprivkey` fails with the error message `Error: Keypair import failed: Wallet instance has no attribute 'synchronizer'`

The `self.synchronizer` attribute is accessed before it ever exists when using `electrum importprivkey` on the command line. This change sets it to None (which is a valid state for this attribute) in the wallet's constructor.
