### PR TITLE
replace deprecated assertEquals

### DIFF
--- a/lib/tests/test_mnemonic.py
+++ b/lib/tests/test_mnemonic.py
@@ -15,7 +15,7 @@ class Test_NewMnemonic(unittest.TestCase):
 
     def test_to_seed(self):
         seed = mnemonic.Mnemonic.mnemonic_to_seed(mnemonic='foobar', passphrase='none')
-        self.assertEquals(bh2u(seed),
+        self.assertEqual(bh2u(seed),
                           '741b72fd15effece6bfe5a26a52184f66811bd2be363190e07a42cca442b1a5b'
                           'b22b3ad0eb338197287e6d314866c7fba863ac65d3f156087a5052ebc7157fce')
 
@@ -25,7 +25,7 @@ class Test_NewMnemonic(unittest.TestCase):
         for _ in range(iters):
             seed = m.make_seed()
             i = m.mnemonic_decode(seed)
-            self.assertEquals(m.mnemonic_encode(i), seed)
+            self.assertEqual(m.mnemonic_encode(i), seed)
 
 
 class Test_OldMnemonic(unittest.TestCase):
@@ -34,8 +34,8 @@ class Test_OldMnemonic(unittest.TestCase):
         seed = '8edad31a95e7d59f8837667510d75a4d'
         result = old_mnemonic.mn_encode(seed)
         words = 'hardly point goal hallway patience key stone difference ready caught listen fact'
-        self.assertEquals(result, words.split())
-        self.assertEquals(old_mnemonic.mn_decode(result), seed)
+        self.assertEqual(result, words.split())
+        self.assertEqual(old_mnemonic.mn_decode(result), seed)
 
 class Test_BIP39Checksum(unittest.TestCase):
 

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -30,10 +30,10 @@ class TestBCDataStream(unittest.TestCase):
         with self.assertRaises(transaction.SerializationError):
             s.write_compact_size(-1)
 
-        self.assertEquals(bh2u(s.input),
+        self.assertEqual(bh2u(s.input),
                           '0001fcfdfd00fdfffffe00000100feffffffffff0000000001000000ffffffffffffffffff')
         for v in values:
-            self.assertEquals(s.read_compact_size(), v)
+            self.assertEqual(s.read_compact_size(), v)
 
         with self.assertRaises(IndexError):
             s.read_compact_size()
@@ -47,7 +47,7 @@ class TestBCDataStream(unittest.TestCase):
         for msg in msgs:
             s.write_string(msg)
         for msg in msgs:
-            self.assertEquals(s.read_string(), msg)
+            self.assertEqual(s.read_string(), msg)
 
         with self.assertRaises(transaction.SerializationError):
             s.read_string()
@@ -55,10 +55,10 @@ class TestBCDataStream(unittest.TestCase):
     def test_bytes(self):
         s = transaction.BCDataStream()
         s.write(b'foobar')
-        self.assertEquals(s.read_bytes(3), b'foo')
-        self.assertEquals(s.read_bytes(2), b'ba')
-        self.assertEquals(s.read_bytes(4), b'r')
-        self.assertEquals(s.read_bytes(1), b'')
+        self.assertEqual(s.read_bytes(3), b'foo')
+        self.assertEqual(s.read_bytes(2), b'ba')
+        self.assertEqual(s.read_bytes(4), b'r')
+        self.assertEqual(s.read_bytes(1), b'')
 
 class TestTransaction(unittest.TestCase):
 
@@ -85,26 +85,26 @@ class TestTransaction(unittest.TestCase):
                 'version': 1
         }
         tx = transaction.Transaction(unsigned_blob)
-        self.assertEquals(tx.deserialize(), expected)
-        self.assertEquals(tx.deserialize(), None)
+        self.assertEqual(tx.deserialize(), expected)
+        self.assertEqual(tx.deserialize(), None)
 
-        self.assertEquals(tx.as_dict(), {'hex': unsigned_blob, 'complete': False, 'final': True})
-        self.assertEquals(tx.get_outputs(), [('14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs', 1000000)])
-        self.assertEquals(tx.get_output_addresses(), ['14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs'])
+        self.assertEqual(tx.as_dict(), {'hex': unsigned_blob, 'complete': False, 'final': True})
+        self.assertEqual(tx.get_outputs(), [('14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs', 1000000)])
+        self.assertEqual(tx.get_output_addresses(), ['14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs'])
 
         self.assertTrue(tx.has_address('14CHYaaByjJZpx4oHBpfDMdqhTyXnZ3kVs'))
         self.assertTrue(tx.has_address('1446oU3z268EeFgfcwJv6X2VBXHfoYxfuD'))
         self.assertFalse(tx.has_address('1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH'))
 
-        self.assertEquals(tx.serialize(), unsigned_blob)
+        self.assertEqual(tx.serialize(), unsigned_blob)
 
         tx.update_signatures(signed_blob)
-        self.assertEquals(tx.raw, signed_blob)
+        self.assertEqual(tx.raw, signed_blob)
 
         tx.update(unsigned_blob)
         tx.raw = None
         blob = str(tx)
-        self.assertEquals(transaction.deserialize(blob), expected)
+        self.assertEqual(transaction.deserialize(blob), expected)
 
     def test_tx_signed(self):
         expected = {
@@ -129,11 +129,11 @@ class TestTransaction(unittest.TestCase):
             'version': 1
         }
         tx = transaction.Transaction(signed_blob)
-        self.assertEquals(tx.deserialize(), expected)
-        self.assertEquals(tx.deserialize(), None)
-        self.assertEquals(tx.as_dict(), {'hex': signed_blob, 'complete': True, 'final': True})
+        self.assertEqual(tx.deserialize(), expected)
+        self.assertEqual(tx.deserialize(), None)
+        self.assertEqual(tx.as_dict(), {'hex': signed_blob, 'complete': True, 'final': True})
 
-        self.assertEquals(tx.serialize(), signed_blob)
+        self.assertEqual(tx.serialize(), signed_blob)
 
         tx.update_signatures(signed_blob)
 
@@ -146,14 +146,14 @@ class TestTransaction(unittest.TestCase):
 
     def test_parse_xpub(self):
         res = xpubkey_to_address('fe4e13b0f311a55b8a5db9a32e959da9f011b131019d4cebe6141b9e2c93edcbfc0954c358b062a9f94111548e50bde5847a3096b8b7872dcffadb0e9579b9017b01000200')
-        self.assertEquals(res, ('04ee98d63800824486a1cf5b4376f2f574d86e0a3009a6448105703453f3368e8e1d8d090aaecdd626a45cc49876709a3bbb6dc96a4311b3cac03e225df5f63dfc', '19h943e4diLc68GXW7G75QNe2KWuMu7BaJ'))
+        self.assertEqual(res, ('04ee98d63800824486a1cf5b4376f2f574d86e0a3009a6448105703453f3368e8e1d8d090aaecdd626a45cc49876709a3bbb6dc96a4311b3cac03e225df5f63dfc', '19h943e4diLc68GXW7G75QNe2KWuMu7BaJ'))
 
         res = xpubkey_to_address('fd007d260305ef27224bbcf6cf5238d2b3638b5a78d5')
-        self.assertEquals(res, ('fd007d260305ef27224bbcf6cf5238d2b3638b5a78d5', '1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH'))
+        self.assertEqual(res, ('fd007d260305ef27224bbcf6cf5238d2b3638b5a78d5', '1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH'))
 
     def test_version_field(self):
         tx = transaction.Transaction(v2_blob)
-        self.assertEquals(tx.txid(), "b97f9180173ab141b61b9f944d841e60feec691d6daab4d4d932b24dd36606fe")
+        self.assertEqual(tx.txid(), "b97f9180173ab141b61b9f944d841e60feec691d6daab4d4d932b24dd36606fe")
 
 
 class NetworkMock(object):


### PR DESCRIPTION
`assertEquals` is deprecated in favor of `assertEqual`

https://bugs.python.org/issue9424

This change removes warnings such as
```
/home/user/wspace/electrum/lib/tests/test_mnemonic.py:28: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(m.mnemonic_encode(i), seed)
```