### PR TITLE
test_transaction: fix test_sweep case

### DIFF
--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -203,4 +203,4 @@ class NetworkMock(object):
         self.unspent = unspent
 
     def synchronous_get(self, arg):
-        return [self.unspent]
+        return self.unspent


### PR DESCRIPTION
Fix small TypeError at:

```
    @classmethod
    def sweep(klass, privkeys, network, to_address, fee):
        inputs = []
        keypairs = {}
        for privkey in privkeys:
            pubkey = public_key_from_private_key(privkey)
            address = address_from_private_key(privkey)
            u = network.synchronous_get(('blockchain.address.listunspent',[address]))
            pay_script = klass.pay_script('address', address)
            for item in u:
>               item['scriptPubKey'] = pay_script
E               TypeError: list indices must be integers, not str

lib/transaction.py:540: TypeError
```