### PR TITLE
Fix calls to update_fee

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1445,6 +1445,7 @@ class ElectrumWindow(QMainWindow):
     def send_from_addresses(self, addrs):
         self.set_pay_from( addrs )
         self.tabs.setCurrentIndex(1)
+        self.update_fee(False)
 
     def paytomany(self):
         self.tabs.setCurrentIndex(1)
@@ -2527,10 +2528,13 @@ class ElectrumWindow(QMainWindow):
         fee_e.setAmount(self.wallet.fee_per_kb)
         if not self.config.is_modifiable('fee_per_kb'):
             for w in [fee_e, fee_label]: w.setEnabled(False)
-        def on_fee():
-            fee = fee_e.get_amount()
-            self.wallet.set_fee(fee)
-        fee_e.editingFinished.connect(on_fee)
+        def on_fee(is_done):
+            self.wallet.set_fee(fee_e.get_amount(), is_done)
+            if not is_done:
+                self.update_fee(False)
+        fee_e.editingFinished.connect(lambda: on_fee(True))
+        fee_e.textEdited.connect(lambda: on_fee(False))
+
         widgets.append((fee_label, fee_e, fee_help))
 
         units = ['BTC', 'mBTC', 'bits']

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -135,8 +135,6 @@ class PayToEdit(ScanQRTextEdit):
         else:
             self.amount_edit.setText("")
 
-        self.amount_edit.textEdited.emit("")
-
         if total or len(lines)>1:
             self.lock_amount()
         else:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -633,10 +633,9 @@ class Abstract_Wallet(object):
             xx += x
         return cc, uu, xx
 
-    def set_fee(self, fee):
-        if self.fee_per_kb != fee:
-            self.fee_per_kb = fee
-            self.storage.put('fee_per_kb', self.fee_per_kb, True)
+    def set_fee(self, fee, save = True):
+        self.fee_per_kb = fee
+        self.storage.put('fee_per_kb', self.fee_per_kb, save)
 
     def get_address_history(self, address):
         with self.lock:


### PR DESCRIPTION
Fees should be recalculated when send_from changes.
Fees should be recalculated when editing fee preference, but
only save to storage when leaving the fee per kb widget.
No need to emit a textEdited signal; the widget does that already
(with the effect that we used to call update_fee() twice).