### PR TITLE
fix: windows build with hw wallets

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -1,5 +1,7 @@
 # -*- mode: python -*-
 
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
 import sys
 for i, x in enumerate(sys.argv):
     if x == '--name':
@@ -10,6 +12,24 @@ else:
 
 
 home = 'C:\\electrum\\'
+
+# see https://github.com/pyinstaller/pyinstaller/issues/2005
+hiddenimports = []
+hiddenimports += collect_submodules('trezorlib')
+hiddenimports += collect_submodules('btchip')
+hiddenimports += collect_submodules('keepkeylib')
+
+datas = [
+    (home+'lib/currencies.json', 'electrum'),
+    (home+'lib/servers.json', 'electrum'),
+    (home+'lib/wordlist/english.txt', 'electrum/wordlist'),
+    (home+'lib/locale', 'electrum/locale'),
+    (home+'plugins', 'electrum_plugins'),
+    #(home+'packages/requests/cacert.pem', 'requests/cacert.pem')
+]
+datas += collect_data_files('trezorlib')
+datas += collect_data_files('btchip')
+datas += collect_data_files('keepkeylib')
 
 # We don't put these files in to actually include them in the script but to make the Analysis method scan them for imports
 a = Analysis([home+'electrum',
@@ -29,16 +49,9 @@ a = Analysis([home+'electrum',
               home+'plugins/ledger/qt.py',
               #home+'packages/requests/utils.py'
               ],
-             datas = [
-                 (home+'lib/currencies.json', 'electrum'),
-                 (home+'lib/servers.json', 'electrum'),
-                 (home+'lib/wordlist/english.txt', 'electrum/wordlist'),
-                 (home+'lib/locale', 'electrum/locale'),
-                 (home+'plugins', 'electrum_plugins'),
-                 #(home+'packages/requests/cacert.pem', 'requests/cacert.pem')
-             ],
+             datas=datas,
              #pathex=[home+'lib', home+'gui', home+'plugins'],
-             #hiddenimports=["lib", "gui", "plugins", "electrum_gui.qt.icons_rc"],
+             hiddenimports=hiddenimports,
              hookspath=[])
 
 

--- a/contrib/build-wine/prepare-hw.sh
+++ b/contrib/build-wine/prepare-hw.sh
@@ -6,11 +6,13 @@ BTCHIP_GIT_URL=git://github.com/LedgerHQ/btchip-python.git
 
 BRANCH=master
 
+PYTHON_VERSION=3.5.4
+
 # These settings probably don't need any change
 export WINEPREFIX=/opt/wine64
 
-PYHOME=c:/python27
-PYTHON="wine $PYHOME/python.exe "
+PYHOME=c:/python$PYTHON_VERSION
+PYTHON="wine $PYHOME/python.exe -OO -B"
 
 # Let's begin!
 cd `dirname $0`
@@ -37,6 +39,7 @@ cd tmp
 # Install Cython
 $PYTHON -m pip install setuptools --upgrade
 $PYTHON -m pip install cython
+$PYTHON -m pip install hidapi==0.7.99.post20
 $PYTHON -m pip install trezor==0.7.16
 $PYTHON -m pip install keepkey
 $PYTHON -m pip install btchip-python

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -46,7 +46,7 @@ $PYTHON -m pip install pypiwin32
 $PYTHON -m pip install PyQt5
 
 # Install pyinstaller
-$PYTHON -m pip install pyinstaller==3.2.1
+$PYTHON -m pip install pyinstaller==3.3
 
 # Install ZBar
 #wget -q -O zbar.exe "http://sourceforge.net/projects/zbar/files/zbar/0.10/zbar-0.10-setup.exe/download"


### PR DESCRIPTION
Building Windows binaries with hardware wallet support is not working on master currently.
This is my attempt at a fix.

- The `prepare-hw.sh` script still referred to python 2.7
- Trezor 0.7.16 requires `hidapi>=0.7.99.post20` and pip grabs `hidapi 0.7.99.post21` but I couldn't get this version to work --> set `hidapi==0.7.99.post20` explicitly
- AFAICT the migration from pyinstaller 2 to pyinstaller 3 (https://github.com/spesmilo/electrum/commit/b5338006f073b01ee5d563f47f8c5374622ee92d) broke backwards compatibility with a feature  (https://github.com/pyinstaller/pyinstaller/issues/2005) we previously relied on. I based my changes on https://github.com/anfema/pyinstaller/commit/6e9d80225f1f750a36fe8e46ad4227c0c8545c3b. Not sure if something else broke due to this referenced change in pyinstaller.
- Threw in an upgrade to pyinstaller 3.3

Note: I've tested basic functionality with the `portable` binary using a Trezor.