### PR TITLE
Setup same for FreeBSD and DragonFly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if sys.version_info[:3] < (2, 7, 0):
 
 
 data_files = []
-if platform.system() == 'Linux' or platform.system() == 'FreeBSD':
+if platform.system() in [ 'Linux', 'FreeBSD', 'DragonFly']:
     usr_share = os.path.join(sys.prefix, "share")
     data_files += [
         (os.path.join(usr_share, 'applications/'), ['electrum.desktop']),


### PR DESCRIPTION
DragonFly and FreeBSD use same ports system and directory layout.  They should behave the same way throughout electrum, in particular in setup.py.