### PR TITLE
Fix the line terminator in csv

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2507,7 +2507,7 @@ class ElectrumWindow(QMainWindow):
 
         with open(fileName, "w+") as f:
             if is_csv:
-                transaction = csv.writer(f)
+                transaction = csv.writer(f, lineterminator='\n')
                 transaction.writerow(["transaction_hash","label", "confirmations", "value", "fee", "balance", "timestamp"])
                 for line in lines:
                     transaction.writerow(line)


### PR DESCRIPTION
currently the csv output's line breaks are `\r\r\n` where the default line terminator for csv.writer is `\r\n`
and the extra `\r` is probably being inserted from writing a dict to
csv. I get around this by changing the line terminator to `\n` to output
`\r\n` which will make it compatible with most spreadsheet apps.