### PR TITLE
show headers download in GUI

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -630,6 +630,8 @@ class ElectrumWindow(App):
             server_lag = self.network.get_local_height() - server_height
             if not self.wallet.up_to_date or server_height == 0:
                 status = _("Synchronizing...")
+            elif server_lag < -1:
+                status = _("Headers download ({} left)").format(-1 * server_lag)
             elif server_lag > 1:
                 status = _("Server lagging ({} blocks)").format(server_lag)
             else:

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -701,6 +701,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if not self.wallet.up_to_date or server_height == 0:
                 text = _("Synchronizing...")
                 icon = QIcon(":icons/status_waiting.png")
+            elif server_lag < -1:
+                text = _("Headers download ({} left)").format(-1 * server_lag)
+                icon = QIcon(":icons/status_waiting.png")
             elif server_lag > 1:
                 text = _("Server is lagging ({} blocks)").format(server_lag)
                 icon = QIcon(":icons/status_lagging.png")


### PR DESCRIPTION
Closes #3966

`< -1` instead of `< 0` as
- this should mostly eliminate the possibility of displaying the message when we are synced but a new block was just mined
- it shouldn't matter much anyway