### PR TITLE
Update macOS build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,20 +93,12 @@ This directory contains the python dependencies used by Electrum.
 Mac OS X / macOS
 --------
 
-::
-
-    # On MacPorts installs: 
-    sudo python3 setup-release.py py2app
-    
-    # On Homebrew installs: 
-    ARCHFLAGS="-arch i386 -arch x86_64" sudo python3 setup-release.py py2app --includes sip
-    
-    sudo hdiutil create -fs HFS+ -volname "Electrum" -srcfolder dist/Electrum.app dist/electrum-VERSION-macosx.dmg
+See `contrib/build-osx/`.
 
 Windows
 -------
 
-See `contrib/build-wine/README` file.
+See `contrib/build-wine/`.
 
 
 Android

--- a/contrib/build-osx/README.md
+++ b/contrib/build-osx/README.md
@@ -5,6 +5,8 @@ This guide explains how to build Electrum binaries for macOS systems.
 We build our binaries on El Capitan (10.11.6) as building it on High Sierra
 makes the binaries incompatible with older versions.
 
+This assumes that the Xcode command line tools (and thus git) are already installed. 
+
 
 ## 1. Run the script
 
@@ -13,5 +15,3 @@ makes the binaries incompatible with older versions.
     ./make_osx
 
 ## 2. Done
-
-Hopefully it will be that simple.

--- a/contrib/build-osx/README.md
+++ b/contrib/build-osx/README.md
@@ -1,0 +1,17 @@
+Building Mac OS binaries
+========================
+
+This guide explains how to build Electrum binaries for macOS systems.
+We build our binaries on El Capitan (10.11.6) as building it on High Sierra
+makes the binaries incompatible with older versions.
+
+
+## 1. Run the script
+
+
+
+    ./make_osx
+
+## 2. Done
+
+Hopefully it will be that simple.

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -1,14 +1,45 @@
 #!/bin/bash
+RED='\033[0;31m'
+BLUE='\033[0,34m'
+NC='\033[0m' # No Color
+function info {
+	printf "\r💬 ${BLUE}INFO:${NC} ${1}\n"
+}
+function fail {
+    printf "\r🗯 ${RED}ERROR:${NC} ${1}\n"
+    exit 1
+}
+
 build_dir=$(dirname "$0")
 test -n "$build_dir" -a -d "$build_dir" || exit
 cd $build_dir/../..
 
 export PYTHONHASHSEED=22
 VERSION=`git describe --tags`
+PYTHON_VERSION=3.6.4
 
+
+info "Installing Python $PYTHON_VERSION"
+export PATH="~/.pyenv/bin:~/.pyenv/shims:$PATH:~/Library/Python/3.6/bin"
+if [ -d "~/.pyenv" ]; then
+  pyenv update
+else
+  curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash > /dev/null 2>&1
+fi
+PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s $PYTHON_VERSION && \
+pyenv global $PYTHON_VERSION || \
+fail "Unable to use Python $PYTHON_VERSION"
+
+
+if ! which pyinstaller > /dev/null; then
+  info "Installing pyinstaller"
+  python3 -m pip install pyinstaller -I --user || fail "Could not install pyinstaller"
+fi
+
+info "Using these versions for building Electrum:"
 sw_vers
 python3 --version
-echo -n "Pyinstaller version "
+echo -n "Pyinstaller "
 pyinstaller --version
 
 rm -rf ./dist
@@ -17,8 +48,7 @@ rm -rf ./dist
 rm  -rf /tmp/electrum-build > /dev/null 2>&1
 mkdir /tmp/electrum-build
 
-
-echo "Downloading icons and locale..."
+info "Downloading icons and locale..."
 for repo in icons locale; do
   git clone https://github.com/spesmilo/electrum-$repo /tmp/electrum-build/electrum-$repo
 done
@@ -26,9 +56,20 @@ done
 cp -R /tmp/electrum-build/electrum-locale/locale/ ./lib/locale/
 cp    /tmp/electrum-build/electrum-icons/icons_rc.py ./gui/qt/
 
