### PR TITLE
Fix "Back" button in installwizard

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -109,6 +109,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         self.title = QLabel()
         self.main_widget = QWidget()
         self.back_button = QPushButton(_("Back"), self)
+        self.back_button.setText(_('Back') if self.can_go_back() else _('Cancel'))
         self.next_button = QPushButton(_("Next"), self)
         self.next_button.setDefault(True)
         self.logo = QLabel()
@@ -209,8 +210,8 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         while True:
             if self.storage.file_exists() and not self.storage.is_encrypted():
                 break
-            if not self.loop.exec_():
-                return
+            if self.loop.exec_() != 2:  # 2 = next
+                self.close()
             if not self.storage.file_exists():
                 break
             if self.storage.file_exists() and self.storage.is_encrypted():


### PR DESCRIPTION
Since this seems to be the first page of the wizard, there is nothing to go back to. Furthermore, clicking "Back" actually takes you to the next step.

This changes the button to "Close" and closes the wizard.