### PR TITLE
Determine is_local not based on cwd but on existence of setup-release.py

### DIFF
--- a/electrum
+++ b/electrum
@@ -29,7 +29,7 @@ import traceback
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 is_bundle = getattr(sys, 'frozen', False)
-is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "setup.py"))
+is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "setup-release.py"))
 is_android = 'ANDROID_DATA' in os.environ
 
 if is_local or is_android:

--- a/electrum
+++ b/electrum
@@ -29,7 +29,7 @@ import traceback
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 is_bundle = getattr(sys, 'frozen', False)
-is_local = not is_bundle and script_dir == os.getcwd()
+is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "setup.py"))
 is_android = 'ANDROID_DATA' in os.environ
 
 if is_local or is_android:


### PR DESCRIPTION
The goal is to be able to run local instances from arbitrary directories.
It seems that the chances of having a setup-release.py in the same directory
as an installed electrum are extremely remote: not only is the name unusual,
but the file isn't installed anyway.