### PR TITLE
Show an error if Electrum cannot open the wallet file

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -389,7 +389,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         wallet_folder = self.get_wallet_folder()
         filename, __ = QFileDialog.getOpenFileName(self, "Select your wallet file", wallet_folder)
         if not filename:
-            return
+            self.show_error('Error opening the file. Please check if the file is accessible.')
         self.gui_object.new_window(filename)
 
 


### PR DESCRIPTION
This pull request is motivated by [3404](https://github.com/spesmilo/electrum/issues/3404), where the app crashes if for any reason Electrum cannot open the wallet file chosen from the Open File dialog. With this pull it will now show a helpful message instead. 

This was achieved by having `self.show_error('Error message')` instead of a simple `return` inside `if not filename:` condition block. I have currently only implemented this for the `open_wallet()` function, but I think we can use this in other places as well, like `import_invoices()` and `import_contacts()`, for example.