### PR TITLE
Store the daemon's network on the stdio GUI object

### DIFF
--- a/gui/stdio.py
+++ b/gui/stdio.py
@@ -14,7 +14,7 @@ class ElectrumGui:
 
     def __init__(self, config, daemon, plugins):
         self.config = config
-        network = daemon.network
+        self.network = daemon.network
         storage = WalletStorage(config.get_wallet_path())
         if not storage.file_exists:
             print "Wallet not found. try 'electrum create'"

--- a/gui/stdio.py
+++ b/gui/stdio.py
@@ -31,10 +31,10 @@ class ElectrumGui:
         self.str_fee = ""
 
         self.wallet = Wallet(storage)
-        self.wallet.start_threads(network)
+        self.wallet.start_threads(self.network)
         self.contacts = StoreDict(self.config, 'contacts')
 
-        network.register_callback(self.on_network, ['updated', 'banner'])
+        self.network.register_callback(self.on_network, ['updated', 'banner'])
         self.commands = [_("[h] - displays this help text"), \
                          _("[i] - display transaction history"), \
                          _("[o] - enter payment order"), \


### PR DESCRIPTION
I tried using the stdio interface to send a transaction, and it failed because the object didn't have a network attached. This should fix that.