### PR TITLE
finish BTCe to WEX renaming

### DIFF
--- a/lib/currencies.json
+++ b/lib/currencies.json
@@ -2,11 +2,6 @@
     "BTCChina": [
         "CNY"
     ], 
-    "BTCe": [
-        "EUR", 
-        "RUB", 
-        "USD"
-    ], 
     "BitPay": [
         "AED", 
         "AFN", 
@@ -631,5 +626,10 @@
     "Winkdex": [
         "USD"
     ], 
+    "WEX": [
+        "EUR",
+        "RUB",
+        "USD"
+    ],
     "itBit": []
 }


### PR DESCRIPTION
#2881 was incomplete.

```
[FxThread] using exchange BTCe
[profiler] on_update 0.0072
[BitcoinAverage] getting fx quotes for EUR
[BitcoinAverage] received fx quotes
Traceback (most recent call last):
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 2674, in on_history
    update_exchanges()
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 2648, in update_exchanges
    exchanges = self.fx.get_exchanges_by_ccy(c, h)
  File "/home/user/wspace/electrum/lib/exchange_rate.py", line 392, in get_exchanges_by_ccy
    d = get_exchanges_by_ccy(h)
  File "/home/user/wspace/electrum/lib/exchange_rate.py", line 370, in get_exchanges_by_ccy
    klass = globals()[name]
KeyError: 'BTCe'
```