### PR TITLE
Add a transaction reminder plugin

### DIFF
--- a/plugins/schedule.py
+++ b/plugins/schedule.py
@@ -14,10 +14,10 @@ import sys, traceback
 class Plugin(BasePlugin):
 
     def fullname(self):
-        return "Transaction Scheduling"
+        return "Transaction Reminder"
 
     def description(self):
-        return """Provide function to schedule a transaction"""
+        return """Provide function to schedule a transaction. When the time is up, it will automatically remind you to complete the transaction. If the transaction has expired, it will remind you when you open Electrum next time."""
 
     @hook
     def load_wallet(self, wallet):


### PR DESCRIPTION
Hello, I add a plugin for scheduling a transaction. With this plugins, user can select when to execute the transaction. Currently, when the time is up, it will automatically remind you to complete the transaction. If the scheduling transaction has expired, it will remind you when you open Electrum next time.
Give me some feedback if you think this function will be useful with some adjustments. Thanks.
