### PR TITLE
fee calculation: force back-end to use integer sat/bytes

### DIFF
--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -428,7 +428,12 @@ class SimpleConfig(PrintError):
 
     @classmethod
     def estimate_fee_for_feerate(cls, fee_per_kb, size):
-        return int(fee_per_kb * size / 1000.)
+        # note: We only allow integer sat/byte values atm.
+        # The GUI for simplicity reasons only displays integer sat/byte,
+        # and for the sake of consistency, we thus only use integer sat/byte in
+        # the backend too.
+        fee_per_byte = int(fee_per_kb / 1000)
+        return int(fee_per_byte * size)
 
     def update_fee_estimates(self, key, value):
         self.fee_estimates[key] = value


### PR DESCRIPTION
This is trying to avoid the following example scenario:
- the server sends feerate estimates in sat/kbyte resolution
- the GUI displays feerate in sat/byte resolution
- the backend might do the calculation in sat/kbyte resolution and then be inconsistent with what the GUI displays due to rounding

-----

One concrete example:

(we assume: time-based estimates, dynamic fees)

server sends 7.5 sat/byte estimate (7500 sat/kbyte)
user moves slider to that estimate

https://github.com/spesmilo/electrum/blob/95c5815fe3c922807af06547051339b082bcb926/gui/qt/main_window.py#L1091-L1092

feerate displayed will be rounded down to 7 sat/byte

https://github.com/spesmilo/electrum/blob/95c5815fe3c922807af06547051339b082bcb926/gui/qt/main_window.py#L1414-L1424
sets `fee_estimator = None`

https://github.com/spesmilo/electrum/blob/95c5815fe3c922807af06547051339b082bcb926/lib/wallet.py#L1011-L1013

https://github.com/spesmilo/electrum/blob/95c5815fe3c922807af06547051339b082bcb926/lib/simple_config.py#L423-L431

so fee_estimator that is used for the actual tx fee calculation will use 7.5 sat/byte

https://github.com/spesmilo/electrum/blob/95c5815fe3c922807af06547051339b082bcb926/gui/qt/main_window.py#L1320-L1324

displayed feerate and fee in send tab will use 7 sat/byte

result: inconsistency between displayed fee in send tab, and actual fee of tx (displayed fee in preview dialog)