### PR TITLE
show/raise install dialog

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -135,6 +135,10 @@ class InstallWizard(QDialog):
         vbox.addLayout(ok_cancel_buttons(self, _('Next')))
 
         self.set_layout(vbox)
+
+        self.show()
+        self.raise_()
+
         if not self.exec_():
             return None, None
         


### PR DESCRIPTION
make sure install dialog doesn't show up behind other windows when
electrum is started
