### PR TITLE
NetworkDialog: "Node" -> "Connected node"

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -66,7 +66,7 @@ class NodesListWidget(QTreeWidget):
     def __init__(self, parent):
         QTreeWidget.__init__(self)
         self.parent = parent
-        self.setHeaderLabels([_('Node'), _('Height')])
+        self.setHeaderLabels([_('Connected node'), _('Height')])
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.create_menu)
 


### PR DESCRIPTION
Had a discussion with skace in #electrum. He said he had not realised up until that point what the list of servers in the `Overview` tab of the `Network dialog` represents. He also did not know about the fact that Electrum (using default settings) connects to 8-10 electrum servers to get headers from. He suggested that if we make the renaming in present PR, that would make it a lot more obvious.