### PR TITLE
Once a user inputs a fee, retain it.

### DIFF
--- a/gui/qt/amountedit.py
+++ b/gui/qt/amountedit.py
@@ -45,6 +45,9 @@ class AmountEdit(MyLineEdit):
                 s = s.replace('.','')
                 s = s[:p] + '.' + s[p:p+self.decimal_point()]
         self.setText(s)
+        # setText sets Modified to False.  Instead we want to remember
+        # if updates were because of user modification.
+        self.setModified(self.hasFocus())
         self.setCursorPosition(pos)
 
     def paintEvent(self, event):

--- a/plugins/exchange_rate.py
+++ b/plugins/exchange_rate.py
@@ -56,7 +56,7 @@ class Exchanger(threading.Thread):
     def get_json(self, site, get_string):
         resp = requests.request('GET', 'https://' + site + get_string, headers={"User-Agent":"Electrum"})
         return resp.json()
-        
+
     def exchange(self, btc_amount, quote_currency):
         with self.lock:
             if self.quote_currencies is None:
@@ -522,7 +522,7 @@ class Plugin(BasePlugin):
             if exchange_rate is not None:
                 btc_amount = fiat_amount/exchange_rate
                 btc_e.setAmount(int(btc_amount*Decimal(COIN)))
-                if fee_e: self.win.update_fee(False)
+                if fee_e: self.win.update_fee()
         fiat_e.textEdited.connect(fiat_changed)
         def btc_changed():
             if self.exchanger is None:


### PR DESCRIPTION
It has long been a minor annoyance that this isn't the
default behaviour.  Semantics are as follows:

- Fees are calculated automatically, as usual, and shown
  in black
- If the user inputs a fee, it is retained, and shown in
  blue to indicate it is user-overridden
- The user can switch back to automatic fee calculation mode
  in two ways: press Clear, or blank out the fee field
- User fees are also cleared by do_clear(), for instance when
  the payment is sent

I have checked all usage combinations I could think of, including
the ! case, and all work in a sensible and natural fashion.

This also fixes issue #995.