### PR TITLE
fix: witness for non-segwit txins

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -637,6 +637,8 @@ class Transaction:
 
     @classmethod
     def serialize_witness(self, txin):
+        if not self.is_segwit_input(txin):
+            return '00'
         pubkeys, sig_list = self.get_siglist(txin)
         if txin['type'] in ['p2wpkh', 'p2wpkh-p2sh']:
             witness = var_int(2) + push_script(sig_list[0]) + push_script(pubkeys[0])


### PR DESCRIPTION
From BIP-0141:
"A non-witness program (defined hereinafter) txin MUST be associated with an empty witness field, represented by a 0x00"

See #3031