### PR TITLE
Fix error when loading multisig transaction

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -723,7 +723,7 @@ class Transaction:
                 # input is complete
                 continue
             for k, x_pubkey in enumerate(txin['x_pubkeys']):
-                if x_signatures[k] is not None:
+                if k < len(x_signatures) and x_signatures[k] is not None:
                     # this pubkey already signed
                     continue
                 out.add(x_pubkey)


### PR DESCRIPTION
When loading a multisig transaction on different environments this error was found:

```
IndexError: list index out of range
```

This small patch fixes the issue and these transactions are able to load successfully.
