### PR TITLE
Clean up imports

### DIFF
--- a/contrib/make_download
+++ b/contrib/make_download
@@ -1,7 +1,5 @@
 #!/usr/bin/python2
-import sys
 import re
-import hashlib
 import os
 
 from versions import version, version_win, version_mac, version_android, version_apk

--- a/contrib/sign_packages
+++ b/contrib/sign_packages
@@ -1,7 +1,6 @@
 #!/usr/bin/python2
 
-import sys, re, shutil, os, hashlib
-import imp
+import os
 import getpass
 
 if __name__ == '__main__':

--- a/electrum
+++ b/electrum
@@ -87,7 +87,7 @@ if is_local or is_android:
     imp.load_module('electrum_plugins', *imp.find_module('plugins'))
 
 
-from electrum import bitcoin, network
+from electrum import bitcoin
 from electrum import SimpleConfig, Network
 from electrum.wallet import Wallet, Imported_Wallet
 from electrum.storage import WalletStorage

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -23,9 +23,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys
-import os
 import signal
+import sys
+
 
 try:
     import PyQt5
@@ -39,11 +39,12 @@ import PyQt5.QtCore as QtCore
 
 from electrum.i18n import _, set_language
 from electrum.plugins import run_hook
-from electrum import SimpleConfig, Wallet, WalletStorage
-from electrum.synchronizer import Synchronizer
-from electrum.verifier import SPV
-from electrum.util import DebugMem, UserCancelled, InvalidPassword, print_error
-from electrum.wallet import Abstract_Wallet
+from electrum import WalletStorage
+# from electrum.synchronizer import Synchronizer
+# from electrum.verifier import SPV
+# from electrum.util import DebugMem
+from electrum.util import UserCancelled, print_error
+# from electrum.wallet import Abstract_Wallet
 
 from .installwizard import InstallWizard, GoBack
 

--- a/gui/qt/address_dialog.py
+++ b/gui/qt/address_dialog.py
@@ -25,9 +25,9 @@
 
 from electrum.i18n import _
 
-import PyQt5
-from PyQt5.QtGui import *
 from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 
 from .util import *
 from .history_list import HistoryList

--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -26,7 +26,7 @@ import webbrowser
 
 from .util import *
 from electrum.i18n import _
-from electrum.util import block_explorer_URL, format_satoshis, format_time
+from electrum.util import block_explorer_URL
 from electrum.plugins import run_hook
 from electrum.bitcoin import is_address
 

--- a/gui/qt/contact_list.py
+++ b/gui/qt/contact_list.py
@@ -26,14 +26,13 @@ import webbrowser
 
 from electrum.i18n import _
 from electrum.bitcoin import is_address
-from electrum.util import block_explorer_URL, format_satoshis, format_time, age
+from electrum.util import block_explorer_URL
 from electrum.plugins import run_hook
-from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_UNKNOWN, PR_EXPIRED
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import (
     QAbstractItemView, QFileDialog, QMenu, QTreeWidgetItem)
-from .util import MyTreeWidget, pr_tooltips, pr_icons
+from .util import MyTreeWidget
 
 
 class ContactList(MyTreeWidget):

--- a/gui/qt/fee_slider.py
+++ b/gui/qt/fee_slider.py
@@ -1,10 +1,8 @@
 
 from electrum.i18n import _
 
-import PyQt5
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
 from PyQt5.QtWidgets import QSlider, QToolTip
 
 import threading

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -27,8 +27,7 @@ import webbrowser
 
 from .util import *
 from electrum.i18n import _
-from electrum.util import block_explorer_URL, format_satoshis, format_time
-from electrum.plugins import run_hook
+from electrum.util import block_explorer_URL
 from electrum.util import timestamp_to_datetime, profiler
 
 

--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -1,12 +1,13 @@
 
-import sys
 import os
+import sys
+import threading
+import traceback
 
-from PyQt5.QtGui import *
 from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 
