### PR TITLE
Speed up freezing and unfreezing of many addresses

### DIFF
--- a/gui/gtk.py
+++ b/gui/gtk.py
@@ -1079,10 +1079,7 @@ class ElectrumWindow:
                 path, col = treeview.get_cursor()
                 if path:
                     address = liststore.get_value( liststore.get_iter(path), 0)
-                    if address in wallet.frozen_addresses:
-                        wallet.unfreeze(address)
-                    else:
-                        wallet.freeze(address)
+                    wallet.set_frozen_state([address], not wallet.is_frozen(address))
                     self.update_receiving_tab()
             button.connect("clicked", freeze_address, treeview, liststore, self.wallet)
             button.show()
@@ -1151,7 +1148,7 @@ class ElectrumWindow:
             if address in self.wallet.imported_keys.keys():
                 Type = "I"
             c, u, x = self.wallet.get_addr_balance(address)
-            if address in self.wallet.frozen_addresses: Type = Type + "F"
+            if self.wallet.is_frozen(address): Type = Type + "F"
             label = self.wallet.labels.get(address)
             h = self.wallet.history.get(address,[])
             n = len(h)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1291,13 +1291,8 @@ class ElectrumWindow(QMainWindow):
         run_hook('do_clear')
 
 
-    def set_addrs_frozen(self,addrs,freeze):
-        for addr in addrs:
-            if not addr: continue
-            if addr in self.wallet.frozen_addresses and not freeze:
-                self.wallet.unfreeze(addr)
-            elif addr not in self.wallet.frozen_addresses and freeze:
-                self.wallet.freeze(addr)
+    def set_frozen_state(self, addrs, freeze):
+        self.wallet.set_frozen_state(addrs, freeze)
         self.update_address_tab()
         self.update_fee(False)
 
@@ -1416,9 +1411,9 @@ class ElectrumWindow(QMainWindow):
                 menu.addAction(_("View on block explorer"), lambda: webbrowser.open(addr_URL))
 
         if any(addr not in self.wallet.frozen_addresses for addr in addrs):
-            menu.addAction(_("Freeze"), lambda: self.set_addrs_frozen(addrs, True))
+            menu.addAction(_("Freeze"), lambda: self.set_frozen_state(addrs, True))
         if any(addr in self.wallet.frozen_addresses for addr in addrs):
-            menu.addAction(_("Unfreeze"), lambda: self.set_addrs_frozen(addrs, False))
+            menu.addAction(_("Unfreeze"), lambda: self.set_frozen_state(addrs, False))
 
         def can_send(addr):
             return addr not in self.wallet.frozen_addresses and self.wallet.get_addr_balance(addr) != (0, 0)

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -322,10 +322,10 @@ class Commands:
         return {'address':address, 'redeemScript':redeem_script}
 
     def freeze(self,addr):
-        return self.wallet.freeze(addr)
+        return self.wallet.set_frozen_state([addr], True)
 
     def unfreeze(self,addr):
-        return self.wallet.unfreeze(addr)
+        return self.wallet.set_frozen_state([addr], False)
 
     def getprivatekeys(self, addr):
         return self.wallet.get_private_key(addr, self.password)


### PR DESCRIPTION
On my machine, with a wallet with around 500 addresses, freezing a screenful of
addresses pauses the GUI for about 5 seconds.  This brings it closer to 0.25s.
Also freezing was recently broken; this fixes it.

Speedup mainly from writing to storage only once.
Make frozen_addresses a set in memory, as sets give cleaner
code and are more efficient.

Minor change in behaviour: command line freezing used to return
False if the address isn't in the wallet OR the address was already
frozen.  Now it returns more like a success code: it returns False
only if the address isn't in the wallet regardless of frozen state.
Similarly for unfreezing.