### PR TITLE
Fixed some issues with VEF exchanges and general drowning of exceptions

### DIFF
--- a/plugins/exchange_rate.py
+++ b/plugins/exchange_rate.py
@@ -17,6 +17,7 @@ from electrum_gui.qt.amountedit import AmountEdit
 
 EXCHANGES = ["BitcoinAverage",
              "BitcoinVenezuela",
+             "BTCParalelo",
              "Bitcurex",
              "Bitmarket",
              "BitPay",
@@ -63,6 +64,26 @@ class Exchanger(threading.Thread):
         except Exception:
             raise
         return json_resp
+        
+    def get_json_insecure(self, site, get_string):
+        """ get_json_insecure shouldn't be used in production releases
+        It doesn't use SSL, and so prices could be manipulated by a middle man
+        This should be used ONLY when developing plugins when you don't have a
+        SSL certificate that validates against HTTPSConnection
+        """
+        try:
+            connection = httplib.HTTPConnection(site)
+            connection.request("GET", get_string, headers={"User-Agent":"Electrum"})
+        except Exception:
+            raise
+        resp = connection.getresponse()
+        if resp.reason == httplib.responses[httplib.NOT_FOUND]:
+            raise
+        try:
+            json_resp = json.loads(resp.read())
+        except Exception:
+            raise
+        return json_resp
 
 
     def exchange(self, btc_amount, quote_currency):
@@ -82,6 +103,7 @@ class Exchanger(threading.Thread):
         update_rates = {
             "BitcoinAverage": self.update_ba,
             "BitcoinVenezuela": self.update_bv,
+            "BTCParalelo": self.update_bpl,
             "Bitcurex": self.update_bx,
             "Bitmarket": self.update_bm,
             "BitPay": self.update_bp,
@@ -110,6 +132,9 @@ class Exchanger(threading.Thread):
     def update_cd(self):
         try:
             resp_currencies = self.get_json('api.coindesk.com', "/v1/bpi/supported-currencies.json")
+        except SSLError:
+            print("SSL Error when accesing coindesk")
+            return
         except Exception:
             return
 
@@ -138,6 +163,9 @@ class Exchanger(threading.Thread):
             try:
                 resp_rate = self.get_json('api.itbit.com', "/v1/markets/XBT" + str(current_cur) + "/ticker")
                 quote_currencies[str(current_cur)] = decimal.Decimal(str(resp_rate["lastPrice"]))
+            except SSLError:
+                print("SSL Error when accesing itbit")
+                return
             except Exception:
                 return
         with self.lock:
@@ -147,6 +175,9 @@ class Exchanger(threading.Thread):
     def update_wd(self):
         try:
             winkresp = self.get_json('winkdex.com', "/api/v0/price")
+        except SSLError:
+            print("SSL Error when accesing winkdex")
+            return
         except Exception:
             return
         quote_currencies = {"USD": 0.0}
@@ -162,6 +193,9 @@ class Exchanger(threading.Thread):
     def update_cv(self):
         try:
             jsonresp = self.get_json('www.cavirtex.com', "/api/CAD/ticker.json")
+        except SSLError:
+            print("SSL Error when accesing cavirtex")
+            return
         except Exception:
             return
         quote_currencies = {"CAD": 0.0}
@@ -177,6 +211,9 @@ class Exchanger(threading.Thread):
     def update_bm(self):
         try:
             jsonresp = self.get_json('www.bitmarket.pl', "/json/BTCPLN/ticker.json")
+        except SSLError:
+            print("SSL Error when accesing bitmarket")
+            return
         except Exception:
             return
         quote_currencies = {"PLN": 0.0}
@@ -192,6 +229,9 @@ class Exchanger(threading.Thread):
     def update_bx(self):
         try:
             jsonresp = self.get_json('pln.bitcurex.com', "/data/ticker.json")
+        except SSLError:
+            print("SSL Error when accesing bitcurex")
+            return
         except Exception:
             return
         quote_currencies = {"PLN": 0.0}
@@ -207,6 +247,9 @@ class Exchanger(threading.Thread):
     def update_CNY(self):
         try:
             jsonresp = self.get_json('data.btcchina.com', "/data/ticker")
+        except SSLError:
+            print("SSL Error when accesing btcchina")
+            return
         except Exception:
             return
         quote_currencies = {"CNY": 0.0}
@@ -222,6 +265,9 @@ class Exchanger(threading.Thread):
     def update_bp(self):
         try:
             jsonresp = self.get_json('bitpay.com', "/api/rates")
+        except SSLError:
+            print("SSL Error when accesing bitpay")
+            return
         except Exception:
             return
         quote_currencies = {}
@@ -237,6 +283,9 @@ class Exchanger(threading.Thread):
     def update_cb(self):
         try:
             jsonresp = self.get_json('coinbase.com', "/api/v1/currencies/exchange_rates")
+        except SSLError:
+            print("SSL Error when accesing coinbase")
+            return
         except Exception:
             return
 
@@ -255,6 +304,9 @@ class Exchanger(threading.Thread):
     def update_bc(self):
         try:
             jsonresp = self.get_json('blockchain.info', "/ticker")
+        except SSLError:
+            print("SSL Error when accesing blockchain")
+            return
         except Exception:
             return
         quote_currencies = {}
@@ -270,6 +322,9 @@ class Exchanger(threading.Thread):
     def update_lb(self):
         try:
             jsonresp = self.get_json('localbitcoins.com', "/bitcoinaverage/ticker-all-currencies/")
+        except SSLError:
+            print("SSL Error when accesing localbitcoins")
+            return
         except Exception:
             return
         quote_currencies = {}
@@ -285,23 +340,52 @@ class Exchanger(threading.Thread):
 
     def update_bv(self):
         try:
-            jsonresp = self.get_json('api.bitcoinvenezuela.com', "/")
+            jsonresp = self.get_json_insecure('api.bitcoinvenezuela.com', "/")
+            print("**WARNING**: update_bv is using an insecure connection, shouldn't be used on production")
+        except SSLError:
+            print("SSL Error when accesing bitcoinvenezuela")
+            return
         except Exception:
             return
+        
         quote_currencies = {}
         try:
             for r in jsonresp["BTC"]:
                 quote_currencies[r] = Decimal(jsonresp["BTC"][r])
+            
             with self.lock:
                 self.quote_currencies = quote_currencies
         except KeyError:
-            pass
+            print ("KeyError")
         self.parent.set_currencies(quote_currencies)
 
-
+        
+    def update_bpl(self):
+        try:
+            jsonresp = self.get_json_insecure('btcparalelo.com', "/api/price")
+            print("**WARNING**: update_bpl is using an insecure connection, shouldn't be used on production")
+        except SSLError:
+            print("SSL Error when accesing btcparalelo")
+            return
+        except Exception:
+            return
+        
+        
+        quote_currencies = {}
+        try:
+            quote_currencies = {"VEF": Decimal(jsonresp["price"])}
+            with self.lock:
+                self.quote_currencies = quote_currencies
+        except KeyError:
+            print ("KeyError")
+        self.parent.set_currencies(quote_currencies)
+        
     def update_ba(self):
         try:
             jsonresp = self.get_json('api.bitcoinaverage.com', "/ticker/global/all")
+        except SSLError:
+            print("SSL Error when accesing bitcoinaverage")
+            return
         except Exception:
             return
         quote_currencies = {}


### PR DESCRIPTION
* Added BTCParalelo price index for Venezuelan Bolivar VEF
* Fixed all of the update_* functions on the exchange_rate.py plugin to indicate when there are SSL errors, there was a horrorous try-except-pass block that was drowning all the exceptions
* Added get_json_insecure to allow exchange rates over HTTP (I know this is horrendous, but for testing and development purposes and countries that don't have easy access to the amounts needed to issue a good SSL certificate)

Signed-off-by: John Miguel Villar Zavatti <johnvillarzavatti@gmail.com>