### PR TITLE
Fee option in Sweep window and fee showing up in transaction window instead of 'unknown'

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -747,9 +747,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         d = address_dialog.AddressDialog(self, addr)
         d.exec_()
 
-    def show_transaction(self, tx, tx_desc = None):
+    def show_transaction(self, tx, tx_desc = None, tx_type = None):
         '''tx_desc is set only for txs created in the Send tab'''
-        show_transaction(tx, self, tx_desc)
+        show_transaction(tx, self, tx_desc, tx_type=tx_type)
 
     def create_receive_tab(self):
         # A 4-column grid layout.  All the stretch is in the last column.
@@ -2398,7 +2398,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_message(str(e))
             return
         self.warn_if_watching_only()
-        self.show_transaction(tx)
+        self.show_transaction(tx, tx_type='sweep')
 
     def _do_import(self, title, msg, func):
         text = text_dialog(self, title, msg + ' :', _('Import'))

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -39,14 +39,14 @@ from .util import *
 
 dialogs = []  # Otherwise python randomly garbage collects the dialogs...
 
-def show_transaction(tx, parent, desc=None, prompt_if_unsaved=False):
-    d = TxDialog(tx, parent, desc, prompt_if_unsaved)
+def show_transaction(tx, parent, desc=None, prompt_if_unsaved=False, tx_type=None):
+    d = TxDialog(tx, parent, desc, prompt_if_unsaved, tx_type)
     dialogs.append(d)
     d.show()
 
 class TxDialog(QDialog, MessageBoxMixin):
 
-    def __init__(self, tx, parent, desc, prompt_if_unsaved):
+    def __init__(self, tx, parent, desc, prompt_if_unsaved, tx_type):
         '''Transactions in the wallet will show their description.
         Pass desc to give a description for txs not yet in the wallet.
         '''
@@ -62,6 +62,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.prompt_if_unsaved = prompt_if_unsaved
         self.saved = False
         self.desc = desc
+        self.tx_type = tx_type
 
         self.setMinimumWidth(750)
         self.setWindowTitle(_("Transaction"))
@@ -175,7 +176,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         desc = self.desc
         base_unit = self.main_window.base_unit()
         format_amount = self.main_window.format_amount
-        tx_hash, status, label, can_broadcast, can_rbf, amount, fee, height, conf, timestamp, exp_n = self.wallet.get_tx_info(self.tx)
+        tx_hash, status, label, can_broadcast, can_rbf, amount, fee, height, conf, timestamp, exp_n = self.wallet.get_tx_info(self.tx, self.tx_type)
         size = self.tx.estimated_size()
         self.broadcast_button.setEnabled(can_broadcast)
         self.sign_button.setEnabled(self.wallet.can_sign(self.tx))

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -125,11 +125,12 @@ def sweep(privkeys, network, config, recipient, fee=None, imax=100):
         raise BaseException(_('No inputs found. (Note that inputs need to be confirmed)'))
     total = sum(i.get('value') for i in inputs)
     if fee is None:
+        if not network.config.has_fee_estimates():
+            raise BaseException('Dynamic fee estimates not available')
         outputs = [(TYPE_ADDRESS, recipient, total)]
         tx = Transaction.from_io(inputs, outputs)
         fee = config.estimate_fee(tx.estimated_size())
-        if config.fee_per_kb() is None:
-            raise BaseException('Dynamic fee estimates not available')
+
     if total - fee < 0:
         raise BaseException(_('Not enough funds on address.') + '\nTotal: %d satoshis\nFee: %d'%(total, fee))
     if total - fee < dust_threshold(network):
@@ -441,14 +442,17 @@ class Abstract_Wallet(PrintError):
             delta += v
         return delta
 
-    def get_wallet_delta(self, tx):
+    def get_wallet_delta(self, tx, tx_type=None):
         """ effect of tx on wallet """
         addresses = self.get_addresses()
         is_relevant = False
         is_mine = False
         is_pruned = False
         is_partial = False
+        is_sweep = False
         v_in = v_out = v_out_mine = 0
+        if tx_type == 'sweep':
+            is_sweep = True
         for item in tx.inputs():
             addr = item.get('address')
             if addr in addresses:
@@ -492,10 +496,24 @@ class Abstract_Wallet(PrintError):
                 fee = v_in - v_out
         if not is_mine:
             fee = None
+
+        # Calculate fee differently if it's sweep
+        if is_sweep:
+            v_in = v_out = 0
+            # Get all inputs
+            for item in tx.inputs():
+                v_in += item['value']
+            # Get all ouputs
+            outputs = [x[1] for x in tx.get_outputs()]
+            for output in outputs:
+                v_out += output
+            # Actual fee
+            fee = v_in - v_out
+
         return is_relevant, is_mine, v, fee
 
-    def get_tx_info(self, tx):
-        is_relevant, is_mine, v, fee = self.get_wallet_delta(tx)
+    def get_tx_info(self, tx, tx_type=None):
+        is_relevant, is_mine, v, fee = self.get_wallet_delta(tx, tx_type)
         exp_n = None
         can_broadcast = False
         can_bump = False

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -128,6 +128,8 @@ def sweep(privkeys, network, config, recipient, fee=None, imax=100):
         outputs = [(TYPE_ADDRESS, recipient, total)]
         tx = Transaction.from_io(inputs, outputs)
         fee = config.estimate_fee(tx.estimated_size())
+        if config.fee_per_kb() is None:
+            raise BaseException('Dynamic fee estimates not available')
     if total - fee < 0:
         raise BaseException(_('Not enough funds on address.') + '\nTotal: %d satoshis\nFee: %d'%(total, fee))
     if total - fee < dust_threshold(network):


### PR DESCRIPTION
This pull request offers a solution to [2179](https://github.com/spesmilo/electrum/issues/2179) and also, as a consequence, to [3363](https://github.com/spesmilo/electrum/issues/3363) as well. 

The first problem was that the fee for the sweep transaction was getting calculated automatically using the dynamic fee estimations, without giving an option to the user to choose a suitable fee themselves, like through the two fees settings in `Preferences`, for example. This often resulted in very low fee when the transaction size was under estimated. 

The second problem was that after clicking the `Sweep` button, the transaction window that appeared had fee shown as `unknown`.

The first problem is solved in the [first commit](https://github.com/spesmilo/electrum/commit/03e07efe2bcc9eefa07f46cebe36c54fca2d8c0e) and second one in the [second commit](https://github.com/spesmilo/electrum/commit/10582d7d3e341e7f570deda0adcaa3917671f635). This was achieved by:

- Adding a `FeeSlider` to Sweep dialog box (`sweep_key_dialog()`), and additionally showing a `BTCAmountEdit` box, if `Edit fees manually` was chosen.
- Passing the right value of fee to the `sweep` function in `wallet.py`.
- Adding a `tx_type` attribute to certain functions and using that to display the correct fee in the transaction window.

I've tested this reasonably well and tried to catch all the exceptions where the the fee is handled. I've tried to mimic how it is done in the `Send` tab, but have done it very cautiously. 

Here are some screenshots:

![sweep-1](https://user-images.githubusercontent.com/33743210/33406947-9b17bcb2-d588-11e7-831d-ac741cd80a30.jpg)

The slider and the box work as expected with the 'Use dynamic fees' and 'Enter fees manually' settings.

![sweep-2](https://user-images.githubusercontent.com/33743210/33406949-9b44548e-d588-11e7-8ed5-9061bbb0e2d6.jpg)

The transaction window shows the correct fee and not 'unknown' as was the case before.

