### PR TITLE
Option to tip the server in a transaction

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -164,8 +164,13 @@ class ElectrumWindow(QMainWindow):
         for i in range(tabs.count()):
             QShortcut(QKeySequence("Alt+" + str(i + 1)), self, lambda i=i: tabs.setCurrentIndex(i))
 
+        def notify_banner():
+            self.console.showMessage(self.network.banner)
+            if self.wallet:
+                self.wallet.parse_server_addr_from_banner(self.network.banner)
+
         self.connect(self, QtCore.SIGNAL('update_status'), self.update_status)
-        self.connect(self, QtCore.SIGNAL('banner_signal'), lambda: self.console.showMessage(self.network.banner) )
+        self.connect(self, QtCore.SIGNAL('banner_signal'), notify_banner)
         self.connect(self, QtCore.SIGNAL('transaction_signal'), lambda: self.notify_transactions() )
         self.connect(self, QtCore.SIGNAL('payment_request_ok'), self.payment_request_ok)
         self.connect(self, QtCore.SIGNAL('payment_request_error'), self.payment_request_error)
@@ -239,6 +244,8 @@ class ElectrumWindow(QMainWindow):
 
         self.clear_receive_tab()
         self.update_receive_tab()
+        if self.network.banner:
+            self.wallet.parse_server_addr_from_banner(self.network.banner)
         run_hook('load_wallet', wallet)
 
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2685,6 +2685,18 @@ class ElectrumWindow(QMainWindow):
         fee_e.editingFinished.connect(on_fee)
         widgets.append((fee_label, fee_e, fee_help))
 
+        server_fee_label = QLabel(_('Server fee per transaction') + ':')
+        server_fee_help = HelpButton(_('Server donation per transaction.'))
+        server_fee_e = BTCAmountEdit(self.get_decimal_point)
+        server_fee_e.setAmount(self.wallet.server_fee)
+        if not self.config.is_modifiable('server_fee'):
+            for w in [server_fee_e, server_fee_label]: w.setEnabled(False)
+        def on_server_fee():
+            server_fee = server_fee_e.get_amount()
+            self.wallet.set_server_fee(server_fee)
+        server_fee_e.editingFinished.connect(on_server_fee)
+        widgets.append((server_fee_label, server_fee_e, server_fee_help))
+
         units = ['BTC', 'mBTC', 'bits']
         unit_label = QLabel(_('Base unit') + ':')
         unit_combo = QComboBox()

--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -96,6 +96,7 @@ class TestWalletStorage(WalletTestCase):
             contents = f.read()
         self.assertEqual(some_dict, json.loads(contents))
 
+
 class TestNewWallet(WalletTestCase):
 
     seed_text = "travel nowhere air position hill peace suffer parent beautiful rise blood power home crumble teach"
@@ -165,6 +166,10 @@ class TestNewWallet(WalletTestCase):
       tx = self.wallet.make_unsigned_transaction(outputs, fixed_fee=0, coins=coins, change_addr=self.import_key_address)
       self.assertIn(('address', self.wallet.server_fee_addr, self.wallet.server_fee), tx.outputs)
 
-if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestNewWallet)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+
+    def test_parse_banner(self):
+        banner = 'If you like to donate to this server, please send your BTC to 1NzEFKU9DEpJgEmqAc8U9LGgCEEdYu29wP, thanks!'
+        expected = '1NzEFKU9DEpJgEmqAc8U9LGgCEEdYu29wP'
+        actual = self.wallet.parse_banner(banner)
+        self.assertEqual(actual, expected)
+

--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -30,6 +30,9 @@ class FakeSynchronizer(object):
     def add(self, address):
         self.store.append(address)
 
+class FakeNetwork(object):
+    def get_local_height():
+        return 10000
 
 class WalletTestCase(unittest.TestCase):
 
@@ -93,7 +96,6 @@ class TestWalletStorage(WalletTestCase):
             contents = f.read()
         self.assertEqual(some_dict, json.loads(contents))
 
