### PR TITLE
Do not exit when the New Wallet dialog is canceled

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -340,11 +340,11 @@ class ElectrumWindow(QMainWindow):
             QMessageBox.critical(None, "Error", _("File exists"))
             return
 
-        if self.wallet:
-            self.close_wallet()
         wizard = installwizard.InstallWizard(self.config, self.network, storage)
         wallet = wizard.run('new')
         if wallet:
+            if self.wallet:
+                self.close_wallet()
             self.load_wallet(wallet)
 
 


### PR DESCRIPTION
This patch fixes an issue where the Qt interface would shut down if the user cancels the creation of a new wallet.

Steps to reproduce issue (tested at 5f42573):
* Open a wallet in the Qt interface;
* Select New/Restore from the File menu;
* Enter a file name and hit OK;
* Cancel the wallet type selection dialog.