### PR TITLE
Preference item for ignoring dust - min_utxo_value, and highlight in coins list

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2444,6 +2444,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.config.set_key('rbf_policy', x)
         rbf_combo.currentIndexChanged.connect(on_rbf)
         fee_widgets.append((rbf_label, rbf_combo))
+        
+        min_utxo = self.config.get('min_utxo_value', 0)
+        min_utxo_label = HelpLabel(_('Ignore Outputs Below (sat)') + ':', '')
+        min_utxo_e = QLineEdit(str(min_utxo))
+        def on_min_utxo_edit():
+            self.config.set_key('min_utxo_value', str(min_utxo_e.text()), True)
+            self.utxo_list.update()
+        min_utxo_e.editingFinished.connect(on_min_utxo_edit)
+        fee_widgets.append((min_utxo_label, min_utxo_e))
 
         msg = _('OpenAlias record, used to receive coins and to sign payment requests.') + '\n\n'\
               + _('The following alias providers are available:') + '\n'\

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -39,6 +39,7 @@ class UTXOList(MyTreeWidget):
 
     def on_update(self):
         self.wallet = self.parent.wallet
+        min_utxo = int(self.parent.config.get('min_utxo_value', 0))
         item = self.currentItem()
         self.clear()
         self.utxos = self.wallet.get_utxos()
@@ -54,6 +55,8 @@ class UTXOList(MyTreeWidget):
             utxo_item.setData(0, Qt.UserRole, name)
             if self.wallet.is_frozen(address):
                 utxo_item.setBackgroundColor(0, QColor('lightblue'))
+            if min_utxo > 0 and x['value'] <= min_utxo:
+                utxo_item.setBackgroundColor(0, QColor('pink'))
             self.addChild(utxo_item)
 
     def create_menu(self, position):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -534,9 +534,10 @@ class Abstract_Wallet(PrintError):
 
     def get_spendable_coins(self, domain, config):
         confirmed_only = config.get('confirmed_only', False)
-        return self.get_utxos(domain, exclude_frozen=True, mature=True, confirmed_only=confirmed_only)
+        min_value = int(config.get('min_utxo_value', 0))
+        return self.get_utxos(domain, exclude_frozen=True, mature=True, confirmed_only=confirmed_only, min_value=min_value)
 
-    def get_utxos(self, domain = None, exclude_frozen = False, mature = False, confirmed_only = False):
+    def get_utxos(self, domain = None, exclude_frozen = False, mature = False, confirmed_only = False, min_value = 0):
         coins = []
         if domain is None:
             domain = self.get_addresses()
@@ -545,6 +546,8 @@ class Abstract_Wallet(PrintError):
         for addr in domain:
             utxos = self.get_addr_utxo(addr)
             for x in utxos:
+                if min_value > 0 and x['value'] <= min_value:
+                    continue
                 if confirmed_only and x['height'] <= 0:
                     continue
                 if mature and x['coinbase'] and x['height'] + COINBASE_MATURITY > self.get_local_height():


### PR DESCRIPTION
Added config option min_utxo_value - default 0. 

Sets a threshold value for ignoring dust inputs to prevent wasting fees. 

Also highlights in utxo_list when an utxo is below the threshold so it's easy to tell.

Default is 0 so it has no effect. Since even 1 sat/byte fee would give make an input cost 148 sat it may be sensible to make a higher default. Nowadays, even at a low fee of 50 sat/byte outputs below 7400 sat are costing more to spend than the output is worth.

Tested on testnet and appeared to work ok. 