-import electrum
 from electrum import Wallet, WalletStorage
 from electrum.util import UserCancelled, InvalidPassword
 from electrum.base_wizard import BaseWizard
@@ -55,9 +56,8 @@ class CosignWidget(QWidget):
         self.update()
 
     def paintEvent(self, event):
-        import math
         bgcolor = self.palette().color(QPalette.Background)
-        pen = QPen(bgcolor, 7, QtCore.Qt.SolidLine)
+        pen = QPen(bgcolor, 7, Qt.SolidLine)
         qp = QPainter()
         qp.begin(self)
         qp.setPen(pen)

--- a/gui/qt/invoice_list.py
+++ b/gui/qt/invoice_list.py
@@ -23,11 +23,10 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
 from .util import *
 from electrum.i18n import _
-from electrum.util import block_explorer_URL, format_satoshis, format_time
-from electrum.plugins import run_hook
+from electrum.util import format_time
+
 
 class InvoiceList(MyTreeWidget):
     filter_columns = [0, 1, 2, 3]  # Date, Requestor, Description, Amount

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -25,7 +25,6 @@
 import sys, time, threading
 import os, json, traceback
 import shutil
-import socket
 import weakref
 import webbrowser
 import csv
@@ -33,13 +32,11 @@ from decimal import Decimal
 import base64
 from functools import partial
 
-import PyQt5
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import *
-from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
+from PyQt5.QtWidgets import *
 
 from electrum.util import bh2u, bfh
-from . import icons_rc
 
 from electrum import keystore
 from electrum.bitcoin import COIN, is_address, TYPE_ADDRESS
@@ -48,24 +45,20 @@ from electrum.i18n import _
 from electrum.util import (format_time, format_satoshis, PrintError,
                            format_satoshis_plain, NotEnoughFunds,
                            UserCancelled)
-from electrum import Transaction, mnemonic
+from electrum import Transaction
 from electrum import util, bitcoin, commands, coinchooser
-from electrum import SimpleConfig, paymentrequest
-from electrum.wallet import Wallet, Multisig_Wallet
+from electrum import paymentrequest
+from electrum.wallet import Multisig_Wallet
 try:
     from electrum.plot import plot_history
 except:
     plot_history = None
 
-from .amountedit import AmountEdit, BTCAmountEdit, MyLineEdit, BTCkBEdit
+from .amountedit import AmountEdit, BTCAmountEdit, MyLineEdit
 from .qrcodewidget import QRCodeWidget, QRDialog
 from .qrtextedit import ShowQRTextEdit, ScanQRTextEdit
 from .transaction_dialog import show_transaction
 from .fee_slider import FeeSlider
-
-
-from electrum import ELECTRUM_VERSION
-import re
 
 from .util import *
 
@@ -85,11 +78,11 @@ class StatusBarButton(QPushButton):
         self.func()
 
     def keyPressEvent(self, e):
-        if e.key() == QtCore.Qt.Key_Return:
+        if e.key() == Qt.Key_Return:
             self.func()
 
 
-from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_UNKNOWN, PR_EXPIRED
+from electrum.paymentrequest import PR_PAID
 
 
 class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
@@ -928,7 +921,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def new_payment_request(self):
         addr = self.wallet.get_unused_address()
         if addr is None:
