### PR TITLE
[easy] Typo breaks lib.rsakey.RSAKey.generate ?

### DIFF
--- a/lib/rsakey.py
+++ b/lib/rsakey.py
@@ -526,7 +526,7 @@ class RSAKey(object):
         return False
 
     def generate(bits):
-        key = Python_RSAKey()
+        key = RSAKey()
         p = getRandomPrime(bits//2, False)
         q = getRandomPrime(bits//2, False)
         t = lcm(p-1, q-1)
@@ -540,4 +540,3 @@ class RSAKey(object):
         key.qInv = invMod(q, p)
         return key
     generate = staticmethod(generate)
-


### PR DESCRIPTION
Stumbled upon this making tests