### PR TITLE
Updated Requests

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -483,10 +483,10 @@ class Abstract_Wallet(object):
         return addr_list
 
     def get_account_from_address(self, addr):
-        "Returns the account that contains this address, or None"
+        "Returns the account name that contains this address, or None"
         for acc_id in self.accounts:    # similar to get_address_index but simpler
             if addr in self.get_account_addresses(acc_id):
-                return self.accounts[acc_id]
+                return self.get_account_name(acc_id)
         return None
 
     def get_account_balance(self, account):


### PR DESCRIPTION
- added Date and Account field to Saved Requests
- requests are now saved as dict()
  old requests in electrum2.0 wallets will be deleted automatically to prevent electrum crashes.
- Account field is hidden when only 1 account is available
- address line now follows the current_account
- saved requests is sortable, default sorted by date
- saved requests only shows request for current_account
