### PR TITLE
travis: use Tox for test automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ locale/
 *_trial_temp
 packages
 env/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 python:
     - "2.7"
 install:
-    - "pip install ."
-    - "pip install coverage"
+    - pip install tox
 script:
-    - "coverage run --source=lib -m py.test -v"
-    - "coverage report"
+    - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps=
+	pytest
+	coverage
+commands=
+	coverage run --source=lib -m py.test -v
+	coverage report


### PR DESCRIPTION
This way, any user can run the UT suite simply by using the `tox` command.
Travis will also use `tox`, so the test definition is not repeated.