### PR TITLE
py3: signmessage cmd return type

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -405,7 +405,7 @@ class Commands:
         """Sign a message with a key. Use quotes if your message contains
         whitespaces"""
         sig = self.wallet.sign_message(address, message, password)
-        return base64.b64encode(sig)
+        return base64.b64encode(sig).decode('ascii')
 
     @command('')
     def verifymessage(self, address, signature, message):


### PR DESCRIPTION
To retain existing behaviour of release versions. -- And in any case, not sure it makes sense to base64-encode and then return that as bytes.