### PR TITLE
Use info message box for Pay-To-Many instructions

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1545,7 +1545,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             _('Format: address, amount'),
             _('You may load a CSV file using the file icon.')
         ])
-        self.show_warning(msg, title=_('Pay to many'))
+        self.show_message(msg, title=_('Pay to many'))
 
     def payto_contacts(self, labels):
         paytos = [self.get_contact_payto(label) for label in labels]


### PR DESCRIPTION
Show a message instead of a warning.