### PR TITLE
fix fee ui: offline case

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -44,7 +44,7 @@ from electrum.plugins import run_hook
 from electrum.i18n import _
 from electrum.util import (format_time, format_satoshis, PrintError,
                            format_satoshis_plain, NotEnoughFunds,
-                           UserCancelled)
+                           UserCancelled, NoDynamicFeeEstimates)
 from electrum import Transaction
 from electrum import util, bitcoin, commands, coinchooser
 from electrum import paymentrequest
@@ -1068,7 +1068,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             else:
                 self.config.set_key('fee_per_kb', fee_rate, False)
 
-            self.feerate_e.setAmount(fee_rate // 1000)
+            if fee_rate:
+                self.feerate_e.setAmount(fee_rate // 1000)
             self.fee_e.setModified(False)
 
             self.fee_slider.activate()
@@ -1098,6 +1099,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.size_e = TxSizeLabel()
         self.size_e.setAlignment(Qt.AlignCenter)
         self.size_e.setAmount(0)
+        self.size_e.setFixedWidth(140)
         self.size_e.setStyleSheet(ColorScheme.DEFAULT.as_stylesheet())
 
         self.feerate_e = FeerateEdit(lambda: 2 if self.fee_unit else 0)
@@ -1242,16 +1244,23 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if not outputs:
                 _type, addr = self.get_payto_or_dummy()
                 outputs = [(_type, addr, amount)]
-            try:
-                is_sweep = bool(self.tx_external_keypairs)
-                tx = self.wallet.make_unsigned_transaction(
+            is_sweep = bool(self.tx_external_keypairs)
+            make_tx = lambda fee_est: \
+                self.wallet.make_unsigned_transaction(
                     self.get_coins(), outputs, self.config,
-                    fixed_fee=fee_estimator, is_sweep=is_sweep)
+                    fixed_fee=fee_est, is_sweep=is_sweep)
+            try:
+                tx = make_tx(fee_estimator)
                 self.not_enough_funds = False
             except NotEnoughFunds:
                 self.not_enough_funds = True
                 if not freeze_fee:
                     self.fee_e.setAmount(None)
+                return
+            except NoDynamicFeeEstimates:
+                tx = make_tx(0)
+                size = tx.estimated_size()
+                self.size_e.setAmount(size)
                 return
             except BaseException:
                 traceback.print_exc(file=sys.stderr)

--- a/lib/util.py
+++ b/lib/util.py
@@ -47,6 +47,12 @@ def normalize_version(v):
 
 class NotEnoughFunds(Exception): pass
 
+
+class NoDynamicFeeEstimates(Exception):
+    def __str__(self):
+        return _('Dynamic fee estimates not available')
+
+
 class InvalidPassword(Exception):
     def __str__(self):
         return _("Incorrect password")

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -42,7 +42,8 @@ from numbers import Number
 import sys
 
 from .i18n import _
-from .util import NotEnoughFunds, PrintError, UserCancelled, profiler, format_satoshis
+from .util import (NotEnoughFunds, PrintError, UserCancelled, profiler,
+                   format_satoshis, NoDynamicFeeEstimates)
 
 from .bitcoin import *
 from .version import *
@@ -884,7 +885,7 @@ class Abstract_Wallet(PrintError):
             raise NotEnoughFunds()
 
         if fixed_fee is None and config.fee_per_kb() is None:
-            raise BaseException('Dynamic fee estimates not available')
+            raise NoDynamicFeeEstimates()
 
         for item in inputs:
             self.add_input_info(item)


### PR DESCRIPTION
This fixes some problems when using the new fee ui without a network connection (or with `--offline`).
Mostly to do with dynamic fees enabled, and not having those.

-----

For example:
```
Traceback (most recent call last):
  File "/home/user/wspace/electrum/gui/qt/fee_slider.py", line 28, in moved
    self.callback(self.dyn, pos, fee_rate)
  File "/home/user/wspace/electrum/gui/qt/main_window.py", line 1071, in fee_cb
    self.feerate_e.setAmount(fee_rate // 1000)
TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'
Aborted (core dumped)
```
Or `window.size_e` not getting set.