### PR TITLE
transaction: remove unused mmap-related code

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -32,7 +32,6 @@ import struct
 #
 import struct
 import StringIO
-import mmap
 import random
 
 NO_SIGNATURE = 'ff'
@@ -54,16 +53,6 @@ class BCDataStream(object):
             self.input = bytes
         else:
             self.input += bytes
-
-    def map_file(self, file, start):  # Initialize with bytes from file
-        self.input = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
-        self.read_cursor = start
-
-    def seek_file(self, position):
-        self.read_cursor = position
-
-    def close_file(self):
-        self.input.close()
 
     def read_string(self):
         # Strings are encoded depending on length:


### PR DESCRIPTION
I have used the following command to check that no one uses the removed code:

```
git grep -E "map_file|seek_file|close_file|mmap"
```