### PR TITLE
txn: set locktime to local height for RBF, CPFP, sweep

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -920,7 +920,9 @@ class Abstract_Wallet(PrintError):
             raise BaseException(_('Not enough funds on address.') + '\nTotal: %d satoshis\nFee: %d\nDust Threshold: %d'%(total, fee, self.dust_threshold()))
 
         outputs = [(TYPE_ADDRESS, recipient, total - fee)]
-        tx = Transaction.from_io(inputs, outputs)
+        locktime = self.get_local_height()
+
+        tx = Transaction.from_io(inputs, outputs, locktime=locktime)
         tx.set_rbf(True)
         tx.sign(keypairs)
         return tx
@@ -1061,7 +1063,8 @@ class Abstract_Wallet(PrintError):
                     continue
         if delta > 0:
             raise BaseException(_('Cannot bump fee: could not find suitable outputs'))
-        return Transaction.from_io(inputs, outputs)
+        locktime = self.get_local_height()
+        return Transaction.from_io(inputs, outputs, locktime=locktime)
 
     def cpfp(self, tx, fee):
         txid = tx.txid()
@@ -1078,7 +1081,8 @@ class Abstract_Wallet(PrintError):
         self.add_input_info(item)
         inputs = [item]
         outputs = [(TYPE_ADDRESS, address, value - fee)]
-        return Transaction.from_io(inputs, outputs)
+        locktime = self.get_local_height()
+        return Transaction.from_io(inputs, outputs, locktime=locktime)
 
     def add_input_info(self, txin):
         address = txin['address']


### PR DESCRIPTION
nLockTime is currently not set when
- sweeping
- using RBF
- using CPFP

I set it analogous to https://github.com/spesmilo/electrum/blob/6f3c822867bd512e276ef63ad7b8c2af2fa40927/lib/wallet.py#L858-L860
as it's already done in case of `make_unsigned_transaction()`.