### PR TITLE
Wildcard SSL Support

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -129,7 +129,7 @@ class TcpInterface(threading.Thread):
             return False
         if peercert.has_key("subjectAltName"):
             for typ, val in peercert["subjectAltName"]:
-                if typ == "DNS" and val == name:
+                if typ == "DNS"  and (val == name or (val[0] == '*' and name.find(val[1:]) + len(val[1:]) == len(name))):
                     return True
         else:
             # Only check the subject DN if there is no subject alternative

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -121,8 +121,7 @@ class TcpInterface(threading.Thread):
 
     def check_host_name(self, peercert, name):
         """Simple certificate/host name checker.  Returns True if the
-        certificate matches, False otherwise.  Does not support
-        wildcards."""
+        certificate matches, False otherwise."""
         # Check that the peer has supplied a certificate.
         # None/{} is not acceptable.
         if not peercert:

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -128,7 +128,7 @@ class TcpInterface(threading.Thread):
             return False
         if peercert.has_key("subjectAltName"):
             for typ, val in peercert["subjectAltName"]:
-                if typ == "DNS"  and (val == name or (val[0] == '*' and name.find(val[1:]) + len(val[1:]) == len(name))):
+                if typ == "DNS"  and (val == name or (val.find('*.') == 0 and name.find(val[1:]) + len(val[1:]) == len(name))):
                     return True
         else:
             # Only check the subject DN if there is no subject alternative
@@ -139,7 +139,7 @@ class TcpInterface(threading.Thread):
                 if attr == "commonName":
                     cn = val
             if cn is not None:
-                return cn == name
+                return (cn == name or (cn.find('*.') == 0 and name.find(cn[1:]) + len(cn[1:]) == len(name)))
         return False
 
 


### PR DESCRIPTION
I've tested this small change with my wildcard cert as I needed it for internal use on an electrum server.

A good example of what SubjectAltName looks like for wildcards can be seen in the wikipedia.org certificate. 

I try to make sure it can't be abused by matching sum of wildcard part and base name to full name string.

