### PR TITLE
Remove explicit protocol mentions from scripts

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2358,7 +2358,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if ok and txid:
             txid = str(txid).strip()
             try:
-                r = self.network.synchronous_send(('blockchain.transaction.get',[txid]))
+                request = self.network.get_transaction(txid)
+                r = self.network.synchronous_send(request)
             except BaseException as e:
                 self.show_message(str(e))
                 return

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2358,7 +2358,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if ok and txid:
             txid = str(txid).strip()
             try:
-                r = self.network.synchronous_get(('blockchain.transaction.get',[txid]))
+                r = self.network.synchronous_send(('blockchain.transaction.get',[txid]))
             except BaseException as e:
                 self.show_message(str(e))
                 return

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -181,7 +181,7 @@ class Commands:
         walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_get(('blockchain.scripthash.get_history', [sh]))
+        return self.network.synchronous_send(('blockchain.scripthash.get_history', [sh]))
 
     @command('w')
     def listunspent(self):
@@ -199,7 +199,7 @@ class Commands:
         is a walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
+        return self.network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
 
     @command('')
     def serialize(self, jsontx):
@@ -322,7 +322,7 @@ class Commands:
         server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh]))
+        out = self.network.synchronous_send(('blockchain.scripthash.get_balance', [sh]))
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out
@@ -331,7 +331,7 @@ class Commands:
     def getmerkle(self, txid, height):
         """Get Merkle branch of a transaction included in a block. Electrum
         uses this to verify transactions (Simple Payment Verification)."""
-        return self.network.synchronous_get(('blockchain.transaction.get_merkle', [txid, int(height)]))
+        return self.network.synchronous_send(('blockchain.transaction.get_merkle', [txid, int(height)]))
 
     @command('n')
     def getservers(self):
@@ -517,7 +517,7 @@ class Commands:
         if self.wallet and txid in self.wallet.transactions:
             tx = self.wallet.transactions[txid]
         else:
-            raw = self.network.synchronous_get(('blockchain.transaction.get', [txid]))
+            raw = self.network.synchronous_send(('blockchain.transaction.get', [txid]))
             if raw:
                 tx = Transaction(raw)
             else:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -181,7 +181,8 @@ class Commands:
         walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_send(('blockchain.scripthash.get_history', [sh]))
+        request = self.network.get_history_for_scripthash(sh)
+        return self.network.synchronous_send(request)
 
     @command('w')
     def listunspent(self):
@@ -199,7 +200,8 @@ class Commands:
         is a walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
+        request = self.network.listunspent_for_scripthash(sh)
+        return self.network.synchronous_send(request)
 
     @command('')
     def serialize(self, jsontx):
@@ -322,7 +324,8 @@ class Commands:
         server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        out = self.network.synchronous_send(('blockchain.scripthash.get_balance', [sh]))
+        request = self.network.get_balance_for_scripthash(sh)
+        out = self.network.synchronous_send(request)
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out
@@ -331,7 +334,8 @@ class Commands:
     def getmerkle(self, txid, height):
         """Get Merkle branch of a transaction included in a block. Electrum
         uses this to verify transactions (Simple Payment Verification)."""
-        return self.network.synchronous_send(('blockchain.transaction.get_merkle', [txid, int(height)]))
+        request = self.network.get_merkle_for_transaction(txid, int(height))
+        return self.network.synchronous_send(request)
 
     @command('n')
     def getservers(self):
@@ -517,7 +521,8 @@ class Commands:
         if self.wallet and txid in self.wallet.transactions:
             tx = self.wallet.transactions[txid]
         else:
-            raw = self.network.synchronous_send(('blockchain.transaction.get', [txid]))
+            request = self.network.get_transaction(txid)
+            raw = self.network.synchronous_send(request)
             if raw:
                 tx = Transaction(raw)
             else:

--- a/lib/network.py
+++ b/lib/network.py
@@ -1083,6 +1083,18 @@ class Network(util.DaemonThread):
             return False, "error: " + out
         return True, out
 
+    def history_for_scripthash(self, hash):
+        command = 'blockchain.scripthash.get_history'
+        return (command, [hash])
+
+    def subscribe_to_headers(self):
+        command = 'blockchain.headers.subscribe'
+        return (command, [])
+
+    def subscribe_to_address(self, address):
+        command = 'blockchain.address.subscribe'
+        return (command, [address])
+
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints
         cp = self.blockchain().get_checkpoints()

--- a/lib/network.py
+++ b/lib/network.py
@@ -1062,7 +1062,7 @@ class Network(util.DaemonThread):
     def get_local_height(self):
         return self.blockchain().height()
 
-    def synchronous_get(self, request, timeout=30):
+    def synchronous_send(self, request, timeout=30):
         q = queue.Queue()
         self.send([request], q.put)
         try:
@@ -1076,7 +1076,7 @@ class Network(util.DaemonThread):
     def broadcast(self, tx, timeout=30):
         tx_hash = tx.txid()
         try:
-            out = self.synchronous_get(('blockchain.transaction.broadcast', [str(tx)]), timeout)
+            out = self.synchronous_send(('blockchain.transaction.broadcast', [str(tx)]), timeout)
         except BaseException as e:
             return False, "error: " + str(e)
         if out != tx_hash:

--- a/lib/network.py
+++ b/lib/network.py
@@ -1095,6 +1095,14 @@ class Network(util.DaemonThread):
         command = 'blockchain.address.subscribe'
         return (command, [address])
 
