### PR TITLE
Selectable statusbar text

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1748,6 +1748,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         qtVersion = qVersion()
 
         self.balance_label = QLabel("")
+        self.balance_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.balance_label.setStyleSheet("""QLabel { padding: 0 }""")
         sb.addWidget(self.balance_label)
 
         self.search_box = QLineEdit()


### PR DESCRIPTION
This pull request is an attempt to solve #3360 by allowing the user to select and copy the text shown in the statusBar.

This was achieved by using `QLabel's` [`TextInteractionFlag`](https://doc.qt.io/qt-5/qt.html#TextInteractionFlag-enum) property. And the label's padding was set to 0 in order to make it fit inside statusBar's height. 

![selectable-text](https://user-images.githubusercontent.com/33743210/33520378-438bebec-d7d3-11e7-94bc-7d0652a13aec.jpg)
![selectable-text-2](https://user-images.githubusercontent.com/33743210/33520379-43b826b2-d7d3-11e7-9d97-db4ff56dca83.jpg)
