### PR TITLE
Fixing final test in test_wallet.py

### DIFF
--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -54,7 +54,10 @@ class TestWalletStorage(WalletTestCase):
 
         storage = WalletStorage(self.wallet_path)
 
-        some_dict = {"a":"b", "c":"d"}
+        some_dict = {
+          u"a": u"b",
+          u"c": u"d",
+          u"seed_version": 12}
 
         for key, value in some_dict.items():
             storage.put(key, value)


### PR DESCRIPTION
It seems that wallet storage now returns keys & values as **unicode**.
It also **appends** `"seed_version": 12` to the dict it creates.

Please confirm this is correct so we aren't ignoring a real error.