### PR TITLE
wine pip install win_inet_pton

### DIFF
--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -74,4 +74,6 @@ patch < portable.patch
 popd
 $PYTHON "C:/pyinstaller/pyinstaller.py" --noconfirm --ascii --name $NAME_ROOT-$VERSION-portable.exe -w deterministic.spec
 
+wine "$PYHOME\\Scripts\\pip.exe" install win_inet_pton
+
 echo "Done."


### PR DESCRIPTION
I was working on Viacoin Electrum (which I forked from the Litecoin repo)
I noticed I couldn't build the Windows binaries correctly & started a bit of debugging and noticed this problem.

![screenshot from 2017-04-09 21-22-03](https://cloud.githubusercontent.com/assets/6548898/24860540/57b91e3e-1df5-11e7-860b-f7f09738c0ff.png)

![h_1491764812_1306184_8be550b594](https://cloud.githubusercontent.com/assets/6548898/24860544/5b7f76d0-1df5-11e7-822a-00316bddf66b.png)

I figured it was missing wine win_inet_pton
Which should be added to the prepare-wine.sh script.

**I discovered this at Litecoin port (see link https://github.com/pooler/electrum-ltc/pull/44 )
And thought this may effected Electrum as well** 