### PR TITLE
urlparse puts arguements in uri.query, not uri.path.

### DIFF
--- a/plugins/qrscanner.py
+++ b/plugins/qrscanner.py
@@ -350,10 +350,10 @@ def parse_uri(uri):
     uri = urlparse(uri)
     result = {'address': uri.netloc} 
     
-    if uri.path.startswith('?'):
-        params = parse_qs(uri.path[1:])
+    if uri.query.startswith('?'):
+        params = parse_qs(uri.query[1:])
     else:
-        params = parse_qs(uri.path)    
+        params = parse_qs(uri.query)    
 
     for k,v in params.items():
         if k in ('amount', 'label', 'message'):


### PR DESCRIPTION
Current code just pulled the address from the QR code.  Parsing uri.query instead of uri.path correctly pulls in "amount", "label" and "message" if set.
