### PR TITLE
add missing electrum_gui.qt.qrwindow to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
         'electrum_gui.qt.paytoedit',
         'electrum_gui.qt.qrcodewidget',
         'electrum_gui.qt.qrtextedit',
+        'electrum_gui.qt.qrwindow',
         'electrum_gui.qt.receiving_widget',
         'electrum_gui.qt.seed_dialog',
         'electrum_gui.qt.transaction_dialog',


### PR DESCRIPTION
Hello,

I was building an electrum package and noticed that
qrwindow.py was not installed by setup.py.

Thx!
