### PR TITLE
updated snap packaging details

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,8 +16,8 @@ parts:
   electrum:
     source: .
     plugin: python
-    python-version: python2
-    stage-packages: [python-qt4]
-    build-packages: [pyqt4-dev-tools]
-    install: pyrcc4 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages/electrum_gui/qt/icons_rc.py
-    after: [desktop-qt4]
+    python-version: python3
+    stage-packages: [python3-pyqt5]
+    build-packages: [pyqt5-dev-tools]
+    install: pyrcc5 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python3.5/site-packages/electrum_gui/qt/icons_rc.py
+    after: [desktop-qt5]


### PR DESCRIPTION
See #2521 

I have tested this on Ubuntu 16.04 - where it worked, and 17.04 - where it did not.
I could not get it to work with 17.04, due to https://github.com/ubuntu/snapcraft-desktop-helpers/issues/62

If someone wants to have a go at fixing for 17.04, then with the below patch (on top of this PR), the build succeeds, but when one starts Electrum, it fails to import parts of `PyQt5` :(

```
diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
index 5c3fcf18..897abc47 100644
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,3 +21,15 @@ parts:
     build-packages: [pyqt5-dev-tools]
     install: pyrcc5 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python3.5/site-packages/electrum_gui/qt/icons_rc.py
     after: [desktop-qt5]
+
+  desktop-qt5:
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5
+      - locales-all
```