### PR TITLE
use explicit utf-8 encoding when opening files in text mode

### DIFF
--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -66,7 +66,7 @@ class ExchangeBase(PrintError):
         if os.path.exists(filename):
             timestamp = os.stat(filename).st_mtime
             try:
-                with open(filename, 'r') as f:
+                with open(filename, 'r', encoding='utf-8') as f:
                     h = json.loads(f.read())
                 h['timestamp'] = timestamp
             except:
@@ -87,7 +87,7 @@ class ExchangeBase(PrintError):
             self.print_error("failed fx history:", e)
             return
         filename = os.path.join(cache_dir, self.name() + '_' + ccy)
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             f.write(json.dumps(h))
         h['timestamp'] = time.time()
         self.history[ccy] = h
@@ -382,7 +382,7 @@ def get_exchanges_and_currencies():
     import os, json
     path = os.path.join(os.path.dirname(__file__), 'currencies.json')
     try:
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding='utf-8') as f:
             return json.loads(f.read())
     except:
         pass
@@ -399,7 +399,7 @@ def get_exchanges_and_currencies():
         except:
             print(name, "error")
             continue
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(json.dumps(d, indent=4, sort_keys=True))
     return d
 

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -172,7 +172,7 @@ class TcpConnection(threading.Thread, util.PrintError):
                 # workaround android bug
                 cert = re.sub("([^\n])-----END CERTIFICATE-----","\\1\n-----END CERTIFICATE-----",cert)
                 temporary_path = cert_path + '.temp'
-                with open(temporary_path,"w") as f:
+                with open(temporary_path, "w", encoding='utf-8') as f:
                     f.write(cert)
                     f.flush()
                     os.fsync(f.fileno())
@@ -201,7 +201,7 @@ class TcpConnection(threading.Thread, util.PrintError):
                         os.unlink(rej)
                     os.rename(temporary_path, rej)
                 else:
-                    with open(cert_path) as f:
+                    with open(cert_path, encoding='utf-8') as f:
                         cert = f.read()
                     try:
                         b = pem.dePem(cert, 'CERTIFICATE')
@@ -398,7 +398,7 @@ def test_certificates():
     certs = os.listdir(mydir)
     for c in certs:
         p = os.path.join(mydir,c)
-        with open(p) as f:
+        with open(p, encoding='utf-8') as f:
             cert = f.read()
         check_cert(c, cert)
 

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -91,7 +91,7 @@ def normalize_text(seed):
 
 def load_wordlist(filename):
     path = os.path.join(os.path.dirname(__file__), 'wordlist', filename)
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         s = f.read().strip()
     s = unicodedata.normalize('NFKD', s)
     lines = s.split('\n')

--- a/lib/network.py
+++ b/lib/network.py
@@ -246,7 +246,7 @@ class Network(util.DaemonThread):
             return []
         path = os.path.join(self.config.path, "recent_servers")
         try:
-            with open(path, "r") as f:
+            with open(path, "r", encoding='utf-8') as f:
                 data = f.read()
                 return json.loads(data)
         except:
@@ -258,7 +258,7 @@ class Network(util.DaemonThread):
         path = os.path.join(self.config.path, "recent_servers")
         s = json.dumps(self.recent_servers, indent=4, sort_keys=True)
         try:
-            with open(path, "w") as f:
+            with open(path, "w", encoding='utf-8') as f:
                 f.write(s)
         except:
             pass
@@ -1089,7 +1089,7 @@ class Network(util.DaemonThread):
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints
         cp = self.blockchain().get_checkpoints()
-        with open(path, 'w') as f:
+        with open(path, 'w', encoding='utf-8') as f:
             f.write(json.dumps(cp, indent=4))
 
     def max_checkpoint(self):

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -89,7 +89,7 @@ def get_payment_request(url):
             error = "payment URL not pointing to a valid server"
     elif u.scheme == 'file':
         try:
-            with open(u.path, 'r') as f:
+            with open(u.path, 'r', encoding='utf-8') as f:
                 data = f.read()
         except IOError:
             data = None
@@ -385,9 +385,9 @@ def check_ssl_config(config):
     from . import pem
     key_path = config.get('ssl_privkey')
     cert_path = config.get('ssl_chain')
-    with open(key_path, 'r') as f:
+    with open(key_path, 'r', encoding='utf-8') as f:
         params = pem.parse_private_key(f.read())
