### PR TITLE
Fix timeout problem in interface.py.

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -427,7 +427,9 @@ class Interface(threading.Thread):
                 except ssl.SSLError:
                     timeout = True
                 except socket.error, err:
-                    if err.errno in [11, 10035]:
+                    if err.errno == 60:
+                        timeout = True
+                    elif err.errno in [11, 10035]:
                         print_error("socket errno", err.errno)
                         time.sleep(0.1)
                         continue


### PR DESCRIPTION
Fix timeout problem under Python 2.7.1 where a socket.error 60 is thrown instead of socket.timeout exception.

I was seeing the following exception thrown periodically:

Traceback (most recent call last):
  File "/Users/mattb/Personal/Bitcoin/Electrum-1.9.6/lib/interface.py", line 421, in run_tcp
    msg = self.s.recv(1024)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py", line 219, in recv
    return self.read(buflen)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py", line 138, in read
    return self._sslobj.read(len)
error: [Errno 60] Operation timed out

Based on the stack trace it looks like Python 2.7.1 ssl doesn't throw socket.timeout but instead throws socket.error with errno == 60. Proposed fix just catches that and handles it as a timeout.
