### PR TITLE
Install latest version of Trezor on Windows

### DIFF
--- a/contrib/build-wine/prepare-hw.sh
+++ b/contrib/build-wine/prepare-hw.sh
@@ -39,8 +39,7 @@ cd tmp
 # Install Cython
 $PYTHON -m pip install setuptools --upgrade
 $PYTHON -m pip install cython
-$PYTHON -m pip install hidapi==0.7.99.post20
-$PYTHON -m pip install trezor==0.7.16
+$PYTHON -m pip install trezor
 $PYTHON -m pip install keepkey
 $PYTHON -m pip install btchip-python
 


### PR DESCRIPTION
The need to do this was fixed in trezor/cython-hidapi#44 and trezor/cython-hidapi#45.