### PR TITLE
Make build location independent

### DIFF
--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -15,7 +15,7 @@ $here/prepare-hw.sh || exit 1
 echo "Resetting modification time in C:\Python..."
 # (Because of some bugs in pyinstaller)
 pushd /opt/wine64/drive_c/python*
-find -type f -exec touch -d '2000-11-11 11:11:11' {} +
+find -type f -exec touch -d '2000-11-11T11:11:11+00:00' {} +
 popd
 ls -l /opt/wine64/drive_c/python*
 


### PR DESCRIPTION
Passes UTC as timezone to the touch command so it doesn't depend on the local timezone.