### PR TITLE
fix a minor typo (beyong -> beyond)

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -687,7 +687,7 @@ command_options = {
     'memo':        ("-m", "--memo",        "Description of the request"),
     'expiration':  (None, "--expiration",  "Time in seconds"),
     'timeout':     (None, "--timeout",     "Timeout in seconds"),
-    'force':       (None, "--force",       "Create new address beyong gap limit, if no more address is available."),
+    'force':       (None, "--force",       "Create new address beyond gap limit, if no more addresses are available."),
     'pending':     (None, "--pending",     "Show only pending requests."),
     'expired':     (None, "--expired",     "Show only expired requests."),
     'paid':        (None, "--paid",        "Show only paid requests."),


### PR DESCRIPTION
This fixes a minor typo in the help output for `--force`