### PR TITLE
Avoid modifying self.transactions in prepare_for_verifier

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -969,7 +969,7 @@ class Abstract_Wallet(PrintError):
         # if we are on a pruning server, remove unverified transactions
         with self.lock:
             vr = list(self.verified_tx.keys()) + list(self.unverified_tx.keys())
-        for tx_hash in self.transactions.keys():
+        for tx_hash in list(self.transactions):
             if tx_hash not in vr:
                 self.print_error("removing transaction", tx_hash)
                 self.transactions.pop(tx_hash)


### PR DESCRIPTION
In python3, the `.keys()` function returns an iterator, not a list,
so to get a list that can be iterated over, use `list()` instead to
avoid modification of a list while in use.