### PR TITLE
Add wallet function get_addr_received()

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -487,6 +487,16 @@ class Abstract_Wallet(object):
                 coins.pop(txi)
         return coins.items()
 
+    #return the total amount ever received by an address
+    def get_addr_received(self, address):
+        h = self.history.get(address, [])
+        received = 0
+        for tx_hash, height in h:
+            l = self.txo.get(tx_hash, {}).get(address, [])
+            for n, v, is_cb in l:
+                received += v
+        return received
+
     def get_addr_balance(self, address):
         "returns the confirmed balance and pending (unconfirmed) balance change of a bitcoin address"
         coins = self.get_addr_utxo(address)


### PR DESCRIPTION
get_addr_received() allows the user to see the total amount of coins an address has ever received.

Use case: a merchant wants to view the total amount of coins a customer has ever sent to an address. If the merchant regularly sweeps coins from the address, the standard balance query using UTXO doesn't help.