### PR TITLE
Update standard fee calculation to not round tx size to nearest KB

### DIFF
--- a/gui/qt/amountedit.py
+++ b/gui/qt/amountedit.py
@@ -92,6 +92,6 @@ class BTCAmountEdit(AmountEdit):
             return
 
         p = pow(10, self.decimal_point())
-        x = amount / Decimal(p)
+        x = Decimal(amount) / Decimal(p)
         self.setText(str(x))
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -612,7 +612,7 @@ class Abstract_Wallet(object):
 
     def estimated_fee(self, inputs, num_outputs):
         estimated_size =  len(inputs) * 180 + num_outputs * 34    # this assumes non-compressed keys
-        fee = self.fee * int(math.ceil(estimated_size/1000.))
+        fee = self.fee * (estimated_size/1000.)
         return fee
 
     def add_tx_change( self, inputs, outputs, amount, fee, total, change_addr=None):


### PR DESCRIPTION
I'm still unclear on how this should be working.  If other wallets don't do this, and electrum does, it could potentially cause issues with tx confirmation time being higher for electrum.  If most wallets conform to this standard, then confirmation times shouldn't be impacted.
