### PR TITLE
Add confirmation count to API command 'history'

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -320,7 +320,7 @@ class Commands:
 
             label, is_default_label = self.wallet.get_label(tx_hash)
 
-            out.append({'txid':tx_hash, 'date':"%16s"%time_str, 'label':label, 'value':format_satoshis(value)})
+            out.append({'txid':tx_hash, 'date':"%16s"%time_str, 'label':label, 'value':format_satoshis(value), 'confirmations':conf})
         return out
 
     def setlabel(self, key, label):


### PR DESCRIPTION
Include the amount of confirmations alongside the date, label, txid and value entries when using the API command 'history'