-
 class TestNewWallet(WalletTestCase):
 
     seed_text = "travel nowhere air position hill peace suffer parent beautiful rise blood power home crumble teach"
@@ -108,6 +110,7 @@ class TestNewWallet(WalletTestCase):
         super(TestNewWallet, self).setUp()
         self.storage = WalletStorage(self.fake_config)
         self.wallet = NewWallet(self.storage)
+        self.wallet.network = FakeNetwork()
         # This cannot be constructed by electrum at random, it should be safe
         # from eventual collisions.
         self.wallet.add_seed(self.seed_text, self.password)
@@ -152,3 +155,16 @@ class TestNewWallet(WalletTestCase):
         new_password = "secret2"
         self.wallet.update_password(self.password, new_password)
         self.wallet.get_seed(new_password)
+
+    def test_transaction_with_server_fee(self):
+      outputs = [('address', '1MQaPKJTVZt7vKNtdXZBUiv4smtf5yZ9Ao', 90000)]
+      self.wallet.server_fee = 10000
+      self.wallet.server_fee_addr = '1MYwrbuXqHyyvk8pTRNTH7b92DHsv9BSmz'
+      coins = [{'coinbase': '', 'height': 1, 'value': 100000}]
+      self.wallet.add_input_info = lambda x: x #Skip this as we do not have an account for the address
+      tx = self.wallet.make_unsigned_transaction(outputs, fixed_fee=0, coins=coins, change_addr=self.import_key_address)
+      self.assertIn(('address', self.wallet.server_fee_addr, self.wallet.server_fee), tx.outputs)
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestNewWallet)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -162,6 +162,7 @@ class Abstract_Wallet(object):
 
         self.history               = storage.get('addr_history',{})        # address -> list(txid, height)
         self.fee_per_kb            = int(storage.get('fee_per_kb', RECOMMENDED_FEE))
+        self.server_fee            = int(storage.get('server_fee', 0))
 
         # This attribute is set when wallet.start_threads is called.
         self.synchronizer = None

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -22,6 +22,7 @@ import hashlib
 import ast
 import threading
 import random
+import re
 import time
 import math
 import json
@@ -687,7 +688,28 @@ class Abstract_Wallet(object):
             fee = MIN_RELAY_TX_FEE
         return fee
 
-    def make_unsigned_transaction(self, outputs, fixed_fee=None, change_addr=None, domain=None, coins=None):
+    def set_server_fee(self, fee):
+        self.server_fee = fee
+        self.storage.put('server_fee', self.server_fee, True)
+
+
+    def parse_server_addr_from_banner(self, banner):
+        addr = self.parse_banner(banner)
+        self.server_fee_addr = addr
+
+    def parse_banner(self, banner):
+        pattern = '[13][a-km-zA-HJ-NP-Z0-9]{26,33}'
+        match = re.search(pattern, banner)
+        if not match:
+            return None
+        # first matching address
+        addr = match.group(0)
+        if not is_address(addr):
+            return None
+        return addr
+
+
+    def make_unsigned_transaction(self, outputs, fixed_fee=None, change_addr=None, domain=None, coins=None ):
         # check outputs
         for type, data, value in outputs:
             if type == 'address':
@@ -760,7 +782,7 @@ class Abstract_Wallet(object):
         run_hook('make_unsigned_transaction', tx)
         return tx
 
-    def mktx(self, outputs, password, fee=None, change_addr=None, domain= None, coins = None):
+    def mktx(self, outputs, password, fee=None, change_addr=None, domain= None, coins = None ):
         tx = self.make_unsigned_transaction(outputs, fee, change_addr, domain, coins)
         self.sign_transaction(tx, password)
         return tx


### PR DESCRIPTION
This adds a new field in preferences which tips the server on every transaction.

Default server fee is 0. Server address is parsed from the welcome banner. If parsing fails then no tip is added to the transaction.

[See discussion on bitcointalk](https://bitcointalk.org/index.php?topic=975796.0)