### PR TITLE
win binaries: build a proper setup.exe that uses local folder

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -65,7 +65,14 @@ for d in a.datas:
 a.binaries = [x for x in a.binaries if not x[1].lower().startswith(r'c:\windows')]
 
 pyz = PYZ(a.pure)
-exe = EXE(pyz,
+
+
+#####
+# "standalone" exe with all dependencies packed into it
+# (or "portable", depending on cmdline_name)
+
+exe_standalone = EXE(
+          pyz,
           a.scripts,
           a.binaries,
           a.datas,
@@ -77,7 +84,23 @@ exe = EXE(pyz,
           console=False)
           # The console True makes an annoying black box pop up, but it does make Electrum output command line commands, with this turned off no output will be given but commands can still be used
 
-coll = COLLECT(exe,
+#####
+# exe and separate files that NSIS uses to build installer "setup" exe
+# FIXME: this is redundantly done again, when building the "portable" exe
+
+exe_dependent = EXE(
+          pyz,
+          a.scripts,
+          exclude_binaries=True,
+          name=os.path.join('build\\pyi.win32\\electrum', cmdline_name),
+          debug=False,
+          strip=None,
+          upx=False,
+          icon=home+'icons/electrum.ico',
+          console=False)
+
+coll = COLLECT(
+               exe_dependent,
                a.binaries,
                a.zipfiles,
                a.datas,


### PR DESCRIPTION
Currently there are three Windows binaries we build: `standalone`, `setup`, and `portable`.
`standalone` and `portable` only differ in where they put the datadir, hence let's consider them identical for the purposes of this description.

The main part of the Windows build is done by PyInstaller. There are two common ways to distribute apps using PyInstaller:
- `One-File`, which packages all dependencies and the app itself into a single executable
- `One-Folder`, which packages all dependencies and an executable for the app into a folder

The `standalone` Windows binary is built using the `One-File` mode of PyInstaller.
The `setup` binary aims to be built using NSIS into a single installer FROM the folder created using the `One-Folder` mode of PyInstaller.

This intended behaviour would mean that:
- whenever the `standalone` executable is run, it unpacks the dependencies into a folder such as `%appdata%/../Local/Temp/_MEI268602` and uses that.
- whenever the executable unpacked during installation from `setup` is run, it uses the dependencies from the local folder (`%programfiles(x86)%/Electrum`) that was unpacked during installation.

What this PR fixes, is that currently the `setup` installer binary contains the `standalone` exe, which gets unpacked along with the dependencies into `%programfiles(x86)%/Electrum` during installation. Hence, all the local dependencies are actually not used, and when the exe is run, it unpacks the dependencies from itself (the exe) into e.g. `%appdata%/../Local/Temp/_MEI268602` and uses those.

This fixes #3228 
The size of the `setup` exe is reduced from ~27 MB to ~13 MB.