### PR TITLE
allow loading plugins from custom folder

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3073,6 +3073,25 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.print_msg("error: cannot display plugin", name)
                 traceback.print_exc(file=sys.stdout)
         grid.setRowStretch(len(plugins.descriptions.values()), 1)
+
+        def on_path_select():
+            default_path = self.config.get('custom_plugins_folder', self.config.path)
+            path = QFileDialog.getExistingDirectory(self, "Select folder of custom plugins", default_path)
+            if path:
+                self.config.set_key('custom_plugins_folder', path, True)
+                load_successful = plugins.load_custom_plugins()
+                if load_successful:
+                    self.show_message(_('Custom plugins loaded successfully.'))
+                else:
+                    self.show_warning(_('Failed to load plugins from folder.') + '\n' +
+                                      _('Note') + ': ' +
+                                      _('The folder needs to contain a file named __init__.py'))
+
+        custom_plugins_button = QPushButton(_('Select folder for custom plugins'))
+        custom_plugins_button.setToolTip(_('The folder needs to contain a file named __init__.py'))
+        custom_plugins_button.clicked.connect(on_path_select)
+        vbox.addWidget(custom_plugins_button)
+
         vbox.addLayout(Buttons(CloseButton(d)))
         d.exec_()
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -2284,6 +2284,8 @@ class Multisig_Wallet(Deterministic_Wallet):
 wallet_types = ['standard', 'multisig', 'imported']
 
 def register_wallet_type(category):
+    if category in wallet_types:
+        return
     wallet_types.append(category)
 
 wallet_constructors = {


### PR DESCRIPTION
The usecase is importing 3rd party plugins when using the binaries.
E.g. using the Windows standalone exe, currently you can't use custom plugins.

The idea is that the user creates a folder somewhere, puts all custom plugins into that folder; puts an empty `__init__.py` there too (so that python can import it as a package); and then selects the folder using the GUI. The path to the folder is persisted in the config.