### PR TITLE
Fix "Invalid Fee" issue when start with fiat in send (exchange rate plugin)

### DIFF
--- a/plugins/exchange_rate.py
+++ b/plugins/exchange_rate.py
@@ -662,6 +662,7 @@ class Plugin(BasePlugin):
             if exchange_rate is not None:
                 btc_amount = fiat_amount/exchange_rate
                 self.btc_e.setAmount(int(btc_amount*Decimal(100000000)))
+                self.btc_e.textEdited.emit("")
         self.fiat_e.textEdited.connect(fiat_changed)
         def btc_changed():
             btc_amount = self.btc_e.get_amount()
@@ -670,7 +671,9 @@ class Plugin(BasePlugin):
                 return
             fiat_amount = self.exchanger.exchange(Decimal(btc_amount)/Decimal(100000000), self.fiat_unit())
             if fiat_amount is not None:
+                pos = self.fiat_e.cursorPosition()
                 self.fiat_e.setText("%.2f"%fiat_amount)
+                self.fiat_e.setCursorPosition(pos)
         self.btc_e.textEdited.connect(btc_changed)
         self.btc_e.frozen.connect(lambda: self.fiat_e.setFrozen(self.btc_e.isReadOnly()))
         self.win.send_grid.addWidget(self.fiat_e, 4, 3, Qt.AlignHCenter)


### PR DESCRIPTION
Problem:

Using the exchange rate plugin in the send dialog one can start with
entering a fiat amount, e.g. 5 USD, and the BTC amount is updated,
but no fee is calculated.

In this case can get "Invalid fee" error until the BTC amount is
touched manually and fee is calculated. This can cause confusion
when "set transaction fees manually" is disabled.

Reproducing:
- enable exchange rate plugin
- start Electrum
- in send dialog fill out any receive address
- add a value (e.g. 5) into the fiat dialog and see the BTC value filled out
- fee is not filled out, or if disabled the manual transaction fees then directly
  get "Invalid Fee" error

Expectation:
- Fees are calculated just as it would be by filling out the BTC field

Fix:

Fixed by triggering a fee setting the same way as it is done when
the BTC field is edited, by calling `textEdited.emit("")` of the relevant
`BTCAmountEdit` element. One problematic  thing is that this also triggers
a change on the fiat we just edited, and thus cursor positions need to be saved
and restored. This is not ideal, there should be a way to avoid such cascades
and trigger fee calculation directly instead of by proxy.

Editing the fiat field with these changes is more or less okay, there can be
some strange steps when the decimal point is edited, but IMHO not worse
than the BTC field when the decimal point is edited there.
