### PR TITLE
better trezor version checks

### DIFF
--- a/plugins/trezor.py
+++ b/plugins/trezor.py
@@ -133,7 +133,7 @@ class Plugin(BasePlugin):
             tx.error = str(e)
     @hook
     def receive_menu(self, menu, addrs):
-        if not self.wallet.is_watching_only() and len(addrs) == 1:
+        if not self.wallet.is_watching_only() and self.wallet.atleast_version(1, 3) and len(addrs) == 1:
             menu.addAction(_("Show on TREZOR"), lambda: self.wallet.show_address(addrs[0]))
 
     def settings_widget(self, window):
@@ -216,14 +216,21 @@ class TrezorWallet(BIP32_HD_Wallet):
             except:
                 give_error('Could not connect to your Trezor. Please verify the cable is connected and that no other app is using it.')
             self.client = QtGuiTrezorClient(self.transport)
-	    if (self.client.features.major_version == 1 and self.client.features.minor_version < 2) or (self.client.features.major_version == 1 and self.client.features.minor_version == 2 and self.client.features.patch_version < 1):
-		give_error('Outdated Trezor firmware. Please update the firmware from https://www.mytrezor.com') 
             self.client.set_tx_api(self)
             #self.client.clear_session()# TODO Doesn't work with firmware 1.1, returns proto.Failure
             self.client.bad = False
             self.device_checked = False
             self.proper_device = False
+            if not self.atleast_version(1, 2, 1):
+                give_error('Outdated Trezor firmware. Please update the firmware from https://www.mytrezor.com')
         return self.client
+
+    def compare_version(self, major, minor=0, patch=0):
+        features = self.get_client().features
+        return cmp([features.major_version, features.minor_version, features.patch_version], [major, minor, patch])
+
+    def atleast_version(self, major, minor=0, patch=0):
+        return self.compare_version(major, minor, patch) >= 0
 
     def address_id(self, address):
         account_id, (change, address_index) = self.get_address_index(address)


### PR DESCRIPTION
Better version checks, used for mandatory firmware check and avoiding 'show on Trezor' feature for firmware below 1.3.0