### PR TITLE
Let wallet recovery use 64 character hex strings and legacy 24 word seeds.

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -163,11 +163,11 @@ def is_old_seed(seed):
 
     try:
         seed.decode('hex')
-        is_hex = (len(seed) == 32)
+        is_hex = (len(seed) == 32 or len(seed) == 64)
     except Exception:
         is_hex = False
 
-    return is_hex or (uses_electrum_words and len(words) == 12)
+    return is_hex or (uses_electrum_words and (len(words) == 12 or len(words) == 24))
 
 
 # pywallet openssl private key implementation


### PR DESCRIPTION
Single commit version of https://github.com/spesmilo/electrum/pull/1087 . I wasn't able to reopen that pull request after I fixed the issue so creating a new one.

1. Allow wallet recovery from 64 character hex strings.
2. Allow wallet recovery from 24 word legacy seeds.

In Electrum 1.9.x, one could input 64 character hex strings and have using the method described in https://bitcointalk.org/index.php?topic=153990.0 . Specifically any procedure e.g the section titled "Custom seeds" at https://bitcoinspakistan.com/blog/electrum-seed-explained/ .

This results in a wallet that has an associated 24 word seed. This seed can be re entered into 1.9.x and the wallet successfully recovered. However in 2.x this no longer works and breaks compatibility with such wallets.

I propose this simple fix that restores backward compatibility with legacy 24 word seeds and 64 character hex strings.