### PR TITLE
QT: Only set if hasattr(QtCore.QCoreAplication, "AA_ShareOpenGLContexts")

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -92,7 +92,8 @@ class ElectrumGui:
         #network.add_jobs([DebugMem([Abstract_Wallet, SPV, Synchronizer,
         #                            ElectrumWindow], interval=5)])
         QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_X11InitThreads)
-        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
+        if hasattr(QtCore.Qt, "AA_ShareOpenGLContexts"):
+            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
         self.config = config
         self.daemon = daemon
         self.plugins = plugins


### PR DESCRIPTION
If the attribute does not exist (presumably in older versions of Qt),
this change prevents the following error:

  AttributeError: type object 'Qt' has no attribute 'AA_ShareOpenGLContexts'