### PR TITLE
Sort imported addresses. First one with balance sorted, then all other sorted, case-insensitive.

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1232,6 +1232,7 @@ class ElectrumWindow(QMainWindow):
         if address in self.wallet.frozen_addresses:
             item.setBackgroundColor(0, QColor('lightblue'))
 
+        return (c,u)
 
     def update_receive_tab(self):
         l = self.receive_list
@@ -1314,12 +1315,16 @@ class ElectrumWindow(QMainWindow):
             account_item = QTreeWidgetItem( [ _('Imported'), '', self.format_amount(c+u), ''] )
             l.addTopLevelItem(account_item)
             account_item.setExpanded(True)
-            for address in self.wallet.imported_keys.keys():
+            last_nonzero_balance = 0
+            for address in sorted(self.wallet.imported_keys.keys(), key=str.upper):
                 item = QTreeWidgetItem( [ address, '', '', ''] )
-                self.update_receive_item(item)
-                account_item.addChild(item)
-
-
+                addr_c, addr_u = self.update_receive_item(item)
+                if addr_c + addr_u:
+                    account_item.insertChild(last_nonzero_balance,item)
+                    last_nonzero_balance += 1
+                else:
+                    account_item.addChild(item)
+                
         # we use column 1 because column 0 may be hidden
         l.setCurrentItem(l.topLevelItem(0),1)
 


### PR DESCRIPTION
I was heavy user of bitcoin-qt, so when migrating to electrum I had to import many addresses into electrum. Currently they are not sorted in Receive tab, it's hard to find one specific address, especially vanity ones or which ones have balance. 

Sorting is done just prior to display in Qt GUI, no other functions/GUIs are affected.
