### PR TITLE
Fix rm -rf

### DIFF
--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -7,10 +7,11 @@ if [ ! -z "$1" ]; then
 fi
 
 here=$(dirname "$0")
+test -n "$here" -a -d "$here" || exit
 
 echo "Clearing $here/build and $here/dist..."
-rm $here/build/* -rf
-rm $here/dist/* -rf
+rm "$here"/build/* -rf
+rm "$here"/dist/* -rf
 
 $here/prepare-wine.sh && \
 $here/prepare-pyinstaller.sh && \


### PR DESCRIPTION
@bauerj, can you have a look?

```
# here=$(dirname "$0")
# ...
# rm $here/build/* -rf
# rm $here/dist/* -rf
```

This script looks **dangerous**. If user does not have _coreutils_ or if there is another _dirname_ executable in the local bin directory - this script can remove _/build/*_ and _/dist/*_ in the root of user's filesystem.

```
here=$(nothing "$0")
echo rm $here/build/* -rf
echo rm $here/dist/* -rf
```

We have to check that _"${here}"_ is not empty at least. Also do we really need it? Can we just use _"${PWD}"_?

```
here=$PWD
test -n "$here" -a -d "$here" || exit 
```

...or simply omit it?
```
echo "Clearing $PWD/build and $PWD/dist..."
rm build/* -rf
rm dist/* -rf

prepare-wine.sh && \
prepare-pyinstaller.sh && \
prepare-hw.sh || exit 1
```

Follow-up: 5778102 (PR #3397).