### PR TITLE
Fix the error: locktime is always reset to zero when serialize the js…

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -201,7 +201,7 @@ class Commands:
         keypairs = {}
         inputs = jsontx.get('inputs')
         outputs = jsontx.get('outputs')
-        locktime = jsontx.get('locktime', 0)
+        locktime = jsontx.get('lockTime', 0)
         for txin in inputs:
             if txin.get('output'):
                 prevout_hash, prevout_n = txin['output'].split(':')


### PR DESCRIPTION
…on data

The "lockTime" field in the json object was ignored due to the wrong attribute name "locktime" was called.