### PR TITLE
storage: upgrade format version in storage.load_data()

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -243,7 +243,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                     return
 
         path = self.storage.path
-        if self.storage.requires_split():
+        if self.storage.requires_split():  # FIXME always False due to auto-upgrades
             self.hide()
             msg = _("The wallet '%s' contains multiple accounts, which are no longer supported in Electrum 2.7.\n\n"
                     "Do you want to split your wallet into multiple files?"%path)
@@ -256,7 +256,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                 self.show_warning(_('The file was removed'))
             return
 
-        if self.storage.requires_upgrade():
+        if self.storage.requires_upgrade():  # FIXME always False due to auto-upgrades
             self.hide()
             msg = _("The format of your wallet '%s' must be upgraded for Electrum. This change will not be backward compatible"%path)
             if not self.question(msg):

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -217,11 +217,6 @@ class Daemon(DaemonThread):
             if not password:
                 return
             storage.decrypt(password)
-        if storage.requires_split():
-            return
-        if storage.requires_upgrade():
-            self.print_error('upgrading wallet format')
-            storage.upgrade()
         if storage.get_action():
             return
         wallet = Wallet(storage)

--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -45,9 +45,9 @@ class WalletTestCase(unittest.TestCase):
 
 class TestWalletStorage(WalletTestCase):
 
-    def test_read_dictionnary_from_file(self):
+    def test_read_dictionary_from_file(self):
 
-        some_dict = {"a":"b", "c":"d"}
+        some_dict = {"a":"b", "c":"d", "seed_version": FINAL_SEED_VERSION}
         contents = json.dumps(some_dict)
         with open(self.wallet_path, "w") as f:
             contents = f.write(contents)
@@ -56,7 +56,7 @@ class TestWalletStorage(WalletTestCase):
         self.assertEqual("b", storage.get("a"))
         self.assertEqual("d", storage.get("c"))
 
-    def test_write_dictionnary_to_file(self):
+    def test_write_dictionary_to_file(self):
 
         storage = WalletStorage(self.wallet_path)
 


### PR DESCRIPTION
I have found that there are quite a few places in the code where a `WalletStorage` is created. It is evidently error-prone to rely on the programmer to remember to call `storage.upgrade()` in every case. See #3021

This is an alternative solution.

Another solution would be to call `storage.upgrade()` in the constructor of `Abstract_Wallet`.
Even another could be to call `storage.upgrade()` in `storage.put()` and in `storage.get()`; but I think that needs serious locking (~2 locks and maybe even thread.local variables?)...