### PR TITLE
Remove interfaces in one place only

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -346,13 +346,9 @@ class Network(util.DaemonThread):
 
 
     def switch_to_random_interface(self):
-        while self.interfaces:
-            i = random.choice(self.interfaces.values())
-            if i.is_connected():
-                self.switch_to_interface(i.server)
-                break
-            else:
-                self.remove_interface(i)
+        if self.interfaces:
+            server = random.choice(self.interfaces.keys())
+            self.switch_to_interface(server)
 
     def switch_to_interface(self, server):
         '''Switch to server as our interface, it must be in self.interfaces'''
@@ -501,8 +497,7 @@ class Network(util.DaemonThread):
         # main interface
         if not self.is_connected():
             if self.config.get('auto_cycle'):
-                if self.interfaces:
-                    self.switch_to_random_interface()
+                self.switch_to_random_interface()
             else:
                 if self.default_server in self.interfaces.keys():
                     self.switch_to_interface(self.default_server)


### PR DESCRIPTION
switch_to_random_interface used to do is_connected()
checks and remove interfaces when switching.  This
is redundant: interfaces are only added to self.interfaces
once in is_connected() state from process_if_notification().
When they are disconnected, a notification is also received
and process_if_notification() performs the removal.  Furthermore,
two other callers of switch_to_interface do not do explicit
is_connected() checks before calling it.