### PR TITLE
sweeping minikeys: search for both compressed and uncompressed pubkeys

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -600,7 +600,7 @@ def is_minikey(text):
     # permits any length of 20 or more provided the minikey is valid.
     # A valid minikey must begin with an 'S', be in base58, and when
     # suffixed with '?' have its SHA256 hash begin with a zero byte.
-    # They are widely used in Casascius physical bitoins.
+    # They are widely used in Casascius physical bitcoins.
     return (len(text) >= 20 and text[0] == 'S'
             and all(ord(c) in __b58chars for c in text)
             and sha256(text + '?')[0] == 0x00)


### PR DESCRIPTION
When sweeping, similar to how P2PK outputs were handled in #3125, I suggest doing server lookups for both compressed and uncompressed pubkeys in case of minikeys.

see #2748

Note that this PR only affects sweeping, so e.g. imported wallets won't see and monitor outputs for both compressed and uncompressed pubkeys.