### PR TITLE
include servers_testnet.json and checkpoints_testnet.json in binaries

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -24,6 +24,7 @@ datas = [
     (home+'lib/servers.json', 'electrum'),
     (home+'lib/checkpoints.json', 'electrum'),
     (home+'lib/servers_testnet.json', 'electrum'),
+    (home+'lib/checkpoints_testnet.json', 'electrum'),
     (home+'lib/wordlist/english.txt', 'electrum/wordlist'),
     (home+'lib/locale', 'electrum/locale'),
     (home+'plugins', 'electrum_plugins'),

--- a/contrib/osx.spec
+++ b/contrib/osx.spec
@@ -23,6 +23,8 @@ datas = [
     (home+'lib/currencies.json', 'electrum'),
     (home+'lib/servers.json', 'electrum'),
     (home+'lib/checkpoints.json', 'electrum'),
+    (home+'lib/servers_testnet.json', 'electrum'),
+    (home+'lib/checkpoints_testnet.json', 'electrum'),
     (home+'lib/wordlist/english.txt', 'electrum/wordlist'),
     (home+'lib/locale', 'electrum/locale'),
     (home+'plugins', 'electrum_plugins'),

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
             'servers_testnet.json',
             'currencies.json',
             'checkpoints.json',
+            'checkpoints_testnet.json',
             'www/index.html',
             'wordlist/*.txt',
             'locale/*/LC_MESSAGES/electrum.mo',


### PR DESCRIPTION
`servers_testnet.json` is currently not included in binaries for Mac. I don't have a Mac to test but I suspect testnet might not work due to this, similar to https://github.com/spesmilo/electrum/issues/3321

Also, I think we could include `checkpoints_testnet.json` in all binaries, as otherwise there's not much point in having the file in the first place :) And the speed-up for the initial startup is significant.