### PR TITLE
Allow to build older commits

### DIFF
--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -3,10 +3,6 @@
 NAME_ROOT=electrum
 PYTHON_VERSION=3.5.4
 
-if [ "$#" -gt 0 ]; then
-    BRANCH="$1"
-fi
-
 # These settings probably don't need any change
 export WINEPREFIX=/opt/wine64
 export PYTHONDONTWRITEBYTECODE=1
@@ -43,6 +39,10 @@ done
 popd
 
 pushd electrum
+if [ ! -z "$1" ]; then
+    git checkout $1
+fi
+
 VERSION=`git describe --tags`
 echo "Last commit: $VERSION"
 find -exec touch -d '2000-11-11T11:11:11+00:00' {} +

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -2,6 +2,10 @@
 # Lucky number
 export PYTHONHASHSEED=22
 
+if [ ! -z "$1" ]; then
+    to_build="$1"
+fi
+
 here=$(dirname "$0")
 
 echo "Clearing $here/build and $here/dist..."
@@ -19,5 +23,5 @@ find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
 popd
 ls -l /opt/wine64/drive_c/python*
 
-$here/build-electrum-git.sh && \
+$here/build-electrum-git.sh $to_build && \
 echo "Done."


### PR DESCRIPTION
This is especially useful if you want to reproduce some version while there already is a new commit in master.

We still need to figure out what to do with the icons and locale repository. Maybe we can use the timestamp from the commit of the main repository and check out the latest version on that date.