### PR TITLE
fix qt plugins crash

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2817,7 +2817,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             except Exception:
                 self.print_msg("error: cannot display plugin", name)
                 traceback.print_exc(file=sys.stdout)
-        grid.setRowStretch(i+1,1)
+        grid.setRowStretch(len(plugins.descriptions.values()), 1)
         vbox.addLayout(Buttons(CloseButton(d)))
         d.exec_()
 


### PR DESCRIPTION
In the QT GUI, going into `Tools/Plugins` crashed the app for me with
```
Traceback (most recent call last):
  File "site-packages\electrum-3.0-py3.5.egg\electrum_gui\qt\main_window.py", line 2830, in plugins_dialog
UnboundLocalError: local variable 'i' referenced before assignment
```

The trace is when running the windows binary for https://github.com/spesmilo/electrum/pull/2911/commits/ffdafc57b735abf76f53e3f28d665aeffb29501b from @bauerj given in https://github.com/spesmilo/electrum/pull/2916#issuecomment-331650946

The crash does not happen on master (worth looking into?), but the change I think is still warranted.