### PR TITLE
Add sat/byte fee info in preview.

### DIFF
--- a/gui/qt/fee_slider.py
+++ b/gui/qt/fee_slider.py
@@ -29,7 +29,7 @@ class FeeSlider(QSlider):
 
     def get_tooltip(self, pos, fee_rate):
         from electrum.util import fee_levels
-        rate_str = self.window.format_amount(fee_rate) + ' ' + self.window.base_unit() + '/kB'
+        rate_str = '%.0d sat/byte' % (fee_rate/1e3) if self.window.fee_unit == 0 else '%1.3f mBTC/kB' % (fee_rate/1e5)
         if self.dyn:
             tooltip = fee_levels[pos] + '\n' + rate_str
         else:

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -116,6 +116,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.need_update = threading.Event()
 
         self.decimal_point = config.get('decimal_point', 5)
+        self.fee_unit = config.get('fee_unit', 0)
         self.num_zeros     = int(config.get('num_zeros',0))
 
         self.completions = QStringListModel()
@@ -2457,6 +2458,18 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.config.set_key('rbf_policy', x)
         rbf_combo.currentIndexChanged.connect(on_rbf)
         fee_widgets.append((rbf_label, rbf_combo))
+        
+        self.fee_unit = self.config.get('fee_unit', 0)
+        fee_unit_label = HelpLabel(_('Fee Unit') + ':', '')
+        fee_unit_combo = QComboBox()
+        fee_unit_combo.addItems([_('sat/byte'), _('mBTC/kB')])
+        fee_unit_combo.setCurrentIndex(self.fee_unit)
+        def on_fee_unit(x):
+            self.fee_unit = x
+            self.config.set_key('fee_unit', x)
+            self.fee_slider.update()
+        fee_unit_combo.currentIndexChanged.connect(on_fee_unit)
+        fee_widgets.append((fee_unit_label, fee_unit_combo))
 
         msg = _('OpenAlias record, used to receive coins and to sign payment requests.') + '\n\n'\
               + _('The following alias providers are available:') + '\n'\

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -209,7 +209,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         size_str = _("Size:") + ' %d bytes'% size
         fee_str = _("Fee") + ': %s'% (format_amount(fee) + ' ' + base_unit if fee is not None else _('unknown'))
         if fee is not None:
-            fee_str += '  ( %s )' % (format_amount(fee * 1000 / size) + ' ' + base_unit + '/kB')
+            fee_str += '   ( %d bytes @ %s ' % (size, '%.0d sat/byte)' % (fee/size) if self.main_window.fee_unit == 0 else '%1.3f mBTC/kB)' % (float(fee)/size/100) )
         self.amount_label.setText(amount_str)
         self.fee_label.setText(fee_str)
         self.size_label.setText(size_str)


### PR DESCRIPTION
Adds an extra sat/byte fee value to tx preview dialog, and to slider tool tip.

Requested by some users as sat/byte is commonly felt to be more standard and makes comparison with mempool status sites easier.

See issue #2490.
