### PR TITLE
fix small typos at lib/interface.py and lib/commands.py

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -199,8 +199,8 @@ class Commands:
         t = Transaction(tx)
         t.deserialize()
         if privkey:
-            pubkey = bitcoin.public_key_from_private_key(sec)
-            t.sign({pubkey:sec})
+            pubkey = bitcoin.public_key_from_private_key(privkey)
+            t.sign({pubkey:privkey})
         else:
             self.wallet.sign_transaction(t, self.password)
         return t

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -228,7 +228,6 @@ class TcpInterface(threading.Thread):
                     try:
                         x = x509.X509()
                         x.parse(cert)
-                        x.slow_parse()
                     except:
                         traceback.print_exc(file=sys.stderr)
                         self.print_error("wrong certificate")
@@ -342,7 +341,6 @@ def check_cert(host, cert):
     try:
         x = x509.X509()
         x.parse(cert)
-        x.slow_parse()
     except:
         traceback.print_exc(file=sys.stdout)
         return


### PR DESCRIPTION
Running `python lib/interface.py` failed with:

    AttributeError: 'X509' object has no attribute 'slow_parse'

After removing the lines, it runs successfully.