### PR TITLE
persist history and addresses toolbars (qt)

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -58,6 +58,9 @@ class AddressList(MyTreeWidget):
         self.show_used = 0
         self.update()
 
+    def save_toolbar_state(self, state, config):
+        config.set_key('show_toolbar_addresses', state)
+
     def refresh_headers(self):
         headers = [_('Type'), _('Address'), _('Label'), _('Balance')]
         fx = self.parent.fx

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -125,6 +125,9 @@ class HistoryList(MyTreeWidget, AcceptFileDragDrop):
         self.end_timestamp = None
         self.update()
 
+    def save_toolbar_state(self, state, config):
+        config.set_key('show_toolbar_history', state)
+
     def select_start_date(self):
         self.start_timestamp = self.select_date(self.start_button)
         self.update()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -475,13 +475,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.import_address_menu = wallet_menu.addAction(_("Import addresses"), self.import_addresses)
         wallet_menu.addSeparator()
 
-        history_menu = wallet_menu.addMenu(_("&Addresses"))
-        history_menu.addAction(_("&Filter"), lambda: self.address_list.show_toolbar(True))
+        addresses_menu = wallet_menu.addMenu(_("&Addresses"))
+        addresses_menu.addAction(_("&Filter"), lambda: self.address_list.toggle_toolbar(self.config))
         labels_menu = wallet_menu.addMenu(_("&Labels"))
         labels_menu.addAction(_("&Import"), self.do_import_labels)
         labels_menu.addAction(_("&Export"), self.do_export_labels)
         history_menu = wallet_menu.addMenu(_("&History"))
-        history_menu.addAction(_("&Filter"), lambda: self.history_list.show_toolbar(True))
+        history_menu.addAction(_("&Filter"), lambda: self.history_list.toggle_toolbar(self.config))
         history_menu.addAction(_("&Summary"), self.history_list.show_summary)
         history_menu.addAction(_("&Plot"), self.history_list.plot_history_dialog)
         history_menu.addAction(_("&Export"), self.history_list.export_history_dialog)
@@ -754,7 +754,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         from .history_list import HistoryList
         self.history_list = l = HistoryList(self)
         l.searchable_list = l
-        return self.create_list_tab(l, l.create_toolbar())
+        toolbar = l.create_toolbar(self.config)
+        toolbar_shown = self.config.get('show_toolbar_history', False)
+        l.show_toolbar(toolbar_shown)
+        return self.create_list_tab(l, toolbar)
 
     def show_address(self, addr):
         from . import address_dialog
@@ -1745,7 +1748,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def create_addresses_tab(self):
         from .address_list import AddressList
         self.address_list = l = AddressList(self)
-        return self.create_list_tab(l, l.create_toolbar())
+        toolbar = l.create_toolbar(self.config)
+        toolbar_shown = self.config.get('show_toolbar_addresses', False)
+        l.show_toolbar(toolbar_shown)
+        return self.create_list_tab(l, toolbar)
 
     def create_utxo_tab(self):
         from .utxo_list import UTXOList

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -406,6 +406,7 @@ class MyTreeWidget(QTreeWidget):
         self.current_filter = ""
 
         self.setRootIsDecorated(False)  # remove left margin
+        self.toolbar_shown = False
 
     def update_headers(self, headers):
         self.setColumnCount(len(headers))
@@ -522,7 +523,7 @@ class MyTreeWidget(QTreeWidget):
             item.setHidden(all([item.text(column).lower().find(p) == -1
                                 for column in columns]))
 
-    def create_toolbar(self):
+    def create_toolbar(self, config=None):
         hbox = QHBoxLayout()
         buttons = self.get_toolbar_buttons()
         for b in buttons:
@@ -530,17 +531,28 @@ class MyTreeWidget(QTreeWidget):
             hbox.addWidget(b)
         hide_button = QPushButton('x')
         hide_button.setVisible(False)
-        hide_button.pressed.connect(lambda: self.show_toolbar(False))
+        hide_button.pressed.connect(lambda: self.show_toolbar(False, config))
         self.toolbar_buttons = buttons + (hide_button,)
         hbox.addStretch()
         hbox.addWidget(hide_button)
         return hbox
 
-    def show_toolbar(self, x):
+    def save_toolbar_state(self, state, config):
+        pass  # implemented in subclasses
+
+    def show_toolbar(self, state, config=None):
+        if state == self.toolbar_shown:
+            return
+        self.toolbar_shown = state
+        if config:
+            self.save_toolbar_state(state, config)
         for b in self.toolbar_buttons:
-            b.setVisible(x)
-        if not x:
+            b.setVisible(state)
+        if not state:
             self.on_hide_toolbar()
+
+    def toggle_toolbar(self, config=None):
+        self.show_toolbar(not self.toolbar_shown, config)
 
 
 class ButtonsWidget(QWidget):


### PR DESCRIPTION
(re visibility, not full state)

I would mainly like the address filters to be persisted but I guess why not do it for history too.