### PR TITLE
Don't crash if self.verifier is None (i.e. offline).

### DIFF
--- a/gui/qt/history_widget.py
+++ b/gui/qt/history_widget.py
@@ -40,8 +40,6 @@ class HistoryWidget(MyTreeWidget):
         for item in h:
             tx_hash, conf, value, timestamp, balance = item
             time_str = _("unknown")
-            if conf is None and timestamp is None:
-                continue  # skip history in offline mode
             if conf > 0:
                 time_str = format_time(timestamp)
             if conf == -1:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -733,11 +733,17 @@ class Abstract_Wallet(object):
 
         # 3. create sorted list
         history = []
-        for tx_hash, v in merged.items():
-            height, value = v
-            conf, timestamp = self.verifier.get_confirmations(tx_hash) if self.verifier else (None, None)
-            history.append((tx_hash, conf, value, timestamp))
-        history.sort(key = lambda x: self.verifier.get_txpos(x[0]))
+        if self.verifier:
+            for tx_hash, (height, value) in merged.items():
+                conf, timestamp = self.verifier.get_confirmations(tx_hash)
+                history.append((tx_hash, conf, value, timestamp))
+            history.sort(key = lambda x: self.verifier.get_txpos(x[0]))
+        else:
+            for tx_hash, (height, value) in merged.items():
+                history.append((tx_hash, height, value))
+            # Sort by height, but then set confs to -1 so shows as unverified
+            history.sort(key = lambda x: x[1])
+            history = map(lambda (th, h, v): (th, -1, v, None), history)
 
         # 4. add balance
         c, u = self.get_balance(domain)


### PR DESCRIPTION
Still show history (from wallet file) if offline, but show everything as unverified.
Sort according to the saved height, highest first.