### PR TITLE
more robust getprivatekeys() and is_segwit_address()

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -569,7 +569,10 @@ def address_from_private_key(sec):
     return pubkey_to_address(txin_type, public_key)
 
 def is_segwit_address(addr):
-    witver, witprog = segwit_addr.decode(NetworkConstants.SEGWIT_HRP, addr)
+    try:
+        witver, witprog = segwit_addr.decode(NetworkConstants.SEGWIT_HRP, addr)
+    except Exception as e:
+        return False
     return witprog is not None
 
 def is_b58_address(addr):

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -273,6 +273,8 @@ class Commands:
     @command('wp')
     def getprivatekeys(self, address, password=None):
         """Get private keys of addresses. You may pass a single wallet address, or a list of wallet addresses."""
+        if isinstance(address, str):
+            address = address.strip()
         if is_address(address):
             return self.wallet.export_private_key(address, password)[0]
         domain = address


### PR DESCRIPTION
fixes #3334

Without this PR, only one of the following three usages work.
With this PR, all three work.
```
user@debian:~/wspace/electrum$ echo '["1EmM5ASoeNYoRELRkfBKueatumrss9HBex"]' | ./electrum -w ~/.electrum/wallets/tmp5 getprivatekeys -
WARNING: ALL your private keys are secret.
Exposing a single private key can compromise your entire wallet!
In particular, DO NOT use 'redeem private key' services proposed by third parties.
Password:
Traceback (most recent call last):
  File "./electrum", line 423, in <module>
    result = run_offline_command(config, config_options)
  File "./electrum", line 288, in run_offline_command
    result = func(*args, **kwargs)
  File "/home/user/wspace/electrum/lib/commands.py", line 87, in func_wrapper
    return func(*args, **kwargs)
  File "/home/user/wspace/electrum/lib/commands.py", line 276, in getprivatekeys
    if is_address(address):
  File "/home/user/wspace/electrum/lib/bitcoin.py", line 585, in is_address
    return is_segwit_address(addr) or is_b58_address(addr)
  File "/home/user/wspace/electrum/lib/bitcoin.py", line 572, in is_segwit_address
    witver, witprog = segwit_addr.decode(NetworkConstants.SEGWIT_HRP, addr)
  File "/home/user/wspace/electrum/lib/segwit_addr.py", line 105, in decode
    hrpgot, data = bech32_decode(addr)
  File "/home/user/wspace/electrum/lib/segwit_addr.py", line 64, in bech32_decode
    if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
  File "/home/user/wspace/electrum/lib/segwit_addr.py", line 64, in <genexpr>
    if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
TypeError: ord() expected a character, but string of length 34 found
```
```
user@debian:~/wspace/electrum$ echo '1EmM5ASoeNYoRELRkfBKueatumrss9HBex' | ./electrum -w ~/.electrum/wallets/tmp5 getprivatekeys -
WARNING: ALL your private keys are secret.
Exposing a single private key can compromise your entire wallet!
In particular, DO NOT use 'redeem private key' services proposed by third parties.
Password:
Traceback (most recent call last):
  File "./electrum", line 423, in <module>
    result = run_offline_command(config, config_options)
  File "./electrum", line 288, in run_offline_command
    result = func(*args, **kwargs)
  File "/home/user/wspace/electrum/lib/commands.py", line 87, in func_wrapper
    return func(*args, **kwargs)
  File "/home/user/wspace/electrum/lib/commands.py", line 279, in getprivatekeys
    return [self.wallet.export_private_key(address, password)[0] for address in domain]
  File "/home/user/wspace/electrum/lib/commands.py", line 279, in <listcomp>
    return [self.wallet.export_private_key(address, password)[0] for address in domain]
  File "/home/user/wspace/electrum/lib/wallet.py", line 268, in export_private_key
    index = self.get_address_index(address)
  File "/home/user/wspace/electrum/lib/wallet.py", line 262, in get_address_index
    raise Exception("Address not found", address)
Exception: ('Address not found', '1')
```
```
user@debian:~/wspace/electrum$ printf '1EmM5ASoeNYoRELRkfBKueatumrss9HBex' | ./electrum -w ~/.electrum/wallets/tmp5 getprivatekeys -
WARNING: ALL your private keys are secret.
Exposing a single private key can compromise your entire wallet!
In particular, DO NOT use 'redeem private key' services proposed by third parties.
Password:
L47jNK4H1ASZR5RYBg1uvZW8VpNTVbtBGF2tarAc1As8ku7MwtGx
```