### PR TITLE
History list - GUI fix + small improvements

### DIFF
--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -92,6 +92,7 @@ class HistoryList(MyTreeWidget):
                     entry.append(text)
             item = QTreeWidgetItem(entry)
             item.setIcon(0, icon)
+            item.setToolTip(0, str(conf) + " confirmation" + ("s" if conf != 1 else ""))
             if has_invoice:
                 item.setIcon(3, QIcon(":icons/seal"))
             for i in range(len(entry)):
@@ -99,6 +100,7 @@ class HistoryList(MyTreeWidget):
                     item.setTextAlignment(i, Qt.AlignRight)
                 if i!=2:
                     item.setFont(i, QFont(MONOSPACE_FONT))
+                    item.setTextAlignment(i, Qt.AlignVCenter)
             if value < 0:
                 item.setForeground(3, QBrush(QColor("#BC1E1E")))
                 item.setForeground(4, QBrush(QColor("#BC1E1E")))
@@ -107,6 +109,14 @@ class HistoryList(MyTreeWidget):
             self.insertTopLevelItem(0, item)
             if current_tx == tx_hash:
                 self.setCurrentItem(item)
+
+    def on_doubleclick(self, item, column):
+        if self.permit_edit(item, column):
+            super(HistoryList, self).on_doubleclick(item, column)
+        else:
+            tx_hash = str(item.data(0, Qt.UserRole).toString())
+            tx = self.wallet.transactions.get(tx_hash)
+            self.parent.show_transaction(tx)
 
     def update_labels(self):
         root = self.invisibleRootItem()


### PR DESCRIPTION
Fix to text alignment + small usability improvements:
  + fix: vertically align monospace columns
  + add: icon tooltip for quick check of confirmation count
  + add: double click row to access transaction details

The monospaced columns were not vertically aligned. Also added tooltip on the status icon, and quick access to details by double-clicking row (previously double clicking did nothing, except on edit column).

![Confirmation tooltip](http://i.imgur.com/L8N7ssi.png)
