### PR TITLE
change cmd_runner's wallet iff wallet is not None

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -173,7 +173,8 @@ class Daemon(DaemonThread):
         elif sub == 'load_wallet':
             path = config.get_wallet_path()
             wallet = self.load_wallet(path, config.get('password'))
-            self.cmd_runner.wallet = wallet
+            if wallet is not None:
+                self.cmd_runner.wallet = wallet
             response = wallet is not None
         elif sub == 'close_wallet':
             path = config.get_wallet_path()


### PR DESCRIPTION
Currently, every time `daemon load_wallet` is called, cmd's wallet is modified even if wallet loading failed due to whatever reason.

I think it's confusing a failed execution to load wallet actually modifying the behavior of daemon.

IMHO, when loading wallet is failed, then the cmd_runner's wallet should not change.  If on any case we want nullify the cmd_runner's wallet, but keep it loaded on the daemon (so that it can be synchronized with the network), then such feature should be implemented by a separate subcommand of daemon, not by this load_wallet subcommand.

So, this patch attempts to fixes it.  I might be missing points so any kind of feedback is welcome.