### PR TITLE
QT: AA_ShareOpenGLContexts

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -92,6 +92,7 @@ class ElectrumGui:
         #network.add_jobs([DebugMem([Abstract_Wallet, SPV, Synchronizer,
         #                            ElectrumWindow], interval=5)])
         QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_X11InitThreads)
+        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
         self.config = config
         self.daemon = daemon
         self.plugins = plugins


### PR DESCRIPTION
When I scan for hardware wallets, with --verbose log, this is what I see:

```
[WalletStorage] wallet path /home/user/.electrum/wallets/wallet_212
[WalletStorage] wallet path /home/user/.electrum/wallets/wallet_212
[WalletStorage] wallet path /home/user/.electrum/wallets/wallet_212
Qt WebEngine seems to be initialized from a plugin. Please set Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute before constructing QGuiApplication.
[Plugins] loaded ledger
[Plugins] loaded digitalbitbox
[Plugins] loaded keepkey
[Plugins] loaded trezor
[DeviceMgr] scanning devices...
[DeviceMgr] scanning devices...
[DeviceMgr] scanning devices...
[DeviceMgr] scanning devices...
```
I am unsure; shall we just do what the log line suggests? (That makes it go away.)

Would there be security-related consequences of this? I personally don't think so; based on http://doc.qt.io/qt-5/qopenglcontext.html#globalShareContext it seems to me that the "global shared context" this change might introduce would still be limited to THIS application and this process.