### PR TITLE
Update paymentrequests.proto

### DIFF
--- a/lib/paymentrequest.proto
+++ b/lib/paymentrequest.proto
@@ -6,6 +6,7 @@
 // https://github.com/bitcoin/bips/bip-0070/extensions.mediawiki
 //
 
+syntax = "proto2";
 package payments;
 option java_package = "org.bitcoin.protocols.payments";
 option java_outer_classname = "Protos";


### PR DESCRIPTION
Was installing electrum on my Kali Linux and when running this command: 
protoc --proto_path=lib/ --python_out=lib/ lib/paymentrequest.proto 
i got the following error: 
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: paymentrequest.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)

Fixed it myself and wanted to share it for people that might have the same issue.