### PR TITLE
electrum-env creates python3 virtualenv

### DIFF
--- a/electrum-env
+++ b/electrum-env
@@ -12,7 +12,7 @@
 if [ -e ./env/bin/activate ]; then
     source ./env/bin/activate
 else
-    virtualenv env
+    virtualenv env -p `which python3`
     source ./env/bin/activate
     python3 setup.py install
 fi


### PR DESCRIPTION
Without this fix electrum-env creates a python2 virtualenv if the system default python is version 2