### PR TITLE
Follow-up #3245: Fix wrong branch name in badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Electrum - Lightweight Bitcoin client
 .. image:: https://travis-ci.org/spesmilo/electrum.svg?branch=master
     :target: https://travis-ci.org/spesmilo/electrum
     :alt: Build Status
-.. image:: https://coveralls.io/repos/github/spesmilo/electrum/badge.svg?branch=coverage
-    :target: https://coveralls.io/github/spesmilo/electrum?branch=coverage
+.. image:: https://coveralls.io/repos/github/spesmilo/electrum/badge.svg?branch=master
+    :target: https://coveralls.io/github/spesmilo/electrum?branch=master
     :alt: Test coverage statistics
 
 


### PR DESCRIPTION
Sorry, I missed that in #3245.

Also a heads-up: You will need to login to [coveralls.io](https://coveralls.io/sign-up) with your Github account and activate coverage reports for electrum to link it with the Travis builds.