### PR TITLE
storage: more helpful logs/errors when creating storage/wallet

### DIFF
--- a/lib/storage.py
+++ b/lib/storage.py
@@ -51,10 +51,13 @@ FINAL_SEED_VERSION = 16     # electrum >= 2.7 will set this to prevent
 def multisig_type(wallet_type):
     '''If wallet_type is mofn multi-sig, return [m, n],
     otherwise return None.'''
-    match = re.match('(\d+)of(\d+)', wallet_type)
-    if match:
-        match = [int(x) for x in match.group(1, 2)]
-    return match
+    try:
+        match = re.match('(\d+)of(\d+)', wallet_type)
+        if match:
+            match = [int(x) for x in match.group(1, 2)]
+        return match
+    except Exception as e:
+        return None
 
 
 class WalletStorage(PrintError):
@@ -73,6 +76,7 @@ class WalletStorage(PrintError):
             if not self.is_encrypted():
                 self.load_data(self.raw)
         else:
+            self.print_error('did not find existing wallet file')
             # avoid new wallets getting 'upgraded'
             self.put('seed_version', FINAL_SEED_VERSION)
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1865,5 +1865,5 @@ class Wallet(object):
             return Multisig_Wallet
         if wallet_type in wallet_constructors:
             return wallet_constructors[wallet_type]
-        raise RuntimeError("Unknown wallet type: " + wallet_type)
+        raise RuntimeError("Unknown wallet type: " + str(wallet_type))
 


### PR DESCRIPTION
Re chat with @cluelessperson in #electrum.

This would make it more obvious when one was trying to use the Wallet "factory" erroneously.
Specifically, if the storage path is mistyped, there would be a helpful log message, and perhaps the error would be more suggestive.