### PR TITLE
Remove the ability to "Send From" a frozen address.

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1170,7 +1170,8 @@ class ElectrumWindow(QMainWindow):
         if any(addr in self.wallet.frozen_addresses for addr in addrs):
             menu.addAction(_("Unfreeze"), lambda: self.set_addrs_frozen(addrs, False))
 
-        menu.addAction(_("Send From"), lambda: self.send_from_addresses(addrs))
+        if any(addr not in self.wallet.frozen_addresses for addr in addrs):
+            menu.addAction(_("Send From"), lambda: self.send_from_addresses(addrs))
 
         run_hook('receive_menu', menu, addrs)
         menu.exec_(self.receive_list.viewport().mapToGlobal(position))


### PR DESCRIPTION
Got burned by this...

If an address is frozen, and you select "Send From", it the spend will be taken from a random(?) unfrozen address.  Patch just removes the option from the context menu of a frozen address.
