### PR TITLE
fix: py3 network_dialog - dict.keys()

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -391,7 +391,7 @@ class NetworkChoiceLayout(object):
         host = self.server_host.text()
         pp = self.servers.get(host, DEFAULT_PORTS)
         if p not in pp.keys():
-            p = pp.keys()[0]
+            p = list(pp.keys())[0]
         port = pp[p]
         self.server_host.setText(host)
         self.server_port.setText(port)
@@ -426,7 +426,7 @@ class NetworkChoiceLayout(object):
                 protocol = 's'
                 port = pp.get(protocol)
             else:
-                protocol = pp.keys()[0]
+                protocol = list(pp.keys())[0]
                 port = pp.get(protocol)
         self.server_host.setText(host)
         self.server_port.setText(port)


### PR DESCRIPTION
I was playing around in the network dialog and the client crashed with
```
Traceback (most recent call last):
  File "/home/user/wspace/electrum/gui/qt/network_dialog.py", line 394, in change_protocol
    p = pp.keys()[0]
TypeError: 'dict_keys' object does not support indexing
Aborted
```
dict.keys() return type was changed between python 2 to python 3
See https://stackoverflow.com/questions/16819222/how-to-return-dictionary-keys-as-a-list-in-python