### PR TITLE
Fix download failed blockchain headers

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -982,10 +982,10 @@ class Network(util.DaemonThread):
         filename = b.path()
         def download_thread():
             try:
-                import urllib, socket
+                import urllib.request, socket
                 socket.setdefaulttimeout(30)
                 self.print_error("downloading ", bitcoin.HEADERS_URL)
-                urllib.urlretrieve(bitcoin.HEADERS_URL, filename + '.tmp')
+                urllib.request.urlretrieve(bitcoin.HEADERS_URL, filename + '.tmp')
                 os.rename(filename + '.tmp', filename)
                 self.print_error("done.")
             except Exception:


### PR DESCRIPTION
[Network] downloading  https://headers.electrum.org/blockchain_headers
[Network] download failed. creating file /home/wakiyamap/.electrum/blockchain_headers

I fix it.