### PR TITLE
Retrieve version information using HTTPS

### DIFF
--- a/gui/qt/version_getter.py
+++ b/gui/qt/version_getter.py
@@ -33,7 +33,7 @@ class VersionGetter(threading.Thread):
 
     def run(self):
         try:
-            con = httplib.HTTPConnection('electrum.org', 80, timeout=5)
+            con = httplib.HTTPSConnection('electrum.org', timeout=5)
             con.request("GET", "/version")
             res = con.getresponse()
         except socket.error as msg:


### PR DESCRIPTION
http://electrum.org/version currently redirects to https://electrum.org/version, and the resulting 301 status code makes VersionGetter fail silently.

For backwards compatibility, http://electrum.org/version should serve version information directly.