### PR TITLE
 digitalbitbox: correctly handle user aborts

### DIFF
--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -472,7 +472,7 @@ class DeviceMgr(ThreadJob, PrintError):
             infos = self.unpaired_device_infos(handler, plugin, devices)
             if infos:
                 break
-            msg = _('Could not connect to your %s.  Verify the cable is '
+            msg = _('Please insert your %s.  Verify the cable is '
                     'connected and that no other application is using it.\n\n'
                     'Try to connect again?') % plugin.device
             if not handler.yes_no_question(msg):


### PR DESCRIPTION
1. When the pairing is being forced and the user clicks 'No', the tx
was cancelled completely because the UserCancelled exception was
accidentally converted to an Exception.
2. Same with user aborting the signing process with a short touch on
the device (or a timeout).