### PR TITLE
Save the description to the wallet on broadcasting

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -101,7 +101,7 @@ class TxDialog(QWidget):
         self.update()
 
     def do_broadcast(self):
-        self.parent.broadcast_transaction(self.tx, None)
+        self.parent.broadcast_transaction(self.tx, self.desc)
         self.saved = True
 
     def close(self):


### PR DESCRIPTION
Resolves a long-standing bug with view-before-broadcast