### PR TITLE
make sweep txs always RBF

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -911,6 +911,7 @@ class Abstract_Wallet(PrintError):
 
         outputs = [(TYPE_ADDRESS, recipient, total - fee)]
         tx = Transaction.from_io(inputs, outputs)
+        tx.set_rbf(True)
         tx.sign(keypairs)
         return tx
 


### PR DESCRIPTION
As the fee for sweep transactions are not set by the user (in the current code at least), it would be nice for the transactions to be replace-by-fee.