### PR TITLE
Update text.py

### DIFF
--- a/gui/text.py
+++ b/gui/text.py
@@ -181,7 +181,7 @@ class ElectrumGui:
         s = StringIO.StringIO()
         self.qr = qrcode.QRCode()
         self.qr.add_data(data)
-        self.qr.print_ascii(out=s, invert=True)
+        self.qr.print_ascii(out=s, invert=False)
         msg = s.getvalue()
         lines = msg.split('\n')
         for i, l in enumerate(lines):


### PR DESCRIPTION
Inverted QR-codes do not work with many QR scanners including Android's "Barcode Scanner" and the one used by Circle.com.