### PR TITLE
plugins: fix buttons insertion

### DIFF
--- a/plugins/audio_modem.py
+++ b/plugins/audio_modem.py
@@ -85,7 +85,7 @@ class Plugin(BasePlugin):
             self.sender = self._send(parent=dialog, blob=blob)
             self.sender.start()
         b.clicked.connect(handler)
-        dialog.buttons.insertWidget(1, b)
+        dialog.buttons.insert(0, b)
 
     @hook
     def scan_text_edit(self, parent):

--- a/plugins/greenaddress_instant.py
+++ b/plugins/greenaddress_instant.py
@@ -53,7 +53,7 @@ class Plugin(BasePlugin):
         self.wallet = d.wallet
         self.verify_button = b = QPushButton(self.button_label)
         b.clicked.connect(lambda: self.do_verify(d.tx))
-        d.buttons.insertWidget(2, b)
+        d.buttons.insert(1, b)
         self.transaction_dialog_update(d)
 
     def get_my_addr(self, tx):


### PR DESCRIPTION
Update `audio_modem` and `greenaddress_instant` plugins to use list.insert() instead of insertWidget API, after https://github.com/spesmilo/electrum/commit/66de59234345ccc4a272c2f3d40d414f074682b5 change.