### PR TITLE
travis: add code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,9 @@ sudo: false
 language: python
 python:
     - "2.7"
-install: "pip install slowaes==0.1a1 ecdsa>=0.9 pbkdf2 requests pyasn1 pyasn1-modules tlslite>=0.4.5 qrcode SocksiPy-branch protobuf"
-script: py.test -v
+install:
+    - "pip install ."
+    - "pip install coverage"
+script:
+    - "coverage run --source=lib -m py.test -v"
+    - "coverage report"


### PR DESCRIPTION
Also, use `pip install .` for installing dependencies via `setup.py`.