### PR TITLE
wallet: speed up get_address_history

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -900,6 +900,7 @@ class Abstract_Wallet(PrintError):
                     if dd.get(addr) is None:
                         dd[addr] = []
                     dd[addr].append((ser, v))
+                    self._add_tx_to_local_history(next_tx)
             # add to local history
             self._add_tx_to_local_history(tx_hash)
             # save


### PR DESCRIPTION
Test wallet:
```
>> len(wallet.transactions)
4066
>> len(wallet.get_addresses())
3565
```
From:
```
[profiler] get_full_history 11.0779
```
To:
```
[profiler] get_full_history 0.2657
```
