### PR TITLE
Changed CSV History export to UTF-8 labels

### DIFF
--- a/gui/qt/lite_window.py
+++ b/gui/qt/lite_window.py
@@ -122,6 +122,7 @@ def csv_transaction(wallet):
 
                     if tx_hash:
                         label, is_default_label = wallet.get_label(tx_hash)
+                        label = label.encode('utf-8')
                     else:
                       label = ""
 


### PR DESCRIPTION
Japanese characters were causing history to be aborted halfway through
export, so by changing the label to UTF-8 I was able to export the CSV
properly.
