### PR TITLE
fix AttributeError: 'Standard_Wallet' object has no attribute 'account'

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1459,7 +1459,7 @@ class Deterministic_Wallet(Abstract_Wallet):
         # fixme: this assumes wallet is synchronized
         n = 0
         nmax = 0
-        addresses = self.account.get_receiving_addresses()
+        addresses = self.get_receiving_addresses()
         k = self.num_unused_trailing_addresses(addresses)
         for a in addresses[0:-k]:
             if self.history.get(a):


### PR DESCRIPTION
If you use wallet.change_gap_limit with a value below the current gap
limit, you get this exception:

```
>> wallet.change_gap_limit(1)
Traceback (most recent call last):
File "lib\wallet.py", line 1455, in change_gap_limit
elif value >= self.min_acceptable_gap():
File "lib\wallet.py", line 1479, in min_acceptable_gap
addresses = self.account.get_receiving_addresses()
AttributeError: 'Standard_Wallet' object has no attribute 'account'
>> 
```