### PR TITLE
When connected to a Tor proxy, only use onion-servers

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -28,7 +28,7 @@ from PyQt4.QtGui import *
 from PyQt4.QtCore import *
 
 from electrum.i18n import _
-from electrum.network import DEFAULT_PORTS
+from electrum.network import DEFAULT_PORTS, Network
 from electrum.network import serialize_server, deserialize_server
 
 from util import *
@@ -300,20 +300,6 @@ class TorDetector(QThread):
         # Probable ports for Tor to listen at
         ports = [9050, 9150]
         for p in ports:
-            if TorDetector.is_tor_port(p):
+            if Network.is_tor_port(p):
                 self.found_proxy.emit(("127.0.0.1", p))
                 return
-
-    @staticmethod
-    def is_tor_port(port):
-        try:
-            s = socket._socketobject(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.1)
-            s.connect(("127.0.0.1", port))
-            # Tor responds uniquely to HTTP-like requests
-            s.send("GET\n")
-            if "Tor is not an HTTP Proxy" in s.recv(1024):
-                return True
-        except socket.error:
-            pass
-        return False

--- a/lib/network.py
+++ b/lib/network.py
@@ -61,6 +61,9 @@ DEFAULT_SERVERS = {
     'elec.luggs.co':{'t':'80', 's':'443'},
     'btc.smsys.me':{'t':'110', 's':'995'},
     'btc.mustyoshi.com':{'t':'50001', 's':'50002'},
+    'bauerjhejlv6di7s.onion': DEFAULT_PORTS,
+    'hsmiths4fyqlw5xw.onion': DEFAULT_PORTS,
+    'fdkbwjykvl2f3hup.onion': DEFAULT_PORTS,
 }
 
 def set_testnet():
@@ -374,6 +377,8 @@ class Network(util.DaemonThread):
                     continue
                 if host not in out:
                     out[host] = { protocol:port }
+        if self.onion_only:
+            out = {s: p for s, p in out.iteritems() if s.endswith(".onion")}
         return out
 
     def start_interface(self, server):
@@ -399,12 +404,20 @@ class Network(util.DaemonThread):
         self.proxy = proxy
         if proxy:
             self.print_error('setting proxy', proxy)
+            if Network.is_tor_port(int(proxy["port"])):
+                self.onion_only = True
+                # If we are connected to clearnet servers, disconnect
+                self.default_server = pick_random_server()
+                for server, interface in self.interfaces.iteritems():
+                    if not server.endswith(".onion"):
+                        self.close_interface(interface)
             proxy_mode = proxy_modes.index(proxy["mode"]) + 1
             socks.setdefaultproxy(proxy_mode, proxy["host"], int(proxy["port"]))
             socket.socket = socks.socksocket
             # prevent dns leaks, see http://stackoverflow.com/questions/13184205/dns-over-proxy
             socket.getaddrinfo = lambda *args: [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (args[0], args[1]))]
         else:
+            self.onion_only = False
             socket.socket = socket._socketobject
             socket.getaddrinfo = socket._socket.getaddrinfo
 
@@ -856,3 +869,17 @@ class Network(util.DaemonThread):
         if out != tx_hash:
             return False, "error: " + out
         return True, out
+
+    @staticmethod
+    def is_tor_port(port):
+        try:
+            s = socket._socketobject(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.1)
+            s.connect(("127.0.0.1", port))
+            # Tor responds uniquely to HTTP-like requests
+            s.send("GET\n")
+            if "Tor is not an HTTP Proxy" in s.recv(1024):
+                return True
+        except socket.error:
+            pass
+        return False


### PR DESCRIPTION
This commit:
- adds .onion servers to the default servers
- moves `is_tor_port` to the `Network` class
- Changes `get_servers` to only return `.onion-servers` when connected to a Tor proxy
- Makes the network thread disconnect all clearnet servers when the proxy is switched to a Tor proxy

I'm not if it would be better to use clearnet servers if there a not enough onion-servers available. Any thoughts on that?

Closes: #2160