### PR TITLE
Rename auto_cycle to auto_connect in config

### DIFF
--- a/electrum
+++ b/electrum
@@ -195,7 +195,7 @@ if __name__ == '__main__':
             'portable': True,
             'verbose': True,
             'gui': 'android',
-            'auto_cycle': True,
+            'auto_connect': True,
         }
     else:
         config_options = eval(str(options))
@@ -203,7 +203,7 @@ if __name__ == '__main__':
             if v is None:
                 config_options.pop(k)
         if config_options.get('server'):
-            config_options['auto_cycle'] = False
+            config_options['auto_connect'] = False
 
     set_verbosity(config_options.get('verbose'))
     config = SimpleConfig(config_options)

--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -241,7 +241,7 @@ class InstallWizard(QDialog):
         if b2.isChecked():
             return NetworkDialog(self.network, self.config, None).do_exec()
         else:
-            self.config.set_key('auto_cycle', True, True)
+            self.config.set_key('auto_connect', True, True)
             return
 
 

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -96,10 +96,10 @@ class NetworkDialog(QDialog):
         self.ssl_cb.stateChanged.connect(self.change_protocol)
 
         # auto connect
-        self.autocycle_cb = QCheckBox(_('Auto-connect'))
-        self.autocycle_cb.setChecked(auto_connect)
-        grid.addWidget(self.autocycle_cb, 0, 1)
-        if not self.config.is_modifiable('auto_cycle'): self.autocycle_cb.setEnabled(False)
+        self.autoconnect_cb = QCheckBox(_('Auto-connect'))
+        self.autoconnect_cb.setChecked(auto_connect)
+        grid.addWidget(self.autoconnect_cb, 0, 1)
+        self.autoconnect_cb.setEnabled(self.config.is_modifiable('auto_connect'))
         msg = _("If auto-connect is enabled, Electrum will always use a server that is on the longest blockchain.") + " " \
             + _("If it is disabled, Electrum will warn you if your server is lagging.")
         grid.addWidget(HelpButton(msg), 0, 4)
@@ -122,15 +122,15 @@ class NetworkDialog(QDialog):
 
         def enable_set_server():
             if config.is_modifiable('server'):
-                enabled = not self.autocycle_cb.isChecked()
+                enabled = not self.autoconnect_cb.isChecked()
                 self.server_host.setEnabled(enabled)
                 self.server_port.setEnabled(enabled)
                 self.servers_list_widget.setEnabled(enabled)
             else:
-                for w in [self.autocycle_cb, self.server_host, self.server_port, self.ssl_cb, self.servers_list_widget]:
+                for w in [self.autoconnect_cb, self.server_host, self.server_port, self.ssl_cb, self.servers_list_widget]:
                     w.setEnabled(False)
 
-        self.autocycle_cb.clicked.connect(enable_set_server)
+        self.autoconnect_cb.clicked.connect(enable_set_server)
         enable_set_server()
 
         # proxy setting
@@ -235,7 +235,7 @@ class NetworkDialog(QDialog):
         else:
             proxy = None
 
-        auto_connect = self.autocycle_cb.isChecked()
+        auto_connect = self.autoconnect_cb.isChecked()
 
         self.network.set_parameters(host, port, protocol, proxy, auto_connect)
         return True

--- a/lib/network.py
+++ b/lib/network.py
@@ -252,7 +252,7 @@ class Network(util.DaemonThread):
         return host, port, protocol, self.proxy, self.auto_connect()
 
     def auto_connect(self):
-        return self.config.get('auto_cycle', False)
+        return self.config.get('auto_connect', False)
 
     def get_interfaces(self):
         return self.interfaces.keys()

--- a/lib/network_proxy.py
+++ b/lib/network_proxy.py
@@ -209,7 +209,7 @@ class NetworkProxy(util.DaemonThread):
     def set_parameters(self, host, port, protocol, proxy, auto_connect):
         proxy_str = serialize_proxy(proxy)
         server_str = serialize_server(host, port, protocol)
-        self.config.set_key('auto_cycle', auto_connect, True)
+        self.config.set_key('auto_connect', auto_connect, True)
         self.config.set_key("proxy", proxy_str, True)
         self.config.set_key("server", server_str, True)
         # abort if changes were not allowed by config

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -64,6 +64,8 @@ class SimpleConfig(object):
         self.user_config = {}  # for self.get in electrum_path()
         self.path = self.electrum_path()
         self.user_config = read_user_config_function(self.path)
+        # Upgrade obsolete keys
+        self.fixup_keys({'auto_cycle': 'auto_connect'})
         # Make a singleton instance of 'self'
         set_config(self)
 
@@ -80,6 +82,23 @@ class SimpleConfig(object):
 
         print_error("electrum directory", path)
         return path
+
+    def fixup_config_keys(self, config, keypairs):
+        updated = False
+        for old_key, new_key in keypairs.iteritems():
+            if old_key in config:
+                if not new_key in config:
+                    config[new_key] = config[old_key]
+                del config[old_key]
+                updated = True
+        return updated
+
+    def fixup_keys(self, keypairs):
+        '''Migrate old key names to new ones'''
+        self.fixup_config_keys(self.cmdline_options, keypairs)
+        self.fixup_config_keys(self.system_config, keypairs)
+        if self.fixup_config_keys(self.user_config, keypairs):
+            self.save_user_config()
 
     def set_key(self, key, value, save = True):
         if not self.is_modifiable(key):

--- a/lib/tests/test_simple_config.py
+++ b/lib/tests/test_simple_config.py
@@ -35,6 +35,25 @@ class Test_SimpleConfig(unittest.TestCase):
         # Restore the "real" stdout
         sys.stdout = self._saved_stdout
 
+    def test_simple_config_key_rename(self):
+        """auto_cycle was renamed auto_connect"""
+        fake_read_system = lambda : {}
+        fake_read_user = lambda _: {"auto_cycle": True}
+        read_user_dir = lambda : self.user_dir
+        config = SimpleConfig(options=self.options,
+                              read_system_config_function=fake_read_system,
+                              read_user_config_function=fake_read_user,
+                              read_user_dir_function=read_user_dir)
+        self.assertEqual(config.get("auto_connect"), True)
+        self.assertEqual(config.get("auto_cycle"), None)
+        fake_read_user = lambda _: {"auto_connect": False, "auto_cycle": True}
+        config = SimpleConfig(options=self.options,
+                              read_system_config_function=fake_read_system,
+                              read_user_config_function=fake_read_user,
+                              read_user_dir_function=read_user_dir)
+        self.assertEqual(config.get("auto_connect"), False)
+        self.assertEqual(config.get("auto_cycle"), None)
+
     def test_simple_config_command_line_overrides_everything(self):
         """Options passed by command line override all other configuration
         sources"""


### PR DESCRIPTION
User config is rewritten if appropriate.
Add tests behaviour is as expected.
Just the one rename-it reference to auto_cycle remains.