### PR TITLE
Add JPY exchange rate

### DIFF
--- a/lib/currencies.json
+++ b/lib/currencies.json
@@ -798,5 +798,14 @@
         "RUB",
         "USD"
     ],
-    "itBit": []
-}
+     "itBit": [],
+     "Bitbank": [
+         "JPY"
+     ],
+     "BitFlyer": [
+         "JPY"
+     ],
+     "Zaif": [
+         "JPY"
+     ]
+ }

--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -160,6 +160,20 @@ class BitcoinVenezuela(ExchangeBase):
                              "/historical/index.php?coin=BTC")[ccy +'_BTC']
 
 
+class Bitbank(ExchangeBase):
+
+    def get_rates(self, ccy):
+        json = self.get_json('public.bitbank.cc', '/btc_jpy/ticker')
+        return {'JPY': Decimal(json['data']['last'])}
+
+
+class BitFlyer(ExchangeBase):
+
+    def get_rates(self, ccy):
+        json = self.get_json('bitflyer.jp', '/api/echo/price')
+        return {'JPY': Decimal(json['mid'])}
+
+
 class Bitmarket(ExchangeBase):
 
     def get_rates(self, ccy):
@@ -348,6 +362,12 @@ class Winkdex(ExchangeBase):
         history = json['series'][0]['results']
         return dict([(h['timestamp'][:10], h['price'] / 100.0)
                      for h in history])
+
+
+class Zaif(ExchangeBase):
+    def get_rates(self, ccy):
+        json = self.get_json('api.zaif.jp', '/api/1/last_price/btc_jpy')
+        return {'JPY': Decimal(json['last_price'])}
 
 
 def dictinvert(d):


### PR DESCRIPTION
I fix crash the preferences dialog. https://github.com/spesmilo/electrum/pull/4007
sorry.
```
Traceback (most recent call last):
  File "/home/wakiyamap/electrum/gui/qt/main_window.py", line 2909, in on_history
    update_exchanges()
  File "/home/wakiyamap/electrum/gui/qt/main_window.py", line 2883, in update_exchanges
    exchanges = self.fx.get_exchanges_by_ccy(c, h)
  File "/home/wakiyamap/electrum/lib/exchange_rate.py", line 440, in get_exchanges_by_ccy
    d = get_exchanges_by_ccy(h)
  File "/home/wakiyamap/electrum/lib/exchange_rate.py", line 415, in get_exchanges_by_ccy
    klass = globals()[name]
KeyError: 'Bitflyer'
```
