### PR TITLE
Use combo box instead of buttons to filter address tab

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -46,16 +46,18 @@ class AddressList(MyTreeWidget):
         self.refresh_headers()
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.show_change = False
-        self.show_used = 3
-        self.change_button = QToolButton(self)
-        self.used_button = QToolButton(self)
-        self.change_button.clicked.connect(self.toggle_change)
-        self.used_button.clicked.connect(self.toggle_used)
-        self.set_change_button_text()
-        self.set_used_button_text()
+        self.show_used = 0
+        self.change_button = QComboBox(self)
+        self.change_button.currentIndexChanged.connect(self.toggle_change)
+        for t in [_('Change'), _('Receiving')]:
+            self.change_button.addItem(t)
+        self.used_button = QComboBox(self)
+        self.used_button.currentIndexChanged.connect(self.toggle_used)
+        for t in [_('All'), _('Unused'), _('Funded'), _('Used')]:
+            self.used_button.addItem(t)
 
-    def get_buttons(self):
-        return self.change_button, self.used_button
+    def get_list_header(self):
+        return QLabel(_("Filter:")), self.change_button, self.used_button
 
     def refresh_headers(self):
         headers = [ _('Address'), _('Label'), _('Balance')]
@@ -65,23 +67,18 @@ class AddressList(MyTreeWidget):
         headers.extend([_('Tx')])
         self.update_headers(headers)
 
-    def toggle_change(self):
-        self.show_change = not self.show_change
-        self.set_change_button_text()
+    def toggle_change(self, show):
+        show = bool(show)
+        if show == self.show_change:
+            return
+        self.show_change = show
         self.update()
 
-    def set_change_button_text(self):
-        s = [_('Receiving'), _('Change')]
-        self.change_button.setText(s[self.show_change])
-
-    def toggle_used(self):
-        self.show_used = (self.show_used + 1) % 4
-        self.set_used_button_text()
+    def toggle_used(self, state):
+        if state == self.show_used:
+            return
+        self.show_used = state
         self.update()
-
-    def set_used_button_text(self):
-        s = [_('Unused'), _('Funded'), _('Used'), _('All')]
-        self.used_button.setText(s[self.show_used])
 
     def on_update(self):
         self.wallet = self.parent.wallet

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1569,16 +1569,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.utxo_list.update()
         self.update_fee()
 
-    def create_list_tab(self, l, buttons=None):
+    def create_list_tab(self, l, list_header=None):
         w = QWidget()
         w.searchable_list = l
         vbox = QVBoxLayout()
         w.setLayout(vbox)
         vbox.setContentsMargins(0, 0, 0, 0)
         vbox.setSpacing(0)
-        if buttons:
+        if list_header:
             hbox = QHBoxLayout()
-            for b in buttons:
+            for b in list_header:
                 hbox.addWidget(b)
             hbox.addStretch()
             vbox.addLayout(hbox)
@@ -1588,7 +1588,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def create_addresses_tab(self):
         from .address_list import AddressList
         self.address_list = l = AddressList(self)
-        return self.create_list_tab(l, l.get_buttons())
+        return self.create_list_tab(l, l.get_list_header())
 
     def create_utxo_tab(self):
         from .utxo_list import UTXOList


### PR DESCRIPTION
The concept of clicking buttons to change their text is not really straight-forward and might confuse users. For example, clicking "All" doesn't show all addresses.

This changes the user interaction to use combo boxes instead:

![image](https://user-images.githubusercontent.com/598790/32188212-7cc6415a-bda7-11e7-890e-12876d457971.png)


I also added a label to the buttons.