### PR TITLE
solution for #1011 - open last used wallet on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ locale/
 .devlocaltmp/
 *_trial_temp
 packages
+env/

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -294,6 +294,10 @@ class ElectrumWindow(QMainWindow):
                 return
         else:
             wallet.start_threads(self.network)
+        
+        # set new wallet as last_wallet
+        self.config.set_key('last_wallet', filename)
+
         # load new wallet in gui
         self.load_wallet(wallet)
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -75,7 +75,12 @@ class WalletStorage(object):
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
 
-        new_path = os.path.join(config.path, "wallets", "default_wallet")
+        # try to open last used wallet
+        wallet = config.get('last_wallet')
+        if not wallet:
+            wallet = "default_wallet"
+
+        new_path = os.path.join(config.path, "wallets", wallet)
 
         # default path in pre 1.9 versions
         old_path = os.path.join(config.path, "electrum.dat")


### PR DESCRIPTION
A potential solution to #1011 - set the key 'last_wallet' in the config file when opening a wallet from the File > Open menu. When opening up electrum after being closed, try to read 'last_wallet' from config