### PR TITLE
Show op_return in tx dialogue

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -212,7 +212,7 @@ class TxDialog(QDialog):
         vbox.addWidget(i_text)
 
         vbox.addWidget(QLabel(_("Outputs")))
-        lines = map(lambda x: x[0] + u'\t\t' + self.parent.format_amount(x[1]), self.tx.get_outputs())
+        lines = map(lambda x: x[0] + u'\t\t' + self.parent.format_amount(x[1]) if x[1] else x[0], self.tx.get_outputs())
         o_text = QTextEdit()
         o_text.setText('\n'.join(lines))
         o_text.setReadOnly(True)

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -429,6 +429,11 @@ def get_address_from_output_script(bytes):
     if match_decoded(decoded, match):
         return 'address', hash_160_to_bc_address(decoded[1][1],5)
 
+    # OP_RETURN
+    match = [ opcodes.OP_RETURN, opcodes.OP_PUSHDATA4 ]
+    if match_decoded(decoded, match):
+        return 'op_return', decoded[1][1]
+
     return "(None)", "(None)"
 
 
@@ -765,6 +770,11 @@ class Transaction:
                 addr = x
             elif type == 'pubkey':
                 addr = public_key_to_bc_address(x.decode('hex'))
+            elif type == 'op_return':
+                try:
+                    addr = 'OP_RETURN: "' + x.decode('utf8') + '"'
+                except:
+                    addr = 'OP_RETURN: "' + x.encode('hex') + '"'
             else:
                 addr = "(None)"
             o.append((addr,v))


### PR DESCRIPTION
Very basic as of now... needs more polish. But I am open to more suggestions as to how to sanitize etc.

It seems as though these two places are the only three places necessary to show op_returns.

Please let me know if you have any other info / suggestions.

P.S.: If you load `d29c9c0e8e4d2a9790922af73f0b8d51f0bd4bb19940d9cf910ead8fbe85bc9b` "From the blockchain" with this commit, you will not be disappointed.
Hint: here's a screen cap. (I made the text box larger to accommodate.)
http://i.imgur.com/QOKyRO1.png
