### PR TITLE
Fix typo in import from i18n

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -2,7 +2,7 @@ import os, sys, re, json
 import platform
 import shutil
 from datetime import datetime
-from i18n import _
+from i18n import *
 
 class NotEnoughFunds(Exception): pass
 


### PR DESCRIPTION
There seems to be a slight typo in the import statement of `i18n` in `lib/util.py` that prevents the building of the package with `setup.py`.
