### PR TITLE
 hotfix: pre-Windows10 binaries

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -61,6 +61,9 @@ for d in a.datas:
         a.datas.remove(d)
         break
 
+# hotfix for #3171 (pre-Win10 binaries)
+a.binaries = [x for x in a.binaries if not x[1].lower().startswith(r'c:\windows')]
+
 pyz = PYZ(a.pure)
 exe = EXE(pyz,
           a.scripts,

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -111,6 +111,4 @@ wine nsis.exe /S
 #cp upx*/upx.exe .
 
 # add dlls needed for pyinstaller:
-cp $WINEPREFIX/drive_c/windows/system32/msvcp90.dll $WINEPREFIX/drive_c/python$PYTHON_VERSION/
-cp $WINEPREFIX/drive_c/windows/system32/msvcm90.dll $WINEPREFIX/drive_c/python$PYTHON_VERSION/
 cp $WINEPREFIX/drive_c/python$PYTHON_VERSION/Lib/site-packages/PyQt5/Qt/bin/* $WINEPREFIX/drive_c/python$PYTHON_VERSION/


### PR DESCRIPTION
See #3171

This is essentially "stolen" from https://github.com/pyinstaller/pyinstaller/issues/1566#issuecomment-279884163

With this, binaries should work on Windows 10 by default (as with 3.0.0).

On Windows 7 and 8.1, binaries **might** work by default; if they don't work, the end-user should
- try installing the KB2999226 Windows update
- try installing [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-US/download/details.aspx?id=48145)

Either of these two things should fix it. To clarify, the **end-user** has to install one of these.
Hence I would call this a "hotfix".

I've tested on Windows 10 and 7; and skace (from #electrum) tested on 8.1 - thanks for that.
No idea about earlier Windows versions.

These are the DLLs we are removing (in my dev environment):
```
{('api-ms-win-crt-stdio-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-stdio-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-filesystem-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-filesystem-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-multibyte-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-multibyte-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-locale-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-locale-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-process-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-process-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-time-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-time-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-math-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-math-l1-1-0.dll', 'BINARY'),
 ('MSVCR100.dll', 'C:\\windows\\system32\\msvcr100.dll', 'BINARY'),
 ('api-ms-win-crt-convert-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-convert-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-string-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-string-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-conio-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-conio-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-runtime-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-runtime-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-environment-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-environment-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-heap-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-heap-l1-1-0.dll', 'BINARY'),
 ('api-ms-win-crt-utility-l1-1-0.dll', 'C:\\windows\\system32\\api-ms-win-crt-utility-l1-1-0.dll', 'BINARY')}
```

The `MSVCR100.dll` seems to be redundant. The `'api-ms-win-crt-*` DLLs are stubs from Wine, which don't actually work on Windows. I think 3.0.0 only works on Windows 10 as it somehow successfully fallbacks to the real DLLs which are part of Win10 by default. The above linked Win update or the VC++ redist both make sure that these are available on the older Windows versions.