### PR TITLE
Put getting of auto_cycle into one place.

### DIFF
--- a/gui/text.py
+++ b/gui/text.py
@@ -352,7 +352,6 @@ class ElectrumGui:
 
     def network_dialog(self):
         if not self.network: return
-        auto_connect = self.network.config.get('auto_cycle')
         host, port, protocol, proxy_config, auto_connect = self.network.get_parameters()
         srv = 'auto-connect' if auto_connect else self.network.default_server
 


### PR DESCRIPTION
Default to False consistently; this may change the behaviour of
network.py's get_parameters().