### PR TITLE
close Trezor USB transport on wallet close

### DIFF
--- a/plugins/trezor.py
+++ b/plugins/trezor.py
@@ -96,6 +96,7 @@ class Plugin(BasePlugin):
         print_error("trezor: clear session")
         if self.wallet and self.wallet.client:
             self.wallet.client.clear_session()
+            self.wallet.client.transport.close()
 
     @hook
     def load_wallet(self, wallet):


### PR DESCRIPTION
Trezor HID transport must be closed upon releasing the wallet to prevent problem connecting with the device when opening another Trezor wallet