### PR TITLE
Trezor plugin fixes

### DIFF
--- a/plugins/trezor.py
+++ b/plugins/trezor.py
@@ -179,7 +179,7 @@ class TrezorWallet(NewWallet):
 
     def address_id(self, address):
         account_id, (change, address_index) = self.get_address_index(address)
-        return "%s/%d/%d" % (account_id, change, address_index)
+        return "44'/0'/%s'/%d/%d" % (account_id, change, address_index)
 
     def create_main_account(self, password):
         self.create_account('Main account', None) #name, empty password


### PR DESCRIPTION
I ran into a couple of issues when trying to create a transaction with the Trezor. This pull request fixes both of them.

1) Wallet.get_address_index() now returns the purpose and coin type, so it shouldn't be hard coded in TrezorWallet.address_id()
2) TrezorWallet.tx_inputs was expecting each input to have an 'address' key, which is only the case for non-coinbase transactions
