### PR TITLE
Add QR Display for Private Key export

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1700,6 +1700,7 @@ class ElectrumWindow(QMainWindow):
         keys.setReadOnly(True)
         keys.setText('\n'.join(pk_list))
         vbox.addWidget(keys)
+        vbox.addWidget( QRCodeWidget('\n'.join(pk_list)) )
         vbox.addLayout(close_button(d))
         d.setLayout(vbox)
         d.exec_()


### PR DESCRIPTION
add a QR display on the private key window

requested in IRC for transferring an address to a mobile device wallet
