### PR TITLE
fix: storage.convert_version_14() is missing redeem_scripts

### DIFF
--- a/lib/storage.py
+++ b/lib/storage.py
@@ -352,7 +352,11 @@ class WalletStorage(PrintError):
                 for pubkey in pubkeys:
                     addr = bitcoin.pubkey_to_address('p2pkh', pubkey)
                     assert addr in addresses
-                    d[addr] = { 'pubkey':pubkey, 'type':'p2pkh'}
+                    d[addr] = {
+                        'pubkey': pubkey,
+                        'redeem_script': None,
+                        'type': 'p2pkh'
+                    }
                 self.put('addresses', d)
                 self.put('pubkeys', None)
                 self.put('wallet_type', 'imported')


### PR DESCRIPTION
Seems #3004 missed this.

```
Traceback (most recent call last):
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 1871, in show_private_key
    pk, redeem_script = self.wallet.export_private_key(address, password)
  File "/home/user/wspace/electrum/lib/wallet.py", line 1461, in export_private_key
    redeem_script = d['redeem_script']
KeyError: 'redeem_script'
```

Note that wallets closely following master that had already upgraded to v14 will remain in a "broken" state.