### PR TITLE
switch_to_interface() to start interface if not connected

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -368,7 +368,7 @@ class Network(util.DaemonThread):
             self.send_subscriptions()
             self.set_status('connected')
             self.notify('updated')
-        else:
+        elif server not in self.pending_servers:
             self.print_error("starting %s; will switch once connected" % server)
             self.start_interface(server)
 


### PR DESCRIPTION
Two places currently have switch-to-or-start-interface logic.
Put that common logic into switch_to_interface().