### PR TITLE
Add script to check and sign executables on Windows

### DIFF
--- a/contrib/build-wine/README.md
+++ b/contrib/build-wine/README.md
@@ -36,3 +36,30 @@ $ wine --version
 2. Make sure `/opt` is writable by the current user.
 3. Run `build.sh`.
 4. The generated binaries are in `./dist`.
+
+
+Code Signing
+============
+
+Electrum Windows builds are signed with a Microsoft Authenticode™ code signing
+certificate in addition to the GPG-based signatures.
+
+The advantage of using Authenticode is that Electrum users won't receive a 
+Windows SmartScreen warning when starting it.
+
+The release signing procedure involves a signer (the holder of the
+certificate/key) and one or multiple trusted verifiers:
+
+
+| Signer                                                    | Verifier                          |
+|-----------------------------------------------------------|-----------------------------------|
+| Build .exe files using `build.sh`                         |                                   |
+|                                                           | Build .exe files using `build.sh` |
+|                                                           | Sign .exe files using `gpg -b`    |
+|                                                           | Send signatures to signer         |
+| Place signatures as `$filename.$builder.asc` in `./dist`  |                                   |
+| Run `./sign.sh`                                           |                                   |
+
+
+`sign.sh` will check if the signatures match the signer's files. This ensures that the signer's
+build environment is not compromised and that the binaries can be reproduced by anyone.

--- a/contrib/build-wine/README.md
+++ b/contrib/build-wine/README.md
@@ -63,3 +63,21 @@ certificate/key) and one or multiple trusted verifiers:
 
 `sign.sh` will check if the signatures match the signer's files. This ensures that the signer's
 build environment is not compromised and that the binaries can be reproduced by anyone.
+
+
+Verify Integrity of signed binary
+=================================
+
+Every user can verify that the official binary was created from the source code in this 
+repository. To do so, the Authenticode signature needs to be stripped since the signature
+is not reproducible.
+
+This procedure removes the differences between the signed and unsigned binary:
+
+1. Remove the signature from the signed binary using osslsigncode or signtool.
+2. Set the COFF image checksum for the signed binary to 0x0. This is necessary
+   because pyinstaller doesn't generate a checksum.
+3. Append null bytes to the _unsigned_ binary until the byte count is a multiple
+   of 8.
+
+The script `unsign.sh` performs these steps.

--- a/contrib/build-wine/sign.sh
+++ b/contrib/build-wine/sign.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+here=$(dirname "$0")
+test -n "$here" -a -d "$here" || exit
+cd $here
+
+
+CERT_FILE=${CERT_FILE:-~/codesigning/cert.pem}
+KEY_FILE=${KEY_FILE:-~/codesigning/key.pem}
+if [[ ! -f "$CERT_FILE" ]]; then
+    ls $CERT_FILE
+    echo "Make sure that $CERT_FILE and $KEY_FILE exist"
+fi
+
+if ! which osslsigncode > /dev/null 2>&1; then
+    echo "Please install osslsigncode"
+fi
+
+mkdir -p ./signed/dist >/dev/null 2>&1
+
+echo "Found $(ls dist/*.exe | wc -w) files to sign."
+for f in $(ls dist/*.exe); do
+    echo "Checking GPG signatures for $f..."
+    bad=0
+    good=0
+    for sig in $(ls $f.*.asc); do
+        if gpg --verify $sig $f > /dev/null 2>&1; then
+            (( good++ ))
+        else
+            (( bad++ ))
+        fi
+    done
+    echo "$good good signature(s) for $f".
+    if (( bad > 0 )); then
+        echo "WARNING: $bad bad signature(s)"
+        for sig in $(ls $f.*.asc); do
+            gpg --verify $sig $f
+            gpg --list-packets --verbose $sig
+        done
+        read -p "Do you want to continue (y/n)? " answer
+        if [ "$answer" != "y" ]; then
+            exit
+        fi
+    fi
+    echo "Signing $f..."
+    osslsigncode sign \
+      -certs "$CERT_FILE" \
+      -key "$KEY_FILE" \
+      -n "Electrum" \
+      -i "https://electrum.org/" \
+      -t "http://timestamp.digicert.com/" \
+      -in "$f" \
+      -out "signed/$f"
+    ls signed/$f -lah      
+done

--- a/contrib/build-wine/unsign.sh
+++ b/contrib/build-wine/unsign.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+here=$(dirname "$0")
+test -n "$here" -a -d "$here" || exit
+cd $here
+
+if ! which osslsigncode > /dev/null 2>&1; then
+    echo "Please install osslsigncode"
+fi
+
+if [ $# -neq 2 ]; then
+    echo "Usage: $0 signed_binary unsigned_binary"
+fi
+
+out="$1-stripped.exe"
+
+set -ex
+
+echo "Step 1: Remove PE signature from signed binary"
+osslsigncode remove-signature -in $1 -out $out
+
+echo "Step 2: Remove checksum from signed binary"
+python3 <<EOF
+pe_file = "$out"
+with open(pe_file, "rb") as f:
+    binary = bytearray(f.read())
+
+pe_offset = int.from_bytes(binary[0x3c:0x3c+4], byteorder="little")
+checksum_offset = pe_offset + 88
+
+for b in range(4):
+    binary[checksum_offset + b] = 0
+
+with open(pe_file, "wb") as f:
+    f.write(binary)
+EOF
+
+bytes=$( wc -c < $2 )
+bytes=$((8 - ($bytes%8)))
+bytes=$(($bytes % 8))
+
+echo "Step 3: Appending $bytes null bytes to unsigned binary"
+
+truncate -s +$bytes $2
+
+diff $out $2 && echo "Success!"


### PR DESCRIPTION
This is based on a proposal by @EagleTM 

Signing Windows builds using the Authenticode key is simple enough. This script integrates the deterministic builds into the process by checking if the files match with someone else's files.

osslsigncode needs to be installed in order to use this script.