### PR TITLE
Show coinbases transactions maturing over the full 100 confirmations.

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -394,6 +394,15 @@ class Abstract_Wallet(object):
         """ return number of transactions where address is involved """
         return len(self.history.get(address, []))
 
+    def get_coinbase_txs(self):
+        """Returns a set containing all tx hashes that are coinbases"""
+        cbs = set()
+        for tx_hash, tx in self.transactions.iteritems():
+            tx_dict = tx.as_dict()
+            if any(i.get('is_coinbase', False) for i in tx.inputs):
+                cbs.add(tx_hash)
+        return cbs
+        
     def get_tx_delta(self, tx_hash, address):
         "effect of tx on address"
         # pruned


### PR DESCRIPTION
The first confirmation shows the single-confirmation timer.
It switches to the 2-confirmation timer at 20 confirms.
...
5-confirmation timer at 80 confirms and finally confirms at 100.

Tested on 1FadDQWq27kyoWkwWYmNBaZvN9qFz4Dsuj.

How is this Thomas?  Note I had to use self.transactions() as the is_cb field in the tuples is always false, even for coinbases.  Try on the address above.  I suspect this is a bug.