### PR TITLE
follow-up of wallet.get_private_key() -> wallet.export_private_key()

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2134,7 +2134,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 time.sleep(0.1)
                 if done:
                     break
-                private_keys[addr] = "\n".join(self.wallet.get_private_key(addr, password))
+                privkey = self.wallet.export_private_key(addr, password)[0]
+                private_keys[addr] = privkey
                 self.computing_privkeys_signal.emit()
             self.show_privkeys_signal.emit()
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -275,9 +275,9 @@ class Commands:
     def getprivatekeys(self, address, password=None):
         """Get private keys of addresses. You may pass a single wallet address, or a list of wallet addresses."""
         if is_address(address):
-            return self.wallet.get_private_key(address, password)
+            return self.wallet.export_private_key(address, password)[0]
         domain = address
-        return [self.wallet.get_private_key(address, password) for address in domain]
+        return [self.wallet.export_private_key(address, password)[0] for address in domain]
 
     @command('w')
     def ismine(self, address):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1256,7 +1256,7 @@ class Abstract_Wallet(PrintError):
 
     def sign_payment_request(self, key, alias, alias_addr, password):
         req = self.receive_requests.get(key)
-        alias_privkey = self.get_private_key(alias_addr, password)[0]
+        alias_privkey = self.export_private_key(alias_addr, password)[0]
         pr = paymentrequest.make_unsigned_request(req)
         paymentrequest.sign_request_with_alias(pr, alias, alias_privkey)
         req['name'] = pr.pki_data


### PR DESCRIPTION
follow-up of e8b564c0e728e1ca15d39f48a0153c984e2acc3c

Perhaps the csv/json exports should include (or could later include) the redeem_scripts as well.