### PR TITLE
audio_modem: update plugin to work with latest version.

### DIFF
--- a/plugins/audio_modem.py
+++ b/plugins/audio_modem.py
@@ -106,10 +106,8 @@ class Plugin(BasePlugin):
         button.clicked.connect(handler)
 
     def _audio_interface(self):
-        return amodem.audio.Interface(
-            config=self.modem_config,
-            name=self.library_name
-        )
+        interface = amodem.audio.Interface(config=self.modem_config)
+        return interface.load(self.library_name)
 
     def _send(self, parent, blob):
         def sender_thread():


### PR DESCRIPTION
Loading the library is now done after creating the interface.
(tested with https://github.com/romanz/amodem/releases/tag/v1.7)