### PR TITLE
fix parsing values in setconfig

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -150,11 +150,20 @@ class Commands:
         """Return a configuration variable. """
         return self.config.get(key)
 
+    @classmethod
+    def _setconfig_normalize_value(cls, key, value):
+        if key not in ('rpcuser', 'rpcpassword'):
+            value = json_decode(value)
+            try:
+                value = ast.literal_eval(value)
+            except:
+                pass
+        return value
+
     @command('')
     def setconfig(self, key, value):
         """Set a configuration variable. 'value' may be a string or a Python expression."""
-        if key not in ('rpcuser', 'rpcpassword'):
-            value = json_decode(value)
+        value = self._setconfig_normalize_value(key, value)
         self.config.set_key(key, value)
         return True
 

--- a/lib/tests/test_commands.py
+++ b/lib/tests/test_commands.py
@@ -1,0 +1,33 @@
+import unittest
+from decimal import Decimal
+
+from lib.commands import Commands
+
+
+class TestCommands(unittest.TestCase):
+
+    def test_setconfig_non_auth_number(self):
+        self.assertEqual(7777, Commands._setconfig_normalize_value('rpcport', "7777"))
+        self.assertEqual(7777, Commands._setconfig_normalize_value('rpcport', '7777'))
+        self.assertAlmostEqual(Decimal(2.3), Commands._setconfig_normalize_value('somekey', '2.3'))
+
+    def test_setconfig_non_auth_number_as_string(self):
+        self.assertEqual("7777", Commands._setconfig_normalize_value('somekey', "'7777'"))
+
+    def test_setconfig_non_auth_boolean(self):
+        self.assertEqual(True, Commands._setconfig_normalize_value('show_console_tab', "true"))
+        self.assertEqual(True, Commands._setconfig_normalize_value('show_console_tab', "True"))
+
+    def test_setconfig_non_auth_list(self):
+        self.assertEqual(['file:///var/www/', 'https://electrum.org'],
+            Commands._setconfig_normalize_value('url_rewrite', "['file:///var/www/','https://electrum.org']"))
+        self.assertEqual(['file:///var/www/', 'https://electrum.org'],
+            Commands._setconfig_normalize_value('url_rewrite', '["file:///var/www/","https://electrum.org"]'))
+
+    def test_setconfig_auth(self):
+        self.assertEqual("7777", Commands._setconfig_normalize_value('rpcuser', "7777"))
+        self.assertEqual("7777", Commands._setconfig_normalize_value('rpcuser', '7777'))
+        self.assertEqual("7777", Commands._setconfig_normalize_value('rpcpassword', '7777'))
+        self.assertEqual("2asd", Commands._setconfig_normalize_value('rpcpassword', '2asd'))
+        self.assertEqual("['file:///var/www/','https://electrum.org']",
+            Commands._setconfig_normalize_value('rpcpassword', "['file:///var/www/','https://electrum.org']"))


### PR DESCRIPTION
https://github.com/spesmilo/electrum/commit/a58d01ed54320e2e8eb2a495a8d9b48d8d4c4949 broke certain cases of value parsing for setconfig

Notably `electrum setconfig url_rewrite "['file:///var/www/','https://electrum.org']"` set the value to a json string, not a json array, which made it non-functional.

related: https://github.com/spesmilo/electrum/issues/4220