### PR TITLE
p2sh-segwit multisig (keystore+wizard changes) for bip39 seed

### DIFF
--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -305,7 +305,7 @@ class BaseWizard(object):
         self.on_keystore(k)
 
     def on_bip43(self, seed, passphrase, derivation):
-        k = keystore.from_bip39_seed(seed, passphrase, derivation)
+        k = keystore.from_bip39_seed(seed, passphrase, derivation, self.wallet_type == 'multisig')
         self.on_keystore(k)
 
     def on_keystore(self, k):

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -573,11 +573,15 @@ def bip39_is_checksum_valid(mnemonic):
     calculated_checksum = hashed >> (256 - checksum_length)
     return checksum == calculated_checksum, True
 
-def from_bip39_seed(seed, passphrase, derivation):
+def from_bip39_seed(seed, passphrase, derivation, is_multisig):
     k = BIP32_KeyStore({})
     bip32_seed = bip39_to_seed(seed, passphrase)
-    t = 'p2wpkh-p2sh' if derivation.startswith("m/49'") else 'standard'  # bip43
-    k.add_xprv_from_seed(bip32_seed, t, derivation)
+    t = 'segwit' if derivation.startswith("m/49'") else 'standard'  # bip43
+    if t == 'standard':
+        xtype = 'standard'
+    else:
+        xtype = 'p2wsh-p2sh' if is_multisig else 'p2wpkh-p2sh'
+    k.add_xprv_from_seed(bip32_seed, xtype, derivation)
     return k
 
 # extended pubkeys

--- a/lib/tests/test_wallet_vertical.py
+++ b/lib/tests/test_wallet_vertical.py
@@ -99,7 +99,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
-        ks = keystore.from_bip39_seed(seed_words, '', "m/44'/0'/0'")
+        ks = keystore.from_bip39_seed(seed_words, '', "m/44'/0'/0'", False)
 
         self.assertTrue(isinstance(ks, keystore.BIP32_KeyStore))
 
@@ -115,7 +115,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
-        ks = keystore.from_bip39_seed(seed_words, '', "m/49'/0'/0'")
+        ks = keystore.from_bip39_seed(seed_words, '', "m/49'/0'/0'", False)
 
         self.assertTrue(isinstance(ks, keystore.BIP32_KeyStore))
 
@@ -169,7 +169,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
-        ks1 = keystore.from_bip39_seed(seed_words, '', "m/45'/0")
+        ks1 = keystore.from_bip39_seed(seed_words, '', "m/45'/0", True)
         self.assertTrue(isinstance(ks1, keystore.BIP32_KeyStore))
         self.assertEqual(ks1.xpub, 'xpub69xafV4YxC6o8Yiga5EiGLAtqR7rgNgNUGiYgw3S9g9pp6XYUne1KxdcfYtxwmA3eBrzMFuYcNQKfqsXCygCo4GxQFHfywxpUbKNfYvGJka')
 


### PR DESCRIPTION
No reason not to allow p2sh-segwit multisig for software bip39 seeds.

EDIT: Well, okay, this was hasty of me; there's a reason: bip49 is for p2wpkh-p2sh, not for multisig...
Hmm... Suggestions? :)
```python
t = 'segwit' if derivation.startswith("m/49'") else 'standard'
```