### PR TITLE
Added blockonomics as blockexplorer

### DIFF
--- a/gui/qt/history_widget.py
+++ b/gui/qt/history_widget.py
@@ -94,7 +94,19 @@ class HistoryWidget(MyTreeWidget):
         tx_hash = str(item.data(0, Qt.UserRole).toString())
         if not tx_hash:
             return
-        tx_URL = block_explorer_URL(self.config, 'tx', tx_hash)
+          
+        my_tx_addresses = [] 
+        tx = self.wallet.transactions.get(tx_hash)
+        tx_dict = tx.as_dict()
+        for x in self.wallet.transactions.get(tx_hash).inputs:
+          addr = x.get('address')
+          if self.wallet.is_mine(addr):
+            my_tx_addresses.append(addr)
+        
+        output_addrs = [x for x in tx.get_output_addresses() if self.wallet.is_mine(x)]
+        my_tx_addresses.extend(output_addrs)
+
+        tx_URL = block_explorer_URL(self.config, 'tx', tx_hash, my_tx_addresses)
         if not tx_URL:
             return
         menu = QMenu()

--- a/lib/util.py
+++ b/lib/util.py
@@ -218,6 +218,9 @@ block_explorer_info = {
                         {'tx': 'tx', 'addr': 'address'}),
     'TradeBlock.com': ('https://tradeblock.com/blockchain',
                         {'tx': 'tx', 'addr': 'address'}),
+    'blockonomics.co': ('https://www.blockonomics.co',
+                        {'tx': 'api/tx', 'addr': '#/search',
+                         'use_noslash_format': True}),
 }
 
 def block_explorer(config):
@@ -226,13 +229,20 @@ def block_explorer(config):
 def block_explorer_tuple(config):
     return block_explorer_info.get(block_explorer(config))
 
-def block_explorer_URL(config, kind, item):
+def block_explorer_URL(config, kind, item, my_tx_addresses=None):
     be_tuple = block_explorer_tuple(config)
     if not be_tuple:
         return
     kind_str = be_tuple[1].get(kind)
     if not kind_str:
         return
+    if (be_tuple[1].get('use_noslash_format')):
+      if kind == 'tx':
+        params = "?txid={0}&addr={1}".format(item,','.join(my_tx_addresses)) 
+      else:
+        params = "?q={0}".format(item)
+      return "{0}/{1}{2}".format(be_tuple[0], kind_str, params)  
+
     url_parts = [be_tuple[0], kind_str, item]
     return "/".join(url_parts)
 


### PR DESCRIPTION
- blockonomics supports taking user addresses as parameter in tx url and then calculates correct net amount and highlights user address (similar to show details in electrum). 
- If you require any changes in url format in blockonomics to support this , let me know we can get that done