### PR TITLE
Getfeerate cmd options

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -260,7 +260,9 @@ class Daemon(DaemonThread):
         password = config_options.get('password')
         new_password = config_options.get('new_password')
         config = SimpleConfig(config_options)
+        # FIXME this is ugly...
         config.fee_estimates = self.network.config.fee_estimates.copy()
+        config.mempool_fees  = self.network.config.mempool_fees.copy()
         cmdname = config.get('cmd')
         cmd = known_commands[cmdname]
         if cmd.requires_wallet:


### PR DESCRIPTION
closes https://github.com/spesmilo/electrum/issues/2447#issuecomment-381360086

```
$ ./electrum getfeerate
26000
$ ./electrum getfeerate --fee_method "static" --fee_level 0.1
10000
$ ./electrum getfeerate --fee_method "static" --fee_level 0.4
50000
$ ./electrum getfeerate --fee_method "static" --fee_level 0.8
150000
$ ./electrum getfeerate --fee_method "eta" --fee_level 0.1
1081
$ ./electrum getfeerate --fee_method "eta" --fee_level 0.4
10705
$ ./electrum getfeerate --fee_method "eta" --fee_level 0.8
21190
$ ./electrum getfeerate --fee_method "mempool" --fee_level 0.1
1000
$ ./electrum getfeerate --fee_method "mempool" --fee_level 0.4
1000
$ ./electrum getfeerate --fee_method "mempool" --fee_level 0.8
20000
```