### PR TITLE
check for keypairs before access attributes

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -729,7 +729,7 @@ class Transaction:
             redeem_pubkeys = txin['pubkeys']
             for_sig = Hash(self.tx_for_sig(i).decode('hex'))
             for pubkey in redeem_pubkeys:
-                if pubkey in keypairs.keys():
+                if keypairs and pubkey in keypairs.keys():
                     # add signature
                     sec = keypairs[pubkey]
                     pkey = regenerate_key(sec)


### PR DESCRIPTION
This fixed this error: https://imgur.com/dPxzPXU

Not sure if this is only due to an old wallet type or not.
