### PR TITLE
Added electrum-env to use a virtualenv for python dependencies

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -50,6 +50,11 @@
 
  * Documentation is now hosted on a wiki: http://electrum.orain.org
 
+ * ECIES encrypt/decrypt methods, availabe in the GUI and using the
+   command line:
+      encrypt <pubkey> <message>
+      decrypt <pubkey> <message>
+
 
 
 # Release 1.9.8

--- a/electrum-env
+++ b/electrum-env
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# This script creates a virtualenv named 'env' and installs all
+# python dependencies before activating the env and running Electrum.
+# If 'env' already exists, it is activated and Electrum is started
+# without any installations. Additionally, the PYTHONPATH environment
+# variable is set properly before running Electrum.
+#
+# python-qt and its dependencies will still need to be installed with
+# your package manager.
+
+if [ -e ./env/bin/activate ]; then
+	source ./env/bin/activate
+else
+	virtualenv env
+	source ./env/bin/activate
+	pip install slowaes 'ecdsa>=0.9' pbkdf2 requests pyasn1 pyasn1-modules qrcode SocksiPy-branch protobuf tlslite
+fi
+
+export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
+
+./electrum

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1310,7 +1310,7 @@ class ElectrumWindow(QMainWindow):
         if not request_url:
             if label:
                 if self.wallet.labels.get(address) != label:
-                    if self.question(_('Save label "%s" for address %s ?'%(label,address))):
+                    if self.question(_('Save label "%(label)s" for address %(address)s ?'%{'label':label,'address':address})):
                         if address not in self.wallet.addressbook and not self.wallet.is_mine(address):
                             self.wallet.addressbook.append(address)
                             self.wallet.set_label(address, label)

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -156,7 +156,7 @@ class TxDialog(QDialog):
                 self.broadcast_button.show()
         else:
             s, r = self.tx.signature_count()
-            status = _("Unsigned") if s == 0 else _('Partially signed (%d/%d)'%(s,r))
+            status = _("Unsigned") if s == 0 else _('Partially signed') + ' (%d/%d)'%(s,r)
             time_str = None
             self.broadcast_button.hide()
             tx_hash = 'unknown'


### PR DESCRIPTION
The added file 'electrum-env' is useful for situations where you don't want to add the required python modules to your system installation of python. Also, installing to a virtualenv allows for python module management without admin access on most systems.