### PR TITLE
fix verification of CA signed certs

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -88,7 +88,7 @@ class TcpConnection(threading.Thread, util.PrintError):
             # Only check the subject DN if there is no subject alternative
             # name.
             cn = None
-            for attr, val in peercert["subject"]:
+            for attr, val in peercert["subject"][0]:
                 # Use most-specific (last) commonName attribute.
                 if attr == "commonName":
                     cn = val


### PR DESCRIPTION
peercert["subject"]
returns this:
((('commonName', u'somehost.domain'),),)

running for attr, val on it does this:

Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/site-packages/electrum/interface.py", line 208, in run
    socket = self.get_socket()
  File "/usr/lib/python2.7/site-packages/electrum/interface.py", line 131, in get_socket
    if s and self.check_host_name(s.getpeercert(), self.host):
  File "/usr/lib/python2.7/site-packages/electrum/interface.py", line 92, in check_host_name
    for attr, val in peercert["subject"]:
ValueError: need more than 1 value to unpack

adding [0] creates the second value for val