### PR TITLE
Update util.py data directory for OpenBSD

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -72,9 +72,10 @@ def appdata_dir():
         return os.path.join(os.environ["APPDATA"], "Electrum")
     elif platform.system() == "Linux":
         return os.path.join(usr_share_dir(), "electrum")
+    elif platform.system() == "OpenBSD":
+    	return "/usr/local/share/electrum"
     elif (platform.system() == "Darwin" or
           platform.system() == "DragonFly" or
-          platform.system() == "OpenBSD" or
           platform.system() == "FreeBSD" or
 	  platform.system() == "NetBSD"):
         return "/Library/Application Support/Electrum"


### PR DESCRIPTION
The path "/Library/Application Support/Electrum" doesn't exist on OpenBSD. Searching for the wordlist failed when generating a wallet. Updated path for OpenBSD so it can find the file.