### PR TITLE
prepare self.unverified_tx regardless of network

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1242,8 +1242,9 @@ class Abstract_Wallet(PrintError):
 
     def start_threads(self, network):
         self.network = network
+        # prepare self.unverified_tx regardless of network
+        self.prepare_for_verifier()
         if self.network is not None:
-            self.prepare_for_verifier()
             self.verifier = SPV(self.network, self)
             self.synchronizer = Synchronizer(self, network)
             network.add_jobs([self.verifier, self.synchronizer])


### PR DESCRIPTION
Without this, unconfirmed and unverified txns are displayed as local in an offline client.