### PR TITLE
Enter password once for initial setup of an erased device

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -89,10 +89,10 @@ class DigitalBitbox_Client():
         return pbkdf2.PBKDF2(key, 'Digital Bitbox', iterations = 20480, macmodule = hmac, digestmodule = hashlib.sha512).read(64).encode('hex')
 
 
-    def backup_password_dialog(self, confirm=False):
+    def backup_password_dialog(self):
         msg = _("Enter the password used when the backup was created:")
         while True:
-            password = self.handler.get_passphrase(msg, confirm)
+            password = self.handler.get_passphrase(msg, False)
             if password is None:
                 return None
             if len(password) < 4:
@@ -103,9 +103,9 @@ class DigitalBitbox_Client():
                 return str(password)
 
 
-    def password_dialog(self, msg, confirm=False):
+    def password_dialog(self, msg):
         while True:
-            password = self.handler.get_passphrase(msg, confirm)
+            password = self.handler.get_passphrase(msg, False)
             if password is None:
                 return False
             if len(password) < 4:
@@ -126,7 +126,7 @@ class DigitalBitbox_Client():
                     "Enter a new password below.\r\n\r\n REMEMBER THE PASSWORD!\r\n\r\n" \
                     "You cannot access your coins or a backup without the password.\r\n" \
                     "A backup is saved automatically when generating a new wallet.")
-            if self.password_dialog(msg, True):
+            if self.password_dialog(msg):
                 reply = self.hid_send_plain('{"password":"' + self.password + '"}')
             else:
                 return False


### PR DESCRIPTION
These lines https://github.com/spesmilo/electrum/blob/master/plugins/hw_wallet/qt.py#L114-L115 got broken by commit https://github.com/spesmilo/electrum/commit/fcc92c1ebdee77a4a414384f23f85d37152fbe7b

The `# If confirm is true, require the user to enter the passphrase twice` functionality was removed from https://github.com/spesmilo/electrum/blob/master/gui/qt/password_dialog.py#L194. It could be reimplemented in different ways (or dropped?), so I didn't make a PR to fix it specifically. 

The lost functionality breaks the set up process for a freshly erased Digital Bitbox https://github.com/spesmilo/electrum/blob/master/plugins/digitalbitbox/digitalbitbox.py#L108 and possibly also for a fresh Trezor https://github.com/spesmilo/electrum/blob/master/plugins/trezor/clientbase.py#L65, where `get_passphrase()` activates the affected `hw_wallet/qt.py` lines. 

A simple quick fix for our plugin is to always send `confirm=False`, done in this PR. If the `# If confirm is true, require the user to enter the passphrase twice` functionality will get re-added, then feel free to ignore this PR.
