### PR TITLE
disallow editing labels in Coins tab (QT)

### DIFF
--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -69,3 +69,7 @@ class UTXOList(MyTreeWidget):
             menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx))
 
         menu.exec_(self.viewport().mapToGlobal(position))
+
+    def on_permit_edit(self, item, column):
+        # disable editing fields in this tab (labels)
+        return False


### PR DESCRIPTION
See https://github.com/spesmilo/electrum/issues/3317#issuecomment-345114444

Edit: I can add the mentioned storage version upgrade, if it's deemed to worth it.