### PR TITLE
fix dumpprivkeys, wallet.get_private_key and export_privkeys_dialog

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2335,6 +2335,9 @@ class ElectrumWindow(QMainWindow):
 
         private_keys = {}
         addresses = self.wallet.addresses(True)
+        # don't show privkey for next account
+        next_account = self.wallet.storage.get("next_account")
+        if next_account: addresses.remove(next_account[2])
         done = False
         def privkeys_thread():
             for addr in addresses:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -202,6 +202,9 @@ class Commands:
     def dumpprivkeys(self, addresses = None):
         if addresses is None:
             addresses = self.wallet.addresses(True)
+        # don't show privkey for next account
+        next_account = self.wallet.storage.get("next_account")
+        if next_account: addresses.remove(next_account[2])
         return [self.wallet.get_private_key(address, self.password) for address in addresses]
 
     def validateaddress(self, addr):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -352,7 +352,10 @@ class Abstract_Wallet(object):
         if self.is_watching_only():
             return []
         account_id, sequence = self.get_address_index(address)
-        return self.accounts[account_id].get_private_key(sequence, self, password)
+        if account_id in self.accounts:
+            return self.accounts[account_id].get_private_key(sequence, self, password)
+        else:
+            return []
 
     def get_public_keys(self, address):
         account_id, sequence = self.get_address_index(address)


### PR DESCRIPTION
Don't show private key for the next_account.
Wallet does not return the private key for PendingAccount, but an empty list instead.
It could be implemented, but I don't see the need.

See https://github.com/spesmilo/electrum/issues/884 and https://github.com/spesmilo/electrum/issues/935.
Overrides https://github.com/spesmilo/electrum/pull/936