### PR TITLE
fix: deleting a passworded wallet did not work

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1871,14 +1871,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     @protected
     def _delete_wallet(self, password):
         wallet_path = self.wallet.storage.path
-        dirname = os.path.dirname(wallet_path)
         basename = os.path.basename(wallet_path)
-        if self.wallet.has_password():
-            try:
-                self.wallet.check_password(pw)
-            except:
-                self.show_error("Invalid Password")
-                return
         self.gui_object.daemon.stop_wallet(wallet_path)
         self.close()
         os.unlink(wallet_path)


### PR DESCRIPTION
Note: the `@protected` decorator already checks that the password is correct.

Fixes #3234