### PR TITLE
Installer fix missing hw_wallet plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'electrum_plugins.email_requests',
         'electrum_plugins.exchange_rate',
         'electrum_plugins.greenaddress_instant',
+	'electrum_plugins.hw_wallet',
         'electrum_plugins.keepkey',
         'electrum_plugins.labels',
         'electrum_plugins.ledger',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'electrum_plugins.email_requests',
         'electrum_plugins.exchange_rate',
         'electrum_plugins.greenaddress_instant',
-	'electrum_plugins.hw_wallet',
+        'electrum_plugins.hw_wallet',
         'electrum_plugins.keepkey',
         'electrum_plugins.labels',
         'electrum_plugins.ledger',


### PR DESCRIPTION
Hello,

the new hw_wallet plugin needs to be added to setup.py installer.