### PR TITLE
electrum: cleanup plugin imports

### DIFF
--- a/electrum
+++ b/electrum
@@ -69,7 +69,6 @@ if is_local or is_android:
     import imp
     imp.load_module('electrum', *imp.find_module('lib'))
     imp.load_module('electrum_gui', *imp.find_module('gui'))
-    imp.load_module('electrum_plugins', *imp.find_module('plugins'))
 
 
 
@@ -84,7 +83,6 @@ from electrum.commands import get_parser, known_commands, Commands, config_varia
 from electrum import daemon
 from electrum import keystore
 from electrum.mnemonic import Mnemonic
-import electrum_plugins
 
 # get password routine
 def prompt_password(prompt, confirm=True):

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -50,7 +50,7 @@ class Plugins(DaemonThread):
             find = imp.find_module('plugins')
             plugins = imp.load_module('electrum_plugins', *find)
         else:
-            plugins = __import__('electrum_plugins')
+            import electrum_plugins as plugins
         self.pkgpath = os.path.dirname(plugins.__file__)
         self.config = config
         self.hw_wallets = {}


### PR DESCRIPTION
`electrum_plugins` is imported in the `electrum` script
without being used - I assume it's done to make PyInstaller
find that package. But this can be achieved by avoiding
the usage of `__import__()` when importing `electrum_plugins`
where it's effectively used.