### PR TITLE
fix type mismatch bug in signrawtransaction

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -503,6 +503,8 @@ class Transaction:
     def add_signature(self, i, pubkey, sig):
         txin = self.inputs[i]
         signatures = txin.get("signatures",{})
+        if len(signatures) == 0:
+            signatures = {}
         signatures[pubkey] = sig
         txin["signatures"] = signatures
         self.inputs[i] = txin


### PR DESCRIPTION
The 'signatures' key is being read as a (empty) list, but treated as a dict. It looks like #464 and #550 may be related. I was able to sign an offline transaction with this fix in place.

Feel free to re-implement to make this more python-ish.
