### PR TITLE
Add Github issue/PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+**Note**: Please only report bugs or feature requests for the Electrum Bitcoin wallet here. For altcoin forks please check their website.
+If you have a question about Electrum or need help using it, check either:
+Reddit: https://www.reddit.com/r/Electrum/
+Bitcointalk: https://bitcointalk.org/index.php?board=98.0
+Our chat on Freenode: http://webchat.freenode.net?randomnick=1&channels=%23electrum&prompt=1
+------

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+(Thanks for sending a pull request! Below is a proposed structure but feel free to change it or discard it 😊)
+
+Changes in this Pull Request
+----------------------------
+Briefly describe what your Pull Request changes/fixes.
+
+
+Related Issues
+--------------
+* Closes: #
+* Related: #
+
+
+Testing Instructions
+--------------------
+How can we test that your changes work?
+
+
+Screenshots
+-----------
+If this is something UI related, please include a screenshot. Simply drag the image here to do so.


### PR DESCRIPTION
Changes in this Pull Request
----------------------------
This adds an issue and pull request template. Whenever a new issue/PR is opened, the users sees the corresponding document.

Hopefully this decreases the number of questions like "I lost my phone, what can I do?" and bug reports from altcoin forks.
 
It also adds a PR template. I don't think we had any problems with missing information in Pull Requests but I guess it can't hurt.
 
Related Issues (Selection)
--------------
* Various issues from "ZCL" users: #3905, #3852, #3843, #3840, #3828, #3815, #3809 #3808...
* #3888 

Screenshots
-----------
![image](https://user-images.githubusercontent.com/598790/36221985-296277c8-11c0-11e8-99f0-66d71adf9562.png)
