### PR TITLE
Added bitcoin price to status panel (appended to balance)

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -496,6 +496,12 @@ class ElectrumWindow(QMainWindow):
                 if quote:
                     text += "  (%s)"%quote
 
+                r = {}
+                run_hook('set_quote_text', 100000000, r)
+                quote = r.get(0)
+                if quote:
+                    text += "      1 BTC~%s "%quote
+
                 self.tray.setToolTip(text)
                 icon = QIcon(":icons/status_connected.png")
         else:


### PR DESCRIPTION
For example, " 1 BTC~734.55 USD". Uses settings from Exchange Rate plugin and behaves same way as existing fiat balance in status panel.
![electrumstatus](https://cloud.githubusercontent.com/assets/6622335/2539224/0c8b14e8-b5c6-11e3-9f18-0cf55cad3ea4.jpg)
