### PR TITLE
Add plugin hook `init_menubar_tools`

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -482,6 +482,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         raw_transaction_menu.addAction(_("&From the blockchain"), self.do_process_from_txid)
         raw_transaction_menu.addAction(_("&From QR code"), self.read_tx_from_qrcode)
         self.raw_transaction_menu = raw_transaction_menu
+        run_hook('init_menubar_tools', self, tools_menu)
 
         help_menu = menubar.addMenu(_("&Help"))
         help_menu.addAction(_("&About"), self.show_about)


### PR DESCRIPTION
New plugin hook `init_menubar_tools` that allows plugins to add submenu item in Tools menu.