### PR TITLE
tweaked resolve and DNSSEC timeouts to be less aggressive

### DIFF
--- a/plugins/openalias.py
+++ b/plugins/openalias.py
@@ -185,7 +185,7 @@ class Plugin(BasePlugin):
             try:
                 resolver = dns.resolver.Resolver()
                 resolver.timeout = 2.0
-                resolver.lifetime = 2.0
+                resolver.lifetime = 4.0
                 records = resolver.query(url, dns.rdatatype.TXT)
                 for record in records:
                     string = record.strings[0]
@@ -232,7 +232,7 @@ class Plugin(BasePlugin):
         for i in xrange(len(parts), 0, -1):
             sub = '.'.join(parts[i - 1:])
             query = dns.message.make_query(sub, dns.rdatatype.NS)
-            response = dns.query.udp(query, ns, 1)
+            response = dns.query.udp(query, ns, 3)
             if response.rcode() != dns.rcode.NOERROR:
                 self.print_error("query error")
                 return 0
@@ -250,7 +250,7 @@ class Plugin(BasePlugin):
             query = dns.message.make_query(sub,
                                            dns.rdatatype.DNSKEY,
                                            want_dnssec=True)
-            response = dns.query.udp(query, ns, 1)
+            response = dns.query.udp(query, ns, 3)
             if response.rcode() != 0:
                 self.print_error("query error")
                 return 0


### PR DESCRIPTION
So in the original PR (https://github.com/spesmilo/electrum/pull/986) I said -

"One point for discussion is the timeouts I've set are quite "aggressive". Timeout for initial resolve of the address is 2 seconds, and timeout for the DNSSEC trust chain is 1 second per UDP request. I based that on my real-life example (South African ADSL + wifi, as well as 3G + wifi) and consistently had UDP pings returning from 8.8.8.8 in <600ms. That having been said, its entirely possible that this may be too aggressive as far as timeouts go, we'll have to see how the general Electrum populace responds."

Then I completely forgot to keep my eye on it:) Looks like they were too aggressive. Initial resolve timeouts stay at 2 seconds, but the resolve lifetime has changed to 4 seconds (so dnspython can retry or it can use recursion if necessary), and the DNSSEC query timeouts have changed to 3 seconds per check, which is reasonable.