### PR TITLE
Trezor firmware version check bugfix and log on error

### DIFF
--- a/plugins/trezor/clientbase.py
+++ b/plugins/trezor/clientbase.py
@@ -212,7 +212,7 @@ class TrezorClientBase(GuiMixin, PrintError):
         return (f.major_version, f.minor_version, f.patch_version)
 
     def atleast_version(self, major, minor=0, patch=0):
-        return cmp(self.firmware_version(), (major, minor, patch))
+        return cmp(self.firmware_version(), (major, minor, patch)) >= 0
 
     @staticmethod
     def wrapper(func):

--- a/plugins/trezor/plugin.py
+++ b/plugins/trezor/plugin.py
@@ -126,6 +126,7 @@ class TrezorCompatiblePlugin(HW_PluginBase):
             msg = (_('Outdated %s firmware for device labelled %s. Please '
                      'download the updated firmware from %s') %
                    (self.device, client.label(), self.firmware_URL))
+            self.print_error(msg)
             handler.show_error(msg)
             return None
 


### PR DESCRIPTION
Problem: Plugin doesn't work with Trezor when the firmware version is exactly the required version. 

This change fixes it work with the minimum version (it actually fixes the method 'atleast_version' to return 1 or 0 instead of -1,0 or 1) and also shows an error message in the debug log on outdated firmware.