### PR TITLE
fix: import_address() for Imported_Wallet

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1455,6 +1455,8 @@ class Imported_Wallet(Simple_Wallet):
         return []
 
     def import_address(self, address):
+        if not bitcoin.is_address(address):
+            return ''
         if address in self.addresses:
             return ''
         self.addresses[address] = {}


### PR DESCRIPTION
"Addresses" should be tested for being addresses.
See #3186
Present PR does NOT fix referenced issue, as already imported garbage will need to be sanitized.

Current master only tests addresses in the wizard, when creating a new wallet:
https://github.com/spesmilo/electrum/blob/7e4e96e5eb0f15f65d45a0baba677647ddf40d04/lib/base_wizard.py#L146-L150
Not when importing into an existing wallet:
https://github.com/spesmilo/electrum/blob/7e4e96e5eb0f15f65d45a0baba677647ddf40d04/gui/qt/main_window.py#L2396-L2400