### PR TITLE
Fixup to get PyQt5 5.10 working ok and looking right on Mac

### DIFF
--- a/contrib/deterministic-build/requirements-binaries.txt
+++ b/contrib/deterministic-build/requirements-binaries.txt
@@ -1,5 +1,5 @@
 pycryptodomex==3.4.12
-PyQt5==5.9
+PyQt5==5.10
 sip==4.19.7
 six==1.11.0
 websocket-client==0.46.0


### PR DESCRIPTION
As per the discussion in Electron Cash slack -- this is a PR that addresses the weirdness in PyQt5 5.10 not looking right on Mac.  Turns out libqmacstyle.dylib wasn't being picked up by PyInstaller, hence the horrible look.  This fixes that.

(NB: On Windows things should look ok as I think the Windows style is hard-compiled into Qt5 5.10 from my groking of the files, but I haven't tested this on Windows)
