### PR TITLE
Finish removing coinbase cert

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ data_files += [
         "data/dark/background.png",
         "data/dark/name.cfg",
         "data/dark/style.css"
-    ]),
-    (os.path.join(util.appdata_dir(), "certs"), [
-        "data/certs/ca-coinbase.crt",
     ])
 ]
 


### PR DESCRIPTION
This commit modifies setup.py so it doesn't try to install the no longer present coinbase certificate.
