### PR TITLE
Add fee rate to transaction details dialog.

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -204,6 +204,9 @@ class TxDialog(QDialog, MessageBoxMixin):
         else:
             amount_str = _("Amount sent:") + ' %s'% format_amount(-amount) + ' ' + base_unit
         fee_str = _("Transaction fee") + ': %s'% (format_amount(fee) + ' ' + base_unit if fee is not None else _('unknown'))
+        if fee is not None:
+            size = self.tx.estimated_size()
+            fee_str += '   ( %d bytes @ %s ' % (size, format_amount(fee * 1000 / size)) + base_unit + '/kB, %.0d sat/byte )' % (fee/size)
         self.amount_label.setText(amount_str)
         self.fee_label.setText(fee_str)
         run_hook('transaction_dialog_update', self)

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -670,7 +670,7 @@ class Transaction:
     @profiler
     def estimated_size(self):
         '''Return an estimated tx size in bytes.'''
-        return len(self.serialize(-1)) / 2  # ASCII hex string
+        return len(self.serialize(-1)) / 2 if not self.is_complete() or self.raw is None else len(self.raw) / 2 # ASCII hex string
 
     @classmethod
     def estimated_input_size(self, txin):


### PR DESCRIPTION
As per my issue 2051 feature request.

Add fee rate info as base_unit/kB and sat/byte in brackets after fee in details. 

Allow users to see rate used without having to manually calculate.

Tested with new tx and also in history list popup. Only shows when fee is available.