### PR TITLE
check arg type in change_gap_limit()

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1142,6 +1142,7 @@ class Deterministic_Wallet(Abstract_Wallet):
         return self.get_seed(password)
 
     def change_gap_limit(self, value):
+        assert isinstance(value, int), 'gap limit must be of type int, not of %s'%type(value)
         if value >= self.gap_limit:
             self.gap_limit = value
             self.storage.put('gap_limit', self.gap_limit, True)


### PR DESCRIPTION
I realize that console usage is 100% at-your-own-risk, but I think change_gap_limit() performs oddly enough if called with a string to warrant an assert. Specifically, calling it like so:
```python
wallet.change_gap_limit('100')
```
causes Electrum to try to create an infinite number of keys/addresses (presumably up until an out-of-memory), which continues even after a restart.