### PR TITLE
fix: p2pk output serialisation

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -357,6 +357,10 @@ def address_to_scripthash(addr):
     h = sha256(bytes.fromhex(script))[0:32]
     return bytes(reversed(h)).hex()
 
+def public_key_to_p2pk_script(pubkey):
+    script = push_script(pubkey)
+    script += 'ac'                                           # op_checksig
+    return script
 
 __b58chars = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 assert len(__b58chars) == 58

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -623,10 +623,9 @@ class Transaction:
         elif output_type == TYPE_ADDRESS:
             return bitcoin.address_to_script(addr)
         elif output_type == TYPE_PUBKEY:
-            return addr
+            return bitcoin.public_key_to_p2pk_script(addr)
         else:
             raise TypeError('Unknown output type')
-        return script
 
     @classmethod
     def get_siglist(self, txin, estimate_size=False):
@@ -713,6 +712,9 @@ class Transaction:
             pubkey = txin['pubkeys'][0]
             pkh = bh2u(bitcoin.hash_160(bfh(pubkey)))
             return '76a9' + push_script(pkh) + '88ac'
+        elif txin['type'] == 'p2pk':
+            pubkey = txin['pubkeys'][0]
+            return bitcoin.public_key_to_p2pk_script(pubkey)
         else:
             raise TypeError('Unknown txin type', txin['type'])
 


### PR DESCRIPTION
While #2859 fixed the crash, it seems it wasn't logically correct.
Pay-to-pubkey outputs were incorrectly serialised, which e.g. resulted in incorrect TXIDs.