### PR TITLE
Enable sorting of list widgets

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -38,6 +38,7 @@ class AddressList(MyTreeWidget):
         MyTreeWidget.__init__(self, parent, self.create_menu, [], 1)
         self.refresh_headers()
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSortingEnabled(True)
         self.show_change = False
         self.show_used = 0
         self.change_button = QComboBox(self)
@@ -96,10 +97,10 @@ class AddressList(MyTreeWidget):
             if fx and fx.get_fiat_address_config():
                 rate = fx.exchange_rate()
                 fiat_balance = fx.value_str(balance, rate)
-                address_item = QTreeWidgetItem([address, label, balance_text, fiat_balance, "%d"%num])
+                address_item = SortableTreeWidgetItem([address, label, balance_text, fiat_balance, "%d"%num])
                 address_item.setTextAlignment(3, Qt.AlignRight)
             else:
-                address_item = QTreeWidgetItem([address, label, balance_text, "%d"%num])
+                address_item = SortableTreeWidgetItem([address, label, balance_text, "%d"%num])
                 address_item.setTextAlignment(2, Qt.AlignRight)
             address_item.setFont(0, QFont(MONOSPACE_FONT))
             address_item.setData(0, Qt.UserRole, address)

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -53,6 +53,8 @@ class HistoryList(MyTreeWidget):
         MyTreeWidget.__init__(self, parent, self.create_menu, [], 3)
         self.refresh_headers()
         self.setColumnHidden(1, True)
+        self.setSortingEnabled(True)
+        self.sortByColumn(0, Qt.AscendingOrder)
 
     def refresh_headers(self):
         headers = ['', '', _('Date'), _('Description') , _('Amount'), _('Balance')]
@@ -88,9 +90,10 @@ class HistoryList(MyTreeWidget):
                 for amount in [value, balance]:
                     text = fx.historical_value_str(amount, date)
                     entry.append(text)
-            item = QTreeWidgetItem(entry)
+            item = SortableTreeWidgetItem(entry)
             item.setIcon(0, icon)
             item.setToolTip(0, str(conf) + " confirmation" + ("s" if conf != 1 else ""))
+            item.setData(0, SortableTreeWidgetItem.DataRole, (status, conf))
             if has_invoice:
                 item.setIcon(3, QIcon(":icons/seal"))
             for i in range(len(entry)):
@@ -131,6 +134,7 @@ class HistoryList(MyTreeWidget):
         if items:
             item = items[0]
             item.setIcon(0, icon)
+            item.setData(0, SortableTreeWidgetItem.DataRole, (status, conf))
             item.setText(2, status_str)
 
     def create_menu(self, position):

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -635,6 +635,23 @@ class ColorScheme:
         if ColorScheme.has_dark_background(widget):
             ColorScheme.dark_scheme = True
 
+
+class SortableTreeWidgetItem(QTreeWidgetItem):
+    DataRole = Qt.UserRole + 1
+
+    def __lt__(self, other):
+        column = self.treeWidget().sortColumn()
+        if None not in [x.data(column, self.DataRole) for x in [self, other]]:
+            # We have set custom data to sort by
+            return self.data(column, self.DataRole) < other.data(column, self.DataRole)
+        try:
+            # Is the value something numeric?
+            return float(self.text(column)) < float(other.text(column))
+        except ValueError:
+            # If not, we will just do string comparison
+            return self.text(column) < other.text(column)
+
+
 if __name__ == "__main__":
     app = QApplication([])
     t = WaitingDialog(None, 'testing ...', lambda: [time.sleep(1)], lambda x: QMessageBox.information(None, 'done', "done"))

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -32,6 +32,7 @@ class UTXOList(MyTreeWidget):
     def __init__(self, parent=None):
         MyTreeWidget.__init__(self, parent, self.create_menu, [ _('Address'), _('Label'), _('Amount'), _('Height'), _('Output point')], 1)
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSortingEnabled(True)
 
     def get_name(self, x):
         return x.get('prevout_hash') + ":%d"%x.get('prevout_n')
@@ -47,7 +48,7 @@ class UTXOList(MyTreeWidget):
             name = self.get_name(x)
             label = self.wallet.get_label(x.get('prevout_hash'))
             amount = self.parent.format_amount(x['value'])
-            utxo_item = QTreeWidgetItem([address, label, amount, '%d'%height, name[0:10] + '...' + name[-2:]])
+            utxo_item = SortableTreeWidgetItem([address, label, amount, '%d'%height, name[0:10] + '...' + name[-2:]])
             utxo_item.setFont(0, QFont(MONOSPACE_FONT))
             utxo_item.setFont(4, QFont(MONOSPACE_FONT))
             utxo_item.setData(0, Qt.UserRole, name)


### PR DESCRIPTION
This allows users to sort the list widgets by column value simply by clicking on the column they want to sort by.

It is based on fyookball/electrum#512 by @ContrarianUnderscoreUnderscore.

---
![bildschirmfoto 2018-01-28 um 13 11 34](https://user-images.githubusercontent.com/598790/35481887-dbdc95d8-042c-11e8-8249-5e18ef21de7e.png)
 This is the default sorting (status, conf)

---
![bildschirmfoto 2018-01-28 um 13 11 53](https://user-images.githubusercontent.com/598790/35481886-dbb37cb6-042c-11e8-9c21-2d68a5375b1d.png)
This is sorted by amount.