### PR TITLE
Expand default BTC / fiat amount widget width.

### DIFF
--- a/gui/qt/amountedit.py
+++ b/gui/qt/amountedit.py
@@ -18,6 +18,8 @@ class AmountEdit(MyLineEdit):
 
     def __init__(self, base_unit, is_int = False, parent=None):
         QLineEdit.__init__(self, parent)
+        # This seems sufficient for hundred-BTC amounts with 8 decimals
+        self.setFixedWidth(140)
         self.base_unit = base_unit
         self.textChanged.connect(self.numbify)
         self.is_int = is_int


### PR DESCRIPTION
  Seems to suffice for expected usage.  Best I could figure out at least...