### PR TITLE
python 3 changes in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Getting started
 Electrum is a pure python application. If you want to use the
 Qt interface, install the Qt dependencies::
 
-    sudo apt-get install python-qt4
+    sudo apt-get install python3-pyqt4
 
 If you downloaded the official package (tar.gz), you can run
 Electrum from its root directory, without installing it on your
@@ -34,7 +34,7 @@ directory. To run Electrum from its root directory, just do::
 
 You can also install Electrum on your system, by running this command::
 
-    python setup.py install
+    python3 setup.py install
 
 This will download and install the Python dependencies used by
 Electrum, instead of using the 'packages' directory.
@@ -55,12 +55,12 @@ Check out the code from Github::
 
 Run install (this should install dependencies)::
 
-    python setup.py install
+    python3 setup.py install
 
 Compile the icons file for Qt::
 
     sudo apt-get install pyqt4-dev-tools
-    pyrcc4 icons.qrc -o gui/qt/icons_rc.py
+    pyrcc4 icons.qrc -o gui/qt/icons_rc.py -py3
 
 Compile the protobuf description file::
 


### PR DESCRIPTION
Had problems getting Electrum to work after python3 migration.

Following commands in old README, notably ran into:

```
user@debian:~/wspace/electrum$ ./electrum 
Error: Could not import PyQt4 on Linux systems, you may try 'sudo apt-get install python3-pyqt4'

user@debian:~/wspace/electrum$ ./electrum 
qRegisterResourceData(int, str, str, str): argument 2 has unexpected type 'str'
Error: Could not find icons file.
Please run 'pyrcc4 icons.qrc -o gui/qt/icons_rc.py -py3', and reinstall Electrum
```