### PR TITLE
Pass the response_queue to the constructor, not start().

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -271,9 +271,9 @@ class Network(util.DaemonThread):
     def start_interface(self, server):
         if server in self.interfaces.keys():
             return
-        i = interface.Interface(server, self.config)
+        i = interface.Interface(server, self.queue, self.config)
         self.pending_servers.add(server)
-        i.start(self.queue)
+        i.start()
         return i
 
     def start_random_interface(self):

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -25,10 +25,10 @@ def send_request(peers, request):
     # start interfaces
     q2 = Queue.Queue()
     config = SimpleConfig()
-    interfaces = map ( lambda server: Interface(server, config), peers )
+    interfaces = map( lambda server: Interface(server, q2, config), peers )
     reached_servers = []
     for i in interfaces:
-        i.start(q2)
+        i.start()
     t0 = time.time()
     while peers:
         try:


### PR DESCRIPTION
Removes an unnecessary Thread base-class override.  The python
documentation also strongly discourages overriding anything other
than run().