### PR TITLE
Upload coverage statistics from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ python:
 install:
     - pip install tox
     - pip install tox-travis
+    - pip install python-coveralls
 script:
     - tox
 after_success:
     - if [ "$TRAVIS_BRANCH" = "master" ]; then pip install pycurl requests && contrib/make_locale; fi
+    - coveralls

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ Electrum - Lightweight Bitcoin client
 .. image:: https://travis-ci.org/spesmilo/electrum.svg?branch=master
     :target: https://travis-ci.org/spesmilo/electrum
     :alt: Build Status
+.. image:: https://coveralls.io/repos/github/spesmilo/electrum/badge.svg?branch=coverage
+    :target: https://coveralls.io/github/spesmilo/electrum?branch=coverage
+    :alt: Test coverage statistics
+
 
 
 


### PR DESCRIPTION
This makes the CI build generate and upload helpful statistics about the test coverage ([like this one](https://coveralls.io/builds/14101696/source?filename=lib%2Fkeystore.py) 📊 ).

Might be useful to determine which modules still need unit tests.

If you want to merge this you will also need to login on [coveralls.io](https://coveralls.io/sign-up) and activate the repo there.