### PR TITLE
Add arbitrary non-standard outputs

### DIFF
--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -73,9 +73,15 @@ class PayToEdit(ScanQRTextEdit):
             amount = 0
         else:
             x, y = line.split(',')
-            _type = 'address'
-            address = self.parse_address(x)
-            amount = self.parse_amount(y)
+            n = re.match('^CUSTOM_OUT\s+([0-9a-fA-F]+)$', x.strip())
+            if n:
+                _type = 'custom'
+                address = n.group(1).decode('hex')
+                amount = self.parse_amount(y)
+            else:
+                _type = 'address'
+                address = self.parse_address(x)
+                amount = self.parse_amount(y)
         return _type, address, amount
 
 

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -66,22 +66,16 @@ class PayToEdit(ScanQRTextEdit):
         self.setStyleSheet("QWidget { background-color:#ffcccc;}")
 
     def parse_address_and_amount(self, line):
-        m = re.match('^OP_RETURN\s+([0-9a-fA-F]+)$', line.strip())
-        if m:
-            _type = 'op_return'
-            address = m.group(1).decode('hex')
-            amount = 0
+        x, y = line.split(',')
+        n = re.match('^SCRIPT\s+([0-9a-fA-F]+)$', x.strip())
+        if n:
+            _type = 'script'
+            address = n.group(1).decode('hex')
+            amount = self.parse_amount(y)
         else:
-            x, y = line.split(',')
-            n = re.match('^CUSTOM_OUT\s+([0-9a-fA-F]+)$', x.strip())
-            if n:
-                _type = 'custom'
-                address = n.group(1).decode('hex')
-                amount = self.parse_amount(y)
-            else:
-                _type = 'address'
-                address = self.parse_address(x)
-                amount = self.parse_amount(y)
+            _type = 'address'
+            address = self.parse_address(x)
+            amount = self.parse_amount(y)
         return _type, address, amount
 
 

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -424,7 +424,7 @@ def get_address_from_output_script(bytes):
     if match_decoded(decoded, match):
         return 'op_return', decoded[1][1]
 
-    return 'custom', bytes
+    return 'script', bytes
 
 
 
@@ -564,9 +564,8 @@ class Transaction:
 
     @classmethod
     def pay_script(self, output_type, addr):
-        if output_type == 'op_return':
-            h = addr.encode('hex')
-            return '6a' + push_script(h)
+        if output_type == 'script':
+            return addr.encode('hex')
         elif output_type == 'address':
             addrtype, hash_160 = bc_address_to_hash_160(addr)
             if addrtype == 0:
@@ -580,7 +579,7 @@ class Transaction:
             else:
                 raise
         else:
-            script = addr.encode('hex')
+            raise
         return script
 
     def input_script(self, txin, i, for_sig):
@@ -757,10 +756,8 @@ class Transaction:
                 addr = x
             elif type == 'pubkey':
                 addr = public_key_to_bc_address(x.decode('hex'))
-            elif type == 'op_return':
-                addr = 'OP_RETURN ' + x.encode('hex')
             else:
-                addr = 'CUSTOM ' + x.encode('hex')
+                addr = 'SCRIPT ' + x.encode('hex')
             o.append((addr,v))      # consider using yield (addr, v)
         return o
 


### PR DESCRIPTION
Seeing as 0.10 will loosen restrictions on non-standard transactions, this might be a good step towards allowing more Scripting functionality.

Todo list:
1. A method for redeeming outputs that are non-standard.
2. Perhaps the transaction dialogue should attempt to decode the hex into op codes and display them in the transaction summary?

This may be out of the focus for Electrum though... so "don't bother" also seems like a valid choice... (which is why I just left it at creating arbitrary outputs for now.)