### PR TITLE
fix unresolved variable

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -667,7 +667,7 @@ class Transaction:
             pkh = bh2u(bitcoin.hash_160(bfh(pubkey)))
             return '76a9' + push_script(pkh) + '88ac'
         else:
-            raise TypeError('Unknown txin type', _type)
+            raise TypeError('Unknown txin type', txin['type'])
 
     @classmethod
     def serialize_outpoint(self, txin):


### PR DESCRIPTION
Wasn't sure if it was better to keep the change minimal or to be consistent.

i.e. input_script() method has
```
_type = txin['type']
```
so feel free to do that instead