### PR TITLE
Update Windows build to Python 3.5 and PyQt5

### DIFF
--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -4,6 +4,7 @@
 ELECTRUM_GIT_URL=git://github.com/spesmilo/electrum.git
 BRANCH=master
 NAME_ROOT=electrum
+PYTHON_VERSION=3.5.4
 
 if [ "$#" -gt 0 ]; then
     BRANCH="$1"
@@ -14,7 +15,7 @@ export WINEPREFIX=/opt/wine64
 export PYTHONHASHSEED=22
 
 
-PYHOME=c:/python34
+PYHOME=c:/python$PYTHON_VERSION
 PYTHON="wine $PYHOME/python.exe -OO -B"
 
 
@@ -51,7 +52,7 @@ cp electrum-git/LICENCE .
 cp -r ../../../lib/locale $WINEPREFIX/drive_c/electrum/lib/
 
 # Build Qt resources
-wine $WINEPREFIX/drive_c/Python34/Lib/site-packages/PyQt4/pyrcc4.exe C:/electrum/icons.qrc -o C:/electrum/gui/qt/icons_rc.py -py3
+wine $WINEPREFIX/drive_c/python$PYTHON_VERSION/Scripts/pyrcc5.exe C:/electrum/icons.qrc -o C:/electrum/gui/qt/icons_rc.py
 
 
 pushd $WINEPREFIX/drive_c/electrum
@@ -63,7 +64,7 @@ cd ..
 rm -rf dist/
 
 # build standalone version
-wine "C:/python34/scripts/pyinstaller.exe" --noconfirm --ascii --name $NAME_ROOT-$VERSION.exe -w deterministic.spec 
+wine "C:/python$PYTHON_VERSION/scripts/pyinstaller.exe" --noconfirm --ascii --name $NAME_ROOT-$VERSION.exe -w deterministic.spec 
 
 # build NSIS installer
 # $VERSION could be passed to the electrum.nsi script, but this would require some rewriting in the script iself.
@@ -78,6 +79,6 @@ cp portable.patch $WINEPREFIX/drive_c/electrum
 pushd $WINEPREFIX/drive_c/electrum
 patch < portable.patch 
 popd
-wine "C:/python34/scripts/pyinstaller.exe" --noconfirm --ascii --name $NAME_ROOT-$VERSION-portable.exe -w deterministic.spec
+wine "C:/python$PYTHON_VERSION/scripts/pyinstaller.exe" --noconfirm --ascii --name $NAME_ROOT-$VERSION-portable.exe -w deterministic.spec
 
 echo "Done."

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
 
-# Please update these links carefully, some versions won't work under Wine
-PYTHON_URL=https://www.python.org/ftp/python/3.4.4/python-3.4.4.amd64.msi
-PYWIN32_URL=https://sourceforge.net/projects/pywin32/files/pywin32/Build%20221/pywin32-221.win-amd64-py3.4.exe
-PYQT4_URL=https://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.4/PyQt4-4.11.4-gpl-Py3.4-Qt4.8.7-x64.exe
-NSIS_URL=http://prdownloads.sourceforge.net/nsis/nsis-2.46-setup.exe?download
-
+# Please update these carefully, some versions won't work under Wine
+NSIS_URL=http://prdownloads.sourceforge.net/nsis/nsis-3.02.1-setup.exe?download
+PYTHON_VERSION=3.5.4
 
 ## These settings probably don't need change
 export WINEPREFIX=/opt/wine64
 #export WINEARCH='win32'
 
-PYHOME=c:/python34
+PYHOME=c:/python$PYTHON_VERSION
 PYTHON="wine $PYHOME/python.exe -OO -B"
 
 # Let's begin!
@@ -33,19 +30,20 @@ echo "done"
 cd tmp
 
 # Install Python
-wget -O python.msi "$PYTHON_URL"
-wine msiexec /q /i python.msi
-
-# Install PyWin32
-wget -O pywin32.exe "$PYWIN32_URL"
-wine pywin32.exe
-
-# Install PyQt4
-wget -O PyQt.exe "$PYQT4_URL"
-wine PyQt.exe
+for msifile in core dev exe lib pip tools; do
+    echo "Installing $msifile..."
+    wget "https://www.python.org/ftp/python/$PYTHON_VERSION/win32/${msifile}.msi"
+    wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/python$PYTHON_VERSION
+done
 
 # upgrade pip
 $PYTHON -m pip install pip --upgrade
+
+# Install PyWin32
+$PYTHON -m pip install pypiwin32
+
+# Install PyQt
+$PYTHON -m pip install PyQt5
 
 # Install pyinstaller
 $PYTHON -m pip install pyinstaller==3.2.1
@@ -82,5 +80,6 @@ wine nsis.exe
 #cp upx*/upx.exe .
 
 # add dlls needed for pyinstaller:
-cp $WINEPREFIX/drive_c/windows/system32/msvcp90.dll $WINEPREFIX/drive_c/Python34/
-cp $WINEPREFIX/drive_c/windows/system32/msvcm90.dll $WINEPREFIX/drive_c/Python34/
+cp $WINEPREFIX/drive_c/windows/system32/msvcp90.dll $WINEPREFIX/drive_c/python$PYTHON_VERSION/
+cp $WINEPREFIX/drive_c/windows/system32/msvcm90.dll $WINEPREFIX/drive_c/python$PYTHON_VERSION/
+cp $WINEPREFIX/drive_c/python$PYTHON_VERSION/Lib/site-packages/PyQt5/Qt/bin/* $WINEPREFIX/drive_c/python$PYTHON_VERSION/


### PR DESCRIPTION
- PyQt5 needs `sip`, which is not available for Python 3.4
- Python3.5 doesn't provide a single msi installer
- I changed `pywin32` to install from pypi so there are less buttons to click
- While I was at it, I updated NSIS too