### PR TITLE
contrib: detect builds with uncommitted changes

### DIFF
--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -12,7 +12,7 @@ src_dir=$(dirname "$0")
 cd $src_dir/../..
 
 export PYTHONHASHSEED=22
-VERSION=`git describe --tags`
+VERSION=`git describe --tags --dirty`
 
 info "Installing Python $PYTHON_VERSION"
 export PATH="~/.pyenv/bin:~/.pyenv/shims:~/Library/Python/3.6/bin:$PATH"

--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -44,7 +44,7 @@ if [ ! -z "$1" ]; then
     git checkout $1
 fi
 
-VERSION=`git describe --tags`
+VERSION=`git describe --tags --dirty`
 echo "Last commit: $VERSION"
 find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
 popd

--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -186,7 +186,8 @@ class Exception_Window(QWidget, MessageBoxMixin):
     @staticmethod
     def get_git_version():
         dir = os.path.dirname(os.path.realpath(sys.argv[0]))
-        version = subprocess.check_output(['git', 'describe', '--always'], cwd=dir)
+        version = subprocess.check_output(
+            ['git', 'describe', '--always', '--dirty'], cwd=dir)
         return str(version, "utf8").strip()
 
 


### PR DESCRIPTION
The `--dirty` flag causes `git describe` to append
`-dirty` to the version string it outputs. This is
useful to detect if a build was - intentionally or
not - created with uncommitted changes.

https://git-scm.com/docs/git-describe#git-describe---dirtyltmarkgt