### PR TITLE
Fix /tmp/electrum-build no such directory

### DIFF
--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -86,6 +86,7 @@ echo "done"
 
 wine 'wineboot'
 
+mkdir /tmp/electrum-build
 cd /tmp/electrum-build
 
 # Install Python


### PR DESCRIPTION
The error for me 

```
001d:fixme:iphlpapi:NotifyIpInterfaceChange (family 0, callback 0x69ebd3de, context 0x8d6520, init_notify 0, handle 0x11cfa10): stub
003d:err:module:load_builtin_dll failed to load .so lib for builtin L"l3codeca.acm": libmpg123.so.0: cannot open shared object file: No such file or directory
003f:err:winediag:gnutls_initialize failed to load libgnutls, no support for encryption
003f:fixme:ntdll:NtLockFile I/O completion on lock not implemented yet
003f:fixme:msi:internal_ui_handler internal UI not implemented for message 0x0b000000 (UI level = 1)
003f:fixme:msi:internal_ui_handler internal UI not implemented for message 0x0b000000 (UI level = 1)
003d:err:winediag:schan_imp_init Failed to load libgnutls, secure connections will not be available.
003d:fixme:dwmapi:DwmIsCompositionEnabled 0x6d5d3018
0041:fixme:iphlpapi:NotifyIpInterfaceChange (family 0, callback 0x6a0cb608, context 0x958860, init_notify 0, handle 0x119fc88): stub
003d:err:module:load_builtin_dll failed to load .so lib for builtin L"winegstreamer.dll": libgstvideo-1.0.so.0: cannot open shared object file: No such file or directory
003d:err:winediag:gnutls_initialize failed to load libgnutls, no support for encryption
wine: configuration in '/opt/wine64' has been updated.
prepare-wine.sh: line 89: cd: /tmp/electrum-build: No such file or directory
```
simple solution that worked for me is to create the directory 