### PR TITLE
Modify tray context menu instead of creating a new one

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -114,8 +114,12 @@ class ElectrumGui:
 
     def build_tray_menu(self):
         # Avoid immediate GC of old menu when window closed via its action
-        self.old_menu = self.tray.contextMenu()
-        m = QMenu()
+        if self.tray.contextMenu() is None:
+            m = QMenu()
+            self.tray.setContextMenu(m)
+        else:
+            m = self.tray.contextMenu()
+            m.clear()
         for window in self.windows:
             submenu = m.addMenu(window.wallet.basename())
             submenu.addAction(_("Show/Hide"), window.show_or_hide)
@@ -123,7 +127,6 @@ class ElectrumGui:
         m.addAction(_("Dark/Light"), self.toggle_tray_icon)
         m.addSeparator()
         m.addAction(_("Exit Electrum"), self.close)
-        self.tray.setContextMenu(m)
 
     def tray_icon(self):
         if self.dark_icon:


### PR DESCRIPTION
Instead of creating a new context menu and setting it with setContextMenu, simply clear and modify the existing context menu.

Fixes #3022