### PR TITLE
daemon status shows current wallet path

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -185,6 +185,9 @@ class Daemon(DaemonThread):
         elif sub == 'status':
             if self.network:
                 p = self.network.get_parameters()
+                current_wallet = self.cmd_runner.wallet
+                current_wallet_path = current_wallet.storage.path \
+                                      if current_wallet else None
                 response = {
                     'path': self.network.config.path,
                     'server': p[0],
@@ -196,6 +199,7 @@ class Daemon(DaemonThread):
                     'version': ELECTRUM_VERSION,
                     'wallets': {k: w.is_up_to_date()
                                 for k, w in self.wallets.items()},
+                    'current_wallet': current_wallet_path,
                     'fee_per_kb': self.config.fee_per_kb(),
                 }
             else:


### PR DESCRIPTION
All the jsonrpc calls against electrum daemon is affected by the
implicit parameter of wallet in the cmd_runner.  AFAIK, there is no way
to check the value of this wallet.  This can be trouble some if multiple
wallets are loaded, or load_wallet command is executed several times.

This patch makes it viewable on the `daemon status`.