### PR TITLE
Modify format_satoshis to display amounts according to locale.

### DIFF
--- a/gui/qt/history_widget_lite.py
+++ b/gui/qt/history_widget_lite.py
@@ -20,6 +20,6 @@ class HistoryWidget(QTreeWidget):
         if date is None:
             date = _("Unknown")
         item = QTreeWidgetItem([amount, address, date])
-        if float(amount) < 0:
+        if amount.find('-') != -1:
             item.setForeground(0, QBrush(QColor("#BC1E1E")))
         self.insertTopLevelItem(0, item)

--- a/lib/util.py
+++ b/lib/util.py
@@ -110,12 +110,12 @@ def user_dir():
 def format_satoshis(x, is_diff=False, num_zeros = 0, decimal_point = 8, whitespaces=False):
     from locale import localeconv
     x = int(x)  # Some callers pass Decimal
-    if is_diff:
-        fmt = "{:+n}"
-    else:
-        fmt = "{:n}"
     scale_factor = pow (10, decimal_point)
-    integer_part = fmt.format(int(x / float(scale_factor)))
+    integer_part = "{:n}".format(int(abs(x) / float(scale_factor)))
+    if x < 0:
+        integer_part = '-' + integer_part
+    elif is_diff:
+        integer_part = '+' + integer_part
     dp = localeconv()['decimal_point']
     fract_part = ("{:0" + str(decimal_point) + "}").format(abs(x) % scale_factor)
     fract_part = fract_part.rstrip('0')

--- a/lib/util.py
+++ b/lib/util.py
@@ -108,28 +108,23 @@ def user_dir():
 
 
 def format_satoshis(x, is_diff=False, num_zeros = 0, decimal_point = 8, whitespaces=False):
-    from decimal import Decimal
-    if x is None:
-        return 'unknown'
-    s = Decimal(x)
-    sign, digits, exp = s.as_tuple()
-    digits = map(str, digits)
-    while len(digits) < decimal_point + 1:
-        digits.insert(0,'0')
-    digits.insert(-decimal_point,'.')
-    s = ''.join(digits).rstrip('0')
-    if sign:
-        s = '-' + s
-    elif is_diff:
-        s = "+" + s
-
-    p = s.find('.')
-    s += "0"*( 1 + num_zeros - ( len(s) - p ))
+    from locale import localeconv
+    if is_diff:
+        fmt = "{:+n}"
+    else:
+        fmt = "{:n}"
+    scale_factor = pow (10, decimal_point)
+    integer_part = fmt.format(int(x / float(scale_factor)))
+    dp = localeconv()['decimal_point']
+    fract_part = ("{:0" + str(decimal_point) + "}").format(abs(x) % scale_factor)
+    fract_part = fract_part.rstrip('0')
+    if len(fract_part) < num_zeros:
+        fract_part += "0" * (num_zeros - len(fract_part))
+    result = integer_part + dp + fract_part
     if whitespaces:
-        s += " "*( 1 + decimal_point - ( len(s) - p ))
-        s = " "*( 13 - decimal_point - ( p )) + s
-    return s
-
+        result += " " * (decimal_point - len(fract_part))
+        result = " " * (17 - len(result)) + result
+    return result
 
 def format_time(timestamp):
     import datetime

--- a/lib/util.py
+++ b/lib/util.py
@@ -109,6 +109,7 @@ def user_dir():
 
 def format_satoshis(x, is_diff=False, num_zeros = 0, decimal_point = 8, whitespaces=False):
     from locale import localeconv
+    x = int(x)  # Some callers pass Decimal
     if is_diff:
         fmt = "{:+n}"
     else:


### PR DESCRIPTION
In particular, thousand separators ('.' or ',' or nothing) and decimal point separators are taken from the locale.

This also resolves issue 302: https://github.com/spesmilo/electrum/issues/302.