### PR TITLE
made sure to check if x_pubkey is valid xpub before parsing it

### DIFF
--- a/plugins/keepkey.py
+++ b/plugins/keepkey.py
@@ -283,13 +283,14 @@ class Plugin(BasePlugin):
                         )
                         # find which key is mine
                         for x_pubkey in x_pubkeys:
-                            xpub, s = BIP32_Account.parse_xpubkey(x_pubkey)
-                            if xpub in self.xpub_path:
-                                xpub_n = self.get_client().expand_path(self.xpub_path[xpub])
-                                txinputtype.address_n.extend(xpub_n + s)
-                                break
-                            else:
-                                raise
+                            if is_extended_pubkey(x_pubkey):
+                                xpub, s = BIP32_Account.parse_xpubkey(x_pubkey)
+                                if xpub in self.xpub_path:
+                                    xpub_n = self.get_client().expand_path(self.xpub_path[xpub])
+                                    txinputtype.address_n.extend(xpub_n + s)
+                                    break
+                                else:
+                                    raise
 
                 prev_hash = unhexlify(txin['prevout_hash'])
                 prev_index = txin['prevout_n']

--- a/plugins/trezor.py
+++ b/plugins/trezor.py
@@ -282,13 +282,14 @@ class Plugin(BasePlugin):
                         )
                         # find which key is mine
                         for x_pubkey in x_pubkeys:
-                            xpub, s = BIP32_Account.parse_xpubkey(x_pubkey)
-                            if xpub in self.xpub_path:
-                                xpub_n = self.get_client().expand_path(self.xpub_path[xpub])
-                                txinputtype.address_n.extend(xpub_n + s)
-                                break
-                            else:
-                                raise
+                            if is_extended_pubkey(x_pubkey):
+                                xpub, s = BIP32_Account.parse_xpubkey(x_pubkey)
+                                if xpub in self.xpub_path:
+                                    xpub_n = self.get_client().expand_path(self.xpub_path[xpub])
+                                    txinputtype.address_n.extend(xpub_n + s)
+                                    break
+                                else:
+                                    raise
 
                 prev_hash = unhexlify(txin['prevout_hash'])
                 prev_index = txin['prevout_n']


### PR DESCRIPTION
Having either Trezor or KeepKey attempt to sign a partially signed transaction was breaking because both plugins were trying to parse an invalid xpub. When I fixed KeepKey's plugin, I tested it with Trezor and it started working too.  So I made the change on Trezor's plugin too.