### PR TITLE
exchange_rate: prefer relative imports

### DIFF
--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -569,6 +569,6 @@ class FxThread(ThreadJob):
         return self.fiat_value(satoshis, self.history_rate(d_t))
 
     def timestamp_rate(self, timestamp):
-        from electrum.util import timestamp_to_datetime
+        from .util import timestamp_to_datetime
         date = timestamp_to_datetime(timestamp)
         return self.history_rate(date)


### PR DESCRIPTION
As this project is currently structured, absolute
imports have the drawback that they'll load modules
from installed paths rather then from the local repo
when running unit tests. This somehow breaks the main
idea of unit tests which is being able to quickly test
newest development changes. Therefore, use a relative
import here.