-echo "Building Electrum..."
-python3 setup.py install --user > /dev/null
-python3 -m pip install pyqt5 --user
+info "Installing requirements..."
+python3 -m pip install -Ir ./contrib/deterministic-build/requirements.txt --user && \
+python3 -m pip install pyqt5 --user || \
+fail "Could not install requirements"
 
-pyinstaller --noconfirm --ascii --name $VERSION contrib/build-osx/osx.spec
-hdiutil create -fs HFS+ -volname "Electrum" -srcfolder dist/Electrum.app dist/electrum-$VERSION.dmg
+info "Installing hardware wallet requirements..."
+python3 -m pip install -Ir ./contrib/deterministic-build/requirements-hw.txt --user || \
+fail "Could not install hardware wallet requirements"
+
+info "Building Electrum..."
+python3 setup.py install --user > /dev/null || fail "Could not build Electrum"
+
+info "Building binary"
+pyinstaller --noconfirm --ascii --name $VERSION contrib/build-osx/osx.spec || fail "Could not build binary"
+
+info "Creating .DMG"
+hdiutil create -fs HFS+ -volname "Electrum" -srcfolder dist/Electrum.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -1,0 +1,34 @@
+#!/bin/bash
+build_dir=$(dirname "$0")
+test -n "$build_dir" -a -d "$build_dir" || exit
+cd $build_dir/../..
+
+export PYTHONHASHSEED=22
+VERSION=`git describe --tags`
+
+sw_vers
+python3 --version
+echo -n "Pyinstaller version "
+pyinstaller --version
+
+rm -rf ./dist
+
+
+rm  -rf /tmp/electrum-build > /dev/null 2>&1
+mkdir /tmp/electrum-build
+
+
+echo "Downloading icons and locale..."
+for repo in icons locale; do
+  git clone https://github.com/spesmilo/electrum-$repo /tmp/electrum-build/electrum-$repo
+done
+
+cp -R /tmp/electrum-build/electrum-locale/locale/ ./lib/locale/
+cp    /tmp/electrum-build/electrum-icons/icons_rc.py ./gui/qt/
+
+echo "Building Electrum..."
+python3 setup.py install --user > /dev/null
+python3 -m pip install pyqt5 --user
+
+pyinstaller --noconfirm --ascii --name $VERSION contrib/build-osx/osx.spec
+hdiutil create -fs HFS+ -volname "Electrum" -srcfolder dist/Electrum.app dist/electrum-$VERSION.dmg

--- a/contrib/build-osx/osx.spec
+++ b/contrib/build-osx/osx.spec
@@ -12,8 +12,8 @@ for i, x in enumerate(sys.argv):
 else:
     raise BaseException('no version')
 
-electrum = "../"
-block_cipher=None
+electrum = os.path.abspath("../../")
+block_cipher = None
 
 # see https://github.com/pyinstaller/pyinstaller/issues/2005
 hiddenimports = []

--- a/contrib/build-osx/osx.spec
+++ b/contrib/build-osx/osx.spec
@@ -12,7 +12,7 @@ for i, x in enumerate(sys.argv):
 else:
     raise BaseException('no version')
 
-electrum = os.path.abspath("../../")
+electrum = os.path.abspath(".") + "/"
 block_cipher = None
 
 # see https://github.com/pyinstaller/pyinstaller/issues/2005

--- a/contrib/make_osx
+++ b/contrib/make_osx
@@ -1,6 +1,0 @@
-#!/bin/bash
-rm -rf dist
-export PYTHONHASHSEED=22
-VERSION=`git describe --tags`
-pyinstaller --noconfirm --ascii --name $VERSION contrib/osx.spec
-hdiutil create -fs HFS+ -volname "Electrum" -srcfolder dist/Electrum.app dist/electrum-$VERSION.dmg


### PR DESCRIPTION
- Updates the outdated building instructions
- Fixes the hard-coded path in the specfile
- Replaces the build script with a new one that:
  - Installs a fixed Python version
  - Installs the frozen dependencies that the Windows builds will use too (#3604 is merged here)
  - Uses the pre-built locales and icon file

I tested it on a fresh VM, no other dependencies are necessary.

Closes: #3775