### PR TITLE
default language to 'en' if nothing else delivers a lang

### DIFF
--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -102,6 +102,8 @@ class Mnemonic(object):
     def __init__(self, lang=None):
         if lang in [None, '']:
             lang = i18n.language.info().get('language')
+        if lang in [None, '']:
+            lang = 'en'
         print_error('language', lang)
         filename = filenames.get(lang[0:2], 'english.txt')
         path = os.path.join(util.data_dir(), 'wordlist', filename)


### PR DESCRIPTION
```
lang = i18n.language.info().get('language')
```

returns None or '' on my system.

This fix defaults to lang = 'en' in such a case, fixing (not really, but it's better) #827
