### PR TITLE
Add the packaging metadata to build the electrum snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ parts:
   electrum:
     source: .
     plugin: python
-    python-version: python
+    python-version: python2
     stage-packages: [python-qt4]
     build-packages: [pyqt4-dev-tools]
     install: pyrcc4 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages/electrum_gui/qt/icons_rc.py

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ confinement: strict
 apps:
   electrum:
     command: desktop-launch electrum
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, x11, unity7]
 
 parts:
   electrum:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: electrum
+version: master
+summary: Bitcoin thin client
+description: |
+  Lightweight Bitcoin client
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  electrum:
+    command: desktop-launch electrum
+    plugs: [network, network-bind]
+
+parts:
+  electrum:
+    source: .
+    plugin: python
+    python-version: python2
+    stage-packages: [python-qt4]
+    after: [desktop-qt4]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,8 @@ parts:
   electrum:
     source: .
     plugin: python
-    python-version: python2
+    python-version: python
     stage-packages: [python-qt4]
+    build-packages: [pyqt4-dev-tools]
+    install: pyrcc4 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages/electrum_gui/qt/icons_rc.py
     after: [desktop-qt4]


### PR DESCRIPTION
This package will let you publish the latest electrum in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.