### PR TITLE
Show wallet basename in tray tooltip

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -211,9 +211,7 @@ class ElectrumWindow(QMainWindow):
         self.dummy_address = a[0] if a else None
         self.accounts_expanded = self.wallet.storage.get('accounts_expanded',{})
         self.current_account = self.wallet.storage.get("current_account", None)
-        title = 'Electrum ' + self.wallet.electrum_version + '  -  ' + os.path.basename(self.wallet.storage.path)
-        if self.wallet.is_watching_only(): title += ' [%s]' % (_('watching only'))
-        self.setWindowTitle( title )
+        self.setWindowTitle( self.wallet.title() )
         self.update_history_tab()
         self.update_wallet()
         # Once GUI has been initialized check if we want to announce something since the callback has been called before the GUI was initialized
@@ -536,7 +534,7 @@ class ElectrumWindow(QMainWindow):
                     text += "%s"%quote
 
                 if self.tray:
-                    self.tray.setToolTip(text)
+                    self.tray.setToolTip("%s (%s)" % (text, self.wallet.basename()))
                 icon = QIcon(":icons/status_connected.png")
         else:
             text = _("Not connected")

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -109,6 +109,9 @@ class WalletStorage(object):
                 self.data[key] = value
         self.file_exists = True
 
+    def basename(self):
+        return os.path.basename(self.path)
+
     def get(self, key, default=None):
         with self.lock:
             v = self.data.get(key)
@@ -230,6 +233,15 @@ class Abstract_Wallet(object):
     # wizard action
     def get_action(self):
         pass
+
+    def basename(self):
+        return self.storage.basename()
+
+    def title(self):
+        s = 'Electrum %s  -  %s' % (self.electrum_version, self.basename())
+        if self.is_watching_only():
+            s += ' [%s]' % (_('watching only'))
+        return s
 
     def convert_imported_keys(self, password):
         for k, v in self.imported_keys.items():


### PR DESCRIPTION
For those of us using multiple electrum instances simultaneously it's nice to know which electrum icon is for which wallet.