### PR TITLE
Fix hide in tray on Qt-based window managers

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -123,7 +123,7 @@ class ElectrumGui:
         self.tray.setIcon(self.tray_icon())
 
     def tray_activated(self, reason):
-        if reason == QSystemTrayIcon.DoubleClick:
+        if reason == self.config.tray_fired_reason():
             if all([w.is_hidden() for w in self.windows]):
                 for w in self.windows:
                     w.bring_to_top()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2417,7 +2417,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         def on_trayclick(x):
             self.config.set_key('tray_simpleclick', x ==  Qt.Checked)
         trayclick = QCheckBox(_('Hiding with simple-click on tray instead of double-click'))
-        trayclick.setChecked(self.config.get('tray_simpleclick'))
+        trayclick.setChecked(self.config.get('tray_simpleclick', False))
         trayclick.setToolTip(_("A quirk for window managers that report two simple-clicks instead of a double-click"))
         gui_widgets.append((trayclick, None))
         trayclick.stateChanged.connect(on_trayclick)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2414,6 +2414,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         nz.valueChanged.connect(on_nz)
         gui_widgets.append((nz_label, nz))
 
+        def on_trayclick(x):
+            self.config.set_key('tray_simpleclick', x ==  Qt.Checked)
+        trayclick = QCheckBox(_('Hiding with simple-click on tray instead of double-click'))
+        trayclick.setChecked(self.config.get('tray_simpleclick'))
+        trayclick.setToolTip(_("A quirk for window managers that report two simple-clicks instead of a double-click"))
+        gui_widgets.append((trayclick, None))
+        trayclick.stateChanged.connect(on_trayclick)
+
         def on_dynfee(x):
             self.config.set_key('dynamic_fees', x == Qt.Checked)
             self.fee_slider.update()


### PR DESCRIPTION
In Qt-based window managers, hide in tray doesn't work because the window manager reports two simple-clicks instead of a double-click.

The bug has been searched for on KDE, LXQt, GNOME, GNOME Classic, Cinnamon, LXDE, XFCE, MATE; it appears only on KDE and LXQt.

This commit adds a configuration option (located under the tab _Appearance_, and named `tray_simpleclick` in config file) that enables hide in tray with a simple-click instead of a double-click, and the option is enabled by default on KDE and LXQt.
