### PR TITLE
add white space before BTC frozen message

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -779,7 +779,7 @@ class ElectrumWindow(QMainWindow):
                 self.funds_error = True
                 text = _( "Not enough funds" )
                 c, u = self.wallet.get_frozen_balance()
-                if c+u: text += ' (' + self.format_amount(c+u).strip() + self.base_unit() + ' ' +_("are frozen") + ')'
+                if c+u: text += ' (' + self.format_amount(c+u).strip() + ' ' + self.base_unit() + ' ' +_("are frozen") + ')'
 
             self.statusBar().showMessage(text)
             self.amount_e.setPalette(palette)


### PR DESCRIPTION
Added a white space before BTC in the not enough funds frozen message.

The ‘Not enough funds…’ message does not disappear even after clicking
the Clear button. Only changing the amount to send restores the
‘Balance’ message
