### PR TITLE
transaction_dialog: allow plugins manipulate transaction sharing buttons

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -99,10 +99,13 @@ class TxDialog(QWidget):
 
         # Action buttons
         self.buttons = [self.sign_button, self.broadcast_button, self.cancel_button]
+        # Transaction sharing buttons
+        self.sharing_buttons = [self.copy_button, self.qr_button, self.save_button]
+
         run_hook('transaction_dialog', self)
 
         hbox = QHBoxLayout()
-        hbox.addLayout(Buttons(self.copy_button, self.qr_button, self.save_button))
+        hbox.addLayout(Buttons(*self.sharing_buttons))
         hbox.addStretch(1)
         hbox.addLayout(Buttons(*self.buttons))
         vbox.addLayout(hbox)

--- a/plugins/audio_modem.py
+++ b/plugins/audio_modem.py
@@ -78,7 +78,7 @@ class Plugin(BasePlugin):
             self.sender = self._send(parent=dialog, blob=blob)
             self.sender.start()
         b.clicked.connect(handler)
-        dialog.buttons.insert(0, b)
+        dialog.sharing_buttons.insert(-1, b)
 
     @hook
     def scan_text_edit(self, parent):


### PR DESCRIPTION
This way, the Audio MODEM plugin button can be near the QR button.
