### PR TITLE
Allow users to specify lock_time for transactions

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1314,6 +1314,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if not r:
             return
         outputs, fee, tx_desc, coins, locktime = r
+
+        if not preview and locktime > time.time():
+            self.show_error(_("The transaction is not valid yet (it's timelocked)."))
+            return
+
         try:
             tx = self.wallet.make_unsigned_transaction(coins, outputs, self.config, fee, locktime=locktime)
         except NotEnoughFunds:
@@ -1535,6 +1540,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             e.setFrozen(False)
         self.set_pay_from([])
         self.rbf_checkbox.setChecked(False)
+        self.locktime_disable.setChecked(True)
         self.update_status()
         run_hook('do_clear', self)
 

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -217,7 +217,11 @@ class TxDialog(QDialog, MessageBoxMixin):
 
     def add_io(self, vbox):
         if self.tx.locktime > 0:
-            vbox.addWidget(QLabel("LockTime: %d\n" % self.tx.locktime))
+            if self.tx.locktime < 500000000:
+                locktime = "Block {}".format(self.tx.locktime)
+            else:
+                locktime = "{} ({})".format(self.tx.locktime, datetime.datetime.fromtimestamp(self.tx.locktime))
+            vbox.addWidget(QLabel("LockTime: {}\n".format(locktime)))
 
         vbox.addWidget(QLabel(_("Inputs") + ' (%d)'%len(self.tx.inputs())))
         ext = QTextCharFormat()

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -128,6 +128,9 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.update()
 
     def do_broadcast(self):
+        if self.tx.locktime > time.time():
+            self.show_error(_("The transaction is not valid yet (it's timelocked)."))
+            return
         self.main_window.push_top_level_window(self)
         try:
             self.main_window.broadcast_transaction(self.tx, self.desc)

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -686,11 +686,12 @@ class Transaction:
         # Script length, script, sequence
         s += var_int(len(script)/2)
         s += script
-        s += int_to_hex(txin.get('sequence', 0xffffffff), 4)
+        s += int_to_hex(txin.get('sequence', 0xfffffffe), 4)
         return s
 
     def set_rbf(self, rbf):
-        nSequence = 0xffffffff - (2 if rbf else 0)
+        # sequences < MAX-1 are replaceable
+        nSequence = 0xffffffff - (2 if rbf else 1)
         for txin in self.inputs():
             txin['sequence'] = nSequence
 
@@ -716,12 +717,12 @@ class Transaction:
         txin = inputs[i]
         if self.is_segwit_input(txin):
             hashPrevouts = Hash(''.join(self.serialize_outpoint(txin) for txin in inputs).decode('hex')).encode('hex')
-            hashSequence = Hash(''.join(int_to_hex(txin.get('sequence', 0xffffffff), 4) for txin in inputs).decode('hex')).encode('hex')
+            hashSequence = Hash(''.join(int_to_hex(txin.get('sequence', 0xfffffffe), 4) for txin in inputs).decode('hex')).encode('hex')
             hashOutputs = Hash(''.join(self.serialize_output(o) for o in outputs).decode('hex')).encode('hex')
             outpoint = self.serialize_outpoint(txin)
             scriptCode = push_script(self.get_preimage_script(txin))
             amount = int_to_hex(txin['value'], 8)
-            nSequence = int_to_hex(txin.get('sequence', 0xffffffff), 4)
+            nSequence = int_to_hex(txin.get('sequence', 0xfffffffe), 4)
             preimage = nVersion + hashPrevouts + hashSequence + outpoint + scriptCode + amount + nSequence + hashOutputs + nLocktime + nHashType
         else:
             txins = var_int(len(inputs)) + ''.join(self.serialize_input(txin, self.get_preimage_script(txin) if i==k else '') for k, txin in enumerate(inputs))
@@ -780,7 +781,7 @@ class Transaction:
         return self.input_value() - self.output_value()
 
     def is_final(self):
-        return not any([x.get('sequence', 0xffffffff) < 0xffffffff - 1 for x in self.inputs()])
+        return not any([x.get('sequence', 0xfffffffe) < 0xffffffff - 1 for x in self.inputs()])
 
     @profiler
     def estimated_size(self):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -790,7 +790,7 @@ class Abstract_Wallet(PrintError):
         # Change <= dust threshold is added to the tx fee
         return 182 * 3 * self.relayfee() / 1000
 
-    def make_unsigned_transaction(self, inputs, outputs, config, fixed_fee=None, change_addr=None):
+    def make_unsigned_transaction(self, inputs, outputs, config, fixed_fee=None, change_addr=None, locktime=None):
         # check outputs
         i_max = None
         for i, o in enumerate(outputs):
@@ -854,7 +854,10 @@ class Abstract_Wallet(PrintError):
         # Sort the inputs and outputs deterministically
         tx.BIP_LI01_sort()
         # Timelock tx to current height.
-        tx.locktime = self.get_local_height()
+        if locktime:
+            tx.locktime = locktime
+        else:
+            tx.locktime = self.get_local_height()
         run_hook('make_unsigned_transaction', self, tx)
         return tx
 


### PR DESCRIPTION
To do:
====
* [X] Add date-time picker to Send tab
* [X] Add timestamp to the transaction
* [x] Set sequence to `MAX-1` in order to enable the lock
* [x] Clarify the "lock time" entry in the preview window (Add "Block" for blocks and readable time for time)
* [x] Disable broadcasting if the lock time is in the future

Anything else?

Screenshots:
====
![python_2017-05-14_20-23-40](https://cloud.githubusercontent.com/assets/598790/26036712/5619938e-38e3-11e7-91ed-6378f55f8447.png)
![python_2017-05-14_20-23-44](https://cloud.githubusercontent.com/assets/598790/26036713/562f340a-38e3-11e7-99bd-0cc8cdd15bea.png)
![python_2017-05-14_22-15-19](https://cloud.githubusercontent.com/assets/598790/26037445/dc6d51b4-38f2-11e7-956e-604247cca866.png)
![python_2017-05-14_22-15-26](https://cloud.githubusercontent.com/assets/598790/26037446/dc6d856c-38f2-11e7-91a3-98fb1fd8db0e.png)


Closes: #1685
See: https://en.bitcoin.it/wiki/Protocol_documentation#tx

cc: @ulrichard @Rspigler