### PR TITLE
fix testnet

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -80,7 +80,7 @@ def set_testnet():
     global TESTNET, HEADERS_URL
     global GENESIS
     global SEGWIT_HRP
-    global DEFAULT_PORTS, SERVERLIST
+    global DEFAULT_PORTS, SERVERLIST, DEFAULT_SERVERS
     TESTNET = True
     ADDRTYPE_P2PKH = 111
     ADDRTYPE_P2SH = 196

--- a/lib/network.py
+++ b/lib/network.py
@@ -65,7 +65,7 @@ def parse_servers(result):
             for v in item[2]:
                 if re.match("[st]\d*", v):
                     protocol, port = v[0], v[1:]
-                    if port == '': port = DEFAULT_PORTS[protocol]
+                    if port == '': port = bitcoin.DEFAULT_PORTS[protocol]
                     out[protocol] = port
                 elif re.match("v(.?)+", v):
                     version = v[1:]
@@ -99,7 +99,7 @@ def filter_protocol(hostmap, protocol = 's'):
 
 def pick_random_server(hostmap = None, protocol = 's', exclude_set = set()):
     if hostmap is None:
-        hostmap = DEFAULT_SERVERS
+        hostmap = bitcoin.DEFAULT_SERVERS
     eligible = list(set(filter_protocol(hostmap, protocol)) - exclude_set)
     return random.choice(eligible) if eligible else None
 
@@ -354,7 +354,7 @@ class Network(util.DaemonThread):
         return list(self.interfaces.keys())
 
     def get_servers(self):
-        out = DEFAULT_SERVERS
+        out = bitcoin.DEFAULT_SERVERS
         if self.irc_servers:
             out.update(filter_version(self.irc_servers.copy()))
         else:
@@ -462,8 +462,7 @@ class Network(util.DaemonThread):
         '''Switch to a random connected server other than the current one'''
         servers = self.get_interfaces()    # Those in connected state
         if self.default_server in servers:
-            servers.remov
-            e(self.default_server)
+            servers.remove(self.default_server)
         if servers:
             self.switch_to_interface(random.choice(servers))
 

--- a/lib/servers_testnet.json
+++ b/lib/servers_testnet.json
@@ -1,8 +1,8 @@
 {
-        'testnetnode.arihanc.com': {'t':'51001', 's':'51002'},
-        'testnet1.bauerj.eu': {'t':'51001', 's':'51002'},
-        '14.3.140.101': {'t':'51001', 's':'51002'},
-        'testnet.hsmiths.com': {'t':'53011', 's':'53012'},
-        'electrum.akinbo.org': {'t':'51001', 's':'51002'},
-        'ELEX05.blackpole.online': {'t':'52011', 's':'52002'},
+        "testnetnode.arihanc.com": {"t":"51001", "s":"51002"},
+        "testnet1.bauerj.eu": {"t":"51001", "s":"51002"},
+        "14.3.140.101": {"t":"51001", "s":"51002"},
+        "testnet.hsmiths.com": {"t":"53011", "s":"53012"},
+        "electrum.akinbo.org": {"t":"51001", "s":"51002"},
+        "ELEX05.blackpole.online": {"t":"52011", "s":"52002"}
 }


### PR DESCRIPTION
This is a minimal but dirty fix. (as a follow-up of 8c5b6bdaf3077d5855b69c71830296917d132931)

Due to how imports work in Python, if `bitcoin.TESTNET == True`, in `network.py`,
```
bitcoin.DEFAULT_SERVERS != DEFAULT_SERVERS
bitcoin.DEFAULT_PORTS != DEFAULT_PORTS
```

Hence, the way Testnet functionality is implemented could use some restructuring.