### PR TITLE
[Python3] Let travis run the tests using Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
 language: python
 python:
-    - "2.7"
+    - "3.5"
+    - "3.6"
 install:
     - pip install tox
+    - pip install tox-travis
 script:
     - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34
+envlist = py35, py36
 
 [testenv]
 deps=


### PR DESCRIPTION
`tox-travis` makes tox only use Travis-configured Python versions when run on Travis.