### PR TITLE
Let Travis upload templates to crowdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ install:
     - pip install tox
 script:
     - tox
+after_success:
+    - if [ "$TRAVIS_BRANCH" = "master" ]; then pip install pycurl requests && contrib/make_locale; fi

--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -19,8 +19,12 @@ crowdin_identifier = 'electrum'
 crowdin_file_name = 'electrum-client/messages.pot'
 locale_file_name = 'locale/messages.pot'
 
+crowdin_api_key = None
 if os.path.exists('../contrib/crowdin_api_key.txt'):
     crowdin_api_key = open('../contrib/crowdin_api_key.txt').read().strip()
+if "crowdin_api_key" in os.environ:
+    crowdin_api_key = os.environ["crowdin_api_key"]
+if crowdin_api_key:
     # Push to Crowdin
     print 'Push to Crowdin'
     url = ('https://api.crowdin.com/api/project/' + crowdin_identifier + '/update-file?key=' + crowdin_api_key)


### PR DESCRIPTION
This uploads updated translation strings to crowdin on every push to master.

You need to [add the API key] as a [Travis environment variable] in order for this to work.

As long as you don't merge something that prints the API key, it should be safe:

> Similarly, we do not provide these values to untrusted builds, triggered by pull requests from another repository.

[Travis environment variable]: https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
[add the API key]: https://travis-ci.org/spesmilo/electrum/settings
Closes: #2377