### PR TITLE
fix: sweep p2pk - small display bug (unknown -> pubkey)

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -871,19 +871,18 @@ class Abstract_Wallet(PrintError):
         return tx
 
     def _append_utxos_to_inputs(self, inputs, network, pubkey, txin_type, imax):
-        address = None
         if txin_type != 'p2pk':
             address = bitcoin.pubkey_to_address(txin_type, pubkey)
             sh = bitcoin.address_to_scripthash(address)
         else:
             script = bitcoin.public_key_to_p2pk_script(pubkey)
             sh = bitcoin.script_to_scripthash(script)
+            address = '(pubkey)'
         u = network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
         for item in u:
             if len(inputs) >= imax:
                 break
-            if address is not None:
-                item['address'] = address
+            item['address'] = address
             item['type'] = txin_type
             item['prevout_hash'] = item['tx_hash']
             item['prevout_n'] = item['tx_pos']


### PR DESCRIPTION
I've missed this in #3125 

Only affects the transaction dialog when doing the sweep: the input type is displayed as "unknown" instead of something more meaningful.

Before / After:
![p2pk_unknown](https://user-images.githubusercontent.com/29142493/32132151-915509f2-bbbe-11e7-8c36-ab6a488a2f23.png)
![p2pk_pubkey](https://user-images.githubusercontent.com/29142493/32132153-932817b0-bbbe-11e7-9e82-9192a83b99e2.png)
