### PR TITLE
Remove usages of deprecated apply() builtin

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -841,7 +841,7 @@ class ElectrumWindow(App):
         if self.wallet.has_password():
             self.password_dialog(msg, f, args)
         else:
-            apply(f, args + (None,))
+            f(*args, None)
 
     def delete_wallet(self):
         from uix.dialogs.question import Question
@@ -918,7 +918,7 @@ class ElectrumWindow(App):
 
     def password_dialog(self, msg, f, args):
         def callback(pw):
-            Clock.schedule_once(lambda x: apply(f, args + (pw,)), 0.1)
+            Clock.schedule_once(lambda _: f(*args, pw), 0.1)
         if self._password_dialog is None:
             from uix.dialogs.password_dialog import PasswordDialog
             self._password_dialog = PasswordDialog()

--- a/gui/kivy/uix/dialogs/installwizard.py
+++ b/gui/kivy/uix/dialogs/installwizard.py
@@ -767,7 +767,7 @@ class InstallWizard(BaseWizard, Widget):
             WizardChoiceDialog(self, **kwargs).open()
         else:
             f = kwargs['run_next']
-            apply(f, (choices[0][0],))
+            f(choices[0][0])
 
     def multisig_dialog(self, **kwargs): WizardMultisigDialog(self, **kwargs).open()
     def show_seed_dialog(self, **kwargs): ShowSeedDialog(self, **kwargs).open()

--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -87,7 +87,7 @@ def wizard_dialog(func):
         #    out = ()
         if type(out) is not tuple:
             out = (out,)
-        apply(run_next, out)
+        run_next(*out)
     return func_wrapper
 
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1708,7 +1708,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         c = commands.Commands(self.config, self.wallet, self.network, lambda: self.console.set_json(True))
         methods = {}
         def mkfunc(f, method):
-            return lambda *args: apply( f, (method, args, self.password_dialog ))
+            return lambda *args: f(method, args, self.password_dialog)
         for m in dir(c):
             if m[0]=='_' or m in ['network','wallet']: continue
             methods[m] = mkfunc(c._run, m)

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -69,7 +69,7 @@ class EnterButton(QPushButton):
 
     def keyPressEvent(self, e):
         if e.key() == Qt.Key_Return:
-            apply(self.func,())
+            self.func()
 
 
 class ThreadedButton(QPushButton):

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -54,10 +54,10 @@ class BaseWizard(object):
             self.plugin, action = action
         if self.plugin and hasattr(self.plugin, action):
             f = getattr(self.plugin, action)
-            apply(f, (self,) + args)
+            f(self, *args)
         elif hasattr(self, action):
             f = getattr(self, action)
-            apply(f, args)
+            f(*args)
         else:
             raise BaseException("unknown action", action)
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -97,7 +97,7 @@ class Commands:
         # this wrapper is called from the python console
         cmd = known_commands[method]
         if cmd.requires_password and self.wallet.has_password():
-            password = apply(password_getter, ())
+            password = password_getter()
             if password is None:
                 return
         f = getattr(self, method)
@@ -105,9 +105,9 @@ class Commands:
             result = f(*args, **{'password':password})
         else:
             result = f(*args)
-        
+
         if self._callback:
-            apply(self._callback, ())
+            self._callback()
         return result
 
     @command('')


### PR DESCRIPTION
Instead of using the deprecated function `apply(f, args, kwargs)` we use the modern Python 3-compatible unpack syntax `f(*args, **kwargs)`, easing the porting effort.