### PR TITLE
avoid shorter seeds 'by luck'

### DIFF
--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -171,7 +171,10 @@ class Mnemonic(object):
         n_custom = int(math.ceil(math.log(custom_entropy, 2)))
         n = max(16, num_bits - n_custom)
         print_error("make_seed", prefix, "adding %d bits"%n)
-        my_entropy = ecdsa.util.randrange(pow(2, n))
+        my_entropy = 1
+        while my_entropy < pow(2, n - bpw):
+            # try again if seed would not contain enough words
+            my_entropy = ecdsa.util.randrange(pow(2, n))
         nonce = 0
         while True:
             nonce += 1


### PR DESCRIPTION
I am not sure if this is deliberate or not, but currently Electrum might generate shorter seeds in rare cases (fewer words).

I only noticed it when the GUI gave me `sniff slender rifle rack express anxiety ecology believe heavy accuse blue`, which is only 11 words.
Suddenly we can longer tell people that "there's no way your seed contains only 9 words", rather "it's extremely unlikely..." :)