### PR TITLE
Update text.py

### DIFF
--- a/gui/text.py
+++ b/gui/text.py
@@ -182,6 +182,7 @@ class ElectrumGui:
         self.qr = qrcode.QRCode()
         self.qr.add_data(data)
         self.qr.print_ascii(out=s, invert=True)
+        self.qr.print_ascii(out=s, invert=False)
         msg = s.getvalue()
         lines = msg.split('\n')
         for i, l in enumerate(lines):


### PR DESCRIPTION
QR codes which are inverted light-dark are not recognised by many QR scanners. It is impossible to know the colour scheme of the terminal emulator in use. Displaying the QR code both inversions, therefore.