### PR TITLE
fix test_simple_config and test_transaction

### DIFF
--- a/lib/tests/test_simple_config.py
+++ b/lib/tests/test_simple_config.py
@@ -4,6 +4,7 @@ import os
 import unittest
 import tempfile
 import shutil
+import json
 
 from StringIO import StringIO
 from lib.simple_config import (SimpleConfig, read_system_config,
@@ -233,7 +234,7 @@ class TestUserConfig(unittest.TestCase):
         thefile = os.path.join(self.user_dir, "config")
         payload = {"gap_limit": 5}
         with open(thefile, "w") as f:
-            f.write(repr(payload))
+            f.write(json.dumps(payload))
 
         result = read_user_config(self.user_dir)
         self.assertEqual(payload, result)

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -77,7 +77,7 @@ class TestTransaction(unittest.TestCase):
         self.assertEquals(tx.deserialize(), expected)
         self.assertEquals(tx.deserialize(), None)
 
-        self.assertEquals(tx.as_dict(), {'hex': unsigned_blob, 'complete': False})
+        self.assertEquals(tx.as_dict(), {'hex': unsigned_blob, 'complete': False, 'final': True})
         self.assertEquals(tx.get_outputs(), [('14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs', 1000000)])
         self.assertEquals(tx.get_output_addresses(), ['14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs'])
 
@@ -121,7 +121,7 @@ class TestTransaction(unittest.TestCase):
         tx = transaction.Transaction(signed_blob)
         self.assertEquals(tx.deserialize(), expected)
         self.assertEquals(tx.deserialize(), None)
-        self.assertEquals(tx.as_dict(), {'hex': signed_blob, 'complete': True})
+        self.assertEquals(tx.as_dict(), {'hex': signed_blob, 'complete': True, 'final': True})
 
         self.assertEquals(tx.inputs_to_sign(), set())
         self.assertEquals(tx.serialize(), signed_blob)


### PR DESCRIPTION
The tests test_simple_config.py and test_transaction.py complete with errors. This PR fixes them.