### PR TITLE
Make verbage from requests a little more clear

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -604,9 +604,10 @@ class ElectrumWindow(QMainWindow, PrintError):
         msg = ' '.join([
             _('Expiration date of your request.'),
             _('This information is seen by the recipient if you send them a signed payment request.'),
-            _('Expired requests have to be deleted manually from your list, in order to free the corresponding Bitcoin addresses'),
+            _('Expired requests have to be deleted manually from your list, in order to free the corresponding Bitcoin addresses.'),
+            _('The bitcoin address never expires and will always be part of this electrum wallet.'),
         ])
-        grid.addWidget(HelpLabel(_('Expires in'), msg), 3, 0)
+        grid.addWidget(HelpLabel(_('Request expires in'), msg), 3, 0)
         grid.addWidget(self.expires_combo, 3, 1)
         self.expires_label = QLineEdit('')
         self.expires_label.setReadOnly(1)


### PR DESCRIPTION
I've seen a few people on IRC confused about when their electrum addresses expire.  I think it is a common enough misunderstanding to try to make the UI more clear.


12:41 < MarginOak> Question, with the electrum wallet even if one of the addressess expires do you get to keep your btc?
12:41 < MarginOak> or does it stay on the address?
12:41 < MarginOak> and you lose it/
12:41 < MarginOak> ?
12:45 < fireduck> MarginOak: addresses don't expire
12:46 < fireduck> Electrum generates new ones as you use them, but you keep all the old ones.  They never expire.
12:46 < MarginOak> Oh
12:46 < MarginOak> Thanks
12:46 < MarginOak> So if they have btc on them they don't expire?
12:46 < MarginOak> otherwise they do?
12:46 < fireduck> Nope, they never expire.
12:46 < MarginOak> That's funny
12:46 < MarginOak> It says "Expires in 1 day"
12:46 < MarginOak> Oh
12:47 < MarginOak> that must be the request xD
12:47 < fireduck> ah, that is for the request money token it is generating
12:47 < fireduck> yeah
12:47  * MarginOak is a noob
12:47 < fireduck> You aren't the only one with that question, it is a little confusing
