### PR TITLE
fix: editing labels in [QT GUI] Addresses tab for headings

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -158,3 +158,6 @@ class AddressList(MyTreeWidget):
         run_hook('receive_menu', menu, addrs, self.wallet)
         menu.exec_(self.viewport().mapToGlobal(position))
 
+    def on_permit_edit(self, item, column):
+        # labels for headings, e.g. "receiving" or "used" should not be editable
+        return item.childCount() == 0

--- a/plugins/labels/labels.py
+++ b/plugins/labels/labels.py
@@ -47,6 +47,8 @@ class LabelsPlugin(BasePlugin):
     def set_label(self, wallet, item, label):
         if not wallet in self.wallets:
             return
+        if not item:
+            return
         nonce = self.get_nonce(wallet)
         wallet_id = self.wallets[wallet][2]
         bundle = {"walletId": wallet_id,


### PR DESCRIPTION
This addresses #2974 and #2975.