### PR TITLE
[fix clearrequests] dictionary changed size during iteration

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -651,7 +651,7 @@ class Commands:
     @command('w')
     def clearrequests(self):
         """Remove all payment requests"""
-        for k in self.wallet.receive_requests.keys():
+        for k in list(self.wallet.receive_requests.keys()):
             self.wallet.remove_payment_request(k, self.config)
 
     @command('n')


### PR DESCRIPTION
Avoid `RuntimeError: dictionary changed size during iteration` by converting into a list