### PR TITLE
QR code fixes

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -128,7 +128,7 @@ class InstallWizard(QDialog):
     def enter_seed_dialog(self, msg, sid, func=None):
         if func is None:
             func = self.is_any
-        vbox, seed_e = seed_dialog.enter_seed_box(msg, sid)
+        vbox, seed_e = seed_dialog.enter_seed_box(msg, self, sid)
         vbox.addStretch(1)
         hbox, button = ok_cancel_buttons2(self, _('Next'))
         vbox.addLayout(hbox)

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -18,7 +18,7 @@
 
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
-from qrtextedit import QRTextEdit
+from qrtextedit import ScanQRTextEdit
 
 import re
 from decimal import Decimal
@@ -30,11 +30,9 @@ RE_ALIAS = '(.*?)\s*\<([1-9A-HJ-NP-Za-km-z]{26,})\>'
 frozen_style = "QWidget { background-color:none; border:none;}"
 normal_style = "QPlainTextEdit { }"
 
-class PayToEdit(QRTextEdit):
-
+class PayToEdit(ScanQRTextEdit):
     def __init__(self, win):
-        QRTextEdit.__init__(self)
-        self.win = win
+        super(PayToEdit,self).__init__(win=win)
         self.amount_edit = win.amount_e
         self.document().contentsChanged.connect(self.update_size)
         self.heightMin = 0
@@ -235,3 +233,10 @@ class PayToEdit(QRTextEdit):
         cr = self.cursorRect()
         cr.setWidth(self.c.popup().sizeHintForColumn(0) + self.c.popup().verticalScrollBar().sizeHint().width())
         self.c.complete(cr)
+
+
+    def qr_input(self):
+        data = super(PayToEdit,self).qr_input()
+        if data.startswith("bitcoin:"):
+            self.scan_f(data)
+            # TODO: update fee

--- a/gui/qt/qrcodewidget.py
+++ b/gui/qt/qrcodewidget.py
@@ -114,7 +114,7 @@ class QRDialog(QDialog):
 
             def copy_to_clipboard():
                 bmp.save_qrcode(qrw.qr, filename)
-                self.parent().app.clipboard().setImage(QImage(filename))
+                QApplication.clipboard().setImage(QImage(filename))
                 QMessageBox.information(None, _('Message'), _("QR code saved to clipboard"), _('OK'))
 
             b = QPushButton(_("Copy"))

--- a/gui/qt/seed_dialog.py
+++ b/gui/qt/seed_dialog.py
@@ -23,7 +23,7 @@ from electrum.i18n import _
 from electrum import mnemonic
 from qrcodewidget import QRCodeWidget, QRDialog
 from util import close_button
-from qrtextedit import QRTextEdit
+from qrtextedit import ShowQRTextEdit, ScanQRTextEdit
 
 class SeedDialog(QDialog):
     def __init__(self, parent, seed, imported_keys):
@@ -72,15 +72,13 @@ def show_seed_box(seed, sid=None):
                + _("If you ever need to recover your wallet from seed, you will need both this seed and your cold seed.") + " " \
 
     label1 = QLabel(msg+ ":")
-    seed_text = QRTextEdit(seed)
-    seed_text.setReadOnly(True)
+    seed_text = ShowQRTextEdit(text=seed)
     seed_text.setMaximumHeight(130)
 
     label2 = QLabel(msg2)
     label2.setWordWrap(True)
 
     logo = QLabel()
-
     logo.setPixmap(QPixmap(icon_filename(sid)).scaledToWidth(56))
     logo.setMaximumWidth(60)
 
@@ -96,8 +94,7 @@ def show_seed_box(seed, sid=None):
     return vbox
 
 
-def enter_seed_box(msg, sid=None):
-
+def enter_seed_box(msg, window, sid=None):
     vbox = QVBoxLayout()
     logo = QLabel()
     logo.setPixmap(QPixmap(icon_filename(sid)).scaledToWidth(56))
@@ -106,7 +103,7 @@ def enter_seed_box(msg, sid=None):
     label = QLabel(msg)
     label.setWordWrap(True)
 
-    seed_e = QRTextEdit()
+    seed_e = ScanQRTextEdit(win=window)
     seed_e.setMaximumHeight(100)
     seed_e.setTabChangesFocus(True)
 

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -137,7 +137,7 @@ def line_dialog(parent, title, label, ok_label, default=None):
         return unicode(txt.text())
 
 def text_dialog(parent, title, label, ok_label, default=None):
-    from qrtextedit import QRTextEdit
+    from qrtextedit import ScanQRTextEdit
     dialog = QDialog(parent)
     dialog.setMinimumWidth(500)
     dialog.setWindowTitle(title)
@@ -145,7 +145,7 @@ def text_dialog(parent, title, label, ok_label, default=None):
     l = QVBoxLayout()
     dialog.setLayout(l)
     l.addWidget(QLabel(label))
-    txt = QRTextEdit()
+    txt = ScanQRTextEdit(parent)
     if default:
         txt.setText(default)
     l.addWidget(txt)

--- a/lib/qrscanner.py
+++ b/lib/qrscanner.py
@@ -6,27 +6,36 @@ try:
 except ImportError:
     zbar = None
 
+proc = None
 
-def scan_qr(config):
+def init(config):
     if not zbar:
         raise BaseException("\n".join([_("Cannot start QR scanner."),_("The zbar package is not available."),_("On Linux, try 'sudo apt-get install python-zbar'")]))
     device = config.get("video_device", "default")
     if device == 'default':
         device = ''
+    global proc
     proc = zbar.Processor()
     proc.init(video_device=device)
+
+def scan_qr(self):
+    if not zbar:
+        raise BaseException("\n".join([_("Cannot start QR scanner."),_("The zbar package is not available."),_("On Linux, try 'sudo apt-get install python-zbar'")]))
+    if proc is None:
+        raise BaseException("Start proc first")
     proc.visible = True
     while True:
         try:
             proc.process_one()
         except Exception:
             # User closed the preview window
-            return {}
+            return ""
         for r in proc.results:
             if str(r.type) != 'QRCODE':
                 continue
+            # hiding the preview window stops the camera
+            proc.visible = False
             return r.data
-
 
 def _find_system_cameras():
     device_root = "/sys/class/video4linux"


### PR DESCRIPTION
New classes ScanQRTextEdit and ShowQRTextEdit.
Reason: dependencies on zbar availability and issues with the QRTextEdit constructor.
- ScanQRTextEdit needs access to the config (fetch camera). It needs to load
  the zbar processor properly before trying to scan. Keeping a reference to
  the processor in qrscaner fixes the crashes on windows.
- ShowQRTextEdit should not have access to scan_qr().
- no need to setReadOnly anymore. It is clear from the class name.

Other fixes:
- Show master pub keys now has a Combobox if multiple accounts are available. Pending accounts are filtered out. Selects the text for faster copying.
- Added bitcoin URI parsing on QR code scan
- Fixed copy to clipboard (parent is not always available)
