### PR TITLE
fix: py3 digitalbitbox hid_send

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -11,7 +11,7 @@ try:
     from electrum.i18n import _
     from electrum.keystore import Hardware_KeyStore
     from ..hw_wallet import HW_PluginBase
-    from electrum.util import print_error
+    from electrum.util import print_error, to_string
 
     import time
     import hid
@@ -365,6 +365,7 @@ class DigitalBitbox_Client():
                 r = self.hid_read_frame()
             r = r.rstrip(b' \t\r\n\0')
             r = r.replace(b"\0", b'')
+            r = to_string(r, 'utf8')
             reply = json.loads(r)
         except Exception as e:
             print_error('Exception caught ' + str(e))
@@ -379,6 +380,7 @@ class DigitalBitbox_Client():
             reply = self.hid_send_plain(msg)
             if 'ciphertext' in reply:
                 reply = DecodeAES(secret, ''.join(reply["ciphertext"]))
+                reply = to_string(reply, 'utf8')
                 reply = json.loads(reply)
             if 'error' in reply:
                 self.password = None


### PR DESCRIPTION
fixes #3339

Without PR, with traceback printed:
```
[DeviceMgr] scanning devices...
[DeviceMgr] Registering <electrum_plugins.digitalbitbox.digitalbitbox.DigitalBitbox_Client object at 0x7f9a0e9be518>
Traceback (most recent call last):
  File "/home/user/wspace/electrum/plugins/digitalbitbox/digitalbitbox.py", line 368, in hid_send_plain
    reply = json.loads(r)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytearray'
Exception caught the JSON object must be str, not 'bytearray'
```

With PR, with extra logging:
```
[DeviceMgr] scanning devices...
[DeviceMgr] Registering <electrum_plugins.digitalbitbox.digitalbitbox.DigitalBitbox_Client object at 0x7fef06e4edd8>
hid_send_plain: r= bytearray(b'{"ping":"password"}')
hid_send_plain: r= {"ping":"password"}
hid_send_plain: reply= {'ping': 'password'}
```