### PR TITLE
Disallow disabling TrustedCoin for 2FA wallets

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2853,8 +2853,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 continue
             try:
                 cb = QCheckBox(descr['fullname'])
-                cb.setEnabled(plugins.is_available(name, self.wallet))
-                cb.setChecked(p is not None and p.is_enabled())
+                plugin_is_loaded = p is not None
+                cb_enabled = (not plugin_is_loaded and plugins.is_available(name, self.wallet)
+                              or plugin_is_loaded and p.can_user_disable())
+                cb.setEnabled(cb_enabled)
+                cb.setChecked(plugin_is_loaded and p.is_enabled())
                 grid.addWidget(cb, i, 0)
                 enable_settings_widget(p, name, i)
                 cb.clicked.connect(partial(do_toggle, cb, name, i))

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -253,6 +253,9 @@ class BasePlugin(PrintError):
     def is_available(self):
         return True
 
+    def can_user_disable(self):
+        return True
+
     def settings_dialog(self):
         pass
 

--- a/plugins/trustedcoin/trustedcoin.py
+++ b/plugins/trustedcoin/trustedcoin.py
@@ -332,6 +332,9 @@ class TrustedCoinPlugin(BasePlugin):
     def is_enabled(self):
         return True
 
+    def can_user_disable(self):
+        return False
+
     @hook
     def get_tx_extra_fee(self, wallet, tx):
         if type(wallet) != Wallet_2fa:


### PR DESCRIPTION
See https://github.com/spesmilo/electrum/issues/3095#issuecomment-338525045

Introduced `BasePlugin.can_user_disable()`. TrustedCoin plugin can't be disabled by user.