-    with open(cert_path, 'r') as f:
+    with open(cert_path, 'r', encoding='utf-8') as f:
         s = f.read()
     bList = pem.dePemList(s, "CERTIFICATE")
     # verify chain
@@ -405,10 +405,10 @@ def check_ssl_config(config):
 
 def sign_request_with_x509(pr, key_path, cert_path):
     from . import pem
-    with open(key_path, 'r') as f:
+    with open(key_path, 'r', encoding='utf-8') as f:
         params = pem.parse_private_key(f.read())
         privkey = rsakey.RSAKey(*params)
-    with open(cert_path, 'r') as f:
+    with open(cert_path, 'r', encoding='utf-8') as f:
         s = f.read()
         bList = pem.dePemList(s, "CERTIFICATE")
     certificates = pb2.X509Certificates()

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -212,7 +212,7 @@ class SimpleConfig(PrintError):
         path = os.path.join(self.path, "config")
         s = json.dumps(self.user_config, indent=4, sort_keys=True)
         try:
-            with open(path, "w") as f:
+            with open(path, "w", encoding='utf-8') as f:
                 f.write(s)
             os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
         except FileNotFoundError:
@@ -498,7 +498,7 @@ def read_user_config(path):
     if not os.path.exists(config_path):
         return {}
     try:
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding='utf-8') as f:
             data = f.read()
         result = json.loads(data)
     except:

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -77,7 +77,7 @@ class WalletStorage(PrintError):
         self.modified = False
         self.pubkey = None
         if self.file_exists():
-            with open(self.path, "r") as f:
+            with open(self.path, "r", encoding='utf-8') as f:
                 self.raw = f.read()
             self._encryption_version = self._init_encryption_version()
             if not self.is_encrypted():
@@ -257,7 +257,7 @@ class WalletStorage(PrintError):
             s = s.decode('utf8')
 
         temp_path = "%s.tmp.%s" % (self.path, os.getpid())
-        with open(temp_path, "w") as f:
+        with open(temp_path, "w", encoding='utf-8') as f:
             f.write(s)
             f.flush()
             os.fsync(f.fileno())

--- a/lib/util.py
+++ b/lib/util.py
@@ -810,7 +810,7 @@ def versiontuple(v):
 
 def import_meta(path, validater, load_meta):
     try:
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding='utf-8') as f:
             d = validater(json.loads(f.read()))
         load_meta(d)
     #backwards compatibility for JSONDecodeError
@@ -824,7 +824,7 @@ def import_meta(path, validater, load_meta):
 
 def export_meta(meta, fileName):
     try:
-        with open(fileName, 'w+') as f:
+        with open(fileName, 'w+', encoding='utf-8') as f:
             json.dump(meta, f, indent=4, sort_keys=True)
     except (IOError, os.error) as e:
         traceback.print_exc(file=sys.stderr)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1616,7 +1616,7 @@ class Abstract_Wallet(PrintError):
                 f.write(pr.SerializeToString())
             # reload
             req = self.get_payment_request(addr, config)
-            with open(os.path.join(path, key + '.json'), 'w') as f:
+            with open(os.path.join(path, key + '.json'), 'w', encoding='utf-8') as f:
                 f.write(json.dumps(req))
         return req
 

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -64,7 +64,7 @@ class WsClientThread(util.DaemonThread):
         # read json file
         rdir = self.config.get('requests_dir')
         n = os.path.join(rdir, 'req', request_id[0], request_id[1], request_id, request_id + '.json')
-        with open(n) as f:
+        with open(n, encoding='utf-8') as f:
             s = f.read()
         d = json.loads(s)
         addr = d.get('address')

--- a/lib/x509.py
+++ b/lib/x509.py
@@ -313,7 +313,7 @@ def load_certificates(ca_path):
     ca_list = {}
     ca_keyID = {}
     # ca_path = '/tmp/tmp.txt'
-    with open(ca_path, 'r') as f:
+    with open(ca_path, 'r', encoding='utf-8') as f:
         s = f.read()
     bList = pem.dePemList(s, "CERTIFICATE")
     for b in bList:


### PR DESCRIPTION
Related: https://github.com/spesmilo/electrum/issues/4168

Based on the [python docs](https://docs.python.org/3/library/functions.html#open), the default encoding is platform dependent.