### PR TITLE
Fix locale documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Compile the protobuf description file::
 
 Create translations (optional)::
 
-    sudo apt-get install python-pycurl gettext
+    sudo apt-get install python-requests gettext
     ./contrib/make_locale
 
 


### PR DESCRIPTION
`./contrib/make_locale` uses `python-requests` as of [`a3ad32b`](https://github.com/spesmilo/electrum/commit/a3ad32bd91e405d918276c50d2995cd86764e518) and dropped `python-pycurl` as of [`9ee10ab`](https://github.com/spesmilo/electrum/commit/9ee10ab3e1d497a28d5783f6acd6861e9656dcd5)