### PR TITLE
log: identify exception source in log for daemon/get_server

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -87,8 +87,7 @@ def get_server(config):
             server.ping()
             return server
         except Exception as e:
-            print_error(e)
-            pass
+            print_error("[get_server]", e)
         if not create_time or create_time < time.time() - 1.0:
             return None
         # Sleep a bit and try again; it might have just been started


### PR DESCRIPTION
When I start Electrum, a typical log looks like:
```
user@debian:~/wspace/electrum$ ./electrum -v
[SimpleConfig] electrum directory /home/user/.electrum
[Errno 111] Connection refused
[Plugins] registering hardware digitalbitbox: ('hardware', 'digitalbitbox', 'Digital Bitbox wallet')
[Plugins] registering hardware keepkey: ('hardware', 'keepkey', 'KeepKey wallet')
[Plugins] registering hardware ledger: ('hardware', 'ledger', 'Ledger wallet')
[Plugins] registering hardware trezor: ('hardware', 'trezor', 'TREZOR wallet')
[Plugins] registering wallet type ('2fa', 'trustedcoin')
[profiler] __init__ 0.0034
[Network] blockchains dict_keys([0])
[Network] starting network
```
The `[Errno 111] Connection refused` line is quite mysterious; this change identifies its source a bit better.