### PR TITLE
readme: Fix typo and grammatical error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Creating Binaries
 =================
 
 
-In oder to creating binaries, you must create the 'packages' directory::
+In order to create binaries, you must create the 'packages' directory::
 
     ./contrib/make_packages
 


### PR DESCRIPTION
This commit fixes two issues in `readme.rst`:
1. Fix misspelled word - `oder` (should be `order`)
2. Fix grammatical error - `creating` (should be `create`)