### PR TITLE
CoinChooser: privacy prefers confirmed and is default

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2668,19 +2668,20 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             return '\n'.join([key, "", " ".join(lines)])
 
         choosers = sorted(coinchooser.COIN_CHOOSERS.keys())
-        chooser_name = coinchooser.get_name(self.config)
-        msg = _('Choose coin (UTXO) selection method.  The following are available:\n\n')
-        msg += '\n\n'.join(fmt_docs(*item) for item in coinchooser.COIN_CHOOSERS.items())
-        chooser_label = HelpLabel(_('Coin selection') + ':', msg)
-        chooser_combo = QComboBox()
-        chooser_combo.addItems(choosers)
-        i = choosers.index(chooser_name) if chooser_name in choosers else 0
-        chooser_combo.setCurrentIndex(i)
-        def on_chooser(x):
-            chooser_name = choosers[chooser_combo.currentIndex()]
-            self.config.set_key('coin_chooser', chooser_name)
-        chooser_combo.currentIndexChanged.connect(on_chooser)
-        tx_widgets.append((chooser_label, chooser_combo))
+        if len(choosers) > 1:
+            chooser_name = coinchooser.get_name(self.config)
+            msg = _('Choose coin (UTXO) selection method.  The following are available:\n\n')
+            msg += '\n\n'.join(fmt_docs(*item) for item in coinchooser.COIN_CHOOSERS.items())
+            chooser_label = HelpLabel(_('Coin selection') + ':', msg)
+            chooser_combo = QComboBox()
+            chooser_combo.addItems(choosers)
+            i = choosers.index(chooser_name) if chooser_name in choosers else 0
+            chooser_combo.setCurrentIndex(i)
+            def on_chooser(x):
+                chooser_name = choosers[chooser_combo.currentIndex()]
+                self.config.set_key('coin_chooser', chooser_name)
+            chooser_combo.currentIndexChanged.connect(on_chooser)
+            tx_widgets.append((chooser_label, chooser_combo))
 
         def on_unconf(x):
             self.config.set_key('confirmed_only', bool(x))

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -135,6 +135,13 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(tx.estimated_weight(), 772)
         self.assertEqual(tx.estimated_size(), 193)
 
+    def test_estimated_output_size(self):
+        estimated_output_size = transaction.Transaction.estimated_output_size
+        self.assertEqual(estimated_output_size('14gcRovpkCoGkCNBivQBvw7eso7eiNAbxG'), 34)
+        self.assertEqual(estimated_output_size('35ZqQJcBQMZ1rsv8aSuJ2wkC7ohUCQMJbT'), 32)
+        self.assertEqual(estimated_output_size('bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af'), 31)
+        self.assertEqual(estimated_output_size('bc1qnvks7gfdu72de8qv6q6rhkkzu70fqz4wpjzuxjf6aydsx7wxfwcqnlxuv3'), 43)
+
     # TODO other tests for segwit tx
     def test_tx_signed_segwit(self):
         tx = transaction.Transaction(signed_segwit_blob)

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -878,6 +878,13 @@ class Transaction:
         return 4 * input_size + witness_size
 
     @classmethod
+    def estimated_output_size(cls, address):
+        """Return an estimate of serialized output size in bytes."""
+        script = bitcoin.address_to_script(address)
+        # 8 byte value + 1 byte script len + script
+        return 9 + len(script) // 2
+
+    @classmethod
     def virtual_size_from_weight(cls, weight):
         return weight // 4 + (weight % 4 > 0)
 


### PR DESCRIPTION
- "privacy" is now the default coinchooser policy, and "priority" has been removed
- "privacy" prefers to spend from confirmed coins
- coinchooser choice has been hidden in QT, the same should be done in kivy

-----

One remark regarding the changed privacy policy, which actually needs detailing the changes...

Any bucket can be:
    1. "confirmed" if it only contains confirmed coins; else
    2. "unconfirmed" if it does not contain coins with unconfirmed parents; else
    3. "unconfirmed parent"

In the current state of the PR, we try to only use buckets of type 1, and if the coins there are not enough, try to use the next type but while also selecting **all buckets of all previous types** (A).
This could be trivially changed to instead simply expand the set of allowed buckets, but do not automatically choose all buckets of all previous types (B).

I am not sure which option is better.

-----

Note: I have been researching ideas for alternative coinchooser policies that could be added (later probably), and found https://github.com/bitcoin/bitcoin/issues/7664 and http://murch.one/wp-content/uploads/2016/11/erhardt2016coinselection.pdf
A potential "fee saver" policy could try to select inputs that are "an exact match" for the target send, and hence not need to create a change output.