### PR TITLE
Use ssl.PROTOCOL_TLSv1 on client side to avoid SSLv23

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -148,7 +148,7 @@ class TcpInterface(threading.Thread):
                     return
                 # try with CA first
                 try:
-                    s = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_SSLv23, cert_reqs=ssl.CERT_REQUIRED, ca_certs=ca_path, do_handshake_on_connect=True)
+                    s = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_TLSv1, cert_reqs=ssl.CERT_REQUIRED, ca_certs=ca_path, do_handshake_on_connect=True)
                 except ssl.SSLError, e:
                     s = None
                 if s and check_host_name(s.getpeercert(), self.host):
@@ -161,7 +161,7 @@ class TcpInterface(threading.Thread):
                 if s is None:
                     return
                 try:
-                    s = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_SSLv23, cert_reqs=ssl.CERT_NONE, ca_certs=None)
+                    s = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_TLSv1, cert_reqs=ssl.CERT_NONE, ca_certs=None)
                 except ssl.SSLError, e:
                     self.print_error("SSL error retrieving SSL certificate:", e)
                     return
@@ -184,7 +184,7 @@ class TcpInterface(threading.Thread):
         if self.use_ssl:
             try:
                 s = ssl.wrap_socket(s,
-                                    ssl_version=ssl.PROTOCOL_SSLv23,
+                                    ssl_version=ssl.PROTOCOL_TLSv1,
                                     cert_reqs=ssl.CERT_REQUIRED,
                                     ca_certs= (temporary_path if is_new else cert_path),
                                     do_handshake_on_connect=True)


### PR DESCRIPTION
After update of openssl a user reported:
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
File "/usr/local/lib/python2.7/dist-packages/electrum/interface.py", line 382, in start_tc

Debian (and possibly other distors) lately compile OpenSSL without SSLv3 support because of security considerations. Also v2 and v3 are both deprecated for SSL / TLS
Source: http://stackoverflow.com/questions/28987891/patch-pyopenssl-for-sslv3-issue

Looking at https://docs.python.org/2/library/ssl.html  - especially at the table there it would make sense to change the client code to TLSv1. On the server side SSLv23 is still good for both forward and backward compatibility.

I've tested the pull request with TLSv1 successfully on Win 7