### PR TITLE
fix: missing import 'stat' in network.py and simple_config.py

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -29,6 +29,7 @@ from __future__ import unicode_literals
 import time
 import queue
 import os
+import stat
 import errno
 import sys
 import random

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -7,6 +7,7 @@ import ast
 import json
 import threading
 import os
+import stat
 
 from copy import deepcopy
 from .util import user_dir, print_error, print_msg, print_stderr, PrintError
@@ -147,7 +148,6 @@ class SimpleConfig(PrintError):
         f.write(s)
         f.close()
         if 'ANDROID_DATA' not in os.environ:
-            import stat
             os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
 
     def get_wallet_path(self):


### PR DESCRIPTION
```
$ ./electrum -v
Traceback (most recent call last):
  File "./electrum", line 364, in <module>
    config = SimpleConfig(config_options)
  File "/home/user/wspace/electrum/lib/simple_config.py", line 74, in __init__
    self.path = self.electrum_path()
  File "/home/user/wspace/electrum/lib/simple_config.py", line 96, in electrum_path
    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
NameError: name 'stat' is not defined
```