### PR TITLE
Made status bar exchange rate display in terms of base unit

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -666,7 +666,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
                 # append fiat balance and price
                 if self.fx.is_enabled():
-                    text += self.fx.get_fiat_status_text(c + u + x) or ''
+                    text += self.fx.get_fiat_status_text(c + u + x,
+                        self.base_unit(), self.get_decimal_point()) or ''
                 if not self.network.proxy:
                     icon = QIcon(":icons/status_connected.png")
                 else:

--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -406,10 +406,10 @@ class FxThread(ThreadJob):
         rate = self.exchange_rate()
         return '' if rate is None else "%s %s" % (self.value_str(btc_balance, rate), self.ccy)
 
-    def get_fiat_status_text(self, btc_balance):
+    def get_fiat_status_text(self, btc_balance, base_unit, decimal_point):
         rate = self.exchange_rate()
-        return _("  (No FX rate available)") if rate is None else " 1 BTC~%s %s" % (self.value_str(COIN, rate), self.ccy)
-
+        return _("  (No FX rate available)") if rate is None else " 1 %s~%s %s" % (base_unit,
+            self.value_str(COIN / (10**(8 - decimal_point)), rate), self.ccy)
 
     def value_str(self, satoshis, rate):
         if satoshis is None:  # Can happen with incomplete history


### PR DESCRIPTION
Status bar showed price of 1 BTC regardless of which base unit (mBTC, etc) was chosen. This PR makes it show the price of the base unit.

Let me know if any style things need to be changed before merging.

![mbtc](https://cloud.githubusercontent.com/assets/8398185/26683480/d7662960-46db-11e7-98ed-f171dd91ad4b.png)