### PR TITLE
[Python3] Make proxies work

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -54,7 +54,7 @@ try:
 except Exception as e:
     print(e)
     print("Error: Could not find icons file.")
-    print("Please run 'pyrcc4 icons.qrc -o gui/qt/icons_rc.py', and reinstall Electrum")
+    print("Please run 'pyrcc4 icons.qrc -o gui/qt/icons_rc.py -py3', and reinstall Electrum")
     sys.exit(1)
 
 from .util import *   # * needed for plugins

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -326,12 +326,12 @@ class TorDetector(QThread):
     @staticmethod
     def is_tor_port(port):
         try:
-            s = socket._socketobject(socket.AF_INET, socket.SOCK_STREAM)
+            s = (socket._socketobject if hasattr(socket, "_socketobject") else socket.socket)(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(0.1)
             s.connect(("127.0.0.1", port))
             # Tor responds uniquely to HTTP-like requests
-            s.send("GET\n")
-            if "Tor is not an HTTP Proxy" in s.recv(1024):
+            s.send(b"GET\n")
+            if b"Tor is not an HTTP Proxy" in s.recv(1024):
                 return True
         except socket.error:
             pass

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -42,7 +42,7 @@ from six.moves import urllib_parse
 
 
 try:
-    from . import paymentrequest_pb2_py3 as pb2
+    from . import paymentrequest_pb2 as pb2
 except ImportError:
     sys.exit("Error: could not find paymentrequest_pb2.py. Create it with 'protoc --proto_path=lib/ --python_out=lib/ lib/paymentrequest.proto'")
 


### PR DESCRIPTION
- `socket` doesn't have `_socketobject` any more, so we have to create that