### PR TITLE
fix py3: do_export_history

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2312,7 +2312,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
             if tx_hash:
                 label = wallet.get_label(tx_hash)
-                label = label.encode('utf-8')
             else:
                 label = ""
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 2279, in export_history_dialog
    self.do_export_history(self.wallet, filename, csv_button.isChecked())
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 2332, in do_export_history
    f.write(json.dumps(lines, indent = 4))
  File "/usr/lib/python3.5/json/__init__.py", line 237, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 200, in encode
    chunks = list(chunks)
  File "/usr/lib/python3.5/json/encoder.py", line 427, in _iterencode
    yield from _iterencode_list(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 324, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 436, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'' is not JSON serializable
Aborted
```