### PR TITLE
Android: make RBF on by default

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -259,7 +259,7 @@ class ElectrumWindow(App):
         self.daemon = self.gui_object.daemon
         self.fx = self.daemon.fx
 
-        self.use_rbf = config.get('use_rbf', False)
+        self.use_rbf = config.get('use_rbf', True)
         self.use_change = config.get('use_change', True)
         self.use_unconfirmed = not config.get('confirmed_only', False)
 


### PR DESCRIPTION
We're doing this in QT already.

Also, note that the user is still prompted for each individual tx:
https://github.com/spesmilo/electrum/blob/5156b60769b365522b263220dfefcca12fea4e97/gui/kivy/uix/screens.py#L266-L271