### PR TITLE
qt: allow copying receiving address using ctrl-c

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -791,7 +791,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         msg = _('Bitcoin address where the payment should be received. Note that each payment request uses a different Bitcoin address.')
         self.receive_address_label = HelpLabel(_('Receiving address'), msg)
         self.receive_address_e.textChanged.connect(self.update_receive_qr)
-        self.receive_address_e.setFocusPolicy(Qt.NoFocus)
+        self.receive_address_e.setFocusPolicy(Qt.ClickFocus)
         grid.addWidget(self.receive_address_label, 0, 0)
         grid.addWidget(self.receive_address_e, 0, 1, 1, -1)
 


### PR DESCRIPTION
"You must enable keyboard focus for a widget if it
processes keyboard events."

https://doc.qt.io/qt-5/qwidget.html#focusPolicy-prop

On macOS it works without this patch already for some reason.