### PR TITLE
Added exchange rate to status panel

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -496,6 +496,12 @@ class ElectrumWindow(QMainWindow):
                 if quote:
                     text += "  (%s)"%quote
 
+                r = {}
+                run_hook('set_quote_text', 100000000, r)
+                quote = r.get(0)
+                if quote:
+                    text += "      1 BTC~%s"%quote
+
                 self.tray.setToolTip(text)
                 icon = QIcon(":icons/status_connected.png")
         else:


### PR DESCRIPTION
Added current exchange rate to status panel after Balance. For example, " 1 BTC~734.55 USD". Uses settings from Exchange Rate plugin and behaves same way as existing fiat balance in status panel.

Also fixed bug with width of combo box on bottom right.

![electrumcombo](https://cloud.githubusercontent.com/assets/6622335/2530822/feaeed68-b52a-11e3-9484-b125503228e9.jpg)

![electrumstatus](https://cloud.githubusercontent.com/assets/6622335/2530825/03ba527a-b52b-11e3-98dc-f9dc8f304373.jpg)
