### PR TITLE
migrated some commands from addr to scripthash

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -34,7 +34,7 @@ from functools import wraps
 from decimal import Decimal
 
 from .import util
-from .util import bfh, bh2u, format_satoshis, json_decode
+from .util import bfh, bh2u, format_satoshis, json_decode, print_error
 from .import bitcoin
 from .bitcoin import is_address,  hash_160, COIN, TYPE_ADDRESS
 from .i18n import _
@@ -175,7 +175,8 @@ class Commands:
         """Return the transaction history of any address. Note: This is a
         walletless server query, results are not checked by SPV.
         """
-        return self.network.synchronous_get(('blockchain.address.get_history', [address]))
+        sh = bitcoin.address_to_scripthash(address)
+        return self.network.synchronous_get(('blockchain.scripthash.get_history', [sh]))
 
     @command('w')
     def listunspent(self):
@@ -192,7 +193,8 @@ class Commands:
         """Returns the UTXO list of any address. Note: This
         is a walletless server query, results are not checked by SPV.
         """
-        return self.network.synchronous_get(('blockchain.address.listunspent', [address]))
+        sh = bitcoin.address_to_scripthash(address)
+        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
 
     @command('')
     def serialize(self, jsontx):
@@ -314,7 +316,8 @@ class Commands:
         """Return the balance of any address. Note: This is a walletless
         server query, results are not checked by SPV.
         """
-        out = self.network.synchronous_get(('blockchain.address.get_balance', [address]))
+        sh = bitcoin.address_to_scripthash(address)
+        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh]))
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out
@@ -322,6 +325,8 @@ class Commands:
     @command('n')
     def getproof(self, address):
         """Get Merkle branch of an address in the UTXO set"""
+        # Servers no longer support this query.
+        raise NotImplementedError()
         p = self.network.synchronous_get(('blockchain.address.get_proof', [address]))
         out = []
         for i,s in p:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -323,17 +323,6 @@ class Commands:
         return out
 
     @command('n')
-    def getproof(self, address):
-        """Get Merkle branch of an address in the UTXO set"""
-        # Servers no longer support this query.
-        raise NotImplementedError()
-        p = self.network.synchronous_get(('blockchain.address.get_proof', [address]))
-        out = []
-        for i,s in p:
-            out.append(i)
-        return out
-
-    @command('n')
     def getmerkle(self, txid, height):
         """Get Merkle branch of a transaction included in a block. Electrum
         uses this to verify transactions (Simple Payment Verification)."""


### PR DESCRIPTION
Note: how should `getproof` be handled? We could just delete the method completely.