### PR TITLE
Win binaries: use pywin32-ctypes instead of pypiwin32

### DIFF
--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -72,8 +72,8 @@ done
 # upgrade pip
 $PYTHON -m pip install pip --upgrade
 
-# Install PyWin32
-$PYTHON -m pip install pypiwin32
+# Install pywin32-ctypes (needed by pyinstaller)
+$PYTHON -m pip install pywin32-ctypes
 
 # Install PyQt
 $PYTHON -m pip install PyQt5


### PR DESCRIPTION
pypiwin32 might be going away for pywin32 at some point; and after looking into this it seems that pywin32-ctypes should be enough for our needs