### PR TITLE
main_window: fix typo at do_process_from_text()

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2259,7 +2259,7 @@ class ElectrumWindow(QMainWindow):
         text = text_dialog(self, _('Input raw transaction'), _("Transaction:"), _("Load transaction"))
         if not text:
             return
-        tx = self.tx_from_text()
+        tx = self.tx_from_text(text)
         if tx:
             self.show_transaction(tx)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/roman/Code/Bitcoin/electrum/gui/qt/main_window.py", line 2262, in do_process_from_text
    tx = self.tx_from_text()
TypeError: tx_from_text() takes exactly 2 arguments (1 given)
```