### PR TITLE
get_spendable_coins and frozen addrs

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -265,7 +265,7 @@ class Commands:
         return self.network.synchronous_get([ ('blockchain.address.get_history',[addr]) ])[0]
 
     def listunspent(self):
-        l = copy.deepcopy(self.wallet.get_spendable_coins())
+        l = copy.deepcopy(self.wallet.get_spendable_coins(exclude_frozen = False))
         for i in l: i["value"] = str(Decimal(i["value"])/100000000)
         return l
 
@@ -278,7 +278,7 @@ class Commands:
             return {'address':r[0] }
 
     def createrawtransaction(self, inputs, outputs):
-        coins = self.wallet.get_spendable_coins(None)
+        coins = self.wallet.get_spendable_coins(exclude_frozen = False)
         tx_inputs = []
         for i in inputs:
             prevout_hash = i['txid']

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -562,10 +562,12 @@ class Abstract_Wallet(object):
         return c, u, x
 
 
-    def get_spendable_coins(self, domain=None):
+    def get_spendable_coins(self, domain = None, exclude_frozen = True):
         coins = []
         if domain is None:
             domain = self.addresses(True)
+        if exclude_frozen:
+            domain = set(domain) - self.frozen_addresses
         for addr in domain:
             c = self.get_addr_utxo(addr)
             for txo, v in c.items():
@@ -846,11 +848,6 @@ class Abstract_Wallet(object):
 
         # get coins
         if not coins:
-            if domain is None:
-                domain = self.addresses(True)
-            for i in self.frozen_addresses:
-                if i in domain:
-                    domain.remove(i)
             coins = self.get_spendable_coins(domain)
 
         amount = sum(map(lambda x:x[2], outputs))


### PR DESCRIPTION
Two callers of get_spendable_coins were removing frozen addrs
before calling.  Put that functionality in the function.
We shouldn't be able to send_from a frozen address.  This was
possible in the current release because logic assumed a two-element
tuple was returned when it is now three-element.  Fix that too.

Command line options listunspent and createrawtransaction currently
ignore frozen addresses.  I've preserved that behaviour.

With this patch only the wallet class refers to self.frozen_addresses;
other clients use is_frozen() now.