### PR TITLE
fix Qt threading issue

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -82,6 +82,7 @@ class ElectrumGui:
         # GC-ed when windows are closed
         #network.add_jobs([DebugMem([Abstract_Wallet, SPV, Synchronizer,
         #                            ElectrumWindow], interval=5)])
+        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_X11InitThreads)
         self.config = config
         self.daemon = daemon
         self.plugins = plugins


### PR DESCRIPTION
Issue: #2209

Fixes this error when signing with a HW wallet:

``` 
$ ./electrum
[xcb] Unknown sequence number while processing queue
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
python3: xcb_io.c:259: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed.
Aborted (core dumped)
```
The cause is likely with the `show_message()` calls. The proper fix
would be to hunt down where QT Gui elements are touched from a wrong
thread.

The workaround is to call XInitThreads(), as the error message suggests.