### PR TITLE
wallet storage upgrade will now happen silently whenever possible

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -192,7 +192,7 @@ class ElectrumGui:
                 d.exec_()
                 return
             if not wallet:
-                storage = WalletStorage(path)
+                storage = WalletStorage(path, manual_upgrades=True)
                 wizard = InstallWizard(self.config, self.app, self.plugins, storage)
                 try:
                     wallet = wizard.run_and_get_wallet()

--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -240,7 +240,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         path = self.storage.path
         if self.storage.requires_split():
             self.hide()
-            msg = _("The wallet '%s' contains multiple accounts, which are no longer supported in Electrum 2.7.\n\n"
+            msg = _("The wallet '%s' contains multiple accounts, which are no longer supported since Electrum 2.7.\n\n"
                     "Do you want to split your wallet into multiple files?"%path)
             if not self.question(msg):
                 return
@@ -252,12 +252,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
             return
 
         if self.storage.requires_upgrade():
-            self.hide()
-            msg = _("The format of your wallet '%s' must be upgraded for Electrum. This change will not be backward compatible"%path)
-            if not self.question(msg):
-                return
             self.storage.upgrade()
-            self.show_warning(_('Your wallet was upgraded successfully'))
             self.wallet = Wallet(self.storage)
             return self.wallet
 

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -220,7 +220,7 @@ class Daemon(DaemonThread):
         if storage.requires_split():
             return
         if storage.requires_upgrade():
-            storage.upgrade()
+            return
         if storage.get_action():
             return
         wallet = Wallet(storage)


### PR DESCRIPTION
See #3181

This PR changes the behaviour to consistently offer upgrades to the user when using the QT GUI (in all four scenarios listed in above linked issue). Users of other GUIs/CLIs/daemon should be unaffected by this change, I think, and upgrades should happen for them silently as before.