### PR TITLE
travis.yml: add protobuf to requirements and exclude plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: false
 language: python
 python:
     - "2.7"
-install: "pip install slowaes==0.1a1 ecdsa>=0.9 pbkdf2 requests pyasn1 pyasn1-modules tlslite>=0.4.5 qrcode SocksiPy-branch"
-script: nosetests -e gui
+install: "pip install slowaes==0.1a1 ecdsa>=0.9 pbkdf2 requests pyasn1 pyasn1-modules tlslite>=0.4.5 qrcode SocksiPy-branch protobuf"
+script: nosetests -e gui -e plugins


### PR DESCRIPTION
This should fix Travis build errors:
- protobuf module was missing.
- `import electrum` failed at `plugins` package (so it is excluded, as `gui` package).