### PR TITLE
Remove two redundant refreshes of history tab during startup.

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -241,7 +241,6 @@ class ElectrumGui:
             self.set_url(url)
 
         w.connect_slots(s)
-        w.update_wallet()
 
         signal.signal(signal.SIGINT, lambda *args: self.app.quit())
         self.app.exec_()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -216,7 +216,7 @@ class ElectrumWindow(QMainWindow):
             title += ' [%s]' % (_('watching only'))
         self.setWindowTitle( title )
         self.update_history_tab()
-        self.update_wallet()
+        self.need_update.set()
         # Once GUI has been initialized check if we want to announce something since the callback has been called before the GUI was initialized
         self.notify_transactions()
         self.update_account_selector()


### PR DESCRIPTION
The call to update_wallet() is redundant with earlier call to load_wallet().
Set the need_update boolean so the timer will refresh rather than
unconditionally refreshing.  This typically results in it merging with
the first network "updated" event resulting in one less refresh.

For me in online mode this results in history being calculated and shown
only twice during startup rather than four times.