### PR TITLE
Increase the timeout when using a single server

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -85,7 +85,7 @@ def cert_verify_hostname(s):
 class Interface(threading.Thread):
 
 
-    def __init__(self, server, config = None):
+    def __init__(self, server, connect_timeout, connected_timeout, config = None):
 
         threading.Thread.__init__(self)
         self.daemon = True
@@ -125,7 +125,8 @@ class Interface(threading.Thread):
         self.proxy = self.parse_proxy_options(self.config.get('proxy'))
         if self.proxy:
             self.proxy_mode = proxy_modes.index(self.proxy["mode"]) + 1
-
+        self.connect_timeout = connect_timeout
+        self.connected_timeout = connected_timeout
 
 
 
@@ -363,7 +364,7 @@ class Interface(threading.Thread):
         for res in addrinfo:
             try:
                 s = socket.socket( res[0], socket.SOCK_STREAM )
-                s.settimeout(2)
+                s.settimeout(self.connect_timeout)
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 s.connect(res[4])
             except:
@@ -407,7 +408,7 @@ class Interface(threading.Thread):
                 print_error("saving certificate for", self.host)
                 os.rename(temporary_path, cert_path)
 
-        s.settimeout(60)
+        s.settimeout(self.connected_timeout)
         self.s = s
         self.is_connected = True
         print_error("connected to", self.host, self.port)

--- a/lib/network.py
+++ b/lib/network.py
@@ -198,7 +198,13 @@ class Network(threading.Thread):
     def start_interface(self, server):
         if server in self.interfaces.keys():
             return
-        i = interface.Interface(server, self.config)
+
+        if self.config.get('auto_cycle'):
+            connect_timeout = 2
+        else:
+            connect_timeout = 60
+
+        i = interface.Interface(server, connect_timeout, 60, self.config)
         self.pending_servers.add(server)
         i.start(self.queue)
         return i 


### PR DESCRIPTION
Only waiting 2 seconds before giving up is not a good idea when using a
single server, especially when using a slow connection. This led to
Electrum not being able to connect at all.

Waiting only 2 seconds in the case of auto-select should be fine, given
a decent network connection, as when one server doesn't reply within 2
seconds, the next will be tried at least.
