### PR TITLE
Move root_name to parent class

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1266,6 +1266,7 @@ class Deterministic_Wallet(Abstract_Wallet):
 
 class BIP32_Wallet(Deterministic_Wallet):
     # abstract class, bip32 logic
+    root_name = 'x/'
     gap_limit = 20
 
     def __init__(self, storage):
@@ -1342,7 +1343,6 @@ class BIP32_Wallet(Deterministic_Wallet):
 class BIP32_Simple_Wallet(BIP32_Wallet):
     # Wallet with a single BIP32 account, no seed
     # gap limit 20
-    root_name = 'x/'
     wallet_type = 'xpub'
 
     def create_xprv_wallet(self, xprv, password):
@@ -1470,7 +1470,6 @@ class BIP32_HD_Wallet(BIP32_Wallet):
 
 class NewWallet(BIP32_Wallet, Mnemonic):
     # Standard wallet
-    root_name = 'x/'
     root_derivation = "m/"
     wallet_type = 'standard'
 


### PR DESCRIPTION
I was having trouble creating or using a Trezor wallet, with this error:

```
Traceback (most recent call last):
  File "/usr/local/src/electrum/gui/qt/main_window.py", line 309, in new_wallet
    wallet = wizard.run('new')
  File "/usr/local/src/electrum/gui/qt/installwizard.py", line 392, in run
    wallet.create_main_account(password)
  File "/usr/local/src/electrum/plugins/trezor.py", line 222, in create_main_account
    self.create_account('Main account', None) #name, empty password
  File "/usr/local/src/electrum/lib/wallet.py", line 1420, in create_account
    account_id, xpub, addr = self.get_next_account(password)
  File "/usr/local/src/electrum/lib/wallet.py", line 1403, in get_next_account
    derivation = self.root_name + "%d'"%int(account_id)
AttributeError: 'TrezorWallet' object has no attribute 'root_name'
```

When I gave the TrezorWallet class the attribute 'root_name' as the other wallets have, it worked. So this patch moves the definition `root_name = 'x/'` to the BIP32_Wallet class, from which the other classes that use root_name inherit, to make sure that all subclasses have the attribute defined.