### PR TITLE
Added scroll pane in install wizard confirmation dialog.

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -423,8 +423,12 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         self.confirm(message, title)
 
     def confirm(self, message, title):
+        area = QScrollArea()
+        label = WWLabel(message)
+        area.setWidget(label)
+
         vbox = QVBoxLayout()
-        vbox.addWidget(WWLabel(message))
+        vbox.addWidget(area)
         self.exec_layout(vbox, title)
 
     @wizard_dialog


### PR DESCRIPTION
Prevent cropping of text that occurs when you have just a label.

In response to issue 2888. The issue was that, in some cases, text would be cropped out of the window. This really simply fix prevents that from happening by embedding the offending label a scrollpane, allowing users to scroll to see the full content.