### PR TITLE
Fix transaction broadcasting issues

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1147,7 +1147,6 @@ class ElectrumWindow(QMainWindow):
         def broadcast_thread():
             # non-GUI thread
             pr = self.payment_request
-            key = pr.get_id()
             if pr is None:
                 return self.wallet.sendtx(tx)
             if pr.has_expired():
@@ -1156,6 +1155,7 @@ class ElectrumWindow(QMainWindow):
             status, msg =  self.wallet.sendtx(tx)
             if not status:
                 return False, msg
+            key = pr.get_id()
             self.invoices.set_paid(key, tx.hash())
             self.payment_request = None
             refund_address = self.wallet.addresses()[0]

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -178,6 +178,7 @@ class TxDialog(QDialog):
 
         # if we are not synchronized, we cannot tell
         if self.parent.network is None or not self.parent.network.is_running() or not self.parent.network.is_connected():
+            self.broadcast_button.hide()  # cannot broadcast when offline
             return
         if not self.wallet.up_to_date:
             return


### PR DESCRIPTION
This should fix the following 2 exceptions:

 - Unable to broadcast a signed transaction (loaded from file/text):
```
Traceback (most recent call last):
  File "/home/roman/Code/Bitcoin/electrum/gui/qt/util.py", line 37, in run
    self.result = self.run_task()
  File "/home/roman/Code/Bitcoin/electrum/gui/qt/main_window.py", line 1150, in broadcast_thread
    key = pr.get_id()
AttributeError: 'NoneType' object has no attribute 'get_id'
```
 - "Broadcast" button should be hidden in offline mode (since there is no network connection to broadcast the transaction):
```
Traceback (most recent call last):
  File "/home/roman/Code/Bitcoin/electrum/gui/qt/util.py", line 37, in run
    self.result = self.run_task()
  File "/home/roman/Code/Bitcoin/electrum/gui/qt/main_window.py", line 1151, in broadcast_thread
    return self.wallet.sendtx(tx)
  File "/home/roman/Code/Bitcoin/electrum/lib/wallet.py", line 918, in sendtx
    h = self.send_tx(tx)
  File "/home/roman/Code/Bitcoin/electrum/lib/wallet.py", line 925, in send_tx
    self.network.send([('blockchain.transaction.broadcast', [str(tx)])], self.on_broadcast)
AttributeError: 'NoneType' object has no attribute 'send'
```