### PR TITLE
FX plugin and interfaces to inherit from DaemonThread

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -48,11 +48,10 @@ def Interface(server, response_queue, config = None):
     else:
         raise Exception('Unknown protocol: %s'%protocol)
 
-class TcpInterface(threading.Thread):
+class TcpInterface(util.DaemonThread):
 
     def __init__(self, server, response_queue, config = None):
-        threading.Thread.__init__(self)
-        self.daemon = True
+        util.DaemonThread.__init__(self)
         self.config = config if config is not None else SimpleConfig()
         # Set by stop(); no more data is exchanged and the thread exits after gracefully
         # closing the socket

--- a/plugins/exchange_rate.py
+++ b/plugins/exchange_rate.py
@@ -41,7 +41,6 @@ class Exchanger(DaemonThread):
 
     def __init__(self, parent):
         DaemonThread.__init__(self)
-        self.daemon = True
         self.parent = parent
         self.quote_currencies = None
         self.lock = threading.Lock()

--- a/plugins/exchange_rate.py
+++ b/plugins/exchange_rate.py
@@ -15,7 +15,7 @@ from electrum.plugins import BasePlugin, hook
 from electrum.i18n import _
 from electrum_gui.qt.util import *
 from electrum_gui.qt.amountedit import AmountEdit
-
+from electrum.util import DaemonThread
 
 EXCHANGES = ["BitcoinAverage",
              "BitcoinVenezuela",
@@ -37,10 +37,10 @@ EXCH_SUPPORT_HIST = [("CoinDesk", "USD"),
                      ("BitcoinVenezuela", "ARS"),
                      ("BitcoinVenezuela", "VEF")]
 
-class Exchanger(threading.Thread):
+class Exchanger(DaemonThread):
 
     def __init__(self, parent):
-        threading.Thread.__init__(self)
+        DaemonThread.__init__(self)
         self.daemon = True
         self.parent = parent
         self.quote_currencies = None


### PR DESCRIPTION
If I understood your suggestion correctly.  However this doesn't solve the problem I want to fix:

Exception in thread Thread-16 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
File "/usr/local/lib/python2.7/threading.py", line 810, in __bootstrap_inner
File "/home/neil/src/electrum/plugins/exchange_rate.py", line 102, in run
File "/home/neil/src/electrum/plugins/exchange_rate.py", line 72, in update_rate
File "/home/neil/src/electrum/lib/simple_config.py", line 109, in get
File "/usr/local/lib/python2.7/threading.py", line 168, in acquire
: 'NoneType' object is not callable