### PR TITLE
Always include default servers in the server list

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -363,7 +363,8 @@ class Network(util.DaemonThread):
 
     def get_servers(self):
         if self.irc_servers:
-            out = self.irc_servers
+            out = self.irc_servers.copy()
+            out.update(DEFAULT_SERVERS)
         else:
             out = DEFAULT_SERVERS
             for s in self.recent_servers:


### PR DESCRIPTION
This prevents "bad" servers from sending a list of unusable servers to leave the client without a connection.