### PR TITLE
Prevent race with two electrum instances on same wallet.

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -115,7 +115,7 @@ class WalletStorage(object):
 
     def write(self):
         assert not threading.currentThread().isDaemon()
-        temp_path = self.path + '.tmp'
+        temp_path = "%s.tmp.%s" % (self.path, os.getpid())
         s = json.dumps(self.data, indent=4, sort_keys=True)
         with open(temp_path, "w") as f:
             f.write(s)


### PR DESCRIPTION
Whilst it's not a good idea to have two electrum instances
open on the same wallet, we should avoid throwing an
exception.  Also note how the old code's handling of the
exception (caused by both renaming the file almost at the
same time, rather than a non-POSIX system not supporting
the atomic rename) can lead to the wallet file being lost
enirely because os.remove(self.path) succeeds and the
rename of the temporary no-longer-existing file then fails.