+    def get_merkle_for_transaction(transaction_hash, transaction_height):
+        command = 'blockchain.transaction.get_merkle'
+        return (command, [transaction_hash, transaction_height])
+
+    def subscribe_to_scripthash(scripthash):
+        command = 'blockchain.scripthash.subscribe'
+        return (command, [scripthash])
+
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints
         cp = self.blockchain().get_checkpoints()

--- a/lib/network.py
+++ b/lib/network.py
@@ -673,6 +673,7 @@ class Network(util.DaemonThread):
                     self.subscriptions[k] = l
                     # check cached response for subscriptions
                     r = self.sub_cache.get(k)
+
                 if r is not None:
                     self.print_error("cache hit", k)
                     callback(r)
@@ -1083,7 +1084,7 @@ class Network(util.DaemonThread):
             return False, "error: " + out
         return True, out
 
-    def history_for_scripthash(self, hash):
+    def get_history_for_scripthash(self, hash):
         command = 'blockchain.scripthash.get_history'
         return (command, [hash])
 
@@ -1101,6 +1102,18 @@ class Network(util.DaemonThread):
 
     def subscribe_to_scripthash(scripthash):
         command = 'blockchain.scripthash.subscribe'
+        return (command, [scripthash])
+
+    def get_transaction(transaction_hash):
+        command = 'blockchain.transaction.get'
+        return (command, [transaction_hash])
+
+    def listunspent_for_scripthash(scripthash):
+        command = 'blockchain.scripthash.listunspent'
+        return (command, [scripthash])
+
+    def get_balance_for_scripthash(scripthash):
+        command = 'blockchain.scripthash.get_balance'
         return (command, [scripthash])
 
     def export_checkpoints(self, path):

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -167,7 +167,7 @@ class Synchronizer(ThreadJob):
                 continue
             if tx_hash in self.wallet.transactions:
                 continue
-            requests.append(('blockchain.transaction.get', [tx_hash]))
+            requests.append(self.network.get_transaction(tx_hash))
             self.requested_tx[tx_hash] = tx_height
         self.network.send(requests, self.tx_response)
 

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -767,5 +767,5 @@ class NetworkMock(object):
     def __init__(self, unspent):
         self.unspent = unspent
 
-    def synchronous_get(self, arg):
+    def synchronous_send(self, arg):
         return self.unspent

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -54,8 +54,8 @@ class SPV(ThreadJob):
                         self.network.request_chunk(interface, index)
                 else:
                     if tx_hash not in self.merkle_roots:
-                        request = ('blockchain.transaction.get_merkle',
-                                   [tx_hash, tx_height])
+                        request = self.network.get_merkle_for_transaction(
+				tx_hash, tx_height)
                         self.network.send([request], self.verify_merkle)
                         self.print_error('requested merkle', tx_hash)
                         self.merkle_roots[tx_hash] = None

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -97,7 +97,7 @@ def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):
         script = bitcoin.public_key_to_p2pk_script(pubkey)
         sh = bitcoin.script_to_scripthash(script)
         address = '(pubkey)'
-    u = network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
+    u = network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
     for item in u:
         if len(inputs) >= imax:
             break
@@ -1460,7 +1460,7 @@ class Abstract_Wallet(PrintError):
         if not tx and self.network:
             request = ('blockchain.transaction.get', [tx_hash])
             try:
-                tx = Transaction(self.network.synchronous_get(request))
+                tx = Transaction(self.network.synchronous_send(request))
             except TimeoutException as e:
                 self.print_error('getting input txn from network timed out for {}'.format(tx_hash))
                 if not ignore_timeout:

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -95,17 +95,17 @@ class WsClientThread(util.DaemonThread):
                 continue
             util.print_error('response', r)
             method = r.get('method')
-            params = r.get('params')
+            scripthash = r.get('params')[0]
             result = r.get('result')
             if result is None:
                 continue    
             if method == 'blockchain.scripthash.subscribe':
-                self.network.send([('blockchain.scripthash.get_balance', params)], self.response_queue.put)
+                request = self.network.subscribe_to_scripthash(scripthash)
+                self.network.send([request], self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
-                h = params[0]
-                addr = self.network.h2addr.get(h, None)
+                addr = self.network.h2addr.get(scripthash, None)
                 if addr is None:
-                    util.print_error("can't find address for scripthash: %s" % h)
+                    util.print_error("can't find address for scripthash: %s" % scripthash)
                 l = self.subscriptions.get(addr, [])
                 for ws, amount in l:
                     if not ws.closed:

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -21,7 +21,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([('blockchain.headers.subscribe',[])], callback)
+network.send([network.subscribe_to_headers()], callback)
 
 # 3. wait for results
 while network.is_connected():

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_get(('blockchain.scripthash.get_history',[_hash]))
+h = n.synchronous_send(('blockchain.scripthash.get_history',[_hash]))
 print_msg(json_encode(h))

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_send(n.history_for_scripthash(_hash))
+h = n.synchronous_send(n.get_history_for_scripthash(_hash))
 print_msg(json_encode(h))

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_send(('blockchain.scripthash.get_history',[_hash]))
+h = n.synchronous_send(n.history_for_scripthash(_hash))
 print_msg(json_encode(h))

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -26,7 +26,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([('blockchain.address.subscribe',[addr])], callback)
+network.send([network.subscribe_to_address(addr)], callback)
 
 # 3. wait for results
 while network.is_connected():


### PR DESCRIPTION
See the commit message for additional information!

I'd be willing to investigate if the `scripts/util.py` module can be removed in favor of the plain network handling as is done in `scripts/watch_address` for example. 

You'll be seeing more of these small PRs from me soon, I've opted to keep them small in order to give you an opportunity to comment often.