### PR TITLE
try to sweep p2pk outputs from old type WIF privkeys

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -405,6 +405,9 @@ def address_to_script(addr):
 
 def address_to_scripthash(addr):
     script = address_to_script(addr)
+    return script_to_scripthash(script)
+
+def script_to_scripthash(script):
     h = sha256(bytes.fromhex(script))[0:32]
     return bh2u(bytes(reversed(h)))
 


### PR DESCRIPTION
See #2857 

Now that the most widely used server implementation, ElectrumX, with [version 1.2](https://github.com/kyuupichan/electrumx/blob/1da8cb547d733fe3da9924a0d31187a6d5bb58a1/README.rst#version-12), properly separates P2PK and P2PKH scripts, we can implement a way for users to spend P2PK outputs.

In this PR, I propose enabling the `sweep` functionality to redeem these coins. Unfortunately, the WIF format for private keys gives no hint if P2PK scripts are to be used. What I do, is search for both P2PK and P2PKH scripts whenever an "old type" (pre-segwit) WIF is swept from. The `compressed` byte is assumed to be correct, the same boolean is used for both script types.

I think the fact that (in some sense) duplicate queries are sent to servers (hence e.g. increasing load/bandwidth), can be overlooked, given sweeping is a rare operation. IMHO it is more important for users to be able to access these coins than to avoid looking up both script types at all costs. So while it might not be desirable to always subscribe to both script types (say) in an imported wallet, this one-time cost can be afforded.

I've tested this on regtest with ElectrumX 1.2.