### PR TITLE
trezor: segwit offline signing

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -40,6 +40,7 @@ from .bitcoin import *
 from .interface import Connection, Interface
 from . import blockchain
 from .version import ELECTRUM_VERSION, PROTOCOL_VERSION
+from .i18n import _
 
 
 NODES_RETRY_INTERVAL = 60
@@ -1069,7 +1070,7 @@ class Network(util.DaemonThread):
         try:
             r = q.get(True, timeout)
         except queue.Empty:
-            raise BaseException('Server did not answer')
+            raise util.TimeoutException(_('Server did not answer'))
         if r.get('error'):
             raise BaseException(r.get('error'))
         return r.get('result')

--- a/lib/util.py
+++ b/lib/util.py
@@ -74,6 +74,16 @@ class FileExportFailed(Exception):
         return _("Failed to export to file.") + "\n" + self.message
 
 
+class TimeoutException(Exception):
+    def __init__(self, message=''):
+        self.message = str(message)
+
+    def __str__(self):
+        if not self.message:
+            return _("Operation timed out.")
+        return self.message
+
+
 # Throw this exception to unwind the stack like when an error occurs.
 # However unlike other exceptions the user won't be informed.
 class UserCancelled(Exception):

--- a/plugins/trezor/trezor.py
+++ b/plugins/trezor/trezor.py
@@ -434,6 +434,9 @@ class TrezorPlugin(HW_PluginBase):
 
     def electrum_tx_to_txtype(self, tx):
         t = self.types.TransactionType()
+        if tx is None:
+            # probably for segwit input and we don't need this prev txn
+            return t
         d = deserialize(tx.raw)
         t.version = d['version']
         t.lock_time = d['lockTime']


### PR DESCRIPTION
As in https://github.com/spesmilo/electrum/issues/3302 but for Trezor

Tested with both p2sh-segwit and native segwit; both Trezor and also with emulator for Trezor T.

The intended usage is with the `--offline` flag; then we won't even try asking the network. Without the `--offline` flag, we ask the network but ignore the timeout (which is 30 sec!).

To play it safe, if there is a network, we ask for the parent txns; otherwise it would depend on lots of things and functionality could easily break (don't want to branch on hw wallet type; and even for a given hw wallet it is often not clear from its API whether it needs the parent txns).