### PR TITLE
qt pay to script: append hex as is, instead of pushing to script

### DIFF
--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -99,7 +99,7 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit):
                 script += bitcoin.int_to_hex(opcode_int)
             else:
                 bfh(word)  # to test it is hex data
-                script += push_script(word)
+                script += word
         return script
 
     def parse_amount(self, x):


### PR DESCRIPTION
It's not always the case that `push_script` is what the user wants.