### PR TITLE
initial fix for #2897

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -267,7 +267,18 @@ class Xpub:
         assert len(s) == 2
         return xkey, s
 
+    def get_pubkey_derivation_from_addr(self, x_pubkey):
+        _, needle = xpubkey_to_address(x_pubkey)
+        for c in range(0, 2):
+            for i in range(0, 20):
+                _, candidate = xpubkey_to_address(self.derive_pubkey(c, i))
+                if needle == candidate:
+                    return [c, i]
+        return
+
     def get_pubkey_derivation(self, x_pubkey):
+        if x_pubkey[0:2] == 'fd':
+            return self.get_pubkey_derivation_from_addr(x_pubkey)
         if x_pubkey[0:2] != 'ff':
             return
         xpub, derivation = self.parse_xpubkey(x_pubkey)


### PR DESCRIPTION
This is my initial proposal for fixing #2897, which was closed prematurely IMO (please reopen until this is merged).

This allows offline-signing a transaction that was prepared using a watch-only address-based online wallet.

Generating the 40 addresses is a bit slow and this could surely be improved, but I'm not sure where the generated keys are stored -- and particularly how to access them from the Keystore. I'll be happy to fix this if you point me at the right direction.

I have successfully signed a testnet transaction using this patch (from 0th Receiving address), but this probably needs more testing than that. I'll be happy to have a look at how tests work too, if that's what you want.