### PR TITLE
Fix parsing of witnesses

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -116,19 +116,6 @@ class BCDataStream(object):
     def write_int64(self, val): return self._write_num('<q', val)
     def write_uint64(self, val): return self._write_num('<Q', val)
 
-    def read_push_size(self):
-        size = self.input[self.read_cursor]
-        self.read_cursor += 1
-        if size < 0x4c:
-            return size
-        if size == 0x4c:
-            nsize = self.read_bytes(1)[0]
-        elif size == 0x4d:
-            nsize = self._read_num('<H')
-        elif size == 0x4e:
-            nsize = self._read_num('<I')
-        return nsize
-
     def read_compact_size(self):
         size = self.input[self.read_cursor]
         self.read_cursor += 1
@@ -445,7 +432,7 @@ def parse_input(vds):
 
 def parse_witness(vds, txin):
     n = vds.read_compact_size()
-    w = list(bh2u(vds.read_bytes(vds.read_push_size())) for i in range(n))
+    w = list(bh2u(vds.read_bytes(vds.read_compact_size())) for i in range(n))
     if n > 2:
         txin['num_sig'] = n - 2
         txin['signatures'] = parse_sig(w[1:-1])


### PR DESCRIPTION
The lengths in the witness structure are `var_int` not pushes.

From BIP-141:
The `witness` is a serialization of all witness data of the transaction.
Each txin is associated with a witness field. A witness field starts
with a `var_int` to indicate the number of stack items for the txin. It is
followed by stack items, with each item starts with a `var_int` to
indicate the length. Witness data is NOT script.

This bug was triggered by tx
d379210d85c1346dafbfd60e3cbc5c5573e50b1f9576d39f177afb2b378f1b98