### PR TITLE
Trezor firmware version check bugfix and log on error

### DIFF
--- a/plugins/trezor/plugin.py
+++ b/plugins/trezor/plugin.py
@@ -122,10 +122,11 @@ class TrezorCompatiblePlugin(HW_PluginBase):
             self.print_error("ping failed", str(e))
             return None
 
-        if not client.atleast_version(*self.minimum_firmware):
+        if client.atleast_version(*self.minimum_firmware) < 0:
             msg = (_('Outdated %s firmware for device labelled %s. Please '
                      'download the updated firmware from %s') %
                    (self.device, client.label(), self.firmware_URL))
+            self.print_error(msg)
             handler.show_error(msg)
             return None
 


### PR DESCRIPTION
Plugin doesn't work with Trezor when the firmware version is exactly the required version. This change fixes it work with the minimum version and also shows an error message in the debug log on outdated firmware.