### PR TITLE
qt save_payment_request catch exception

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -904,11 +904,17 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         i = self.expires_combo.currentIndex()
         expiration = list(map(lambda x: x[1], expiration_values))[i]
         req = self.wallet.make_payment_request(addr, amount, message, expiration)
-        self.wallet.add_payment_request(req, self.config)
-        self.sign_payment_request(addr)
-        self.request_list.update()
-        self.address_list.update()
-        self.save_request_button.setEnabled(False)
+        try:
+            self.wallet.add_payment_request(req, self.config)
+        except Exception as e:
+            traceback.print_exc(file=sys.stderr)
+            self.show_error(_('Error adding payment request') + ':\n' + str(e))
+        else:
+            self.sign_payment_request(addr)
+            self.save_request_button.setEnabled(False)
+        finally:
+            self.request_list.update()
+            self.address_list.update()
 
     def view_and_paste(self, title, msg, data):
         dialog = WindowModalDialog(self, title)


### PR DESCRIPTION
fix #3965 

It's not exactly clear how an exception such as #3965 should be handled...
By the time the exception is raised, the unsigned pr is already in storage; only writing to disk fails.
So maybe we could still sign it? Anyway, in this PR we don't; and we also don't revert what has already been done.