### PR TITLE
added env/ to gitignore and fixed an issue with electrum-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ locale/
 .devlocaltmp/
 *_trial_temp
 packages
+env/

--- a/electrum-env
+++ b/electrum-env
@@ -17,8 +17,8 @@ else
 	python setup.py install
 fi
 
-export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
+export PYTHONPATH="/usr/local/lib/python2.7/site-packages:$PYTHONPATH"
 
-./electrum
+./electrum "$@"
 
 deactivate


### PR DESCRIPTION
Added env/ to .gitignore and added quotes around PYTHONPATH variable string to handle directories with spaces better. Also fixed script to properly pass command line arguments.