### PR TITLE
transaction_dialog: broadcast_button.hide() instead of disable()

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -179,7 +179,7 @@ class TxDialog(QWidget):
 
         # if we are not synchronized, we cannot tell
         if self.parent.network is None:
-            self.broadcast_button.disable()  # cannot broadcast when offline
+            self.broadcast_button.hide()  # cannot broadcast when offline
             return
         if not self.wallet.up_to_date:
             return


### PR DESCRIPTION
When trying to load transaction from file/text on offline machine, the following exception was thrown:

```
Traceback (most recent call last):
  File "/media/oldhome/roman/Code/Bitcoin/electrum/gui/qt/main_window.py", line 2124, in do_process_from_text
    self.show_transaction(tx)
  File "/media/oldhome/roman/Code/Bitcoin/electrum/gui/qt/main_window.py", line 571, in show_transaction
    d = transaction_dialog.TxDialog(tx, self)
  File "/media/oldhome/roman/Code/Bitcoin/electrum/gui/qt/transaction_dialog.py", line 103, in __init__
    self.update()
  File "/media/oldhome/roman/Code/Bitcoin/electrum/gui/qt/transaction_dialog.py", line 182, in update
    self.broadcast_button.disable()  # cannot broadcast when offline
AttributeError: 'QPushButton' object has no attribute 'disable'
```