### PR TITLE
fix typo: text gui with no wallet

### DIFF
--- a/gui/text.py
+++ b/gui/text.py
@@ -25,7 +25,7 @@ class ElectrumGui:
         self.config = config
         self.network = daemon.network
         storage = WalletStorage(config.get_wallet_path())
-        if not storage.file_exists:
+        if not storage.file_exists():
             print("Wallet not found. try 'electrum create'")
             exit()
         if storage.is_encrypted():


### PR DESCRIPTION
It's not obvious what's going on when you're presented with this, just because it can't find the wallet file:
```
$ ./electrum --gui=text
Traceback (most recent call last):
  File "./electrum", line 373, in <module>
    d.init_gui(config, plugins)
  File "/home/user/wspace/electrum/lib/daemon.py", line 290, in init_gui
    self.gui = gui.ElectrumGui(config, self, plugins)
  File "/home/user/wspace/electrum/gui/text.py", line 34, in __init__
    self.wallet = Wallet(storage)
  File "/home/user/wspace/electrum/lib/wallet.py", line 1819, in __new__
    WalletClass = Wallet.wallet_class(wallet_type)
  File "/home/user/wspace/electrum/lib/wallet.py", line 1833, in wallet_class
    if multisig_type(wallet_type):
  File "/home/user/wspace/electrum/lib/storage.py", line 57, in multisig_type
    match = re.match('(\d+)of(\d+)', wallet_type)
  File "/usr/lib/python3.5/re.py", line 163, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```