### PR TITLE
Adding i18n to setup.py. Fixes #948

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 import platform
 import imp
 
-
+i18n = imp.load_source('i18n', 'lib/i18n.py')
 version = imp.load_source('version', 'lib/version.py')
 util = imp.load_source('util', 'lib/util.py')
 


### PR DESCRIPTION
There's probably a cleaner way to do this, but I'm not sure of the original reasoning for using `imp.load_source` to import `util` and `version` into `setup.py`. `imp.load_source` isn't able to find relative imports on its own. 

I found the original commit which introduced `imp.load_source`, but there's no documentation as to why: 97b726386e711

Another option which looks messier but is more explicit could be to add the path of `lib` to `sys.path` in `setup.py`:

```
sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lib'))
```

Fixes #948
