### PR TITLE
Fixed a syntax error with python 3.6

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -534,7 +534,7 @@ class SocketPipe:
                 raise timeout
             except ssl.SSLError:
                 raise timeout
-            except socket.error, err:
+            except socket.error as err:
                 if err.errno == 60:
                     raise timeout
                 elif err.errno in [11, 35, 10035]:


### PR DESCRIPTION
This fixes this error:
raceback (most recent call last):
  File "/usr/bin/electrum", line 98, in <module>
    from electrum import bitcoin, network
  File "/usr/lib/python3.6/site-packages/electrum/__init__.py", line 2, in <module>
    from util import format_satoshis, print_msg, print_error, set_verbosity
  File "/usr/lib/python3.6/site-packages/electrum/util.py", line 537
    except socket.error, err:

Also, other exceptions in this file use the except X as Y syntax.