### PR TITLE
Fail better and sooner when sweeping an amount worth less than fee

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -115,6 +115,7 @@ def rev_hex(s):
 
 
 def int_to_hex(i, length=1):
+    assert i >= 0, 'i=%r' % i
     s = hex(i)[2:].rstrip('L')
     s = "0"*(2*length - len(s)) + s
     return rev_hex(s)

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -581,6 +581,7 @@ class Transaction:
             return
 
         total = sum(i.get('value') for i in inputs) - fee
+        assert total > 0, "fee exceeds value"
         outputs = [(TYPE_ADDRESS, to_address, total)]
         self = klass.from_io(inputs, outputs)
         self.sign(keypairs)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1278,7 +1278,7 @@ class Abstract_Wallet(PrintError):
 
 
     def is_watching_only(self):
-        False
+        return False
 
     def can_change_password(self):
         return not self.is_watching_only()


### PR DESCRIPTION
When sweeping a private key, if the balance available was less than the 1kb fee, a negative amount was rendered as hex and that didn't go well when signing. Added some assertions to catch at a higher level.

This is just to the contain the bug, it doesn't provide user feedback, or better, offer to sweep up the UTXO as a miner donation.

Also a trivial typo-bug fix.