### PR TITLE
Prevent crash after pressing "spend max"

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -208,6 +208,7 @@ def rev_hex(s):
 def int_to_hex(i, length=1):
     assert isinstance(i, int)
     s = hex(i)[2:].rstrip('L')
+    s = s.lstrip('0x')
     s = "0"*(2*length - len(s)) + s
     return rev_hex(s)
 


### PR DESCRIPTION
Error log w/o this change
```
Traceback (most recent call last):
  File "/home/rav3n/electrum/gui/qt/main_window.py", line 1232, in spend_max
    self.do_update_fee()
  File "/home/rav3n/electrum/gui/qt/main_window.py", line 1293, in do_update_fee
    size = tx.estimated_size()
  File "/home/rav3n/electrum/lib/util.py", line 226, in <lambda>
    return lambda *args, **kw_args: do_profile(func, args, kw_args)
  File "/home/rav3n/electrum/lib/util.py", line 222, in do_profile
    o = func(*args, **kw_args)
  File "/home/rav3n/electrum/lib/transaction.py", line 866, in estimated_size
    weight = self.estimated_weight()
  File "/home/rav3n/electrum/lib/transaction.py", line 914, in estimated_weight
    total_tx_size = self.estimated_total_size()
  File "/home/rav3n/electrum/lib/transaction.py", line 896, in estimated_total_size
    return len(self.serialize(True)) // 2 if not self.is_complete() or self.raw is None else len(self.raw) // 2  # ASCII hex string
  File "/home/rav3n/electrum/lib/transaction.py", line 810, in serialize
    nLocktime = int_to_hex(self.locktime, 4)
  File "/home/rav3n/electrum/lib/bitcoin.py", line 212, in int_to_hex
    return rev_hex(s)
  File "/home/rav3n/electrum/lib/bitcoin.py", line 205, in rev_hex
    return bh2u(bfh(s)[::-1])
ValueError: non-hexadecimal number found in fromhex() arg at position 6
Aborted
```