### PR TITLE
Test Windows build using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,17 @@ script:
 after_success:
     - if [ "$TRAVIS_BRANCH" = "master" ]; then pip install pycurl requests && contrib/make_locale; fi
     - coveralls
+jobs:
+  include:
+    - stage: windows build
+      sudo: true
+      python: 3.5
+      install:
+        - sudo dpkg --add-architecture i386
+        - wget -nc https://dl.winehq.org/wine-builds/Release.key
+        - sudo apt-key add Release.key
+        - sudo apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq winehq-stable dirmngr gnupg2 p7zip-full
+      script: ./contrib/build-wine/build.sh
+      after_success: true


### PR DESCRIPTION
This makes Travis run the Windows build script on every commit.

This way we notice if the build fails because:
* We broke something
* An upstream package broke something
* A new Wine release broke something

It also prints the resulting hashes for the binaries which might be useful for a quick comparison.