### PR TITLE
efficiency: private key imports, address imports

### DIFF
--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -147,13 +147,15 @@ class BaseWizard(object):
         if keystore.is_address_list(text):
             self.wallet = Imported_Wallet(self.storage)
             for x in text.split():
-                self.wallet.import_address(x)
+                self.wallet.import_address(x, finalize=False)
+            self.wallet.finalize_import_address()
         elif keystore.is_private_key_list(text):
             k = keystore.Imported_KeyStore({})
             self.storage.put('keystore', k.dump())
             self.wallet = Imported_Wallet(self.storage)
             for x in text.split():
-                self.wallet.import_private_key(x, None)
+                self.wallet.import_private_key(x, None, finalize=False)
+            self.wallet.finalize_import_private_key()
         self.terminate()
 
     def restore_from_key(self):


### PR DESCRIPTION
See #3101 

Importing a single private key without this PR takes linear time in the size of the keystore (~number of already imported private keys), so importing n private keys has quadratic time complexity.
With this PR, I think, importing a single private key takes amortized constant time (but certainly sub-linear).

-----

With this PR, in a VM, for me, importing
- 500 private keys takes 35-40 seconds -- instead of 40-45 seconds
- 5000 private keys takes ~7.5 minutes -- instead of ~15 minutes
- 10000 private keys takes ~16 minutes -- instead of ~44 minutes
- 5000 addresses takes 50-60 seconds -- instead of ~3.5 minutes

Hmm. I was expecting a larger improvement...