### PR TITLE
display locktime for transaction

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -180,6 +180,9 @@ class TxDialog(QDialog):
 
     def add_io(self, vbox):
 
+        if self.tx.locktime > 0:
+            vbox.addWidget(QLabel("LockTime: %d\n" % self.tx.locktime))
+
         vbox.addWidget(QLabel(_("Inputs")))
         lines = map(lambda x: x.get('prevout_hash') + ":%d"%x.get('prevout_n') + u'\t' + "%s"%x.get('address') , self.tx.inputs )
         i_text = QTextEdit()

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -376,6 +376,7 @@ class Transaction:
         self.inputs = self.d['inputs']
         self.outputs = self.d['outputs']
         self.outputs = map(lambda x: (x['address'],x['value']), self.outputs)
+        self.locktime = self.d['lockTime']
         self.is_complete = is_complete
         
     def __str__(self):


### PR DESCRIPTION
display locktime for transactions if it is greater than 0.  Majority of
transactions will not display any value because default is 0.
