### PR TITLE
reorganize fee line in send tab

### DIFF
--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -623,6 +623,7 @@ class ColorScheme:
     GREEN = ColorSchemeItem("#117c11", "#8af296")
     RED = ColorSchemeItem("#7c1111", "#f18c8c")
     BLUE = ColorSchemeItem("#123b7c", "#8cb3f2")
+    GREY = ColorSchemeItem("#666666", "#999999")
     DEFAULT = ColorSchemeItem("black", "white")
 
     @staticmethod


### PR DESCRIPTION
This is an attempt to improve how fee is presented in the send tab and implement #2838.

Changes:
- reorder to line up the columns with Amount
  [ amount, optional fiat, controls ]
  [ fee, optional fee in fiat, controls ]
- make fee amount always visible (regardless of whether editable in settings)
- visually distinguish editable and non-editable with border & color
- fix Clear button to respect the editable setting