### PR TITLE
paytoedit: fix insertCompletion() string handling

### DIFF
--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -209,10 +209,10 @@ class PayToEdit(ScanQRTextEdit):
         if self.c.widget() != self:
             return
         tc = self.textCursor()
-        extra = completion.length() - self.c.completionPrefix().length()
+        extra = len(completion) - len(self.c.completionPrefix())
         tc.movePosition(QTextCursor.Left)
         tc.movePosition(QTextCursor.EndOfWord)
-        tc.insertText(completion.right(extra))
+        tc.insertText(completion[-extra:])
         self.setTextCursor(tc)
 
 


### PR DESCRIPTION
The existing code was failing with the following exception, each time I tried to use auto-complete at the "Pay to" text box:

```
Traceback (most recent call last):
  File "/media/roman/data/roman/Code/Bitcoin/electrum/gui/qt/paytoedit.py", line 212, in insertCompletion
    extra = completion.length() - self.c.completionPrefix().length()
AttributeError: 'str' object has no attribute 'length'
```