### PR TITLE
Minor fixes - indentation and lone `self.`

### DIFF
--- a/electrum
+++ b/electrum
@@ -54,7 +54,7 @@ def check_imports():
     try:
         from ecdsa.ecdsa import curve_secp256k1, generator_secp256k1
     except Exception:
-	sys.exit("cannot import ecdsa.curve_secp256k1. You probably need to upgrade ecdsa.\nTry: sudo pip install --upgrade ecdsa")
+        sys.exit("cannot import ecdsa.curve_secp256k1. You probably need to upgrade ecdsa.\nTry: sudo pip install --upgrade ecdsa")
     # make sure that certificates are here
     assert os.path.exists(requests.utils.DEFAULT_CA_BUNDLE_PATH)
 

--- a/gui/kivy/nfc_scanner/scanner_android.py
+++ b/gui/kivy/nfc_scanner/scanner_android.py
@@ -115,7 +115,6 @@ class ScannerAndroid(NFCBase):
             #print 'length', length
             # will contain the NDEF record types
             recTypes = []
-            self.
             for record in ndefrecords:
                 recTypes.append({
                     'type': ''.join(map(unichr, record.getType())),


### PR DESCRIPTION
https://github.com/spesmilo/electrum/blob/6ba43637f58b312e27df514fdf3ec54d430504e0/electrum#L57
has tab instead of spaces.

https://github.com/spesmilo/electrum/blob/6ba43637f58b312e27df514fdf3ec54d430504e0/gui/kivy/nfc_scanner/scanner_android.py#L118
has lone `self.`