### PR TITLE
Save dependency versions in repo

### DIFF
--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -67,6 +67,9 @@ else
 fi
 cp electrum-icons/icons_rc.py $WINEPREFIX/drive_c/electrum/gui/qt/
 
+# Install frozen dependencies
+$PYTHON -m pip install -r ../../deterministic_requirements.txt
+
 pushd $WINEPREFIX/drive_c/electrum
 $PYTHON setup.py install
 popd

--- a/contrib/deterministic_requirements.txt
+++ b/contrib/deterministic_requirements.txt
@@ -1,0 +1,14 @@
+certifi==2017.11.5
+chardet==3.0.4
+dnspython==1.15.0
+ecdsa==0.13
+idna==2.6
+jsonrpclib-pelix==0.3.1
+pbkdf2==1.3
+protobuf==3.5.0.post1
+pyaes==1.6.1
+PySocks==1.6.7
+qrcode==5.3
+requests==2.18.4
+six==1.11.0
+urllib3==1.22

--- a/contrib/freeze_packages.sh
+++ b/contrib/freeze_packages.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Run this after a new release to update dependencies
+
+venv_dir=~/.electrum-venv
+contrib=$(dirname "$0")
+
+which virtualenv > /dev/null 2>&1 || { echo "Please install virtualenv" && exit 1; }
+
+rm $venv_dir -rf
+virtualenv $venv_dir
+
+source $venv_dir/bin/activate
+
+echo "Installing dependencies"
+
+pushd $contrib/..
+python setup.py install
+popd
+
+pip freeze | sed '/^Electrum/ d' > $contrib/deterministic_requirements.txt
+
+echo "Updated requirements"

--- a/contrib/make_packages
+++ b/contrib/make_packages
@@ -1,17 +1,12 @@
 #!/bin/bash
 
+contrib=$(dirname "$0")
 
 whereis pip3
 if [ $? -ne 0 ] ; then echo "Install pip3" ; exit ; fi
 
+rm $contrib/packages/ -r
+
 #Install pure python modules in electrum directory
-pip3 install pyaes -t ./packages
-pip3 install ecdsa -t ./packages
-pip3 install pbkdf2 -t ./packages
-pip3 install requests -t ./packages
-pip3 install qrcode -t ./packages
-pip3 install protobuf -t ./packages
-pip3 install dnspython -t ./packages
-pip3 install jsonrpclib-pelix -t ./packages
-pip3 install PySocks -t ./packages
+pip3 install -r $contrib/deterministic_requirements.txt -t $contrib/packages
 


### PR DESCRIPTION
`contrib/deterministic_requirements.txt` is a pip requirements file containing Electrum's dependencies with frozen versions. It should be generated using `contrib/freeze_packages.sh` whenever dependencies need to be updated.

`make_packages` and `build_electrum_git` will use these versions.

This should bring us one step closer to deterministic builds.