### PR TITLE
Attempt clean shutdown of threads

### DIFF
--- a/electrum
+++ b/electrum
@@ -75,7 +75,7 @@ from electrum import util
 from electrum import SimpleConfig, Network, Wallet, WalletStorage, NetworkProxy, Commands, known_commands, pick_random_server
 from electrum.util import print_msg, print_error, print_stderr, print_json, set_verbosity, InvalidPassword
 from electrum.daemon import get_daemon
-from electrum.plugins import init_plugins
+from electrum.plugins import init_plugins, shutdown_plugins
 
 
 # get password routine
@@ -248,7 +248,7 @@ if __name__ == '__main__':
 
         gui = gui.ElectrumGui(config, network)
         gui.main(url)
-
+        shutdown_plugins()
         if network:
             network.stop()
 

--- a/lib/network.py
+++ b/lib/network.py
@@ -531,6 +531,9 @@ class Network(util.DaemonThread):
         self.print_error("stopping interfaces")
         for i in self.interfaces.values():
             i.stop()
+        # Wait for interfaces to shut down cleanly before continuing
+        for i in self.interfaces.values():
+            i.join(0.25)
 
         self.print_error("stopped")
 

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -28,6 +28,10 @@ def init_plugins(config, local):
             print_msg(_("Error: cannot initialize plugin"),p)
             traceback.print_exc(file=sys.stdout)
 
+def shutdown_plugins():
+    global plugins
+    for plugin in plugins:
+        plugin.shutdown()
 
 hook_names = set()
 hooks = {}
@@ -102,6 +106,8 @@ class BasePlugin:
         return True
 
     def init_qt(self, gui): pass
+
+    def shutdown(self): pass
 
     @hook
     def load_wallet(self, wallet): pass

--- a/plugins/exchange_rate.py
+++ b/plugins/exchange_rate.py
@@ -55,7 +55,7 @@ class Exchanger(threading.Thread):
     def get_json(self, site, get_string):
         resp = requests.request('GET', 'https://' + site + get_string, headers={"User-Agent":"Electrum"})
         return resp.json()
-        
+
     def exchange(self, btc_amount, quote_currency):
         with self.lock:
             if self.quote_currencies is None:
@@ -209,6 +209,13 @@ class Plugin(BasePlugin):
             self.add_send_edit()
             self.add_receive_edit()
             self.win.update_status()
+
+    def shutdown(self):
+        if self.exchanger:
+            self.exchanger.stop()
+            self.exchanger.join(0.25)
+        BasePlugin.shutdown(self)
+        self.print_error("shut down")
 
     def close(self):
         self.exchanger.stop()


### PR DESCRIPTION
At present when electrum shuts down, I almost always get python exceptions from the exchange rate plugin, and occasionally from the interface threads.  This seems to eliminate those.

Network object to wait for interface threads to finish
Clean shutdown for exchanger plugin