### PR TITLE
Move away from requiring network and blockchain objects to be able to re...

### DIFF
--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -30,18 +30,12 @@ class Blockchain(util.DaemonThread):
         self.config = config
         self.network = network
         self.lock = threading.Lock()
-        self.local_height = 0
         self.headers_url = 'http://headers.electrum.org/blockchain_headers'
-        self.set_local_height()
         self.queue = Queue.Queue()
-
-    def height(self):
-        return self.local_height
 
     def run(self):
         self.init_headers_file()
-        self.set_local_height()
-        self.print_error("%d blocks"%self.local_height)
+        self.print_error("%d blocks" % self.config.height)
 
         while self.is_running():
             try:
@@ -54,12 +48,12 @@ class Blockchain(util.DaemonThread):
             if not header:
                 continue
             height = header.get('block_height')
-            if height <= self.local_height:
+            if height <= self.config.height:
                 continue
-            if height > self.local_height + 50:
+            if height > self.config.height + 50:
                 if not self.get_and_verify_chunks(i, header, height):
                     continue
-            if height > self.local_height:
+            if height > self.config.height:
                 # get missing parts from interface (until it connects to my chain)
                 chain = self.get_chain( i, header )
                 # skip that server if the result is not consistent
@@ -161,7 +155,7 @@ class Blockchain(util.DaemonThread):
         return rev_hex(Hash(self.header_to_string(header).decode('hex')).encode('hex'))
 
     def path(self):
-        return os.path.join( self.config.path, 'blockchain_headers')
+        return self.config.headers_filename()
 
     def init_headers_file(self):
         filename = self.path()
@@ -184,7 +178,7 @@ class Blockchain(util.DaemonThread):
         f.seek(index*2016*80)
         h = f.write(chunk)
         f.close()
-        self.set_local_height()
+        self.config.refresh_height()
 
     def save_header(self, header):
         data = self.header_to_string(header).decode('hex')
@@ -195,16 +189,7 @@ class Blockchain(util.DaemonThread):
         f.seek(height*80)
         h = f.write(data)
         f.close()
-        self.set_local_height()
-
-
-    def set_local_height(self):
-        name = self.path()
-        if os.path.exists(name):
-            h = os.path.getsize(name)/80 - 1
-            if self.local_height != h:
-                self.local_height = h
-
+        self.config.refresh_height()
 
     def read_header(self, block_height):
         name = self.path()
@@ -322,7 +307,7 @@ class Blockchain(util.DaemonThread):
     def get_and_verify_chunks(self, i, header, height):
 
         queue = Queue.Queue()
-        min_index = (self.local_height + 1)/2016
+        min_index = (self.config.height + 1)/2016
         max_index = (height + 1)/2016
         n = min_index
         while n < max_index + 1:

--- a/lib/network.py
+++ b/lib/network.py
@@ -562,4 +562,4 @@ class Network(util.DaemonThread):
         return self.blockchain.read_header(tx_height)
 
     def get_local_height(self):
-        return self.blockchain.height()
+        return self.config.height

--- a/lib/network_proxy.py
+++ b/lib/network_proxy.py
@@ -189,7 +189,7 @@ class NetworkProxy(util.DaemonThread):
         return self.synchronous_get([('network.get_header', [height])])[0]
 
     def get_local_height(self):
-        return self.blockchain_height
+        return self.config.height
 
     def get_server_height(self):
         return self.server_height

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -78,6 +78,8 @@ class SimpleConfig(object):
         # user config.
         self.user_config = read_user_config_function(self.path)
 
+        self.refresh_height()
+
         set_config(self)  # Make a singleton instance of 'self'
 
     def init_path(self):
@@ -121,6 +123,16 @@ class SimpleConfig(object):
         if key in self.system_config_keys:
             return False
         return True
+
+    def headers_filename(self):
+        return os.path.join(self.path, 'blockchain_headers')
+
+    def refresh_height(self):
+        name = self.headers_filename()
+        if os.path.exists(name):
+            self.height = os.path.getsize(name) / 80 - 1
+        else:
+            self.height = 0
 
     def save_user_config(self):
         if not self.path:


### PR DESCRIPTION
...quest local height.

We store it in the config object instead of in the blockchain object.
The blockchain object now refers to its config, and calls refresh_height() to update it.
The network objects also refer to the config rather than the blockchain.

This is the first of many small steps to untangle the verifier from stored state and so
permit the history tab to work in offline mode.  The refactoring will simultaneously clean
up a lot of accumulated cruft.