### PR TITLE
gui/text.py curses GUI bug fixes

### DIFF
--- a/gui/text.py
+++ b/gui/text.py
@@ -353,7 +353,7 @@ class ElectrumGui:
     def network_dialog(self):
         if not self.network: return
         auto_connect = self.network.config.get('auto_cycle')
-        host, port, protocol = self.network.default_server.split(':')
+	host, port, protocol, proxy_config, auto_connect = self.network.get_parameters()
         srv = 'auto-connect' if auto_connect else self.network.default_server
 
         out = self.run_dialog('Network', [
@@ -383,7 +383,7 @@ class ElectrumGui:
     def settings_dialog(self):
         out = self.run_dialog('Settings', [
             {'label':'Default GUI', 'type':'list', 'choices':['classic','lite','gtk','text'], 'value':self.config.get('gui')},
-            {'label':'Default fee', 'type':'satoshis', 'value': format_satoshis(self.wallet.fee).strip() }
+            {'label':'Default fee', 'type':'satoshis', 'value': format_satoshis(self.wallet.fee_per_kb).strip() }
             ], buttons = 1)
         if out:
             if out.get('Default GUI'):

--- a/gui/text.py
+++ b/gui/text.py
@@ -353,7 +353,7 @@ class ElectrumGui:
     def network_dialog(self):
         if not self.network: return
         auto_connect = self.network.config.get('auto_cycle')
-	host, port, protocol, proxy_config, auto_connect = self.network.get_parameters()
+        host, port, protocol, proxy_config, auto_connect = self.network.get_parameters()
         srv = 'auto-connect' if auto_connect else self.network.default_server
 
         out = self.run_dialog('Network', [


### PR DESCRIPTION
The current master branch version of the curses GUI exits on an exception when the user selects *Network* or *Settings* dialogs via `Ctrl+N` and `Ctrl+S`.

The reason is because the `self.network` object does not have the attribute `default_server` still being referred to by the **gui/text.py** code. Similarly, the code tries to access the `self.wallet.fee` attribute which, in the current master, is not assigned. `fee_per_kb` is the correct attr name.

I've updated these attrs in **gui/text.py** and tested. The curses GUI works as expected and the dialogs correctly display config settings.