### PR TITLE
TREZOR Testnet support

### DIFF
--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -26,6 +26,7 @@
 import os
 import bitcoin
 import keystore
+from keystore import bip44_derivation
 from wallet import Wallet, Imported_Wallet, Standard_Wallet, Multisig_Wallet, wallet_types
 from i18n import _
 from plugins import run_hook
@@ -219,7 +220,6 @@ class BaseWizard(object):
             # This is partially compatible with BIP45; assumes index=0
             self.on_hw_derivation(name, device_info, "m/45'/0")
         else:
-            from keystore import bip44_derivation
             f = lambda x: self.run('on_hw_derivation', name, device_info, bip44_derivation(int(x)))
             self.account_id_dialog(f)
 
@@ -301,7 +301,7 @@ class BaseWizard(object):
     def on_bip44(self, seed, passphrase, account_id):
         k = keystore.BIP32_KeyStore({})
         bip32_seed = keystore.bip39_to_seed(seed, passphrase)
-        derivation = "m/44'/0'/%d'"%account_id
+        derivation = bip44_derivation(account_id)
         k.add_xprv_from_seed(bip32_seed, 0, derivation)
         self.on_keystore(k)
 

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -650,7 +650,10 @@ is_private_key = lambda x: is_xprv(x) or is_private_key_list(x)
 is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 
 def bip44_derivation(account_id):
-    return "m/44'/0'/%d'"% int(account_id)
+    if TESTNET:
+        return "m/44'/1'/%d'"% int(account_id)
+    else:
+        return "m/44'/0'/%d'"% int(account_id)
 
 def from_seed(seed, passphrase):
     t = seed_type(seed)


### PR DESCRIPTION
This improves Testnet support and fixes TREZOR testnet support

* Use `m/44'/1'` for Testnet
* Don't use hardcoded `addrtype` for TREZOR
* Don't use hardcoded `coin_name` for TREZOR

Ledger and Digital Bitbox have hardcoded occurences of `m/44'/0'`. I have **NOT** changed these but I strongly suggest they do.

Thanks @fivepiece for informing me of this issue

/cc @prusnak @btchip @douglasbakkum 