### PR TITLE
use the send tab when sweeping (qt gui)

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -118,6 +118,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.require_fee_update = False
         self.tx_notifications = []
         self.tl_windows = []
+        self.tx_external_keypairs = {}
 
         self.create_status_bar()
         self.need_update = threading.Event()
@@ -1414,7 +1415,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.on_error(exc_info)
             callback(False)
 
-        task = partial(self.wallet.sign_transaction, tx, password)
+        if self.tx_external_keypairs:
+            task = partial(Transaction.sign, tx, self.tx_external_keypairs)
+        else:
+            task = partial(self.wallet.sign_transaction, tx, password)
         WaitingDialog(self, _('Signing transaction...'), task,
                       on_signed, on_failed)
 
@@ -1557,6 +1561,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             e.setFrozen(False)
         self.set_pay_from([])
         self.rbf_checkbox.setChecked(False)
+        self.tx_external_keypairs = {}
         self.update_status()
         run_hook('do_clear', self)
 
@@ -2364,14 +2369,20 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         address_e.textChanged.connect(on_address)
         if not d.exec_():
             return
-        from electrum.wallet import sweep
+        from electrum.wallet import sweep_preparations
         try:
-            tx = sweep(get_pk(), self.network, self.config, get_address(), None)
+            self.do_clear()
+            coins, keypairs = sweep_preparations(get_pk(), self.network)
+            self.tx_external_keypairs = keypairs
+            self.spend_coins(coins)
+            self.payto_e.setText(get_address())
+            self.spend_max()
+            self.payto_e.setFrozen(True)
+            self.amount_e.setFrozen(True)
         except BaseException as e:
             self.show_message(str(e))
             return
         self.warn_if_watching_only()
-        self.show_transaction(tx)
 
     def _do_import(self, title, msg, func):
         text = text_dialog(self, title, msg + ' :', _('Import'))

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -178,7 +178,9 @@ class TxDialog(QDialog, MessageBoxMixin):
         tx_hash, status, label, can_broadcast, can_rbf, amount, fee, height, conf, timestamp, exp_n = self.wallet.get_tx_info(self.tx)
         size = self.tx.estimated_size()
         self.broadcast_button.setEnabled(can_broadcast)
-        self.sign_button.setEnabled(self.wallet.can_sign(self.tx))
+        can_sign = not self.tx.is_complete() and \
+            (self.wallet.can_sign(self.tx) or bool(self.main_window.tx_external_keypairs))
+        self.sign_button.setEnabled(can_sign)
         self.tx_hash_e.setText(tx_hash or _('Unknown'))
         if desc is None:
             self.tx_desc.hide()

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -101,7 +101,7 @@ def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):
         item['num_sig'] = 1
         inputs.append(item)
 
-def sweep(privkeys, network, config, recipient, fee=None, imax=100):
+def sweep_preparations(privkeys, network, imax=100):
 
     def find_utxos_for_privkey(txin_type, privkey, compressed):
         pubkey = bitcoin.public_key_from_private_key(privkey, compressed)
@@ -123,6 +123,11 @@ def sweep(privkeys, network, config, recipient, fee=None, imax=100):
             find_utxos_for_privkey('p2pk', privkey, compressed)
     if not inputs:
         raise BaseException(_('No inputs found. (Note that inputs need to be confirmed)'))
+    return inputs, keypairs
+
+
+def sweep(privkeys, network, config, recipient, fee=None, imax=100):
+    inputs, keypairs = sweep_preparations(privkeys, network, imax)
     total = sum(i.get('value') for i in inputs)
     if fee is None:
         outputs = [(TYPE_ADDRESS, recipient, total)]


### PR DESCRIPTION
This might not be perfect as is, I haven't done very extensive testing yet (just a bit). However I wanted to get feedback regarding the approach/idea in general.

The primary motivation is #2179

Notes:
1. `Amount` is frozen and set to max. This is to avoid dealing with the user trying to sweep only "some of the coins" (where to put the change in that case?)
2. `Pay to` field is frozen and set to the single address the user entered in the sweep dialog. This is done to block the user from using the advanced functionalities of the `Pay to` field, as then she would be able to set a smaller amount directly or via pay-to-many (see previous point)
3. If the user selects `Pay to many` from the menu, the `Pay to` field will become empty and read-only. To recover she needs to use `Clear`. The `Pay to many` functionality should probably be disabled (#3379).
4. The `Send` button is hidden for watch-only wallets at the moment, but the `Preview` button is there, so the user can work around this and do the sweep. https://github.com/spesmilo/electrum/blob/9425319dcd4c16a63ee3559bde433472b44ec165/gui/qt/main_window.py#L1772
5. For passworded wallets, the user is prompted for a password to sign, but this is of course pointless.
6. Using `Spend` in the `Coins` tab, or `Spend from` in the `Addresses` tab, when the `Send` tab is filled with the sweep details, does not play nicely at the moment... the user needs to use `Clear` to recover.