### PR TITLE
Introducing websocket_announce configuration

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1054,8 +1054,16 @@ class Abstract_Wallet(PrintError):
                 out['request_url'] = os.path.join(baseurl, key)
                 out['URI'] += '&r=' + out['request_url']
                 out['index_url'] = os.path.join(baseurl, 'index.html') + '?id=' + key
-                out['websocket_server'] = config.get('websocket_server', 'localhost')
-                out['websocket_port'] = config.get('websocket_port', 9999)
+                websocket_server_announce = config.get('websocket_server_announce')
+                if websocket_server_announce:
+                    out['websocket_server'] = websocket_server_announce
+                else:
+                    out['websocket_server'] = config.get('websocket_server', 'localhost')
+                websocket_port_announce = config.get('websocket_port_announce')
+                if websocket_port_announce:
+                    out['websocket_port'] = websocket_port_announce
+                else:
+                    out['websocket_port'] = config.get('websocket_port', 9999)
         return out
 
     def get_request_status(self, key):


### PR DESCRIPTION
Currently Electrum daemon runs websocket server on a configured host and
port and sends the same information to merchant payments. There is
likely that those two may be different, when websocket traffic is being
reverse proxied and sent over via different hosts.

This patch introduces two fully optional parameters,
websocket_server_announce and websocket_port_announce, which when
set, are sent to the merchant payments instead of websocket_server and
websocket_port values.