### PR TITLE
Tighten directory permissions

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -239,6 +239,7 @@ class Network(util.DaemonThread):
         dir_path = os.path.join( self.config.path, 'certs')
         if not os.path.exists(dir_path):
             os.mkdir(dir_path)
+            os.chmod(dir_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
         # subscriptions and requests
         self.subscribed_addresses = set()

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -90,6 +90,7 @@ class SimpleConfig(PrintError):
             if os.path.islink(path):
                 raise BaseException('Dangling link: ' + path)
             os.mkdir(path)
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
         self.print_error("electrum directory", path)
         return path
@@ -164,6 +165,7 @@ class SimpleConfig(PrintError):
             if os.path.islink(dirpath):
                 raise BaseException('Dangling link: ' + dirpath)
             os.mkdir(dirpath)
+            os.chmod(dirpath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
         new_path = os.path.join(self.path, "wallets", "default_wallet")
 


### PR DESCRIPTION
Not using `mode` on `mkdir()` as `chmod()` works better under Windows.