### PR TITLE
wizard: (qt) add dedicated button to create new wallet

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -9,7 +9,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 
 from electrum import Wallet, WalletStorage
-from electrum.util import UserCancelled, InvalidPassword
+from electrum.util import UserCancelled, InvalidPassword, get_new_wallet_name
 from electrum.base_wizard import BaseWizard, HWD_SETUP_DECRYPT_WALLET
 from electrum.i18n import _
 
@@ -178,6 +178,18 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         hbox2.addWidget(self.pw_e)
         hbox2.addStretch()
         vbox.addLayout(hbox2)
+
+        vbox.addSpacing(50)
+        vbox_create_new = QVBoxLayout()
+        vbox_create_new.addWidget(QLabel(_('Alternatively') + ':'), alignment=Qt.AlignLeft)
+        button_create_new = QPushButton(_('Create New Wallet'))
+        button_create_new.setMinimumWidth(120)
+        vbox_create_new.addWidget(button_create_new, alignment=Qt.AlignLeft)
+        widget_create_new = QWidget()
+        widget_create_new.setLayout(vbox_create_new)
+        vbox_create_new.setContentsMargins(0, 0, 0, 0)
+        vbox.addWidget(widget_create_new)
+
         self.set_layout(vbox, title=_('Electrum wallet'))
 
         wallet_folder = os.path.dirname(self.storage.path)
@@ -200,6 +212,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                     msg =_("This file does not exist.") + '\n' \
                           + _("Press 'Next' to create this wallet, or choose another file.")
                     pw = False
+                    widget_create_new.setVisible(False)
                 else:
                     if self.storage.is_encrypted_with_user_pw():
                         msg = _("This file is encrypted with a password.") + '\n' \
@@ -212,6 +225,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                     else:
                         msg = _("Press 'Next' to open this wallet.")
                         pw = False
+                    widget_create_new.setVisible(True)
             else:
                 msg = _('Cannot read file')
                 pw = False
@@ -225,6 +239,10 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                 self.pw_e.hide()
 
         button.clicked.connect(on_choose)
+        button_create_new.clicked.connect(
+            partial(
+                self.name_e.setText,
+                get_new_wallet_name(wallet_folder)))
         self.name_e.textChanged.connect(on_filename)
         n = os.path.basename(self.storage.path)
         self.name_e.setText(n)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -65,7 +65,8 @@ from .fee_slider import FeeSlider
 
 from .util import *
 
-from electrum.util import profiler
+from electrum.util import profiler, get_new_wallet_name
+
 
 class StatusBarButton(QPushButton):
     def __init__(self, icon, tooltip, func):
@@ -448,13 +449,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def new_wallet(self):
         wallet_folder = self.get_wallet_folder()
-        i = 1
-        while True:
-            filename = "wallet_%d" % i
-            if filename in os.listdir(wallet_folder):
-                i += 1
-            else:
-                break
+        filename = get_new_wallet_name(wallet_folder)
         full_path = os.path.join(wallet_folder, filename)
         self.gui_object.start_new_window(full_path, None)
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -752,3 +752,14 @@ def setup_thread_excepthook():
 
 def versiontuple(v):
     return tuple(map(int, (v.split("."))))
+
+
+def get_new_wallet_name(wallet_folder):
+    i = 1
+    while True:
+        filename = "wallet_%d" % i
+        if filename in os.listdir(wallet_folder):
+            i += 1
+        else:
+            break
+    return filename


### PR DESCRIPTION
I find newbies often get stuck on this screen if they don't know their password and want to create a new wallet. Some even get stuck if they know their password but want to create a new wallet... :)

![open_wallet_enter_pwd](https://user-images.githubusercontent.com/29142493/36337469-5f5c6ad6-1397-11e8-9363-b5b2d44e5673.png)

-----

I propose:

![open_wallet_enter_pwd_offer_new](https://user-images.githubusercontent.com/29142493/36337477-8e0b0ee6-1397-11e8-9fe3-804063666a83.png)
![open_wallet_no_pwd_offer_new](https://user-images.githubusercontent.com/29142493/36337478-9044427c-1397-11e8-8a8b-19e2c65e64a3.png)
![open_wallet_no_existing](https://user-images.githubusercontent.com/29142493/36337486-c0e40e30-1397-11e8-855d-298e2c786d8d.png)
