### PR TITLE
Loop through inputs to decide change addr

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -599,8 +599,10 @@ class Abstract_Wallet(object):
             if not change_addr:
 
                 # send change to one of the accounts involved in the tx
-                address = inputs[0].get('address')
-                account, _ = self.get_address_index(address)
+                for i in range(len(inputs)):
+                    address = inputs[i].get('address')
+                    account, _ = self.get_address_index(address)
+                    if account != IMPORTED_ACCOUNT: break
 
                 if not self.use_change or account == IMPORTED_ACCOUNT:
                     change_addr = inputs[-1]['address']


### PR DESCRIPTION
Fixes (?) #769

This pull request will loop through the inputs, and send to the change address of the first non-imported-key account that is there. If all inputs are imported, then it will send to `inputs[-1]['address']` as normal.

It may be better to change `if not self.use_change or account == IMPORTED_ACCOUNT:` to `if not self.use_change:` if the preference for use_change could be followed regardless. (The sweep function was added... so maybe this is no longer necessary)
