### PR TITLE
fix: testnet datadir could not be created first

### DIFF
--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -85,15 +85,18 @@ class SimpleConfig(PrintError):
         if path is None:
             path = self.user_dir()
 
+        def make_dir(path):
+            # Make directory if it does not yet exist.
+            if not os.path.exists(path):
+                if os.path.islink(path):
+                    raise BaseException('Dangling link: ' + path)
+                os.mkdir(path)
+                os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+        make_dir(path)
         if self.get('testnet'):
             path = os.path.join(path, 'testnet')
-
-        # Make directory if it does not yet exist.
-        if not os.path.exists(path):
-            if os.path.islink(path):
-                raise BaseException('Dangling link: ' + path)
-            os.mkdir(path)
-            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+            make_dir(path)
 
         self.print_error("electrum directory", path)
         return path


### PR DESCRIPTION
see #3111

Electrum could only start in testnet mode if it had already started in mainnet mode before (so that it created the parent folder of the datadir already).

```
$ ./electrum -v --testnet
Traceback (most recent call last):
  File "./electrum", line 360, in <module>
    config = SimpleConfig(config_options)
  File "/home/user/wspace/electrum/lib/simple_config.py", line 74, in __init__
    self.path = self.electrum_path()
  File "/home/user/wspace/electrum/lib/simple_config.py", line 95, in electrum_path
    os.mkdir(path)
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.electrum/testnet'
```

```
$ ./electrum -v --testnet --dir=tmp
Traceback (most recent call last):
  File "./electrum", line 360, in <module>
    config = SimpleConfig(config_options)
  File "/home/user/wspace/electrum/lib/simple_config.py", line 74, in __init__
    self.path = self.electrum_path()
  File "/home/user/wspace/electrum/lib/simple_config.py", line 95, in electrum_path
    os.mkdir(path)
FileNotFoundError: [Errno 2] No such file or directory: 'tmp/testnet'
```