### PR TITLE
Trezor model T does not provide bootloader hash

### DIFF
--- a/plugins/trezor/qt_generic.py
+++ b/plugins/trezor/qt_generic.py
@@ -321,8 +321,11 @@ class SettingsDialog(WindowModalDialog):
         def update(features):
             self.features = features
             set_label_enabled()
-            bl_hash = bh2u(features.bootloader_hash)
-            bl_hash = "\n".join([bl_hash[:32], bl_hash[32:]])
+            if features.bootloader_hash:
+                bl_hash = bh2u(features.bootloader_hash)
+                bl_hash = "\n".join([bl_hash[:32], bl_hash[32:]])
+            else:
+                bl_hash = "N/A"
             noyes = [_("No"), _("Yes")]
             endis = [_("Enable Passphrases"), _("Disable Passphrases")]
             disen = [_("Disabled"), _("Enabled")]


### PR DESCRIPTION
On Trezor model T, `bootloader_hash` is `None`, which causes tracebacks in the device dialog. This is a quick fix of the problem (otherwise Electrum seems to work perfectly with T2 out of the box), we might want to update the layout in more ways (such as displaying Trezor model :) )