### PR TITLE
electrum.desktop: improve user installation

### DIFF
--- a/electrum.desktop
+++ b/electrum.desktop
@@ -3,7 +3,7 @@
 
 [Desktop Entry]
 Comment=Lightweight Bitcoin Client
-Exec=electrum %u
+Exec=sh -c 'PATH="$HOME/.local/bin:$PATH" electrum %u'
 GenericName[en_US]=Bitcoin Wallet
 GenericName=Bitcoin Wallet
 Icon=electrum
@@ -17,5 +17,5 @@ MimeType=x-scheme-handler/bitcoin;
 Actions=Testnet;
 
 [Desktop Action Testnet]
-Exec=electrum --testnet %u
+Exec=sh -c 'PATH="$HOME/.local/bin:$PATH" electrum --testnet %u'
 Name=Testnet mode


### PR DESCRIPTION
Before, the desktop entry file would only work correctly
if the user has added `$HOME/.local/bin` to his or her
PATH. The PATH variable is an implementation detail and
the user shouldn't be exposed to it.

Now, the shell is used to look for executables in the
aforementioned folder. System-wide installations remain
intact.