### PR TITLE
Stop allowing CORS for the JSON-RPC server

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -28,7 +28,7 @@ import time
 
 # from jsonrpc import JSONRPCResponseManager
 import jsonrpclib
-from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer, SimpleJSONRPCRequestHandler
+from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer
 
 from .version import ELECTRUM_VERSION
 from .network import Network
@@ -87,19 +87,6 @@ def get_server(config):
         time.sleep(1.0)
 
 
-class RequestHandler(SimpleJSONRPCRequestHandler):
-
-     def do_OPTIONS(self):
-         self.send_response(200)
-         self.end_headers()
-
-     def end_headers(self):
-         self.send_header("Access-Control-Allow-Headers",
-                          "Origin, X-Requested-With, Content-Type, Accept")
-         self.send_header("Access-Control-Allow-Origin", "*")
-         SimpleJSONRPCRequestHandler.end_headers(self)
-
-
 class Daemon(DaemonThread):
 
     def __init__(self, config, fd):
@@ -124,7 +111,7 @@ class Daemon(DaemonThread):
         host = config.get('rpchost', '127.0.0.1')
         port = config.get('rpcport', 0)
         try:
-            server = SimpleJSONRPCServer((host, port), logRequests=False, requestHandler=RequestHandler)
+            server = SimpleJSONRPCServer((host, port), logRequests=False)
         except Exception as e:
             self.print_error('Warning: cannot initialize RPC server on host', host, e)
             self.server = None


### PR DESCRIPTION
As far as I can tell, there is no need to allow this, and doing so poses severe security risks (see #3374).