### PR TITLE
Show message hash when signing

### DIFF
--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -220,7 +220,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
     def sign_message(self, sequence, message, password):
         self.signing = True
         message = message.encode('utf8')
-        message_hash = hashlib.sha256(message).hexdigest()
+        message_hash = hashlib.sha256(message).hexdigest().upper()
         # prompt for the PIN before displaying the dialog if necessary
         client = self.get_client()
         address_path = self.get_derivation()[2:] + "/%d/%d"%sequence

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -220,10 +220,11 @@ class Ledger_KeyStore(Hardware_KeyStore):
     def sign_message(self, sequence, message, password):
         self.signing = True
         message = message.encode('utf8')
+        message_hash = hashlib.sha256(message).hexdigest()
         # prompt for the PIN before displaying the dialog if necessary
         client = self.get_client()
         address_path = self.get_derivation()[2:] + "/%d/%d"%sequence
-        self.handler.show_message("Signing message ...")
+        self.handler.show_message("Signing message ...\r\nMessage hash: "+message_hash)
         try:
             info = self.get_client().signMessagePrepare(address_path, message)
             pin = ""


### PR DESCRIPTION
When confirming signing on Ledger it will display the SHA256 hash of the message. Electrum will now also display this allowing verification that the intendened message is being signed.