### PR TITLE
Refresh hist tab once

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -241,7 +241,6 @@ class ElectrumGui:
             self.set_url(url)
 
         w.connect_slots(s)
-        w.update_wallet()
 
         signal.signal(signal.SIGINT, lambda *args: self.app.quit())
         self.app.exec_()


### PR DESCRIPTION
On my machine, a simple print statement shows the history tab is redrawn 4 times before the electrum window appears.  The history tab is slow to refresh on large wallets, so reducing the refreshes to one improves startup time noticeably.

Offline mode currently crashes because of an unrelated bug.  With that fixed, I've tested this in both online and offline mode and it works fine.