### PR TITLE
trezor: pass transport parameter explicitly as a keyword argument

### DIFF
--- a/plugins/trezor/client.py
+++ b/plugins/trezor/client.py
@@ -3,8 +3,8 @@ from .clientbase import TrezorClientBase
 
 class TrezorClient(TrezorClientBase, ProtocolMixin, BaseClient):
     def __init__(self, transport, handler, plugin):
-        BaseClient.__init__(self, transport)
-        ProtocolMixin.__init__(self, transport)
+        BaseClient.__init__(self, transport=transport)
+        ProtocolMixin.__init__(self, transport=transport)
         TrezorClientBase.__init__(self, handler, plugin, proto)
 
 


### PR DESCRIPTION
Following https://github.com/trezor/python-trezor/pull/241.