### PR TITLE
Clean up block explorer handling.  Add menu item to go to block explorer...

### DIFF
--- a/gui/qt/history_widget.py
+++ b/gui/qt/history_widget.py
@@ -21,7 +21,7 @@ import webbrowser
 
 from util import *
 from electrum.i18n import _
-from electrum.util import format_satoshis, format_time
+from electrum.util import block_explorer_URL, format_satoshis, format_time
 from electrum.plugins import run_hook
 
 
@@ -78,24 +78,18 @@ class HistoryWidget(MyTreeWidget):
     def create_menu(self, position):
         self.selectedIndexes()
         item = self.currentItem()
-        be = self.config.get('block_explorer', 'Blockchain.info')
-        if be == 'Blockchain.info':
-            block_explorer = 'https://blockchain.info/tx/'
-        elif be == 'Blockr.io':
-            block_explorer = 'https://blockr.io/tx/info/'
-        elif be == 'Insight.is':
-            block_explorer = 'http://live.insight.is/tx/'
-        elif be == "Blocktrail.com":
-            block_explorer = 'https://www.blocktrail.com/BTC/tx/'
         if not item:
             return
         tx_hash = str(item.data(0, Qt.UserRole).toString())
         if not tx_hash:
             return
+        tx_URL = block_explorer_URL(self.config, 'tx', tx_hash)
+        if not tx_URL:
+            return
         menu = QMenu()
         menu.addAction(_("Copy ID to Clipboard"), lambda: self.parent.app.clipboard().setText(tx_hash))
         menu.addAction(_("Details"), lambda: self.parent.show_transaction(self.wallet.transactions.get(tx_hash)))
         menu.addAction(_("Edit description"), lambda: self.edit_label(item))
-        menu.addAction(_("View on block explorer"), lambda: webbrowser.open(block_explorer + tx_hash))
+        menu.addAction(_("View on block explorer"), lambda: webbrowser.open(tx_URL))
         menu.exec_(self.viewport().mapToGlobal(position))
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -18,6 +18,7 @@
 
 import sys, time, re, threading
 from electrum.i18n import _, set_language
+from electrum.util import block_explorer, block_explorer_info, block_explorer_URL
 from electrum.util import print_error, print_msg
 import os.path, json, ast, traceback
 import shutil
@@ -1402,6 +1403,9 @@ class ElectrumWindow(QMainWindow):
                 menu.addAction(_("Encrypt/decrypt message"), lambda: self.encrypt_message(addr))
             if self.wallet.is_imported(addr):
                 menu.addAction(_("Remove from wallet"), lambda: self.delete_imported_key(addr))
+            addr_URL = block_explorer_URL(self.config, 'addr', addr)
+            if addr_URL:
+                menu.addAction(_("View on block explorer"), lambda: webbrowser.open(addr_URL))
 
         if any(addr not in self.wallet.frozen_addresses for addr in addrs):
             menu.addAction(_("Freeze"), lambda: self.set_addrs_frozen(addrs, True))
@@ -2562,11 +2566,11 @@ class ElectrumWindow(QMainWindow):
         unit_combo.currentIndexChanged.connect(on_unit)
         widgets.append((unit_label, unit_combo, unit_help))
 
-        block_explorers = ['Blockchain.info', 'Blockr.io', 'Insight.is', "Blocktrail.com"]
+        block_explorers = sorted(block_explorer_info.keys())
         block_ex_label = QLabel(_('Online Block Explorer') + ':')
         block_ex_combo = QComboBox()
         block_ex_combo.addItems(block_explorers)
-        block_ex_combo.setCurrentIndex(block_explorers.index(self.config.get('block_explorer', 'Blockchain.info')))
+        block_ex_combo.setCurrentIndex(block_explorers.index(block_explorer(self.config)))
         block_ex_help = HelpButton(_('Choose which online block explorer to use for functions that open a web browser'))
         def on_be(x):
             be_result = block_explorers[block_ex_combo.currentIndex()]

--- a/lib/util.py
+++ b/lib/util.py
@@ -188,6 +188,34 @@ def age(from_date, since_date = None, target_tz=None, include_seconds=False):
     else:
         return "over %d years ago" % (round(distance_in_minutes / 525600))
 
+block_explorer_info = {
+    'Blockchain.info': ('https://blockchain.info',
+                        {'tx': 'tx', 'addr': 'address'}),
+    'Blockr.io': ('https://btc.blockr.io',
+                        {'tx': 'tx/info', 'addr': 'address/info'}),
+    'Insight.is': ('https://insight.bitpay.com',
+                        {'tx': 'tx', 'addr': 'address'}),
+    'Blocktrail.com': ('https://www.blocktrail.com/BTC',
+                        {'tx': 'tx', 'addr': 'address'}),
+    'TradeBlock.com': ('https://tradeblock.com/blockchain',
+                        {'tx': 'tx', 'addr': 'address'}),
+}
+
+def block_explorer(config):
+    return config.get('block_explorer', 'Blockchain.info')
+
+def block_explorer_tuple(config):
+    return block_explorer_info.get(block_explorer(config))
+
+def block_explorer_URL(config, kind, item):
+    be_tuple = block_explorer_tuple(config)
+    if not be_tuple:
+        return
+    kind_str = be_tuple[1].get(kind)
+    if not kind_str:
+        return
+    url_parts = [be_tuple[0], kind_str, item]
+    return "/".join(url_parts)
 
 # URL decode
 #_ud = re.compile('%([0-9a-hA-H]{2})', re.MULTILINE)


### PR DESCRIPTION
... for an address.

Block explorer code is data-driven now.
Put block explorer defaulting in one place.
Fix URLs for insight.is and blockr.io.
Add tradeblock.com explorer.
Add menu item to view address on block explorer provided only one is selected.

This patch also resolves https://github.com/spesmilo/electrum/issues/1157