### PR TITLE
Optimisations in wallet.py

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -62,6 +62,7 @@ from .fee_slider import FeeSlider
 
 from .util import *
 
+from electrum.util import profiler
 
 class StatusBarButton(QPushButton):
     def __init__(self, icon, tooltip, func):
@@ -325,6 +326,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.print_error('close_wallet', self.wallet.storage.path)
         run_hook('close_wallet', self.wallet)
 
+    @profiler
     def load_wallet(self, wallet):
         wallet.thread = TaskThread(self, self.on_error)
         self.wallet = wallet

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -341,7 +341,7 @@ class Abstract_Wallet(PrintError):
     def is_change(self, address):
         if not self.is_mine(address):
             return False
-        return address in self.change_addresses
+        return self.get_address_index(address)[0]
 
     def get_address_index(self, address):
         if hasattr(self, '_addr_to_addr_index'):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -332,6 +332,10 @@ class Abstract_Wallet(PrintError):
         return changed
 
     def is_mine(self, address):
+        if hasattr(self, '_addr_to_addr_index'):  # Deterministic_Wallet
+            return address in self._addr_to_addr_index
+        if hasattr(self, 'addresses'):  # Imported_Wallet
+            return address in self.addresses
         return address in self.get_addresses()
 
     def is_change(self, address):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -340,13 +340,7 @@ class Abstract_Wallet(PrintError):
         return self.get_address_index(address)[0]
 
     def get_address_index(self, address):
-        if hasattr(self, '_addr_to_addr_index'):
-            return self._addr_to_addr_index[address]
-        if address in self.receiving_addresses:
-            return False, self.receiving_addresses.index(address)
-        if address in self.change_addresses:
-            return True, self.change_addresses.index(address)
-        raise Exception("Address not found", address)
+        raise NotImplementedError()
 
     def export_private_key(self, address, password):
         """ extended WIF format """
@@ -1713,6 +1707,9 @@ class Deterministic_Wallet(Abstract_Wallet):
 
     def is_mine(self, address):
         return address in self._addr_to_addr_index
+
+    def get_address_index(self, address):
+        return self._addr_to_addr_index[address]
 
     def get_master_public_keys(self):
         return [self.get_master_public_key()]

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -340,6 +340,8 @@ class Abstract_Wallet(PrintError):
         return address in self.change_addresses
 
     def get_address_index(self, address):
+        if hasattr(self, '_addr_to_addr_index'):
+            return self._addr_to_addr_index[address]
         if address in self.receiving_addresses:
             return False, self.receiving_addresses.index(address)
         if address in self.change_addresses:
@@ -1029,8 +1031,10 @@ class Abstract_Wallet(PrintError):
 
     def is_used(self, address):
         h = self.history.get(address,[])
+        if len(h) == 0:
+            return False
         c, u, x = self.get_addr_balance(address)
-        return len(h) > 0 and c + u + x == 0
+        return c + u + x == 0
 
     def is_empty(self, address):
         c, u, x = self.get_addr_balance(address)
@@ -1647,6 +1651,14 @@ class Deterministic_Wallet(Abstract_Wallet):
                 if n > nmax: nmax = n
         return nmax + 1
 
+    def load_addresses(self):
+        super().load_addresses()
+        self._addr_to_addr_index = {}  # key: address, value: (is_change, index)
+        for i, addr in enumerate(self.receiving_addresses):
+            self._addr_to_addr_index[addr] = (False, i)
+        for i, addr in enumerate(self.change_addresses):
+            self._addr_to_addr_index[addr] = (True, i)
+
     def create_new_address(self, for_change=False):
         assert type(for_change) is bool
         addr_list = self.change_addresses if for_change else self.receiving_addresses
@@ -1654,6 +1666,7 @@ class Deterministic_Wallet(Abstract_Wallet):
         x = self.derive_pubkeys(for_change, n)
         address = self.pubkeys_to_address(x)
         addr_list.append(address)
+        self._addr_to_addr_index[address] = (for_change, n)
         self.save_addresses()
         self.add_address(address)
         return address
@@ -1685,12 +1698,11 @@ class Deterministic_Wallet(Abstract_Wallet):
 
     def is_beyond_limit(self, address, is_change):
         addr_list = self.get_change_addresses() if is_change else self.get_receiving_addresses()
-        i = addr_list.index(address)
-        prev_addresses = addr_list[:max(0, i)]
+        i = self.get_address_index(address)[1]
         limit = self.gap_limit_for_change if is_change else self.gap_limit
-        if len(prev_addresses) < limit:
+        if i < limit:
             return False
-        prev_addresses = prev_addresses[max(0, i - limit):]
+        prev_addresses = addr_list[max(0, i - limit):max(0, i)]
         for addr in prev_addresses:
             if self.history.get(addr):
                 return False

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -332,10 +332,6 @@ class Abstract_Wallet(PrintError):
         return changed
 
     def is_mine(self, address):
-        if hasattr(self, '_addr_to_addr_index'):  # Deterministic_Wallet
-            return address in self._addr_to_addr_index
-        if hasattr(self, 'addresses'):  # Imported_Wallet
-            return address in self.addresses
         return address in self.get_addresses()
 
     def is_change(self, address):
@@ -1466,6 +1462,9 @@ class Imported_Wallet(Simple_Wallet):
     def is_beyond_limit(self, address, is_change):
         return False
 
+    def is_mine(self, address):
+        return address in self.addresses
+
     def get_fingerprint(self):
         return ''
 
@@ -1711,6 +1710,9 @@ class Deterministic_Wallet(Abstract_Wallet):
             if self.history.get(addr):
                 return False
         return True
+
+    def is_mine(self, address):
+        return address in self._addr_to_addr_index
 
     def get_master_public_keys(self):
         return [self.get_master_public_key()]


### PR DESCRIPTION
`wallet.is_beyond_limit` is slow because is looks up addr indices in a list and because it copies sublists

This is a problem as this method gets called inside a for loop when opening a wallet:
https://github.com/spesmilo/electrum/blob/7ab9fa5be48cf5aefec98d94657241c73a6e280c/gui/qt/address_list.py#L109

`wallet.is_mine` is also slow. It usually does linear operations (in the number of addresses in the wallet) but sometimes even more (for Imported Wallet, it even sorts the addresses!).

This is also a problem for the same reason:
https://github.com/spesmilo/electrum/blob/7ab9fa5be48cf5aefec98d94657241c73a6e280c/lib/wallet.py#L275

-----

- make `wallet.get_address_index` faster by storing an addr->index dict, and use it
- make one fewer list copy
- make `wallet.is_mine` faster by looking up in dicts

-----

Opening a wallet with 50k addresses without PR:
```
[WalletStorage] wallet path /home/user/.electrum/testnet/wallets/test_large_wallet
[profiler] load_transactions 0.0001
[profiler] build_reverse_history 0.0070
[profiler] save_transactions 0.0652
[profiler] check_history 57.0266
[profiler] on_update 0.1118
[profiler] load_wallet 31.1191
[profiler] on_update 0.0912
```

With PR:
```
[WalletStorage] wallet path /home/user/.electrum/testnet/wallets/test_large_wallet
[profiler] load_transactions 0.0000
[profiler] build_reverse_history 0.0064
[profiler] check_history 0.0687
[profiler] on_update 0.1119
[profiler] load_wallet 1.6227
[profiler] on_update 0.0851
```

-----

This PR depends on https://github.com/spesmilo/electrum/pull/3777