### PR TITLE
Squash case on user-entered seed when restoring a wallet.

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -127,7 +127,8 @@ class InstallWizard(QDialog):
         if not self.exec_():
             return
 
-        seed = unicode(seed_e.toPlainText())
+        seed = seed_e.toPlainText()
+        seed = unicode(seed.toLower())
 
         if not seed:
             QMessageBox.warning(None, _('Error'), _('No seed'), _('OK'))


### PR DESCRIPTION
Saw this problem report on reddit:  http://www.reddit.com/r/BitcoinBeginners/comments/1wanf9/how_do_i_recover_my_wallet_in_electrum_with_my/

tl;dr - Entering the wallet seed with mixed case fails.  Seed has to be entered as all lower case.

---

Since the seed is taken from the hard coded list of words in mnemonic.py, and all those words are in lower case, there is no need for case to be considered.  In fact, as seen in the bug report above, user expectation is that it is the words that are important, and that if the words are correct (regardless of case) then the seed should produce a valid wallet.

Attached two line patch squashes the case of the seed input from the user during seed verification or wallet restoration.
