### PR TITLE
fix raw_input() in trezor cmdline

### DIFF
--- a/plugins/keepkey/cmdline.py
+++ b/plugins/keepkey/cmdline.py
@@ -1,4 +1,4 @@
-from electrum.util import print_msg
+from electrum.util import print_msg, raw_input
 from .keepkey import KeepKeyPlugin
 
 class KeepKeyCmdLineHandler:

--- a/plugins/trezor/cmdline.py
+++ b/plugins/trezor/cmdline.py
@@ -1,4 +1,4 @@
-from electrum.util import print_msg
+from electrum.util import print_msg, raw_input
 from .trezor import TrezorPlugin
 
 class TrezorCmdLineHandler:


### PR DESCRIPTION
To be honest, I am unsure how to get Electrum to run the `get_pin()` method to test this, but I've tested by invoking it directly using my IDE.