### PR TITLE
Common stale interface testing and switching

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -114,6 +114,7 @@ def deserialize_proxy(s):
 def deserialize_server(server_str):
     host, port, protocol = str(server_str).split(':')
     assert protocol in 'st'
+    int(port)    # Throw if cannot be converted to int
     return host, port, protocol
 
 def serialize_server(host, port, protocol):


### PR DESCRIPTION
A new function switch_interface_if_stale() checks if the
current interface ist stale and switches if so. It optionally
takes a suggestion of the server to switch to, which is
the previous strategy of new_blockchain_height().
It checks the protocol of the suggestion before switching.
The protocol might not match if the network has
just been restarted and the prior interfaces had queued a notification.

Small changes in behaviour:

The main loop check_interfaces(): it now also tests for lag as well
as for connection status.

As check_interfaces() has a regular staleness test, such a test in
set_parameters() and on_header() is no longer necessary.

new_blockchain_height() now uses the slightly
more sophisticated switch logic of check_interfaces() that also
considers disconnected servers.

Diagnotics moved to server_is_lagging().