-            from electrum.wallet import Imported_Wallet
             if not self.wallet.is_deterministic():
                 msg = [
                     _('No more addresses in your wallet.'),
@@ -2071,7 +2063,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         return d.run()
 
     def tx_from_text(self, txt):
-        from electrum.transaction import tx_from_str, Transaction
+        from electrum.transaction import tx_from_str
         try:
             tx = tx_from_str(txt)
             return Transaction(tx)

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -27,11 +27,11 @@ import socket
 
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
 import PyQt5.QtCore as QtCore
 
 from electrum.i18n import _
 from electrum.bitcoin import NetworkConstants
-from electrum.network import serialize_server, deserialize_server
 from electrum.util import print_error
 
 from .util import *

--- a/gui/qt/password_dialog.py
+++ b/gui/qt/password_dialog.py
@@ -23,8 +23,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import *
-from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
 from electrum.i18n import _
 from .util import *
 import re

--- a/gui/qt/qrcodewidget.py
+++ b/gui/qt/qrcodewidget.py
@@ -1,6 +1,6 @@
 
-from PyQt5.QtGui import *
 from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 import PyQt5.QtGui as QtGui
 from PyQt5.QtWidgets import (
     QApplication, QVBoxLayout, QTextEdit, QHBoxLayout, QPushButton, QWidget)

--- a/gui/qt/qrwindow.py
+++ b/gui/qt/qrwindow.py
@@ -23,15 +23,11 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import re
 import platform
-from decimal import Decimal
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import *
-from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
-import PyQt5.QtGui as QtGui
-from PyQt5.QtWidgets import (QHBoxLayout, QVBoxLayout, QLabel, QWidget)
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QLabel, QWidget
 
 from electrum_gui.qt.qrcodewidget import QRCodeWidget
 from electrum.i18n import _
@@ -55,7 +51,7 @@ class QR_Window(QWidget):
         self.address = ''
         self.label = ''
         self.amount = 0
-        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setFocusPolicy(Qt.NoFocus)
 
         main_box = QHBoxLayout()
 

--- a/gui/qt/request_list.py
+++ b/gui/qt/request_list.py
@@ -24,9 +24,9 @@
 # SOFTWARE.
 
 from electrum.i18n import _
-from electrum.util import block_explorer_URL, format_satoshis, format_time, age
+from electrum.util import format_time, age
 from electrum.plugins import run_hook
-from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_UNKNOWN, PR_EXPIRED
+from electrum.paymentrequest import PR_UNKNOWN
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import QTreeWidgetItem, QMenu

--- a/gui/qt/seed_dialog.py
+++ b/gui/qt/seed_dialog.py
@@ -25,6 +25,7 @@
 
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
 from electrum.i18n import _
 
 from .util import *

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -26,12 +26,10 @@ import copy
 import datetime
 import json
 
-import PyQt5
-from PyQt5.QtGui import *
 from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 
-from electrum import transaction
 from electrum.bitcoin import base_encode
 from electrum.i18n import _
 from electrum.plugins import run_hook

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -1,8 +1,6 @@
 import os.path
 import time
-import traceback
 import sys
-import threading
 import platform
 import queue
 from collections import namedtuple
@@ -23,7 +21,7 @@ else:
 
 dialogs = []
 
-from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_UNKNOWN, PR_EXPIRED
+from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_EXPIRED
 
 pr_icons = {
     PR_UNPAID:":icons/unpaid.png",

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -24,7 +24,6 @@
 # SOFTWARE.
 from .util import *
 from electrum.i18n import _
-from electrum.bitcoin import is_address
 
 
 class UTXOList(MyTreeWidget):

--- a/gui/stdio.py
+++ b/gui/stdio.py
@@ -4,8 +4,7 @@ _ = lambda x:x
 from electrum import WalletStorage, Wallet
 from electrum.util import format_satoshis, set_verbosity
 from electrum.bitcoin import is_address, COIN, TYPE_ADDRESS
-from electrum.network import filter_protocol
-import sys, getpass, datetime
+import getpass, datetime
 
 # minimal fdisk like gui for console usage
 # written by rofl0r, with some bits stolen from the text gui (ncurses)

--- a/gui/stdio.py
+++ b/gui/stdio.py
@@ -1,9 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import six
 from decimal import Decimal
 _ = lambda x:x
 #from i18n import _

--- a/gui/text.py
+++ b/gui/text.py
@@ -1,9 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import six
 import tty, sys
 import curses, datetime, locale
 from decimal import Decimal

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -27,9 +27,8 @@ import os
 from . import bitcoin
 from . import keystore
 from .keystore import bip44_derivation
-from .wallet import Wallet, Imported_Wallet, Standard_Wallet, Multisig_Wallet, wallet_types
+from .wallet import Imported_Wallet, Standard_Wallet, Multisig_Wallet, wallet_types
 from .i18n import _
-from .plugins import run_hook
 
 
 class BaseWizard(object):

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -25,7 +25,6 @@
 
 import hashlib
 import base64
-import re
 import hmac
 import os
 import json

--- a/lib/coinchooser.py
+++ b/lib/coinchooser.py
@@ -27,7 +27,7 @@ from math import floor, log10
 
 from .bitcoin import sha256, COIN, TYPE_ADDRESS
 from .transaction import Transaction
-from .util import NotEnoughFunds, PrintError, profiler
+from .util import NotEnoughFunds, PrintError
 
 
 # A simple deterministic PRNG.  Used to deterministically shuffle a

--- a/lib/coinchooser.py
+++ b/lib/coinchooser.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import defaultdict, namedtuple
 from math import floor, log10
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -22,10 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import sys

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -23,10 +23,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
 import sys
 import datetime
-import time
 import copy
 import argparse
 import json
@@ -41,9 +39,7 @@ from .import bitcoin
 from .bitcoin import is_address,  hash_160, COIN, TYPE_ADDRESS
 from .i18n import _
 from .transaction import Transaction
-from .import paymentrequest
 from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
-from .import contacts
 from .plugins import run_hook
 
 known_commands = {}

--- a/lib/contacts.py
+++ b/lib/contacts.py
@@ -20,16 +20,12 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import sys
 import re
 import dns
-import os
 import json
 
 from . import bitcoin
 from . import dnssec
-from .util import print_error
-from .i18n import _
 
 
 class Contacts(dict):

--- a/lib/contacts.py
+++ b/lib/contacts.py
@@ -20,12 +20,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 import sys
 import re
 import dns

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -24,7 +24,6 @@
 # SOFTWARE.
 import ast
 import os
-import sys
 import time
 
 # from jsonrpc import JSONRPCResponseManager
@@ -34,12 +33,11 @@ from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer, SimpleJSONRPCReq
 from .version import ELECTRUM_VERSION
 from .network import Network
 from .util import json_decode, DaemonThread
-from .util import print_msg, print_error, print_stderr, UserCancelled
+from .util import print_error
 from .wallet import Wallet
 from .storage import WalletStorage
 from .commands import known_commands, Commands
 from .simple_config import SimpleConfig
-from .plugins import run_hook
 from .exchange_rate import FxThread
 
 

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import ast
 import os
 import sys

--- a/lib/dnssec.py
+++ b/lib/dnssec.py
@@ -22,12 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 
 # Check DNSSEC trust chain.
 # Todo: verify expiration dates

--- a/lib/dnssec.py
+++ b/lib/dnssec.py
@@ -31,8 +31,8 @@
 #  https://github.com/rthalley/dnspython/blob/master/tests/test_dnssec.py
 
 
-import traceback
-import sys
+# import traceback
+# import sys
 import time
 import struct
 
@@ -56,7 +56,6 @@ import dns.rdtypes.ANY.SOA
 import dns.rdtypes.ANY.TXT
 import dns.rdtypes.IN.A
 import dns.rdtypes.IN.AAAA
-from dns.exception import DNSException
 
 
 # Pure-Python version of dns.dnssec._validate_rsig

--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import inspect
 import requests

--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -4,14 +4,12 @@ import requests
 import sys
 from threading import Thread
 import time
-import traceback
 import csv
 from decimal import Decimal
 
 from .bitcoin import COIN
 from .i18n import _
 from .util import PrintError, ThreadJob
-from .util import format_satoshis
 
 
 # See https://en.wikipedia.org/wiki/ISO_4217

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import gettext, os
 
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), 'locale')

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import re
 import socket

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -24,20 +24,15 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import struct
-
 from unicodedata import normalize
 
