### PR TITLE
send server.version before subscriptions

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -317,6 +317,9 @@ class Network(util.DaemonThread):
         for i in bitcoin.FEE_TARGETS:
             self.queue_request('blockchain.estimatefee', [i])
         self.queue_request('blockchain.relayfee', [])
+        if self.interface.ping_required():
+            params = [ELECTRUM_VERSION, PROTOCOL_VERSION]
+            self.queue_request('server.version', params, self.interface)
         for h in self.subscribed_addresses:
             self.queue_request('blockchain.scripthash.subscribe', [h])
 


### PR DESCRIPTION
See #2899 

I send `server.version` after `blockchain.relayfee` to replicate the order of messages on a new connection.