### PR TITLE
fix: address filters for Imported_Wallet: wallet.is_used()

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1435,9 +1435,6 @@ class Imported_Wallet(Simple_Wallet):
     def is_deterministic(self):
         return False
 
-    def is_used(self, address):
-        return False
-
     def is_change(self, address):
         return False
 


### PR DESCRIPTION
I don't see the reason for this override, and it's causing bugs here:

https://github.com/spesmilo/electrum/blob/4bab8b63e192078be98ebbf0e84581b2056b5dc5/gui/qt/address_list.py#L88-L93