### PR TITLE
fix: bip39 checksum sometimes not calculated

### DIFF
--- a/gui/qt/seed_dialog.py
+++ b/gui/qt/seed_dialog.py
@@ -63,8 +63,8 @@ class SeedLayout(QVBoxLayout):
         if 'bip39' in self.options:
             def f(b):
                 self.is_seed = (lambda x: bool(x)) if b else self.saved_is_seed
-                self.on_edit()
                 self.is_bip39 = b
+                self.on_edit()
                 if b:
                     msg = ' '.join([
                         '<b>' + _('Warning') + ':</b>  ',


### PR DESCRIPTION
Fixes:
1. reach restore seed dialog in wizard
2. enter a bip39 seed
3. enable "bip39" option
4. checksum not calculated