### PR TITLE
Added two new commands, gettxidbyteoffset() and gettxidfrombyteoffset()

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -104,7 +104,8 @@ register_command('getproof',             1, 1, True, False, False, 'get merkle p
 register_command('getutxoaddress',       2, 2, True, False, False, 'get the address of an unspent transaction output','getutxoaddress <txid> <pos>')
 register_command('sweep',                2, 3, True, False, False, 'Sweep a private key.', 'sweep privkey addr [fee]')
 
-
+register_command('gettxidbyteoffset',       2, 1, True, False, False, 'Return the block byte offset of a raw transaction','gettxidbyteoffset <txid> <height>')
+register_command('gettxidfrombyteoffset',   2, 1, True, False, False, 'Return the transaction id of a raw transaction at block byte offset', 'gettxidfrombyteoffset <offset> <height>')
 
 
 class Commands:
@@ -160,6 +161,16 @@ class Commands:
         if r: 
             return {'address':r[0] }
 
+    def gettxidbyteoffset(self, txid, height):
+        """ Given txid and block height, return the byte offset of the raw transaction data in the block. """
+        r = self.network.synchronous_get([ ('blockchain.transaction.get_txid_byte_offset',[txid, height]) ])
+        if r:
+            return r
+
+    def gettxidfrombyteoffset(self, offset, height):
+        """ Given byte offset and block height, see if a valid transaction exists, and if so return the txid."""
+        r = self.network.synchronous_get([ ('blockchain.transaction.get_txid_from_byte_offset',[offset, height]) ])
+        return r
 
     def createrawtransaction(self, inputs, outputs):
         for i in inputs:


### PR DESCRIPTION
Added two new commands which are useful for third-party plugins if they want to find the byte offset within a block of a transaction's raw data.

Assume we are interested in examining Block #266156 which has 297 transactions, of which the first two are listed below:
fcb8173d83bfd70475c8d9af1690308a3d8754d33dcd3ce5db3d9508a5c2fb62
72c8da513e3d3b2ed11e10977c0da6c30531c349d44eb3dfef62ac3f573575b1

Here is some example usage in the console.  You can verify the results by examining blk0089.dat.

```
Welcome to Electrum!
>> gettxidbyteoffset('fcb8173d83bfd70475c8d9af1690308a3d8754d33dcd3ce5db3d9508a5c2fb62', 266156)
[
    83
]

>> gettxidbyteoffset('72c8da513e3d3b2ed11e10977c0da6c30531c349d44eb3dfef62ac3f573575b1', 266156)
[
    206
]

>> gettxidbyteoffset('72c8da513e3d3b2ed11e10977c0da6c30531c349d44eb3dfef62ac3f573575b1', 266157)
gettxidbyteoffset() returns:
[
    null
]

>> gettxidfrombyteoffset(83, 266156)
[
    "fcb8173d83bfd70475c8d9af1690308a3d8754d33dcd3ce5db3d9508a5c2fb62"
]

>> gettxidfrombyteoffset(83, 266157)
[
    null
]

>> gettxidfrombyteoffset(206, 266156)
[
    "72c8da513e3d3b2ed11e10977c0da6c30531c349d44eb3dfef62ac3f573575b1"
]

```
