### PR TITLE
typo fix: rename pay_from_URI() -> pay_to_URI()

### DIFF
--- a/gui/qt/lite_window.py
+++ b/gui/qt/lite_window.py
@@ -306,7 +306,7 @@ class MiniWindow(QDialog):
         self.actuator.g.closeEvent(event)
         qApp.quit()
 
-    def pay_from_URI(self, URI):
+    def pay_to_URI(self, URI):
         try:
             out = util.parse_URI(URI)
         except:

--- a/plugins/trustedcoin.py
+++ b/plugins/trustedcoin.py
@@ -616,7 +616,7 @@ class Plugin(BasePlugin):
             self.window.pluginsdialog.close()
         uri = "bitcoin:" + self.billing_info['billing_address'] + "?message=TrustedCoin %d Prepaid Transactions&amount="%k + str(Decimal(v)/100000000)
         self.is_billing = True
-        self.window.pay_from_URI(uri)
+        self.window.pay_to_URI(uri)
         self.window.payto_e.setFrozen(True)
         self.window.message_e.setFrozen(True)
         self.window.amount_e.setFrozen(True)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/media/oldhome/roman/Code/Bitcoin/electrum/plugins/trustedcoin.py", line 593, in <lambda>
    b.clicked.connect(lambda b, k=k, v=v: self.on_buy(k, v, d))
  File "/media/oldhome/roman/Code/Bitcoin/electrum/plugins/trustedcoin.py", line 619, in on_buy
    self.window.pay_from_URI(uri)
AttributeError: 'ElectrumWindow' object has no attribute 'pay_from_URI'
```
