### PR TITLE
Remove useless enforced dependency of PyUSB

### DIFF
--- a/plugins/btchipwallet.py
+++ b/plugins/btchipwallet.py
@@ -20,7 +20,6 @@ from electrum.util import format_satoshis
 import hashlib
 
 try:
-    from usb.core import USBError
     from btchip.btchipComm import getDongle, DongleWait
     from btchip.btchip import btchip
     from btchip.btchipUtils import compress_public_key,format_transaction, get_regular_input_script


### PR DESCRIPTION
PyUSB will be automatically used if present.