### PR TITLE
fix: Imported_Wallet cannot spend from p2wpkh or p2wpkh-p2sh

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1472,7 +1472,7 @@ class Imported_Wallet(Abstract_Wallet):
             txin['x_pubkeys'] = [x_pubkey]
             txin['signatures'] = [None]
             return
-        if txin['type'] in ['p2pkh', 'p2wkh', 'p2wkh-p2sh']:
+        if txin['type'] in ['p2pkh', 'p2wpkh', 'p2wpkh-p2sh']:
             pubkey = self.addresses[address]['pubkey']
             txin['num_sig'] = 1
             txin['x_pubkeys'] = [pubkey]


### PR DESCRIPTION
typos...

Maybe we should consider refactoring so that txin types are referred to by variables -- so that this would have resulted in static errors (not runtime). Similar error happened before in #2938 