### PR TITLE
Use new LabelSync server for the plugin

### DIFF
--- a/plugins/labels/labels.py
+++ b/plugins/labels/labels.py
@@ -5,7 +5,6 @@ import json
 import sys
 import traceback
 
-import aes
 import base64
 
 import electrum
@@ -19,7 +18,7 @@ class LabelsPlugin(BasePlugin):
 
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
-        self.target_host = 'sync.bytesized-hosting.com:9090'
+        self.target_host = 'labels.bauerj.eu'
         self.wallets = {}
 
     def encode(self, wallet, msg):


### PR DESCRIPTION
Also removes import of aes, seems like that was forgotten in e1515743cd. It isn't used anyway.

Closes #2144