### PR TITLE
Edit install wizard msg to reflect linguistic trends

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -489,7 +489,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
     def init_network(self, network):
         message = _("Electrum communicates with remote servers to get "
                   "information about your transactions and addresses. The "
-                  "servers all fulfil the same purpose only differing in "
+                  "servers all fulfill the same purpose only differing in "
                   "hardware. In most cases you simply want to let Electrum "
                   "pick one at random.  However if you prefer feel free to "
                   "select a server manually.")


### PR DESCRIPTION
In the install wizard message, the prompt uses the word "fulfil". While this is an acceptable spelling of the word, Google ngrams indicates that it is twice as common to spell the word with two l's at the end, aka "fulfill", in modern writing. This PR proposes to use the more common spelling.

https://books.google.com/ngrams/graph?content=fulfill%2C+fulfil&year_start=1800&year_end=2000&corpus=15&smoothing=3&share=&direct_url=t1%3B%2Cfulfill%3B%2Cc0%3B.t1%3B%2Cfulfil%3B%2Cc0