### PR TITLE
ledger: send derivation for change output

### DIFF
--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -418,7 +418,12 @@ class Ledger_KeyStore(Hardware_KeyStore):
             if segwitTransaction:
                 self.get_client().startUntrustedTransaction(True, inputIndex,
                                                             chipInputs, redeemScripts[inputIndex])
-                outputData = self.get_client().finalizeInputFull(txOutput)
+                if changePath:
+                    # we don't set meaningful outputAddress, amount and fees
+                    # as we only care about the alternateEncoding==True branch
+                    outputData = self.get_client().finalizeInput(b'', 0, 0, changePath, bfh(rawTx))
+                else:
+                    outputData = self.get_client().finalizeInputFull(txOutput)
                 outputData['outputData'] = txOutput
                 transactionOutput = outputData['outputData']
                 if outputData['confirmationNeeded']:
@@ -441,7 +446,12 @@ class Ledger_KeyStore(Hardware_KeyStore):
                 while inputIndex < len(inputs):
                     self.get_client().startUntrustedTransaction(firstTransaction, inputIndex,
                                                             chipInputs, redeemScripts[inputIndex])
-                    outputData = self.get_client().finalizeInputFull(txOutput)
+                    if changePath:
+                        # we don't set meaningful outputAddress, amount and fees
+                        # as we only care about the alternateEncoding==True branch
+                        outputData = self.get_client().finalizeInput(b'', 0, 0, changePath, bfh(rawTx))
+                    else:
+                        outputData = self.get_client().finalizeInputFull(txOutput)
                     outputData['outputData'] = txOutput
                     if firstTransaction:
                         transactionOutput = outputData['outputData']


### PR DESCRIPTION
fix https://github.com/spesmilo/electrum/issues/4170
closes https://github.com/spesmilo/electrum/pull/3455
related: https://github.com/spesmilo/electrum/commit/e4659327a136f18fde59e4a1f60f45f3e16f22d6

It seems for the hw.1 to be able to sign a tx with a change output, it needs the derivation for the change. But sending the derivation is a good thing anyway, because then the nano S does not prompt the user for that output.

The `finalizeInputFull` method has a very convenient API but I can't see any way to send the derivation when using it; hence using `finalizeInput`.
This however wants a few more arguments: `outputAddress`, `amount`, `fees`. The first two does not really make sense for me for txns with many outputs, though perhaps that's the point: it has at most two outputs in mind; but looking at the actual implementation, all these arguments are only used at all, if there was an exception raised in the first half of the method:
https://github.com/LedgerHQ/btchip-python/blob/6e985b558f22d1fc0367f5c1730822750337cf94/btchip/btchip.py#L298-L311
If the code gets there, something has already gone wrong AFAICT, so why provide those arguments at all? :P Hence this solution.

It is a bit hackish.

Tested with ledger hw.1, and nano S, using latest firmwares (1.0.4, and SE 1.4.1, MCU 1.5, btc app 1.2.4) available.
Tested sending from legacy multisig; and standard wallets with bip44/49/84 derivations (p2wpkh only for nano S; hw.1 does not support it). I don't think I've tested single/multiple outputs in all combinations but tried to test most..
