### PR TITLE
Handle empty outgoing transactions for plot

### DIFF
--- a/lib/plot.py
+++ b/lib/plot.py
@@ -46,7 +46,9 @@ def plot_history(wallet, history):
     dates, values = zip(*sorted(hist_in.items()))
     r1 = axarr[0].bar(dates, values, width, label='incoming')
     axarr[0].legend(loc='upper left')
-    dates, values = zip(*sorted(hist_out.items()))
-    r2 = axarr[1].bar(dates, values, width, color='r', label='outgoing')
-    axarr[1].legend(loc='upper left')
+    dates_values = list(zip(*sorted(hist_out.items())))
+    if dates_values and len(dates_values) == 2:
+        dates, values = dates_values
+        r2 = axarr[1].bar(dates, values, width, color='r', label='outgoing')
+        axarr[1].legend(loc='upper left')
     return plt


### PR DESCRIPTION
Previously dialog with error:

    need more than 0 values to unpack

was displayed and not a plot.

After this change plot is displayed without any dialog without graph of
outgoing transactions and without legend for outgoing transactions.

Fixes: #3487