### PR TITLE
fix: sweeping into same wallet

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -887,8 +887,9 @@ class Abstract_Wallet(PrintError):
         if fixed_fee is None and config.fee_per_kb() is None:
             raise NoDynamicFeeEstimates()
 
-        for item in inputs:
-            self.add_input_info(item)
+        if not is_sweep:
+            for item in inputs:
+                self.add_input_info(item)
 
         # change address
         if change_addr:


### PR DESCRIPTION
Sweeping UTXOs owned by the same wallet does not work; it starts signing and then finishes without actually signing.

`wallet.add_input_sig_info` changes the pubkeys from 02-04 to ff (for deterministic wallet)

https://github.com/spesmilo/electrum/blob/0dfaf9b97013ce9221bc8589ad806e52643e727d/lib/wallet.py#L1735-L1740

and then `Transaction.sign` won't find the pubkeys:

https://github.com/spesmilo/electrum/blob/0dfaf9b97013ce9221bc8589ad806e52643e727d/lib/transaction.py#L933-L942