### PR TITLE
Preparation for moving the set of verified and unverified txs to the wallet

### DIFF
--- a/gui/gtk.py
+++ b/gui/gtk.py
@@ -813,7 +813,7 @@ class ElectrumWindow:
             self.show_message(str(e))
             return
 
-        if tx.requires_fee(self.wallet.verifier) and fee < MIN_RELAY_TX_FEE:
+        if tx.requires_fee(self.wallet) and fee < MIN_RELAY_TX_FEE:
             self.show_message( "This transaction requires a higher fee, or it will not be propagated by the network." )
             return
 
@@ -1200,7 +1200,7 @@ class ElectrumWindow:
         tx = self.wallet.transactions.get(tx_hash)
         tx.deserialize()
         is_relevant, is_mine, v, fee = self.wallet.get_wallet_delta(tx)
-        conf, timestamp = self.wallet.verifier.get_confirmations(tx_hash)
+        conf, timestamp = self.wallet.get_confirmations(tx_hash)
 
         if timestamp:
             time_str = datetime.datetime.fromtimestamp(timestamp).isoformat(' ')[:-3]

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1121,7 +1121,7 @@ class ElectrumWindow(QMainWindow):
             self.show_message(str(e))
             return
 
-        if tx.get_fee() < MIN_RELAY_TX_FEE and tx.requires_fee(self.wallet.verifier):
+        if tx.get_fee() < MIN_RELAY_TX_FEE and tx.requires_fee(self.wallet):
             QMessageBox.warning(self, _('Error'), _("This transaction requires a higher fee, or it will not be propagated by the network."), _('OK'))
             return
 

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -149,7 +149,7 @@ class TxDialog(QDialog):
             status = _("Signed")
 
             if tx_hash in self.wallet.transactions.keys():
-                conf, timestamp = self.wallet.verifier.get_confirmations(tx_hash)
+                conf, timestamp = self.wallet.get_confirmations(tx_hash)
                 if timestamp:
                     time_str = datetime.datetime.fromtimestamp(timestamp).isoformat(' ')[:-3]
                 else:

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -769,7 +769,7 @@ class Transaction:
         return out
 
 
-    def requires_fee(self, verifier):
+    def requires_fee(self, wallet):
         # see https://en.bitcoin.it/wiki/Transaction_fees
         #
         # size must be smaller than 1 kbyte for free tx
@@ -784,7 +784,7 @@ class Transaction:
         threshold = 57600000
         weight = 0
         for txin in self.inputs:
-            age = verifier.get_confirmations(txin["prevout_hash"])[0]
+            age = wallet.get_confirmations(txin["prevout_hash"])[0]
             weight += txin["value"] * age
         priority = weight / size
         print_error(priority, threshold)

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -36,40 +36,9 @@ class SPV(util.DaemonThread):
         self.network = network
         self.transactions    = {}                                 # requested verifications (with height sent by the requestor)
         self.verified_tx     = storage.get('verified_tx3',{})      # height, timestamp of verified transactions
-        self.merkle_roots    = storage.get('merkle_roots',{})      # hashed by me
+        self.merkle_roots    = {}                                  # hashed by me
         self.lock = threading.Lock()
         self.queue = Queue.Queue()
-
-    def get_confirmations(self, tx):
-        """ return the number of confirmations of a monitored transaction. """
-        with self.lock:
-            if tx in self.verified_tx:
-                height, timestamp, pos = self.verified_tx[tx]
-                conf = (self.network.get_local_height() - height + 1)
-                if conf <= 0: timestamp = None
-            elif tx in self.transactions:
-                conf = -1
-                timestamp = None
-            else:
-                conf = 0
-                timestamp = None
-
-        return conf, timestamp
-
-
-    def get_txpos(self, tx_hash):
-        "return position, even if the tx is unverified"
-        with self.lock:
-            x = self.verified_tx.get(tx_hash)
-            y = self.transactions.get(tx_hash)
-        if x:
-            height, timestamp, pos = x
-            return height, pos
-        elif y:
-            return y, 0
-        else:
-            return 1e12, 0
-
 
     def get_height(self, tx_hash):
         with self.lock:

--- a/scripts/merchant/merchant.py
+++ b/scripts/merchant/merchant.py
@@ -87,7 +87,7 @@ def on_wallet_update():
         for tx_hash, tx_height in h:
             tx = wallet.transactions.get(tx_hash)
             if not tx: continue
-            if wallet.verifier.get_confirmations(tx_hash) < requested_confs: continue
+            if wallet.get_confirmations(tx_hash)[0] < requested_confs: continue
             for o in tx.outputs:
                 o_type, o_address, o_value = o
                 if o_address == addr:


### PR DESCRIPTION
This is the first step of 3 to get offline mode working.
The verifier will retain responsibility for verification, but will no longer hold the transaction sets itself.

Change requires_fee to take a wallet.
Add new function add_unverified_tx()
Move get_confirmations() to the wallet from the verifier.