### PR TITLE
Fix commands that require password with unencrypted wallet

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -100,6 +100,9 @@ class Commands:
             password = password_getter()
             if password is None:
                 return
+        else:
+            password = None
+
         f = getattr(self, method)
         if cmd.requires_password:
             result = f(*args, **{'password':password})


### PR DESCRIPTION
With unencrypted wallet, when trying to use the console to getprivatekeys, exception is raised:
```
>> getprivatekeys("12*************************AC")
Traceback (most recent call last):
  File "/home/skelet/Builds/electrum/gui/qt/main_window.py", line 1711, in <lambda>
    return lambda *args: f(method, args, self.password_dialog)
  File "/home/skelet/Builds/electrum/lib/commands.py", line 105, in _run
    result = f(*args, **{'password':password})
UnboundLocalError: local variable 'password' referenced before assignment
```
The fix seems trivial. The case with unencrypted wallet does not seem to be handled completely. With the fix, getprivatekeys is working as expected.