### PR TITLE
Digital Bitbox cannot send coins bug (due to a later upstream change)

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -367,7 +367,7 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
                 if txin.get('is_coinbase'):
                     self.give_error("Coinbase not supported") # should never happen
                 
-                if len(txin['pubkeys']) > 1:
+                if txin['type'] in ['p2sh']:
                     p2shTransaction = True
                 
                 for x_pubkey in txin['x_pubkeys']:
@@ -384,7 +384,7 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
             # Sanity check
             if p2shTransaction:
                 for txinput in tx.inputs():
-                    if len(txinput['pubkeys']) < 2:
+                    if txinput['type'] != 'p2sh':
                         self.give_error("P2SH / regular input mixed in same transaction not supported") # should never happen
             
             # Build pubkeyarray from outputs (unused because echo for smart verification not implemented)


### PR DESCRIPTION
Looks like a later commit changed something and caused a bug in the Digital Bitbox plugin. This PR fixes it.

I would classify the problem as urgent as users will not be able to send coins with a Digital Bitbox when using the apps available for download on the website.

For information, the error message is `KeyError: 'pubkeys'`.

Cheers.