### PR TITLE
Resize content of address history window

### DIFF
--- a/gui/qt/address_dialog.py
+++ b/gui/qt/address_dialog.py
@@ -59,7 +59,6 @@ class AddressDialog(WindowModalDialog):
         self.hw.get_domain = self.get_domain
         vbox.addWidget(self.hw)
 
-        vbox.addStretch(1)
         vbox.addLayout(Buttons(CloseButton(self)))
         self.format_amount = self.parent.format_amount
         self.hw.update()


### PR DESCRIPTION
Before:
![2017-05-29_20-43-54](https://cloud.githubusercontent.com/assets/598790/26559382/8bc07fa2-44af-11e7-92a9-842c472e6d49.gif)

With this change:
![2017-05-29_20-43-06](https://cloud.githubusercontent.com/assets/598790/26559360/70fd9dbc-44af-11e7-98db-d3261125d975.gif)


Closes: #2464