### PR TITLE
setup.py: fix icon path for user installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,17 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
     parser.add_argument('--root=', dest='root_path', metavar='dir', default='/')
     opts, _ = parser.parse_known_args(sys.argv[1:])
     usr_share = os.path.join(sys.prefix, "share")
+    icons_dirname = 'pixmaps'
     if not os.access(opts.root_path + usr_share, os.W_OK) and \
        not os.access(opts.root_path, os.W_OK):
+        icons_dirname = 'icons'
         if 'XDG_DATA_HOME' in os.environ.keys():
             usr_share = os.environ['XDG_DATA_HOME']
         else:
             usr_share = os.path.expanduser('~/.local/share')
     data_files += [
         (os.path.join(usr_share, 'applications/'), ['electrum.desktop']),
-        (os.path.join(usr_share, 'pixmaps/'), ['icons/electrum.png'])
+        (os.path.join(usr_share, icons_dirname), ['icons/electrum.png'])
     ]
 
 setup(


### PR DESCRIPTION
Before, the user installation used the wrong directory
to store the application's icon resulting in the desktop
environment falling back to an ugly default icon. Now,
the correct icon is displayed in the menu.

"By default, apps should look in $HOME/.icons (for backwards
compatibility), in $XDG_DATA_DIRS/icons and in /usr/share/pixmaps
(in that order)."
https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html