### PR TITLE
locks in wallet

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -718,7 +718,9 @@ class Abstract_Wallet(PrintError):
 
     def get_address_history(self, addr):
         h = []
-        with self.transaction_lock:
+        # we need self.transaction_lock but get_tx_height will take self.lock
+        # so we need to take that too here, to enforce order of locks
+        with self.lock, self.transaction_lock:
             for tx_hash in self.transactions:
                 if addr in self.txi.get(tx_hash, []) or addr in self.txo.get(tx_hash, []):
                     tx_height = self.get_tx_height(tx_hash)[0]
@@ -775,7 +777,9 @@ class Abstract_Wallet(PrintError):
             return conflicting_txns
 
     def add_transaction(self, tx_hash, tx):
-        with self.transaction_lock:
+        # we need self.transaction_lock but get_tx_height will take self.lock
+        # so we need to take that too here, to enforce order of locks
+        with self.lock, self.transaction_lock:
             # NOTE: returning if tx in self.transactions might seem like a good idea
             # BUT we track is_mine inputs in a txn, and during subsequent calls
             # of add_transaction tx, we might learn of more-and-more inputs of


### PR DESCRIPTION
fix #3949

https://github.com/spesmilo/electrum/blob/180480099926946de19e6f5db8296fc5b56683dc/lib/wallet.py#L219-L221

According to [python docs](https://docs.python.org/3.1/reference/compound_stmts.html#with) the compound `with` guarantees the order, and hence we can avoid multiple levels of indentation.