### PR TITLE
added missing import

### DIFF
--- a/plugins/ledger/qt.py
+++ b/plugins/ledger/qt.py
@@ -1,5 +1,6 @@
 from PyQt4.Qt import QApplication, QMessageBox, QDialog, QInputDialog, QLineEdit, QVBoxLayout, QLabel, QThread, SIGNAL
 import PyQt4.QtCore as QtCore
+import threading
 
 from electrum_gui.qt.password_dialog import make_password_dialog, run_password_dialog
 from electrum.plugins import BasePlugin, hook


### PR DESCRIPTION
Added a missing import to be able to use the HW1. 

The following problem is not fixed with this:

Traceback (most recent call last):
  File "/home/richi/sourcecode/electrum/lib/plugins.py", line 148, in _run_hook
    r = f(*args)
  File "/home/richi/sourcecode/electrum/plugins/ledger/qt.py", line 23, in load_wallet
    QMessageBox.information(window, _('Error'), _("Ledger device not detected.\nContinuing in watching-only mode."), _('OK'))
NameError: global name '_' is not defined