### PR TITLE
wizard: allow to choose derivation again if script type is not supported

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -12,6 +12,7 @@ try:
     from electrum.keystore import Hardware_KeyStore
     from ..hw_wallet import HW_PluginBase
     from electrum.util import print_error, to_string, UserCancelled
+    from electrum.base_wizard import ScriptTypeNotSupported
 
     import time
     import hid
@@ -697,6 +698,8 @@ class DigitalBitboxPlugin(HW_PluginBase):
 
 
     def get_xpub(self, device_id, derivation, xtype, wizard):
+        if xtype not in ('standard', 'p2wpkh-p2sh'):
+            raise ScriptTypeNotSupported(_('This type of script is not supported with the Digital Bitbox.'))
         devmgr = self.device_manager()
         client = devmgr.client_by_id(device_id)
         client.handler = self.create_handler(wizard)

--- a/plugins/keepkey/plugin.py
+++ b/plugins/keepkey/plugin.py
@@ -10,6 +10,7 @@ from electrum.i18n import _
 from electrum.plugins import BasePlugin
 from electrum.transaction import deserialize
 from electrum.keystore import Hardware_KeyStore, is_xpubkey, parse_xpubkey
+from electrum.base_wizard import ScriptTypeNotSupported
 
 from ..hw_wallet import HW_PluginBase
 
@@ -208,6 +209,8 @@ class KeepKeyCompatiblePlugin(HW_PluginBase):
         client.used()
 
     def get_xpub(self, device_id, derivation, xtype, wizard):
+        if xtype not in ('standard',):
+            raise ScriptTypeNotSupported(_('This type of script is not supported with KeepKey.'))
         devmgr = self.device_manager()
         client = devmgr.client_by_id(device_id)
         client.handler = wizard


### PR DESCRIPTION
wizard: allow to choose derivation again if script type is not supported (instead of closing the wizard)

I think we should not allow the creation of wallets which won't properly work in any case.

This PR is specifically with https://github.com/spesmilo/electrum/pull/3630 and https://github.com/spesmilo/electrum/pull/3681 in mind, and aims to replace https://github.com/spesmilo/electrum/commit/e218c4a305d3ba25cce0b76e138332c501bf9298.
After those PRs are merged, (forgetting about multisig)
- trezor should support p2pkh, p2wpkh-p2sh, p2wpkh
- ledger (nano S, at least) should support p2pkh, p2wpkh-p2sh, p2wpkh
- dbb should support p2pkh, p2wpkh-p2sh
- keepkey should support p2pkh

-----

**Note that I have disabled creating new p2wpkh-p2sh wallets for keepkey here**, as it can NOT spend atm: https://github.com/spesmilo/electrum/issues/3462
but users could have potentially created such wallets and funded them... so maybe we shouldn't do that? Not sure. (though already created wallet files can still be used)