-from .version import *
 from . import bitcoin
-from .bitcoin import pw_encode, pw_decode, bip32_root, bip32_private_derivation, bip32_public_derivation, bip32_private_key, deserialize_xprv, deserialize_xpub
-from .bitcoin import public_key_from_private_key, public_key_to_p2pkh
 from .bitcoin import *
 
-from .bitcoin import is_old_seed, is_new_seed, is_seed
 from .util import PrintError, InvalidPassword, hfu
 from .mnemonic import Mnemonic, load_wordlist
 from .plugins import run_hook
+
 
 class KeyStore(PrintError):
 

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -22,12 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 import os
 import hmac
 import math

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -35,7 +35,6 @@ import pbkdf2
 from .util import print_error
 from .bitcoin import is_old_seed, is_new_seed
 from . import version
-from . import i18n
 
 # http://www.asahi-net.or.jp/~ax2s-kmtn/ref/unicode/e_asia.html
 CJK_INTERVALS = [
@@ -164,7 +163,6 @@ class Mnemonic(object):
         return i % custom_entropy == 0
 
     def make_seed(self, seed_type='standard', num_bits=132, custom_entropy=1):
-        from . import version
         prefix = version.seed_prefix(seed_type)
         # increase num_bits in order to obtain a uniform distibution for the last word
         bpw = math.log(len(self.wordlist), 2)

--- a/lib/msqr.py
+++ b/lib/msqr.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # from http://eli.thegreenplace.net/2009/03/07/computing-modular-square-roots-in-python/
 
 def modular_sqrt(a, p):

--- a/lib/network.py
+++ b/lib/network.py
@@ -26,11 +26,10 @@ import queue
 import os
 import stat
 import errno
-import sys
 import random
+import re
 import select
-import traceback
-from collections import defaultdict, deque
+from collections import defaultdict
 import threading
 import socket
 import json

--- a/lib/network.py
+++ b/lib/network.py
@@ -21,11 +21,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import time
 import queue
 import os

--- a/lib/old_mnemonic.py
+++ b/lib/old_mnemonic.py
@@ -22,10 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 
 # list of words from http://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/Contemporary_poetry

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import hashlib
 import os.path
 import re

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -23,10 +23,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import hashlib
-import os.path
-import re
 import sys
-import threading
 import time
 import traceback
 import json

--- a/lib/pem.py
+++ b/lib/pem.py
@@ -22,10 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 
 # This module uses code from TLSLlite

--- a/lib/plot.py
+++ b/lib/plot.py
@@ -4,8 +4,6 @@ from electrum.i18n import _
 
 import datetime
 from collections import defaultdict
-
-from electrum.util import format_satoshis
 from electrum.bitcoin import COIN
 
 import matplotlib

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -31,7 +31,7 @@ import pkgutil
 import time
 import threading
 
-from .util import *
+from .util import print_error
 from .i18n import _
 from .util import profiler, PrintError, DaemonThread, UserCancelled, ThreadJob
 from . import bitcoin

--- a/lib/rsakey.py
+++ b/lib/rsakey.py
@@ -33,11 +33,6 @@
 
 """Pure-Python RSA implementation."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import math
 import base64

--- a/lib/rsakey.py
+++ b/lib/rsakey.py
@@ -35,8 +35,6 @@
 
 import os
 import math
-import base64
-import binascii
 import hashlib
 
 from .pem import *

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -1,4 +1,3 @@
-import ast
 import json
 import threading
 import time
@@ -6,7 +5,7 @@ import os
 import stat
 
 from copy import deepcopy
-from .util import user_dir, print_error, print_msg, print_stderr, PrintError
+from .util import user_dir, print_error, print_stderr, PrintError
 
 from .bitcoin import MAX_FEE_RATE, FEE_TARGETS
 

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import ast
 import json
 import threading

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -25,8 +25,6 @@
 import os
 import ast
 import threading
-import random
-import time
 import json
 import copy
 import re
@@ -35,8 +33,7 @@ import pbkdf2, hmac, hashlib
 import base64
 import zlib
 
-from .i18n import _
-from .util import NotEnoughFunds, PrintError, profiler
+from .util import PrintError, profiler
 from .plugins import run_hook, plugin_loaders
 from .keystore import bip44_derivation
 from . import bitcoin

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from threading import Lock
 import hashlib
 

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -25,9 +25,9 @@
 from threading import Lock
 import hashlib
 
-from .bitcoin import Hash, hash_encode
+# from .bitcoin import Hash, hash_encode
 from .transaction import Transaction
-from .util import print_error, print_msg, ThreadJob, bh2u
+from .util import ThreadJob, bh2u
 
 
 class Synchronizer(ThreadJob):

--- a/lib/tests/test_simple_config.py
+++ b/lib/tests/test_simple_config.py
@@ -4,7 +4,6 @@ import os
 import unittest
 import tempfile
 import shutil
-import json
 
 from io import StringIO
 from lib.simple_config import (SimpleConfig, read_system_config,

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -2,10 +2,7 @@ import unittest
 from lib import transaction
 from lib.bitcoin import TYPE_ADDRESS
 
-import pprint
 from lib.keystore import xpubkey_to_address
-
-from lib.util import bh2u
 
 from lib.util import bh2u
 

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -27,21 +27,15 @@
 
 # Note: The deserialization code originally comes from ABE.
 
-from . import bitcoin
-from .bitcoin import *
-from .util import print_error, profiler, to_string
+from .util import print_error, profiler
 
 from . import bitcoin
 from .bitcoin import *
-import time
-import sys
 import struct
 
 #
 # Workalike python implementation of Bitcoin's CDataStream class.
 #
-import struct
-import random
 from .keystore import xpubkey_to_address, xpubkey_to_pubkey
 
 NO_SIGNATURE = 'ff'

--- a/lib/util.py
+++ b/lib/util.py
@@ -20,11 +20,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import binascii
 import os, sys, re, json
 from collections import defaultdict

--- a/lib/util.py
+++ b/lib/util.py
@@ -583,7 +583,6 @@ class timeout(Exception):
     pass
 
 import socket
-import errno
 import json
 import ssl
 import time

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -28,18 +28,14 @@
 
 
 import os
-import hashlib
-import ast
 import threading
 import random
 import time
 import json
 import copy
-import re
-import stat
 import errno
 from functools import partial
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 
 from .i18n import _
 from .util import NotEnoughFunds, PrintError, UserCancelled, profiler, format_satoshis
@@ -56,14 +52,11 @@ from . import bitcoin
 from . import coinchooser
 from .synchronizer import Synchronizer
 from .verifier import SPV
-from .mnemonic import Mnemonic
 
 from . import paymentrequest
 from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 from .paymentrequest import InvoiceStore
 from .contacts import Contacts
-
-from .storage import WalletStorage
 
 TX_STATUS = [
     _('Replaceable'),
@@ -1281,7 +1274,6 @@ class Abstract_Wallet(PrintError):
         self.storage.put('payment_requests', self.receive_requests)
 
     def add_payment_request(self, req, config):
-        import os
         addr = req['address']
         amount = req.get('amount')
         message = req.get('memo')

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -23,7 +23,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import queue
-import threading, os, json, time
+import threading, os, json
 from collections import defaultdict
 try:
     from SimpleWebSocketServer import WebSocket, SimpleSSLWebSocketServer

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import queue
 import threading, os, json, time
 from collections import defaultdict

--- a/lib/x509.py
+++ b/lib/x509.py
@@ -22,10 +22,8 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from datetime import datetime
-import sys
 from . import util
-from .util import profiler, print_error, bh2u
+from .util import profiler, bh2u
 import ecdsa
 import hashlib
 

--- a/lib/x509.py
+++ b/lib/x509.py
@@ -22,11 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import sys
 from . import util

--- a/plugins/cosigner_pool/qt.py
+++ b/plugins/cosigner_pool/qt.py
@@ -23,8 +23,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import socket
-import threading
 import time
 from xmlrpc.client import ServerProxy
 

--- a/plugins/digitalbitbox/cmdline.py
+++ b/plugins/digitalbitbox/cmdline.py
@@ -1,4 +1,3 @@
-from electrum.util import print_msg
 from .digitalbitbox import DigitalBitboxPlugin
 from ..hw_wallet import CmdLineHandler
 

--- a/plugins/digitalbitbox/qt.py
+++ b/plugins/digitalbitbox/qt.py
@@ -1,11 +1,10 @@
-from PyQt5.QtWidgets import (QInputDialog, QLineEdit)
 from ..hw_wallet.qt import QtHandlerBase, QtPluginBase
 from .digitalbitbox import DigitalBitboxPlugin
 
 from electrum.i18n import _
 from electrum.plugins import hook
-from electrum.wallet import Wallet, Standard_Wallet
-from electrum.bitcoin import EncodeAES
+from electrum.wallet import Standard_Wallet
+
 
 class Plugin(DigitalBitboxPlugin, QtPluginBase):
     icon_unpaired = ":icons/digitalbitbox_unpaired.png"

--- a/plugins/email_requests/qt.py
+++ b/plugins/email_requests/qt.py
@@ -37,7 +37,6 @@ from email.encoders import encode_base64
 
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
 import PyQt5.QtGui as QtGui
 from PyQt5.QtWidgets import (QVBoxLayout, QLabel, QGridLayout, QLineEdit)
 

--- a/plugins/keepkey/cmdline.py
+++ b/plugins/keepkey/cmdline.py
@@ -1,5 +1,4 @@
 from electrum.plugins import hook
-from electrum.util import print_msg, raw_input
 from .keepkey import KeepKeyPlugin
 from ..hw_wallet import CmdLineHandler
 

--- a/plugins/ledger/auth2fa.py
+++ b/plugins/ledger/auth2fa.py
@@ -1,7 +1,6 @@
 from binascii import hexlify, unhexlify
-import threading
 
-from PyQt5.Qt import (QDialog, QInputDialog, QLineEdit, QTextEdit, QVBoxLayout, QLabel)
+from PyQt5.Qt import QDialog, QLineEdit, QTextEdit, QVBoxLayout, QLabel
 import PyQt5.QtCore as QtCore
 from PyQt5.QtWidgets import *
 
@@ -9,8 +8,8 @@ from electrum.i18n import _
 from electrum_gui.qt.util import *
 from electrum.util import print_msg
 
-import os, hashlib, websocket, threading, logging, json, copy
-from electrum_gui.qt.qrcodewidget import QRCodeWidget, QRDialog
+import os, hashlib, websocket, logging, json, copy
+from electrum_gui.qt.qrcodewidget import QRCodeWidget
 from btchip.btchip import *
 
 DEBUG = False

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -1,19 +1,16 @@
 from struct import pack, unpack
 import hashlib
-import time
 import sys
-import os
 import traceback
 
-import electrum
 from electrum import bitcoin
 from electrum.bitcoin import TYPE_ADDRESS, int_to_hex, var_int
 from electrum.i18n import _
-from electrum.plugins import BasePlugin, hook
-from electrum.keystore import Hardware_KeyStore, parse_xpubkey
-from electrum.transaction import push_script, Transaction
+from electrum.plugins import BasePlugin
+from electrum.keystore import Hardware_KeyStore
+from electrum.transaction import Transaction
 from ..hw_wallet import HW_PluginBase
-from electrum.util import format_satoshis_plain, print_error, is_verbose, bfh, bh2u
+from electrum.util import print_error, is_verbose, bfh, bh2u
 
 try:
     import hid

--- a/plugins/ledger/qt.py
+++ b/plugins/ledger/qt.py
@@ -1,8 +1,6 @@
 import threading
 
-from PyQt5.Qt import (QDialog, QInputDialog, QLineEdit,
-                      QVBoxLayout, QLabel)
-import PyQt5.QtCore as QtCore
+from PyQt5.Qt import QInputDialog, QLineEdit, QVBoxLayout, QLabel
 
 from electrum.i18n import _
 from .ledger import LedgerPlugin

--- a/plugins/trezor/plugin.py
+++ b/plugins/trezor/plugin.py
@@ -1,18 +1,13 @@
-import base64
-import re
 import threading
 
 from binascii import hexlify, unhexlify
-from functools import partial
 
 from electrum.util import bfh, bh2u
-from electrum.bitcoin import (is_segwit_address, b58_address_to_hash160, xpub_from_pubkey,
-                              public_key_to_p2pkh, EncodeBase58Check,
-                              TYPE_ADDRESS, TYPE_SCRIPT,
-                              NetworkConstants)
+from electrum.bitcoin import (b58_address_to_hash160, xpub_from_pubkey,
+                              TYPE_ADDRESS, TYPE_SCRIPT, NetworkConstants)
 from electrum.i18n import _
-from electrum.plugins import BasePlugin, hook
-from electrum.transaction import deserialize, Transaction
+from electrum.plugins import BasePlugin
+from electrum.transaction import deserialize
 from electrum.keystore import Hardware_KeyStore, is_xpubkey, parse_xpubkey
 
 from ..hw_wallet import HW_PluginBase

--- a/plugins/trustedcoin/trustedcoin.py
+++ b/plugins/trustedcoin/trustedcoin.py
@@ -25,10 +25,8 @@
 
 import socket
 import os
-import re
 import requests
 import json
-from hashlib import sha256
 from urllib.parse import urljoin
 from urllib.parse import quote
 
@@ -38,9 +36,9 @@ from electrum import keystore
 from electrum.bitcoin import *
 from electrum.mnemonic import Mnemonic
 from electrum import version
-from electrum.wallet import Multisig_Wallet, Deterministic_Wallet, Wallet
+from electrum.wallet import Multisig_Wallet, Deterministic_Wallet
 from electrum.i18n import _
-from electrum.plugins import BasePlugin, run_hook, hook
+from electrum.plugins import BasePlugin, hook
 from electrum.util import NotEnoughFunds
 
 # signing_xpub is hardcoded so that the wallet can be restored from seed, without TrustedCoin's server

--- a/scripts/bip70
+++ b/scripts/bip70
@@ -2,12 +2,8 @@
 # create a BIP70 payment request signed with a certificate
 
 import tlslite
-import time
-import hashlib
 
 from electrum.transaction import Transaction
-from electrum import bitcoin
-from electrum import x509
 from electrum import paymentrequest
 from electrum import paymentrequest_pb2 as pb2
 

--- a/scripts/peers
+++ b/scripts/peers
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-import util, json
-from collections import defaultdict
+import util
 
 from electrum.network import filter_protocol
 from electrum.blockchain import hash_header

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1,7 +1,8 @@
-import select, time, electrum, queue
+import select, time, queue
+# import electrum
 from electrum import Connection, Interface, SimpleConfig
 
-from electrum.network import filter_protocol, parse_servers
+from electrum.network import parse_servers
 from collections import defaultdict
 
 # electrum.util.set_verbosity(1)


### PR DESCRIPTION
For every package except kivy, this PR
* Removes Python 2 support imports (`from __futures__…`)
* Removes unused imports
* If an import is only referenced from a comment, comment out the import as well.
* Where QtWidgets were being implicitly imported via importing * from util, explicitly import them.

The kivy packages have a lot of unused imports, but I don't know enough about kivy to ensure my actions aren't destructive. That will have to come later.