### PR TITLE
daemon returns true only if the wallet is loaded

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -174,7 +174,7 @@ class Daemon(DaemonThread):
             path = config.get_wallet_path()
             wallet = self.load_wallet(path, config.get('password'))
             self.cmd_runner.wallet = wallet
-            response = True
+            response = wallet is not None
         elif sub == 'close_wallet':
             path = config.get_wallet_path()
             if path in self.wallets:


### PR DESCRIPTION
Currently, jsonrpc call against `daemon` with `subcommand == 'load_wallet'` returns `True` even if loading is not done, e.g. when file not existed.  I assumed the response should return `True` or `False` depending on the specified wallet actually loaded or not.  This PR makes the daemon return the result of wallet actually loaded or not.

I'm really new to making commits against the electrum code base, so please give any FB which I might be missing.