### PR TITLE
python3: exchange_rate.py

### DIFF
--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -90,7 +90,7 @@ class ExchangeBase(PrintError):
 
     def get_currencies(self):
         rates = self.get_rates('')
-        return sorted([str(a) for (a, b) in rates.iteritems() if b is not None and len(a)==3])
+        return sorted([str(a) for (a, b) in rates.items() if b is not None and len(a)==3])
 
 
 class BitcoinAverage(ExchangeBase):


### PR DESCRIPTION
In Python3, `dict.iteritems()` has been removed. See https://wiki.python.org/moin/Python3.0