### PR TITLE
changed blocktrail baseurl to include network 'BTC' to avoid redirects

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -577,7 +577,7 @@ class ElectrumWindow(QMainWindow):
         elif be == 'Insight.is':
             block_explorer = 'http://live.insight.is/tx/'
         elif be == "Blocktrail.com":
-            block_explorer = 'https://www.blocktrail.com/tx/'
+            block_explorer = 'https://www.blocktrail.com/BTC/tx/'
 
         if not item: return
         tx_hash = str(item.data(0, Qt.UserRole).toString())


### PR DESCRIPTION
blocktrail supports both BTC and tBTC, when there's no network present (which is the case for the old URL) it will redirect to the default (BTC) so the old URL will work just fine but not needing a redirect is always better ;-)