### PR TITLE
old seeds: normalize

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -260,11 +260,14 @@ def is_new_seed(x, prefix=version.SEED_PREFIX):
 
 
 def is_old_seed(seed):
-    from . import old_mnemonic
-    words = seed.strip().split()
+    from . import old_mnemonic, mnemonic
+    seed = mnemonic.normalize_text(seed)
+    words = seed.split()
     try:
-        old_mnemonic.mn_decode(words)
-        uses_electrum_words = True
+        hex_seed = old_mnemonic.mn_decode(words)
+        words2 = old_mnemonic.mn_encode(hex_seed)
+        seed2 = ' '.join(words2)
+        uses_electrum_words = seed == seed2
     except Exception:
         uses_electrum_words = False
     try:

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -264,10 +264,9 @@ def is_old_seed(seed):
     seed = mnemonic.normalize_text(seed)
     words = seed.split()
     try:
-        hex_seed = old_mnemonic.mn_decode(words)
-        words2 = old_mnemonic.mn_encode(hex_seed)
-        seed2 = ' '.join(words2)
-        uses_electrum_words = seed == seed2
+        # checks here are deliberately left weak for legacy reasons, see #3149
+        old_mnemonic.mn_decode(words)
+        uses_electrum_words = True
     except Exception:
         uses_electrum_words = False
     try:

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -355,9 +355,9 @@ class Old_KeyStore(Deterministic_KeyStore):
         self.mpk = mpk
 
     def format_seed(self, seed):
-        from . import old_mnemonic
+        from . import old_mnemonic, mnemonic
+        seed = mnemonic.normalize_text(seed)
         # see if seed was entered as hex
-        seed = seed.strip()
         if seed:
             try:
                 bfh(seed)

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -355,7 +355,8 @@ class Test_seeds(unittest.TestCase):
         ('cell dumb heartbeat north boom tease ship baby bright kingdom rare badword', ''),
         ('cElL DuMb hEaRtBeAt nOrTh bOoM TeAsE ShIp bAbY BrIgHt kInGdOm rArE SqUeEzE', 'old'),
         ('   cElL  DuMb hEaRtBeAt nOrTh bOoM  TeAsE ShIp    bAbY BrIgHt kInGdOm rArE SqUeEzE   ', 'old'),
-        ('hurry idiot prefer sunset mention mist jaw inhale impossible kingdom rare squeeze', ''),  # almost 'old' but maps to 33 hex chars
+        # below seed is actually 'invalid old' as it maps to 33 hex chars
+        ('hurry idiot prefer sunset mention mist jaw inhale impossible kingdom rare squeeze', 'old'),
         ('cram swing cover prefer miss modify ritual silly deliver chunk behind inform able', 'standard'),
         ('cram swing cover prefer miss modify ritual silly deliver chunk behind inform', ''),
         ('ostrich security deer aunt climb inner alpha arm mutual marble solid task', 'standard'),

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -11,7 +11,7 @@ from lib.bitcoin import (
     var_int, op_push, address_to_script, regenerate_key,
     verify_message, deserialize_privkey, serialize_privkey, is_segwit_address,
     is_b58_address, address_to_scripthash, is_minikey, is_compressed, is_xpub,
-    xpub_type, is_xprv, is_bip32_derivation)
+    xpub_type, is_xprv, is_bip32_derivation, seed_type)
 from lib.util import bfh
 
 try:
@@ -348,6 +348,27 @@ class Test_keyImport(unittest.TestCase):
 
 class Test_seeds(unittest.TestCase):
     """ Test old and new seeds. """
+
+    mnemonics = {
+        ('cell dumb heartbeat north boom tease ship baby bright kingdom rare squeeze', 'old'),
+        ('cell dumb heartbeat north boom tease ' * 4, 'old'),
+        ('cell dumb heartbeat north boom tease ship baby bright kingdom rare badword', ''),
+        ('cElL DuMb hEaRtBeAt nOrTh bOoM TeAsE ShIp bAbY BrIgHt kInGdOm rArE SqUeEzE', 'old'),
+        ('   cElL  DuMb hEaRtBeAt nOrTh bOoM  TeAsE ShIp    bAbY BrIgHt kInGdOm rArE SqUeEzE   ', 'old'),
+        ('hurry idiot prefer sunset mention mist jaw inhale impossible kingdom rare squeeze', ''),  # almost 'old' but maps to 33 hex chars
+        ('cram swing cover prefer miss modify ritual silly deliver chunk behind inform able', 'standard'),
+        ('cram swing cover prefer miss modify ritual silly deliver chunk behind inform', ''),
+        ('ostrich security deer aunt climb inner alpha arm mutual marble solid task', 'standard'),
+        ('OSTRICH SECURITY DEER AUNT CLIMB INNER ALPHA ARM MUTUAL MARBLE SOLID TASK', 'standard'),
+        ('   oStRiCh sEcUrItY DeEr aUnT ClImB       InNeR AlPhA ArM MuTuAl mArBlE   SoLiD TaSk  ', 'standard'),
+        ('x8', 'standard'),
+        ('science dawn member doll dutch real can brick knife deny drive list', '2fa'),
+        ('science dawn member doll dutch real ca brick knife deny drive list', ''),
+        (' sCience dawn   member doll Dutch rEAl can brick knife deny drive  lisT', '2fa'),
+        ('frost pig brisk excite novel report camera enlist axis nation novel desert', 'segwit'),
+        ('  fRoSt pig brisk excIte novel rePort CamEra enlist axis nation nOVeL dEsert ', 'segwit'),
+        ('9dk', 'segwit'),
+    }
     
     def test_new_seed(self):
         seed = "cram swing cover prefer miss modify ritual silly deliver chunk behind inform able"
@@ -364,3 +385,7 @@ class Test_seeds(unittest.TestCase):
 
         self.assertTrue(is_old_seed("0123456789ABCDEF" * 2))
         self.assertTrue(is_old_seed("0123456789ABCDEF" * 4))
+
+    def test_seed_type(self):
+        for seed_words, _type in self.mnemonics:
+            self.assertEqual(_type, seed_type(seed_words), msg=seed_words)


### PR DESCRIPTION
- normalize old seeds, see #3143
- ~~made `is_old_seed()` stricter~~. It incorrectly assumed that any permutation of (a subset with the correct size, of) words is a valid old seed (but this is false, e.g. `hurry idiot prefer sunset mention mist jaw inhale impossible kingdom rare squeeze` encodes as 33 hex characters)

edit: I've reverted the stricter check, see #3149 