### PR TITLE
Implemented getunusedaddress command

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -564,6 +564,19 @@ class Commands:
         return map(self._format_request, out)
 
     @command('w')
+    def getunusedaddress(self,force=False):
+        """Returns the first unused address."""
+        addr = self.wallet.get_unused_address()
+        if addr is None and force:
+            addr = self.wallet.create_new_address(False)
+
+        if addr:
+            return addr
+        else:
+            return False
+
+
+    @command('w')
     def addrequest(self, amount, memo='', expiration=None, force=False):
         """Create a payment request."""
         addr = self.wallet.get_unused_address()


### PR DESCRIPTION
The implementation of the getunusedaddress will directly query
the wallet for the first unused address

Although it might be possible to first list all addresses, then check the balance for each of these addresses to determine the first address that has not been used, this is quite cumbersome and probably relatively slow. This convenience function resolves that.

Note that it will return false if not forced and the first unused address is beyond the gap (i.e. due to multiple existing addrequests).