### PR TITLE
paytoedit: Calculate height depending on font's line height

### DIFF
--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -186,8 +186,9 @@ class PayToEdit(ScanQRTextEdit):
         self.update_size()
 
     def update_size(self):
+        lineHeight = QFontMetrics(self.document().defaultFont()).height()
         docHeight = self.document().size().height()
-        h = docHeight*17 + 11
+        h = docHeight * lineHeight + 11
         if self.heightMin <= h <= self.heightMax:
             self.setMinimumHeight(h)
             self.setMaximumHeight(h)


### PR DESCRIPTION
On high-resolution (HiRes) displays, the pixel size of a font is much
larger than the hard-coded 17 pixels, e.g. more than 40 for me. It's
better to get the line high of the current font from it's metrics and
calculate the high of the box with it.