### PR TITLE
Add Kraken exchange to exchange_rate plugin

### DIFF
--- a/plugins/exchange_rate/exchange_rate.py
+++ b/plugins/exchange_rate/exchange_rate.py
@@ -229,6 +229,15 @@ class itBit(ExchangeBase):
             result[ccy] = Decimal(json['lastPrice'])
         return result
 
+class Kraken(ExchangeBase):
+    def get_rates(self, ccy):
+        ccys = ['EUR', 'USD', 'CAD', 'GBP', 'JPY']
+        pairs = ['XBT%s' % c for c in ccys]
+        json = self.get_json('api.kraken.com',
+                             '/0/public/Ticker?pair=%s' % ','.join(pairs))
+        return dict((k[-3:], Decimal(float(v['c'][0])))
+                     for k, v in json['result'].items())
+
 class LocalBitcoins(ExchangeBase):
     def get_rates(self, ccy):
         json = self.get_json('localbitcoins.com',


### PR DESCRIPTION
This adds Kraken exchange rates to the `exchange_rate` plugin for the following currencies: EUR, USD, CAD, GBP, JPY.