### PR TITLE
Added a "Cancel" button to transaction dialog

### DIFF
--- a/plugins/keepkey.py
+++ b/plugins/keepkey.py
@@ -238,9 +238,10 @@ class Plugin(BasePlugin):
         try:
             signed_tx = client.sign_tx('Bitcoin', inputs, outputs)[1]
         except Exception, e:
-            give_error(e)
-        finally:
             self.handler.stop()
+            give_error(e)
+        
+        self.handler.stop()
 
         raw = signed_tx.encode('hex')
         tx.update_signatures(raw)

--- a/plugins/keepkey.py
+++ b/plugins/keepkey.py
@@ -235,12 +235,12 @@ class Plugin(BasePlugin):
         client = self.get_client()
         inputs = self.tx_inputs(tx, True)
         outputs = self.tx_outputs(tx)
-        #try:
-        signed_tx = client.sign_tx('Bitcoin', inputs, outputs)[1]
-        #except Exception, e:
-        #    give_error(e)
-        #finally:
-        self.handler.stop()
+        try:
+            signed_tx = client.sign_tx('Bitcoin', inputs, outputs)[1]
+        except Exception, e:
+            give_error(e)
+        finally:
+            self.handler.stop()
 
         raw = signed_tx.encode('hex')
         tx.update_signatures(raw)
@@ -526,7 +526,7 @@ class KeepKeyGuiMixin(object):
             message = "Confirm address on KeepKey device to continue"
         else:
             message = "Check KeepKey device to continue"
-        self.handler.show_message(message)
+        self.handler.show_message(msg.code, message, self)
         return proto.ButtonAck()
 
     def callback_PinMatrixRequest(self, msg):
@@ -591,8 +591,10 @@ class KeepKeyQtHandler:
     def stop(self):
         self.win.emit(SIGNAL('keepkey_done'))
 
-    def show_message(self, msg):
+    def show_message(self, msg_code, msg, client):
+        self.messsage_code = msg_code
         self.message = msg
+        self.client = client
         self.win.emit(SIGNAL('message_dialog'))
 
     def get_pin(self, msg):
@@ -651,6 +653,11 @@ class KeepKeyQtHandler:
         l = QLabel(self.message)
         vbox = QVBoxLayout(self.d)
         vbox.addWidget(l)
+
+        if self.messsage_code in (3, 8):
+            vbox.addLayout(Buttons(CancelButton(self.d)))
+            self.d.connect(self.d, SIGNAL('rejected()'), self.client.cancel)
+
         self.d.show()
 
     def dialog_stop(self):


### PR DESCRIPTION
Because KeepKey doesn't have a cancel button (unlike Trezor), this needs to be done client side.  I added a "Cancel" button to the transaction dialog that prompts you to confirm requests on KeepKey.  I also made sure that when the window is canceled out or closed, the action on KeepKey is cancelled.

I had to update our python client to get this feature to work, so make sure you have the latest.