### PR TITLE
proper address deletion for imported wallets

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1466,12 +1466,42 @@ class Imported_Wallet(Simple_Wallet):
     def delete_address(self, address):
         if address not in self.addresses:
             return
+
+        transactions_to_remove = set()  # only referred to by this address
+        transactions_new = set()  # txs that are not only referred to by address
+        with self.lock:
+            for addr, details in self.history.items():
+                if addr == address:
+                    for tx_hash, height in details:
+                        transactions_to_remove.add(tx_hash)
+                else:
+                    for tx_hash, height in details:
+                        transactions_new.add(tx_hash)
+            transactions_to_remove -= transactions_new
+            self.history.pop(address, None)
+
+            for tx_hash in transactions_to_remove:
+                self.remove_transaction(tx_hash)
+                self.tx_fees.pop(tx_hash, None)
+                self.verified_tx.pop(tx_hash, None)
+                self.unverified_tx.pop(tx_hash, None)
+                self.transactions.pop(tx_hash, None)
+                # FIXME: what about pruned_txo?
+
+        self.storage.put('verified_tx3', self.verified_tx)
+        self.save_transactions()
+
+        self.set_label(address, None)
+        self.remove_payment_request(address, {})
+        self.set_frozen_state([address], False)
+
         pubkey = self.get_public_key(address)
         self.addresses.pop(address)
         if pubkey:
             self.keystore.delete_imported_key(pubkey)
             self.save_keystore()
         self.storage.put('addresses', self.addresses)
+
         self.storage.write()
 
     def get_address_index(self, address):


### PR DESCRIPTION
Currently when deleting an address from an Imported_Wallet, remnants are left in the wallet file.
This PR tries to do a full deletion instead.