### PR TITLE
serialize server string into config without protocol

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -33,6 +33,7 @@ import PyQt5.QtCore as QtCore
 from electrum.i18n import _
 from electrum.bitcoin import NetworkConstants
 from electrum.util import print_error
+from electrum.network import serialize_server, deserialize_server
 
 from .util import *
 
@@ -145,7 +146,7 @@ class ServerListWidget(QTreeWidget):
         menu.exec_(self.viewport().mapToGlobal(position))
 
     def set_server(self, s):
-        host, port, protocol = s.split(':')
+        host, port, protocol = deserialize_server(s)
         self.parent.server_host.setText(host)
         self.parent.server_port.setText(port)
         self.parent.set_server()
@@ -170,7 +171,7 @@ class ServerListWidget(QTreeWidget):
             port = d.get(protocol)
             if port:
                 x = QTreeWidgetItem([_host, port])
-                server = _host+':'+port+':'+protocol
+                server = serialize_server(_host, port, protocol)
                 x.setData(1, Qt.UserRole, server)
                 self.addTopLevelItem(x)
 
@@ -408,7 +409,7 @@ class NetworkChoiceLayout(object):
     def follow_server(self, server):
         self.network.switch_to_interface(server)
         host, port, protocol, proxy, auto_connect = self.network.get_parameters()
-        host, port, protocol = server.split(':')
+        host, port, protocol = deserialize_server(server)
         self.network.set_parameters(host, port, protocol, proxy, auto_connect)
         self.update()
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -77,7 +77,11 @@ class PrintError(object):
         return self.__class__.__name__
 
     def print_error(self, *msg):
+        # only prints with --verbose flag
         print_error("[%s]" % self.diagnostic_name(), *msg)
+
+    def print_stderr(self, *msg):
+        print_stderr("[%s]" % self.diagnostic_name(), *msg)
 
     def print_msg(self, *msg):
         print_msg("[%s]" % self.diagnostic_name(), *msg)


### PR DESCRIPTION
Supersedes https://github.com/spesmilo/electrum/pull/3707

`server` variable is serialized into config without the protocol letter,
but everywhere else we keep using server strings with the protocol letter.
(Otherwise, the change would need to be quite a bit larger without a clear benefit)