### PR TITLE
Small improvements to transaction_dialog

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -568,9 +568,10 @@ class ElectrumWindow(QMainWindow):
         d.exec_()
 
     def show_transaction(self, tx):
+        '''Show transaction dialog.  Return 1 if Close was pressed, 0 if Cancel'''
         import transaction_dialog
         d = transaction_dialog.TxDialog(tx, self)
-        d.exec_()
+        return d.exec_()
 
     def update_history_tab(self):
         domain = self.wallet.get_account_addresses(self.current_account)


### PR DESCRIPTION
First, merge the sign and broadcast buttons into one.  This is
essentially the action button, and signing and broadcasting
cannot be done simultaneously.

Next, if signing or broadcasting, have cancel_button show
"Cancel" as its text, otherwise "Close".  I think this is more
logical.

Next, once we've broadcast a transaction, hide the broadcast
button.

Finally, have the dialog return 1 if closed (success) and 0
if cancelled (failure).  This will be useful when hooking
into the main window the ability to see a transaction before
sending: at present, if you press Close (this patch changes
the text to Cancel) the Send tab is unconditionally cleared,
which is annoying.  We'll be able to have it clear only if
the tx is broadcast.

I've taken a careful look at the plugins that might be affected
by this (cosigner_pool and greenaddress_instant) and it does
not seem they will be affected.