### PR TITLE
Fix undefined reference error in command line KeepKey plugin.

### DIFF
--- a/plugins/keepkey/cmdline.py
+++ b/plugins/keepkey/cmdline.py
@@ -1,3 +1,4 @@
+from electrum.plugins import hook
 from electrum.util import print_msg, raw_input
 from .keepkey import KeepKeyPlugin
 from ..hw_wallet import CmdLineHandler


### PR DESCRIPTION
`hook` decorator referenced without being imported.