### PR TITLE
conflicting transactions

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -179,10 +179,13 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.main_window.sign_tx(self.tx, sign_done)
 
     def save(self):
-        self.wallet.add_transaction(self.tx.txid(), self.tx)
+        if not self.wallet.add_transaction(self.tx.txid(), self.tx):
+            self.show_error(_("Transaction could not be saved. It conflicts with current history."))
+            return
         self.wallet.save_transactions(write=True)
 
-        self.main_window.history_list.update()
+        # need to update at least: history_list, utxo_list, address_list
+        self.main_window.need_update.set()
 
         self.save_button.setDisabled(True)
         self.show_message(_("Transaction saved successfully"))

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -627,7 +627,8 @@ class Commands:
     def addtransaction(self, tx):
         """ Add a transaction to the wallet history """
         tx = Transaction(tx)
-        self.wallet.add_transaction(tx.txid(), tx)
+        if not self.wallet.add_transaction(tx.txid(), tx):
+            return False
         self.wallet.save_transactions()
         return tx.txid()
 

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -798,6 +798,14 @@ class Transaction:
         return bh2u(bfh(txin['prevout_hash'])[::-1]) + int_to_hex(txin['prevout_n'], 4)
 
     @classmethod
+    def get_outpoint_from_txin(cls, txin):
+        if txin['type'] == 'coinbase':
+            return None
+        prevout_hash = txin['prevout_hash']
+        prevout_n = txin['prevout_n']
+        return prevout_hash + ':%d' % prevout_n
+
+    @classmethod
     def serialize_input(self, txin, script):
         # Prev hash and index
         s = self.serialize_outpoint(txin)


### PR DESCRIPTION
Merging the `local_tx` branch introduced the possibility of having conflicting transactions in history.

atm this PR uses a new data structure `spent_outpoints` instead of extending `pruned_txo`