### PR TITLE
follow-up 198cc9d7376768739e1233cbc67add0c5e416984

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2430,7 +2430,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         def on_dynfee(x):
             self.config.set_key('dynamic_fees', x == Qt.Checked)
             self.fee_slider.update()
-            update_maxfee()
         dynfee_cb = QCheckBox(_('Use dynamic fees'))
         dynfee_cb.setChecked(self.config.is_dynfee())
         dynfee_cb.setToolTip(_("Use fees recommended by the server."))


### PR DESCRIPTION
follow-up 198cc9d7376768739e1233cbc67add0c5e416984
```
Traceback (most recent call last):
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 2433, in on_dynfee
    update_maxfee()
NameError: name 'update_maxfee' is not defined
Aborted
```