### PR TITLE
fix plot history plugin

### DIFF
--- a/plugins/plot/qt.py
+++ b/plugins/plot/qt.py
@@ -8,6 +8,9 @@ from electrum.util import format_satoshis
 from electrum.bitcoin import COIN
 
 try:
+    import matplotlib
+    matplotlib.use('Qt4Agg')
+
     import matplotlib.pyplot as plt
     import matplotlib.dates as md
     from matplotlib.patches import Ellipse
@@ -48,7 +51,7 @@ class Plugin(BasePlugin):
         counter_trans = 0
         balance = 0
         for item in history:
-            tx_hash, confirmations, value, timestamp, balance = item
+            tx_hash, confirmations, value, timestamp, balance, _ = item
             if confirmations:
                 if timestamp is not None:
                     try:


### PR DESCRIPTION
Line 54 had a 'too many values to unpack' error. 

There was also an issue with matplotlib where it was using Qt5Agg as a backend which didn't seem to work with PyQt4.  I manually set the backend in the imports.
