### PR TITLE
Move Electrum to the Finance category

### DIFF
--- a/electrum.desktop
+++ b/electrum.desktop
@@ -4,12 +4,12 @@
 [Desktop Entry]
 Comment=Lightweight Bitcoin Client
 Exec=electrum %u
-GenericName[en_US]=Electrum
-GenericName=Electrum
+GenericName[en_US]=Bitcoin Wallet
+GenericName=Bitcoin Wallet
 Icon=electrum
 Name[en_US]=Electrum Bitcoin Wallet
 Name=Electrum Bitcoin Wallet
-Categories=Network;
+Categories=Finance;Network;
 StartupNotify=false
 Terminal=false
 Type=Application


### PR DESCRIPTION
Adds the “Finance” category, which is specified as an additional category in the Desktop
Menu Specification. Also makes the GenericName a more generic as per the Desktop
Entry Specification.