### PR TITLE
Add suggestions when restoring from seed

### DIFF
--- a/gui/qt/seed_dialog.py
+++ b/gui/qt/seed_dialog.py
@@ -27,6 +27,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from electrum.i18n import _
+from electrum.seed_suggestion import SeedSuggestion
 
 from .util import *
 from .qrtextedit import ShowQRTextEdit, ScanQRTextEdit
@@ -100,6 +101,9 @@ class SeedLayout(QVBoxLayout):
             self.is_seed = is_seed
             self.saved_is_seed = self.is_seed
             self.seed_e.textChanged.connect(self.on_edit)
+            self.suggestion = SeedSuggestion("./lib/wordlist/english.txt")
+            self.suggestion_label = QLabel()
+            self.addWidget(self.suggestion_label)
         self.seed_e.setMaximumHeight(75)
         hbox = QHBoxLayout()
         if icon:
@@ -135,7 +139,17 @@ class SeedLayout(QVBoxLayout):
         text = self.seed_e.text()
         return ' '.join(text.split())
 
+    def display_suggestions(self):
+        suggestion_char_length = 45
+        self.suggestion_label.setText("Suggestions: ")
+        if self.seed_e.text() == "" or self.seed_e.text()[-1] == ' ':
+            return
+        for word in self.suggestion.get_suggestions(self.get_seed().split(' ')[-1],
+                                                    suggestion_char_length):
+            self.suggestion_label.setText(self.suggestion_label.text() + word + " ")
+
     def on_edit(self):
+        self.display_suggestions()
         from electrum.bitcoin import seed_type
         s = self.get_seed()
         b = self.is_seed(s)
@@ -149,6 +163,7 @@ class SeedLayout(QVBoxLayout):
             label = 'BIP39' + ' (%s)'%status
         self.seed_type_label.setText(label)
         self.parent.next_button.setEnabled(b)
+
 
 
 class KeysLayout(QVBoxLayout):

--- a/lib/seed_suggestion.py
+++ b/lib/seed_suggestion.py
@@ -1,0 +1,45 @@
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2012 thomasv@ecdsa.org
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+class SeedSuggestion(object):
+    __words = []
+
+    def __init__(self, wordlist_file):
+        with open(wordlist_file) as wordlist_file:
+            self.__words = [w.strip() for w in wordlist_file.readlines()]
+
+    def get_suggestions(self, prefix, max_characters=float("inf")):
+        if prefix == "": return []
+        suggestions = []
+        for w in range(0, len(self.__words)):
+            if self.__words[w].startswith(prefix):
+                if len(''.join(suggestions)) + \
+                        len(self.__words[w]) < max_characters:
+                    suggestions.append(self.__words[w])
+                else:
+                    suggestions.append("...")
+                    break
+        return suggestions if len(suggestions) > 0 else ["[none]"]
+
+    def get_wordlist(self):
+        return list(self.__words)

--- a/lib/tests/test_seed_suggestion.py
+++ b/lib/tests/test_seed_suggestion.py
@@ -1,0 +1,29 @@
+import unittest
+from lib.seed_suggestion import SeedSuggestion
+
+class TestSeedSuggestion(unittest.TestCase):
+
+    def test_get_suggestions(self):
+        suggestion = SeedSuggestion("../wordlist/english.txt")
+        returned_suggestion = suggestion.get_suggestions("z")
+        expected_suggestion = ["zebra", "zero", "zone", "zoo"]
+        self.assertEqual(expected_suggestion, returned_suggestion)
+
+    def test_get_suggestions_word_length(self):
+        suggestion = SeedSuggestion("../wordlist/english.txt")
+        suggestion_char_length = 10
+        returned_suggestion = suggestion.get_suggestions("z", suggestion_char_length)
+        expected_suggestion = ["zebra", "zero", "..."]
+        self.assertEqual(expected_suggestion, returned_suggestion)
+
+    def test_get_wordlist(self):
+        suggestion = SeedSuggestion("../wordlist/english.txt")
+        with open("../wordlist/english.txt") as wordlist:
+            expected_words = [x.strip() for x in wordlist.readlines()]
+        actual_words = suggestion.get_wordlist()
+        self.assertListEqual(expected_words, actual_words)
+
+    def test_get_suggestions_space(self):
+        suggestion = SeedSuggestion("../wordlist/english.txt")
+        returned_suggestion = suggestion.get_suggestions(" ")
+        self.assertListEqual(["[none]"], returned_suggestion)


### PR DESCRIPTION
In reference to [#1116](https://github.com/spesmilo/electrum/issues/1116), this feature displays a list of suggestions from the seed wordlist file according to which word the user is entering in at the time. I added the new file to the lib folder because I would like for the seed restoration auto suggestion in the kivy code to utilize this feature as well. This may come in a later pull request depending on the feedback I get from this one. 