### PR TITLE
First of several incremental patches tightening up interface.py.

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -38,7 +38,7 @@ import icons_rc
 from electrum.util import format_satoshis, format_time, NotEnoughFunds, StoreDict
 from electrum import Transaction
 from electrum import mnemonic
-from electrum import util, bitcoin, commands, Interface, Wallet
+from electrum import util, bitcoin, commands, Wallet
 from electrum import SimpleConfig, Wallet, WalletStorage
 from electrum import Imported_Wallet
 

--- a/scripts/servers
+++ b/scripts/servers
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from electrum import Interface, SimpleConfig, set_verbosity
+from electrum import SimpleConfig, set_verbosity
 from electrum.network import DEFAULT_SERVERS, filter_protocol
 import time, Queue
 from collections import defaultdict


### PR DESCRIPTION
Remove some unneeded imports, a constant and a line of dead code.
Document the current external API interface.py provides.

On my system, mainline electrum frequently starts up in a permanently sychronizing state.  When run from the command line I can see that exceptions are happening with messages about broken sockets and bad file descriptors.   Electrum also frequently gets stuck whilst running, needing either a kick or a restart to have a sanely connected network again.  After looking at the code I believe these issues can be explained by racy and non-threadsafe logic in interface.py and its main client, network.py.  This sequence of pull requests will eliminate race conditions and clean up the logic to make it threadsafe.  The endpoint of these patches is working well on my system and I have not seen any of the issues referred to above whilst running it.