### PR TITLE
solution for #1011 - open last used wallet on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ locale/
 .devlocaltmp/
 *_trial_temp
 packages
+env/

--- a/electrum-env
+++ b/electrum-env
@@ -19,6 +19,6 @@ fi
 
 export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
 
-./electrum
+./electrum "$@"
 
 deactivate

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -149,7 +149,14 @@ class ElectrumGui:
 
     def main(self, url):
 
-        storage = WalletStorage(self.config)
+        last_wallet = self.config.get('last_wallet')
+        if last_wallet:
+            storage = WalletStorage({'wallet_path': last_wallet})
+            if not storage.file_exists:
+                storage = WalletStorage(self.config)
+        else:
+            storage = WalletStorage(self.config)
+            
         if storage.file_exists:
             try:
                 wallet = Wallet(storage)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -294,6 +294,10 @@ class ElectrumWindow(QMainWindow):
                 return
         else:
             wallet.start_threads(self.network)
+        
+        # set new wallet as last_wallet
+        self.config.set_key('last_wallet', filename)
+
         # load new wallet in gui
         self.load_wallet(wallet)
 


### PR DESCRIPTION
When opening the GUI, Electrum will now check config for the key 'last_wallet' and if it is present, that wallet will be loaded. The 'last_wallet' key is set when opening a wallet from the File > Open menu. Also fixed a minor issues with electrum-env.