### PR TITLE
requirements.txt support for user only pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pyaes>=0.1a1
+ecdsa>=0.9
+pbkdf2
+requests
+qrcode
+protobuf
+dnspython
+jsonrpclib-pelix
+PySocks>=1.6.6

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ import platform
 import imp
 import argparse
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 version = imp.load_source('version', 'lib/version.py')
 
 if sys.version_info[:3] < (3, 4, 0):
@@ -35,17 +38,7 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
 setup(
     name="Electrum",
     version=version.ELECTRUM_VERSION,
-    install_requires=[
-        'pyaes>=0.1a1',
-        'ecdsa>=0.9',
-        'pbkdf2',
-        'requests',
-        'qrcode',
-        'protobuf',
-        'dnspython',
-        'jsonrpclib-pelix',
-        'PySocks>=1.6.6',
-    ],
+    install_requires=requirements,
     packages=[
         'electrum',
         'electrum_gui',


### PR DESCRIPTION
Some linux distros require pip to use the `--user` switch. The use case for installing dependencies in this case would be `pip3 install --user -r requirements.txt` then `sudo python3 setup.py install`.

Small change but useful for others.

Cheers!🥂 