### PR TITLE
building on wine: check hash of NSIS, and GPG sig of Python

### DIFF
--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -2,6 +2,7 @@
 
 # Please update these carefully, some versions won't work under Wine
 NSIS_URL=https://prdownloads.sourceforge.net/nsis/nsis-3.02.1-setup.exe?download
+NSIS_SHA256=736c9062a02e297e335f82252e648a883171c98e0d5120439f538c81d429552e
 PYTHON_VERSION=3.5.4
 
 ## These settings probably don't need change
@@ -10,6 +11,30 @@ export WINEPREFIX=/opt/wine64
 
 PYHOME=c:/python$PYTHON_VERSION
 PYTHON="wine $PYHOME/python.exe -OO -B"
+
+
+# based on https://superuser.com/questions/497940/script-to-verify-a-signature-with-gpg
+verify_signature() {
+    local file=$1 keyring=$2 out=
+    if out=$(gpg --no-default-keyring --keyring "$keyring" --status-fd 1 --verify "$file" 2>/dev/null) &&
+       echo "$out" | grep -qs "^\[GNUPG:\] VALIDSIG "; then
+        return 0
+    else
+        echo "$out" >&2
+        exit 0
+    fi
+}
+
+verify_hash() {
+    local file=$1 expected_hash=$2 out=
+    actual_hash=$(sha256sum $file | awk '{print $1}')
+    if [ "$actual_hash" == "$expected_hash" ]; then
+        return 0
+    else
+        echo "$file $actual_hash (unexpected hash)" >&2
+        exit 0
+    fi
+}
 
 # Let's begin!
 cd `dirname $0`
@@ -30,9 +55,15 @@ echo "done"
 cd tmp
 
 # Install Python
+# note: you might need "sudo apt-get install dirmngr" for the following
+# keys from https://www.python.org/downloads/#pubkeys
+KEYRING_PYTHON_DEV=keyring-electrum-build-python-dev.gpg
+gpg --no-default-keyring --keyring $KEYRING_PYTHON_DEV --recv-keys 531F072D39700991925FED0C0EDDC5F26A45C816 26DEA9D4613391EF3E25C9FF0A5B101836580288 CBC547978A3964D14B9AB36A6AF053F07D9DC8D2 C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF 12EF3DC38047DA382D18A5B999CDEA9DA4135B38 8417157EDBE73D9EAC1E539B126EB563A74B06BF DBBF2EEBF925FAADCF1F3FFFD9866941EA5BBD71 2BA0DB82515BBB9EFFAC71C5C9BE28DEE6DF025C 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D C9B104B3DD3AA72D7CCB1066FB9921286F5E1540 97FC712E4C024BBEA48A61ED3A5CA953F73C700D 7ED10B6531D7C8E1BC296021FC624643487034E5
 for msifile in core dev exe lib pip tools; do
     echo "Installing $msifile..."
     wget "https://www.python.org/ftp/python/$PYTHON_VERSION/win32/${msifile}.msi"
+    wget "https://www.python.org/ftp/python/$PYTHON_VERSION/win32/${msifile}.msi.asc"
+    verify_signature "${msifile}.msi.asc" $KEYRING_PYTHON_DEV
     wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/python$PYTHON_VERSION
 done
 
@@ -72,6 +103,7 @@ $PYTHON -m pip install setuptools --upgrade
 # Install NSIS installer
 echo "Make sure to untick 'Start NSIS' and 'Show release notes'" 
 wget -q -O nsis.exe "$NSIS_URL"
+verify_hash nsis.exe $NSIS_SHA256
 wine nsis.exe
 
 # Install UPX


### PR DESCRIPTION
Despite the "not so simple" look, this should be low maintenance.
Whenever the NSIS URL is updated, the committer should change the corresponding hash; and in case of a signature verification failure for the Python binaries, one should check if they added a new release-signing-key.

While all the `pip` downloads and `setuptools` downloads are still there as is, I guess the point of this PR is to reduce the attack surface.