### PR TITLE
fix: ledger clear_dialog() threading issues

### DIFF
--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -238,7 +238,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
         except Exception as e:
             self.give_error(e, True)
         finally:
-            self.handler.clear_dialog()
+            self.handler.finished()
         self.signing = False
         # Parse the ASN.1 signature
         rLength = signature[3]
@@ -376,13 +376,13 @@ class Ledger_KeyStore(Hardware_KeyStore):
                 transactionOutput = outputData['outputData']
                 if outputData['confirmationNeeded']:
                     outputData['address'] = output
-                    self.handler.clear_dialog()
+                    self.handler.finished()
                     pin = self.handler.get_auth( outputData ) # does the authenticate dialog and returns pin
                     if not pin:
                         raise UserWarning()
                     if pin != 'paired':
                         self.handler.show_message(_("Confirmed. Signing Transaction..."))
-                while inputIndex < len(inputs):                
+                while inputIndex < len(inputs):
                     singleInput = [ chipInputs[inputIndex] ]
                     self.get_client().startUntrustedTransaction(False, 0,
                                                             singleInput, redeemScripts[inputIndex])
@@ -400,7 +400,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
                         transactionOutput = outputData['outputData']
                     if outputData['confirmationNeeded']:
                         outputData['address'] = output
-                        self.handler.clear_dialog()
+                        self.handler.finished()
                         pin = self.handler.get_auth( outputData ) # does the authenticate dialog and returns pin
                         if not pin:
                             raise UserWarning()
@@ -421,7 +421,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
             traceback.print_exc(file=sys.stdout)
             self.give_error(e, True)
         finally:
-            self.handler.clear_dialog()
+            self.handler.finished()
 
         for i, txin in enumerate(tx.inputs()):
             signingPos = inputs[i][4]


### PR DESCRIPTION
fixes #3264

The crash happens at https://github.com/spesmilo/electrum/blob/219a5b02a63a9ee227cff1c83516d003736abf4b/plugins/hw_wallet/qt.py#L161

Delegating the `clear_dialog()` calls to the GUI thread (via signals) seems to fix it. I would appreciate it if someone who understands QT better would enlighten me why... :P

It took me way too long to debug this...