### PR TITLE
Common stale interface testing and switching

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -114,7 +114,7 @@ def deserialize_proxy(s):
 def deserialize_server(server_str):
     host, port, protocol = str(server_str).split(':')
     assert protocol in 'st'
-    int(port)
+    int(port)    # Throw if cannot be converted to int
     return host, port, protocol
 
 def serialize_server(host, port, protocol):
@@ -205,12 +205,15 @@ class Network(util.DaemonThread):
         return self.heights.get(self.default_server, 0)
 
     def server_is_lagging(self):
-        h = self.get_server_height()
-        if not h:
+        sh = self.get_server_height()
+        if not sh:
             self.print_error('no height for main interface')
             return False
-        lag = self.get_local_height() - self.get_server_height()
-        return lag > 1
+        lh = self.get_local_height()
+        result = (lh - sh) > 1
+        if result:
+            self.print_error('%s is lagging (%d vs %d)' % (self.default_server, sh, lh))
+        return result
 
     def set_status(self, status):
         self.connection_status = status
@@ -332,13 +335,21 @@ class Network(util.DaemonThread):
             self.start_network(protocol, proxy)
         elif self.default_server != server:
             self.switch_to_interface(server)
-        elif auto_connect and (not self.is_connected() or self.server_is_lagging()):
-            self.switch_to_random_interface()
+        else:
+            self.switch_lagging_interface()
 
     def switch_to_random_interface(self):
         if self.interfaces:
             server = random.choice(self.interfaces.keys())
             self.switch_to_interface(server)
+
+    def switch_lagging_interface(self, suggestion = None):
+        '''If auto_connect and lagging, switch interface'''
+        if self.server_is_lagging() and self.auto_connect():
+            if suggestion and self.protocol == deserialize_server(suggestion)[2]:
+                self.switch_to_interface(suggestion)
+            else:
+                self.switch_to_random_interface()
 
     def switch_to_interface(self, server):
         '''Switch to server as our interface.  If not already connected, start a
@@ -361,16 +372,6 @@ class Network(util.DaemonThread):
             self.interface.stop()
             self.interface = None
 
-    def set_server(self, server):
-        if self.default_server == server and self.is_connected():
-            return
-
-        if self.protocol != deserialize_server(server)[2]:
-            return
-
-        self.switch_to_interface(server)
-
-
     def add_recent_server(self, i):
         # list is ordered
         s = i.server
@@ -381,11 +382,7 @@ class Network(util.DaemonThread):
         self.save_recent_servers()
 
     def new_blockchain_height(self, blockchain_height, i):
-        if self.is_connected():
-            if self.server_is_lagging():
-                self.print_error("Server is lagging", blockchain_height, self.get_server_height())
-                if self.auto_connect():
-                    self.set_server(i.server)
+        self.switch_lagging_interface(i.server)
         self.notify('updated')
 
     def process_if_notification(self, i):
@@ -526,9 +523,7 @@ class Network(util.DaemonThread):
         self.blockchain.queue.put((i,result))
 
         if i == self.interface:
-            if self.server_is_lagging() and self.auto_connect():
-                self.print_error("Server lagging, stopping interface")
-                self.stop_interface()
+            self.switch_lagging_interface()
             self.notify('updated')
 
 


### PR DESCRIPTION
Thomas - how about this?  It separates lagging and connected tests
which seemed to be your concern.  I'm not sure I prefer it because it
is more code and requires more care about where exactly lag can be
introduced.  Anyway I wanted your feedback.  Still testing locally.

A new function switch_stale_interface() switches servers, optionally
taking a suggestion to switch to, the previous strategy of
new_blockchain_height().  It checks the protocol of the suggestion
before switching.  The protocol might not match if the network has
just been restarted and the prior interfaces had queued a notification.

This is called from various places that check for staleness.  Socket
disconnection is exclusively checked by check_interfaces() in the
main loop.

A lagging server is checked where lag can be introduced, and
in set_parameters() where auto_connect being True may have changed
our ability to switch away.

The common switching logic uses the slightly more sophisticated logic
of check_interfaces() that also considers disconnected servers.

Lagging diagnotics moved to server_is_lagging().