### PR TITLE
fix: openalias resolution unnecessarily done for some payto

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -606,6 +606,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.need_update.clear()
             self.update_wallet()
         # resolve aliases
+        # FIXME this is a blocking network call that has a timeout of 5 sec
         self.payto_e.resolve()
         # update fee
         if self.require_fee_update:

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -278,6 +278,9 @@ class PayToEdit(ScanQRTextEdit):
         self.previous_payto = key
         if not (('.' in key) and (not '<' in key) and (not ' ' in key)):
             return
+        parts = key.split(sep=',')  # assuming single line
+        if parts and len(parts) > 0 and bitcoin.is_address(parts[0]):
+            return
         try:
             data = self.win.contacts.resolve(key)
         except:


### PR DESCRIPTION
See https://github.com/spesmilo/electrum/issues/3477

The point of this PR is to not have Electrum try a DNSSEC resolution if the "pay to" field contains
```
mkP5Hjpke3yUwLH9piLH5QAUsLGFVe9aaP,0.2
```

(so obviously this does NOT properly deal with #3477)