### PR TITLE
Spread payment requests to subdirs

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1046,13 +1046,13 @@ class Abstract_Wallet(PrintError):
         rdir = config.get('requests_dir')
         if rdir:
             key = out.get('id', addr)
-            path = os.path.join(rdir, key)
+            path = os.path.join(rdir, 'req', key[0], key[1], key)
             if os.path.exists(path):
                 baseurl = 'file://' + rdir
                 rewrite = config.get('url_rewrite')
                 if rewrite:
                     baseurl = baseurl.replace(*rewrite)
-                out['request_url'] = os.path.join(baseurl, key)
+                out['request_url'] = os.path.join(baseurl, 'req', key[0], key[1], key, key)
                 out['URI'] += '&r=' + out['request_url']
                 out['index_url'] = os.path.join(baseurl, 'index.html') + '?id=' + key
                 websocket_server_announce = config.get('websocket_server_announce')
@@ -1122,12 +1122,18 @@ class Abstract_Wallet(PrintError):
         if rdir and amount is not None:
             key = req.get('id', addr)
             pr = paymentrequest.make_request(config, req)
-            path = os.path.join(rdir, key)
-            with open(path, 'w') as f:
+            path = os.path.join(rdir, 'req', key[0], key[1], key)
+            if not os.path.exists(path):
+                try:
+                    os.makedirs(path)
+                except OSError as exc:
+                    if exc.errno != errno.EEXIST:
+                        raise
+            with open(os.path.join(path, key), 'w') as f:
                 f.write(pr.SerializeToString())
             # reload
             req = self.get_payment_request(addr, config)
-            with open(os.path.join(rdir, key + '.json'), 'w') as f:
+            with open(os.path.join(path, key + '.json'), 'w') as f:
                 f.write(json.dumps(req))
         return req
 
@@ -1139,7 +1145,7 @@ class Abstract_Wallet(PrintError):
         if rdir:
             key = r.get('id', addr)
             for s in ['.json', '']:
-                n = os.path.join(rdir, key + s)
+                n = os.path.join(rdir, 'req', key[0], key[1], key, key + s)
                 if os.path.exists(n):
                     os.unlink(n)
         self.storage.put('payment_requests', self.receive_requests)

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -63,7 +63,7 @@ class WsClientThread(util.DaemonThread):
     def make_request(self, request_id):
         # read json file
         rdir = self.config.get('requests_dir')
-        n = os.path.join(rdir, request_id + '.json')
+        n = os.path.join(rdir, 'req', request_id[0], request_id[1], request_id, request_id + '.json')
         with open(n) as f:
             s = f.read()
         d = json.loads(s)

--- a/lib/www/index.html
+++ b/lib/www/index.html
@@ -61,7 +61,7 @@ if (id) {
                  }
             });
 
-            var wss_address = "wss://" + websocket_server + ":" + websocket_port +"/");
+            var wss_address = "wss://" + websocket_server + ":" + websocket_port +"/";
             console.log("Opening WSS: " + wss_address)
             var ws = new WebSocket(wss_address);
 

--- a/lib/www/index.html
+++ b/lib/www/index.html
@@ -25,7 +25,8 @@ function getUrlParameter(sParam)
 var id = getUrlParameter('id');
 
 if (id) {
-    var jqxhr = $.getJSON(id + ".json", function() {
+        var uri_path = location.pathname;
+        var jqxhr = $.getJSON(uri_path.replace("index.html", "req/"+  id[0] + "/"+ id[1] + "/"+ id + "/"+ id + ".json"), function() {
 	console.log("getJSON:success");
     })
         .done( function(data) {


### PR DESCRIPTION
Currently Electrum stores all payment requests in main requests
directory. It's not going to be efficient when we have thousands of
thousands of payment requests. This patch spreads that files across
two level of subdirectories.