### PR TITLE
Remove explicit send calls

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -809,7 +809,7 @@ class ElectrumWindow(App):
         Clock.schedule_once(lambda dt: on_success(tx))
 
     def _broadcast_thread(self, tx, on_complete):
-        ok, txid = self.network.broadcast(tx)
+        ok, txid = self.network.broadcast_transaction(tx)
         Clock.schedule_once(lambda dt: on_complete(ok, txid))
 
     def broadcast(self, tx, pr=None):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2359,7 +2359,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if ok and txid:
             txid = str(txid).strip()
             try:
-                r = self.network.synchronous_send(('blockchain.transaction.get',[txid]))
+                request = self.network.get_transaction(txid)
+                r = self.network.synchronous_send(request)
             except BaseException as e:
                 self.show_message(str(e))
                 return

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2359,7 +2359,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if ok and txid:
             txid = str(txid).strip()
             try:
-                r = self.network.synchronous_get(('blockchain.transaction.get',[txid]))
+                r = self.network.synchronous_send(('blockchain.transaction.get',[txid]))
             except BaseException as e:
                 self.show_message(str(e))
                 return

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1600,7 +1600,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if pr and pr.has_expired():
                 self.payment_request = None
                 return False, _("Payment request has expired")
-            status, msg =  self.network.broadcast_transaction(tx)
+            status, msg = self.network.broadcast_transaction(tx)
             if pr and status is True:
                 self.invoices.set_paid(pr, tx.txid())
                 self.invoices.save()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1600,7 +1600,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if pr and pr.has_expired():
                 self.payment_request = None
                 return False, _("Payment request has expired")
-            status, msg =  self.network.broadcast(tx)
+            status, msg =  self.network.broadcast_transaction(tx)
             if pr and status is True:
                 self.invoices.set_paid(pr, tx.txid())
                 self.invoices.save()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2359,8 +2359,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if ok and txid:
             txid = str(txid).strip()
             try:
-                request = self.network.get_transaction(txid)
-                r = self.network.synchronous_send(request)
+                r = self.network.get_transaction(txid)
             except BaseException as e:
                 self.show_message(str(e))
                 return

--- a/gui/stdio.py
+++ b/gui/stdio.py
@@ -198,7 +198,7 @@ class ElectrumGui:
             self.wallet.labels[tx.txid()] = self.str_description
 
         print(_("Please wait..."))
-        status, msg = self.network.broadcast(tx)
+        status, msg = self.network.broadcast_transaction(tx)
 
         if status:
             print(_('Payment sent.'))

--- a/gui/text.py
+++ b/gui/text.py
@@ -349,7 +349,7 @@ class ElectrumGui:
             self.wallet.labels[tx.txid()] = self.str_description
 
         self.show_message(_("Please wait..."), getchar=False)
-        status, msg = self.network.broadcast(tx)
+        status, msg = self.network.broadcast_transaction(tx)
 
         if status:
             self.show_message(_('Payment sent.'))

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -252,7 +252,7 @@ class Commands:
         return tx.deserialize()
 
     @command('n')
-    def broadcast(self, tx, timeout=30):
+    def broadcast(self, tx):
         """Broadcast a transaction to the network. """
         tx = Transaction(tx)
         return self.network.broadcast(tx, timeout)

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -181,8 +181,7 @@ class Commands:
         walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        request = self.network.get_history_for_scripthash(sh)
-        return self.network.synchronous_send(request)
+        return self.network.get_history_for_scripthash(sh)
 
     @command('w')
     def listunspent(self):
@@ -200,8 +199,7 @@ class Commands:
         is a walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        request = self.network.listunspent_for_scripthash(sh)
-        return self.network.synchronous_send(request)
+        return self.network.listunspent_for_scripthash(sh)
 
     @command('')
     def serialize(self, jsontx):
@@ -324,8 +322,7 @@ class Commands:
         server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        request = self.network.get_balance_for_scripthash(sh)
-        out = self.network.synchronous_send(request)
+        out = self.network.get_balance_for_scripthash(sh)
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out
@@ -334,8 +331,7 @@ class Commands:
     def getmerkle(self, txid, height):
         """Get Merkle branch of a transaction included in a block. Electrum
         uses this to verify transactions (Simple Payment Verification)."""
-        request = self.network.get_merkle_for_transaction(txid, int(height))
-        return self.network.synchronous_send(request)
+        return self.network.get_merkle_for_transaction(txid, int(height))
 
     @command('n')
     def getservers(self):

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -181,7 +181,7 @@ class Commands:
         walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_get(('blockchain.scripthash.get_history', [sh]))
+        return self.network.synchronous_send(('blockchain.scripthash.get_history', [sh]))
 
     @command('w')
     def listunspent(self):
@@ -199,7 +199,7 @@ class Commands:
         is a walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
+        return self.network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
 
     @command('')
     def serialize(self, jsontx):
@@ -322,7 +322,7 @@ class Commands:
         server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh]))
+        out = self.network.synchronous_send(('blockchain.scripthash.get_balance', [sh]))
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out
@@ -331,7 +331,7 @@ class Commands:
     def getmerkle(self, txid, height):
         """Get Merkle branch of a transaction included in a block. Electrum
         uses this to verify transactions (Simple Payment Verification)."""
-        return self.network.synchronous_get(('blockchain.transaction.get_merkle', [txid, int(height)]))
+        return self.network.synchronous_send(('blockchain.transaction.get_merkle', [txid, int(height)]))
 
     @command('n')
     def getservers(self):
@@ -517,7 +517,7 @@ class Commands:
         if self.wallet and txid in self.wallet.transactions:
             tx = self.wallet.transactions[txid]
         else:
-            raw = self.network.synchronous_get(('blockchain.transaction.get', [txid]))
+            raw = self.network.synchronous_send(('blockchain.transaction.get', [txid]))
             if raw:
                 tx = Transaction(raw)
             else:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -181,7 +181,8 @@ class Commands:
         walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_send(('blockchain.scripthash.get_history', [sh]))
+        request = self.network.get_history_for_scripthash(sh)
+        return self.network.synchronous_send(request)
 
     @command('w')
     def listunspent(self):
@@ -199,7 +200,8 @@ class Commands:
         is a walletless server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        return self.network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
+        request = self.network.listunspent_for_scripthash(sh)
+        return self.network.synchronous_send(request)
 
     @command('')
     def serialize(self, jsontx):
@@ -322,7 +324,8 @@ class Commands:
         server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        out = self.network.synchronous_send(('blockchain.scripthash.get_balance', [sh]))
+        request = self.network.get_balance_for_scripthash(sh)
+        out = self.network.synchronous_send(request)
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out
@@ -331,7 +334,8 @@ class Commands:
     def getmerkle(self, txid, height):
         """Get Merkle branch of a transaction included in a block. Electrum
         uses this to verify transactions (Simple Payment Verification)."""
-        return self.network.synchronous_send(('blockchain.transaction.get_merkle', [txid, int(height)]))
+        request = self.network.get_merkle_for_transaction(txid, int(height))
+        return self.network.synchronous_send(request)
 
     @command('n')
     def getservers(self):
@@ -517,7 +521,8 @@ class Commands:
         if self.wallet and txid in self.wallet.transactions:
             tx = self.wallet.transactions[txid]
         else:
-            raw = self.network.synchronous_send(('blockchain.transaction.get', [txid]))
+            request = self.network.get_transaction(txid)
+            raw = self.network.synchronous_send(request)
             if raw:
                 tx = Transaction(raw)
             else:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -521,8 +521,7 @@ class Commands:
         if self.wallet and txid in self.wallet.transactions:
             tx = self.wallet.transactions[txid]
         else:
-            request = self.network.get_transaction(txid)
-            raw = self.network.synchronous_send(request)
+            raw = self.network.get_transaction(txid)
             if raw:
                 tx = Transaction(raw)
             else:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -255,7 +255,7 @@ class Commands:
     def broadcast(self, tx):
         """Broadcast a transaction to the network. """
         tx = Transaction(tx)
-        return self.network.broadcast(tx, timeout)
+        return self.network.broadcast_transaction(tx)
 
     @command('')
     def createmultisig(self, num, pubkeys):

--- a/lib/network.py
+++ b/lib/network.py
@@ -1094,6 +1094,7 @@ class Network(util.DaemonThread):
 
         if callback:
             invocation(callback)
+            return
 
         try:
             out = Network.__wait_for(invocation)

--- a/lib/network.py
+++ b/lib/network.py
@@ -1143,9 +1143,11 @@ class Network(util.DaemonThread):
 
 	return Network.__invoke(invocation, callback)
 
-    def listunspent_for_scripthash(scripthash):
+    def listunspent_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.listunspent'
-        return (command, [scripthash])
+        invocation = lambda c: self.send(command, [scripthash], c)
+
+        return Network.__invoke(invocation, callback)
 
     def get_balance_for_scripthash(scripthash):
         command = 'blockchain.scripthash.get_balance'

--- a/lib/network.py
+++ b/lib/network.py
@@ -1102,9 +1102,11 @@ class Network(util.DaemonThread):
             return False, "error: " + out
         return True, out
 
-    def get_history_for_scripthash(self, hash):
+    def get_history_for_scripthash(self, hash, callback=None):
         command = 'blockchain.scripthash.get_history'
-        return (command, [hash])
+        invocation = lambda c: self.send((command, [hash]), c)
+
+        return Network.__invoke(invocation, callback)
 
     def subscribe_to_headers(self, callback=None):
         command = 'blockchain.headers.subscribe'
@@ -1149,9 +1151,11 @@ class Network(util.DaemonThread):
 
         return Network.__invoke(invocation, callback)
 
-    def get_balance_for_scripthash(scripthash):
+    def get_balance_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.get_balance'
-        return (command, [scripthash])
+        invocation = lambda c: self.send(command, [scripthash], c)
+
+        return Network.__invoke(invocation, callback)
 
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints

--- a/lib/network.py
+++ b/lib/network.py
@@ -1060,7 +1060,7 @@ class Network(util.DaemonThread):
     def get_local_height(self):
         return self.blockchain().height()
 
-    def synchronous_get(self, request, timeout=30):
+    def synchronous_send(self, request, timeout=30):
         q = queue.Queue()
         self.send([request], q.put)
         try:
@@ -1074,7 +1074,7 @@ class Network(util.DaemonThread):
     def broadcast(self, tx, timeout=30):
         tx_hash = tx.txid()
         try:
-            out = self.synchronous_get(('blockchain.transaction.broadcast', [str(tx)]), timeout)
+            out = self.synchronous_send(('blockchain.transaction.broadcast', [str(tx)]), timeout)
         except BaseException as e:
             return False, "error: " + str(e)
         if out != tx_hash:

--- a/lib/network.py
+++ b/lib/network.py
@@ -1120,9 +1120,11 @@ class Network(util.DaemonThread):
 
         return Network.__invoke(invocation, callback)
 
-    def subscribe_to_scripthash(scripthash):
+    def subscribe_to_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.subscribe'
-        return (command, [scripthash])
+        invocation = lambda c: self.send((command, [scripthash]), c)
+
+        return Network.__invoke(invocation, callback)
 
     def get_transaction(self, transaction_hash, callback=None):
         command = 'blockchain.transaction.get'

--- a/lib/network.py
+++ b/lib/network.py
@@ -1049,7 +1049,9 @@ class Network(util.DaemonThread):
 
         return result.get('result')
 
-    def __invoke(invocation, callback):
+    def __with_default_synchronous_callback(invocation, callback):
+        """ Use this method if you want to make the network request
+        synchronous. """
         if not callback:
             return Network.__wait_for(invocation)
 
@@ -1104,56 +1106,56 @@ class Network(util.DaemonThread):
         command = 'blockchain.scripthash.get_history'
         invocation = lambda c: self.send((command, [hash]), c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def subscribe_to_headers(self, callback=None):
         command = 'blockchain.headers.subscribe'
         invocation = lambda c: self.send((command, []), c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def subscribe_to_address(self, address, callback=None):
         command = 'blockchain.address.subscribe'
         invocation = lambda c: self.send((command, [address]), c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def get_merkle_for_transaction(self, transaction_hash, transaction_height, callback=None):
         command = 'blockchain.transaction.get_merkle'
         invocation = lambda c: self.send((command, [transaction_hash, transaction_height]), c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def subscribe_to_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.subscribe'
         invocation = lambda c: self.send((command, [scripthash]), c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def get_transaction(self, transaction_hash, callback=None):
         command = 'blockchain.transaction.get'
         invocation = lambda c: self.send((command, [transaction_hash]), c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def get_transactions(self, transaction_hashes, callback=None):
         command = 'blockchain.transaction.get'
         messages = [(command, tx_hash) for tx_hash in transaction_hashes]
         invocation = lambda c: self.send(messages, c)
 
-	return Network.__invoke(invocation, callback)
+	return Network.__with_default_synchronous_callback(invocation, callback)
 
     def listunspent_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.listunspent'
         invocation = lambda c: self.send(command, [scripthash], c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def get_balance_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.get_balance'
         invocation = lambda c: self.send(command, [scripthash], c)
 
-        return Network.__invoke(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints

--- a/lib/network.py
+++ b/lib/network.py
@@ -1046,6 +1046,20 @@ class Network(util.DaemonThread):
             raise Exception(r.get('error'))
         return r.get('result')
 
+    def wait_for(it):
+        """Wait for the result of calling lambda `it`."""
+        q = queue.Queue()
+        it(q.put)
+        try:
+            result = q.get(block=True, timeout=30)
+        except queue.Empty:
+            raise util.TimeoutException(_('Server did not answer'))
+
+        if result.get('error'):
+            raise Exception(result.get('error'))
+
+        return result.get('result')
+
     def request_header(self, interface, height):
         #interface.print_error("requesting header %d" % height)
         self.queue_request('blockchain.block.get_header', [height], interface)
@@ -1102,9 +1116,22 @@ class Network(util.DaemonThread):
         command = 'blockchain.scripthash.subscribe'
         return (command, [scripthash])
 
-    def get_transaction(transaction_hash):
+    def get_transaction(self, transaction_hash, callback=None):
         command = 'blockchain.transaction.get'
-        return (command, [transaction_hash])
+        invocation = lambda c: self.send((command, [transaction_hash]), c)
+        if not callback:
+            return wait_for(invocation)
+
+        invocation(callback)
+
+    def get_transactions(self, transaction_hashes, callback=None):
+        command = 'blockchain.transaction.get'
+        messages = [(command, tx_hash) for tx_hash in transaction_hashes]
+        invocation = lambda c: self.send(messages, c)
+        if not callback:
+            return wait_for(invocation)
+
+        invocation(callback)
 
     def listunspent_for_scripthash(scripthash):
         command = 'blockchain.scripthash.listunspent'

--- a/lib/network.py
+++ b/lib/network.py
@@ -1093,6 +1093,14 @@ class Network(util.DaemonThread):
         command = 'blockchain.address.subscribe'
         return (command, [address])
 
+    def get_merkle_for_transaction(transaction_hash, transaction_height):
+        command = 'blockchain.transaction.get_merkle'
+        return (command, [transaction_hash, transaction_height])
+
+    def subscribe_to_scripthash(scripthash):
+        command = 'blockchain.scripthash.subscribe'
+        return (command, [scripthash])
+
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints
         cp = self.blockchain().get_checkpoints()

--- a/lib/network.py
+++ b/lib/network.py
@@ -1092,7 +1092,7 @@ class Network(util.DaemonThread):
         self.h2addr.update({h: address})
         self.send([('blockchain.scripthash.get_history', [h])], self.map_scripthash_to_address(callback))
 
-    def broadcast(self, tx, timeout=30):
+    def broadcast_transaction(self, transaction, callback=None):
         tx_hash = tx.txid()
         try:
             out = self.synchronous_send(('blockchain.transaction.broadcast', [str(tx)]), timeout)

--- a/lib/network.py
+++ b/lib/network.py
@@ -1058,7 +1058,6 @@ class Network(util.DaemonThread):
         invocation(callback)
 
     def request_header(self, interface, height):
-        #interface.print_error("requesting header %d" % height)
         self.queue_request('blockchain.block.get_header', [height], interface)
         interface.request = height
         interface.req_time = time.time()
@@ -1073,9 +1072,13 @@ class Network(util.DaemonThread):
         return cb2
 
     def subscribe_to_addresses(self, addresses, callback):
-        hash2address = {bitcoin.address_to_scripthash(address): address for address in addresses}
+        hash2address = {
+            bitcoin.address_to_scripthash(address): address
+            for address in addresses}
         self.h2addr.update(hash2address)
-        msgs = [('blockchain.scripthash.subscribe', [x]) for x in hash2address.keys()]
+        msgs = [
+            ('blockchain.scripthash.subscribe', [x])
+            for x in hash2address.keys()]
         self.send(msgs, self.map_scripthash_to_address(callback))
 
     def request_address_history(self, address, callback):
@@ -1120,9 +1123,9 @@ class Network(util.DaemonThread):
 
         return Network.__with_default_synchronous_callback(invocation, callback)
 
-    def get_merkle_for_transaction(self, transaction_hash, transaction_height, callback=None):
+    def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
         command = 'blockchain.transaction.get_merkle'
-        invocation = lambda c: self.send((command, [transaction_hash, transaction_height]), c)
+        invocation = lambda c: self.send((command, [tx_hash, tx_height]), c)
 
         return Network.__with_default_synchronous_callback(invocation, callback)
 
@@ -1143,7 +1146,7 @@ class Network(util.DaemonThread):
         messages = [(command, tx_hash) for tx_hash in transaction_hashes]
         invocation = lambda c: self.send(messages, c)
 
-	return Network.__with_default_synchronous_callback(invocation, callback)
+        return Network.__with_default_synchronous_callback(invocation, callback)
 
     def listunspent_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.listunspent'

--- a/lib/network.py
+++ b/lib/network.py
@@ -671,6 +671,7 @@ class Network(util.DaemonThread):
                     self.subscriptions[k] = l
                     # check cached response for subscriptions
                     r = self.sub_cache.get(k)
+
                 if r is not None:
                     self.print_error("cache hit", k)
                     callback(r)
@@ -1081,7 +1082,7 @@ class Network(util.DaemonThread):
             return False, "error: " + out
         return True, out
 
-    def history_for_scripthash(self, hash):
+    def get_history_for_scripthash(self, hash):
         command = 'blockchain.scripthash.get_history'
         return (command, [hash])
 
@@ -1099,6 +1100,18 @@ class Network(util.DaemonThread):
 
     def subscribe_to_scripthash(scripthash):
         command = 'blockchain.scripthash.subscribe'
+        return (command, [scripthash])
+
+    def get_transaction(transaction_hash):
+        command = 'blockchain.transaction.get'
+        return (command, [transaction_hash])
+
+    def listunspent_for_scripthash(scripthash):
+        command = 'blockchain.scripthash.listunspent'
+        return (command, [scripthash])
+
+    def get_balance_for_scripthash(scripthash):
+        command = 'blockchain.scripthash.get_balance'
         return (command, [scripthash])
 
     def export_checkpoints(self, path):

--- a/lib/network.py
+++ b/lib/network.py
@@ -1106,13 +1106,17 @@ class Network(util.DaemonThread):
         command = 'blockchain.scripthash.get_history'
         return (command, [hash])
 
-    def subscribe_to_headers(self):
+    def subscribe_to_headers(self, callback=None):
         command = 'blockchain.headers.subscribe'
-        return (command, [])
+        invocation = lambda c: self.send((command, []), c)
 
-    def subscribe_to_address(self, address):
+        return Network.__invoke(invocation, callback)
+
+    def subscribe_to_address(self, address, callback=None):
         command = 'blockchain.address.subscribe'
-        return (command, [address])
+        invocation = lambda c: self.send((command, [address]), c)
+
+        return Network.__invoke(invocation, callback)
 
     def get_merkle_for_transaction(self, transaction_hash, transaction_height, callback=None):
         command = 'blockchain.transaction.get_merkle'

--- a/lib/network.py
+++ b/lib/network.py
@@ -623,26 +623,6 @@ class Network(util.DaemonThread):
             # Response is now in canonical form
             self.process_response(interface, response, callbacks)
 
-    def map_scripthash_to_address(self, callback):
-        def cb2(x):
-            x2 = x.copy()
-            p = x2.pop('params')
-            addr = self.h2addr[p[0]]
-            x2['params'] = [addr]
-            callback(x2)
-        return cb2
-
-    def subscribe_to_addresses(self, addresses, callback):
-        hash2address = {bitcoin.address_to_scripthash(address): address for address in addresses}
-        self.h2addr.update(hash2address)
-        msgs = [('blockchain.scripthash.subscribe', [x]) for x in hash2address.keys()]
-        self.send(msgs, self.map_scripthash_to_address(callback))
-
-    def request_address_history(self, address, callback):
-        h = bitcoin.address_to_scripthash(address)
-        self.h2addr.update({h: address})
-        self.send([('blockchain.scripthash.get_history', [h])], self.map_scripthash_to_address(callback))
-
     def send(self, messages, callback):
         '''Messages is a list of (method, params) tuples'''
         messages = list(messages)
@@ -799,12 +779,6 @@ class Network(util.DaemonThread):
             interface.print_error('catch up done', blockchain.height())
             blockchain.catch_up = None
         self.notify('updated')
-
-    def request_header(self, interface, height):
-        #interface.print_error("requesting header %d" % height)
-        self.queue_request('blockchain.block.get_header', [height], interface)
-        interface.request = height
-        interface.req_time = time.time()
 
     def on_get_header(self, interface, response):
         '''Handle receiving a single block header'''
@@ -1071,6 +1045,32 @@ class Network(util.DaemonThread):
         if r.get('error'):
             raise Exception(r.get('error'))
         return r.get('result')
+
+    def request_header(self, interface, height):
+        #interface.print_error("requesting header %d" % height)
+        self.queue_request('blockchain.block.get_header', [height], interface)
+        interface.request = height
+        interface.req_time = time.time()
+
+    def map_scripthash_to_address(self, callback):
+        def cb2(x):
+            x2 = x.copy()
+            p = x2.pop('params')
+            addr = self.h2addr[p[0]]
+            x2['params'] = [addr]
+            callback(x2)
+        return cb2
+
+    def subscribe_to_addresses(self, addresses, callback):
+        hash2address = {bitcoin.address_to_scripthash(address): address for address in addresses}
+        self.h2addr.update(hash2address)
+        msgs = [('blockchain.scripthash.subscribe', [x]) for x in hash2address.keys()]
+        self.send(msgs, self.map_scripthash_to_address(callback))
+
+    def request_address_history(self, address, callback):
+        h = bitcoin.address_to_scripthash(address)
+        self.h2addr.update({h: address})
+        self.send([('blockchain.scripthash.get_history', [h])], self.map_scripthash_to_address(callback))
 
     def broadcast(self, tx, timeout=30):
         tx_hash = tx.txid()

--- a/lib/network.py
+++ b/lib/network.py
@@ -1081,6 +1081,18 @@ class Network(util.DaemonThread):
             return False, "error: " + out
         return True, out
 
+    def history_for_scripthash(self, hash):
+        command = 'blockchain.scripthash.get_history'
+        return (command, [hash])
+
+    def subscribe_to_headers(self):
+        command = 'blockchain.headers.subscribe'
+        return (command, [])
+
+    def subscribe_to_address(self, address):
+        command = 'blockchain.address.subscribe'
+        return (command, [address])
+
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints
         cp = self.blockchain().get_checkpoints()

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -166,7 +166,7 @@ class Synchronizer(ThreadJob):
                 continue
             if tx_hash in self.wallet.transactions:
                 continue
-            requests.append(('blockchain.transaction.get', [tx_hash]))
+            requests.append(self.network.get_transaction(tx_hash))
             self.requested_tx[tx_hash] = tx_height
         self.network.send(requests, self.on_tx_response)
 

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -169,7 +169,7 @@ class Synchronizer(ThreadJob):
             transaction_hashes.append(tx_hash)
             self.requested_tx[tx_hash] = tx_height
 
-        self.network.get_transactions(transaction_hashes, self.tx_response)
+        self.network.get_transactions(transaction_hashes, self.on_tx_response)
 
     def initialize(self):
         '''Check the initial state of the wallet.  Subscribe to all its

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -160,15 +160,16 @@ class Synchronizer(ThreadJob):
 
     def request_missing_txs(self, hist):
         # "hist" is a list of [tx_hash, tx_height] lists
-        requests = []
+        transaction_hashes = []
         for tx_hash, tx_height in hist:
             if tx_hash in self.requested_tx:
                 continue
             if tx_hash in self.wallet.transactions:
                 continue
-            requests.append(self.network.get_transaction(tx_hash))
+            transaction_hashes.append(tx_hash)
             self.requested_tx[tx_hash] = tx_height
-        self.network.send(requests, self.on_tx_response)
+
+        self.network.get_transactions(transaction_hashs, self.tx_response)
 
     def initialize(self):
         '''Check the initial state of the wallet.  Subscribe to all its

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -169,7 +169,7 @@ class Synchronizer(ThreadJob):
             transaction_hashes.append(tx_hash)
             self.requested_tx[tx_hash] = tx_height
 
-        self.network.get_transactions(transaction_hashs, self.tx_response)
+        self.network.get_transactions(transaction_hashes, self.tx_response)
 
     def initialize(self):
         '''Check the initial state of the wallet.  Subscribe to all its

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -773,5 +773,5 @@ class NetworkMock(object):
     def __init__(self, unspent):
         self.unspent = unspent
 
-    def synchronous_get(self, arg):
+    def synchronous_send(self, arg):
         return self.unspent

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -54,8 +54,8 @@ class SPV(ThreadJob):
                 else:
                     if (tx_hash not in self.requested_merkle
                             and tx_hash not in self.merkle_roots):
-                        request = ('blockchain.transaction.get_merkle',
-                                   [tx_hash, tx_height])
+                        request = self.network.get_merkle_for_transaction(
+                            tx_hash, tx_height)
                         self.network.send([request], self.verify_merkle)
                         self.print_error('requested merkle', tx_hash)
                         self.requested_merkle.add(tx_hash)

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -54,9 +54,11 @@ class SPV(ThreadJob):
                 else:
                     if (tx_hash not in self.requested_merkle
                             and tx_hash not in self.merkle_roots):
-                        request = self.network.get_merkle_for_transaction(
-                            tx_hash, tx_height)
-                        self.network.send([request], self.verify_merkle)
+
+                        self.network.get_merkle_for_transaction(
+                                tx_hash,
+                                tx_height,
+                                self.verify_merkle)
                         self.print_error('requested merkle', tx_hash)
                         self.requested_merkle.add(tx_hash)
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -98,7 +98,7 @@ def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):
         script = bitcoin.public_key_to_p2pk_script(pubkey)
         sh = bitcoin.script_to_scripthash(script)
         address = '(pubkey)'
-    u = network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
+    u = network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
     for item in u:
         if len(inputs) >= imax:
             break
@@ -1473,7 +1473,7 @@ class Abstract_Wallet(PrintError):
         if not tx and self.network:
             request = ('blockchain.transaction.get', [tx_hash])
             try:
-                tx = Transaction(self.network.synchronous_get(request))
+                tx = Transaction(self.network.synchronous_send(request))
             except TimeoutException as e:
                 self.print_error('getting input txn from network timed out for {}'.format(tx_hash))
                 if not ignore_timeout:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -99,8 +99,7 @@ def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):
         scripthash = bitcoin.script_to_scripthash(script)
         address = '(pubkey)'
 
-    request = self.network.listunspent_for_scripthash(scripthash)
-    u = network.synchronous_send(request)
+    u = self.network.listunspent_for_scripthash(scripthash)
     for item in u:
         if len(inputs) >= imax:
             break

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1473,9 +1473,8 @@ class Abstract_Wallet(PrintError):
         # all the input txs, in which case we ask the network.
         tx = self.transactions.get(tx_hash, None)
         if not tx and self.network:
-            request = self.network.get_transaction(tx_hash)
             try:
-                tx = Transaction(self.network.synchronous_send(request))
+                tx = Transaction(self.network.get_transaction(tx_hash))
             except TimeoutException as e:
                 self.print_error('getting input txn from network timed out for {}'.format(tx_hash))
                 if not ignore_timeout:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -99,7 +99,7 @@ def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):
         scripthash = bitcoin.script_to_scripthash(script)
         address = '(pubkey)'
 
-    u = self.network.listunspent_for_scripthash(scripthash)
+    u = network.listunspent_for_scripthash(scripthash)
     for item in u:
         if len(inputs) >= imax:
             break

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -93,12 +93,14 @@ def dust_threshold(network):
 def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):
     if txin_type != 'p2pk':
         address = bitcoin.pubkey_to_address(txin_type, pubkey)
-        sh = bitcoin.address_to_scripthash(address)
+        scripthash = bitcoin.address_to_scripthash(address)
     else:
         script = bitcoin.public_key_to_p2pk_script(pubkey)
-        sh = bitcoin.script_to_scripthash(script)
+        scripthash = bitcoin.script_to_scripthash(script)
         address = '(pubkey)'
-    u = network.synchronous_send(('blockchain.scripthash.listunspent', [sh]))
+
+    request = self.network.listunspent_for_scripthash(scripthash)
+    u = network.synchronous_send(request)
     for item in u:
         if len(inputs) >= imax:
             break
@@ -1471,7 +1473,7 @@ class Abstract_Wallet(PrintError):
         # all the input txs, in which case we ask the network.
         tx = self.transactions.get(tx_hash, None)
         if not tx and self.network:
-            request = ('blockchain.transaction.get', [tx_hash])
+            request = self.network.get_transaction(tx_hash)
             try:
                 tx = Transaction(self.network.synchronous_send(request))
             except TimeoutException as e:

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -100,8 +100,7 @@ class WsClientThread(util.DaemonThread):
             if result is None:
                 continue    
             if method == 'blockchain.scripthash.subscribe':
-                request = self.network.subscribe_to_scripthash(scripthash)
-                self.network.send([request], self.response_queue.put)
+                self.network.subscribe_to_scripthash(scripthash, self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
                 addr = self.network.h2addr.get(scripthash, None)
                 if addr is None:

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -100,11 +100,13 @@ class WsClientThread(util.DaemonThread):
             if result is None:
                 continue    
             if method == 'blockchain.scripthash.subscribe':
-                self.network.subscribe_to_scripthash(scripthash, self.response_queue.put)
+                self.network.subscribe_to_scripthash(
+                        scripthash, self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
                 addr = self.network.h2addr.get(scripthash, None)
                 if addr is None:
-                    util.print_error("can't find address for scripthash: %s" % scripthash)
+                    util.print_error(
+                        "can't find address for scripthash: %s" % scripthash)
                 l = self.subscriptions.get(addr, [])
                 for ws, amount in l:
                     if not ws.closed:

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -100,7 +100,7 @@ class WsClientThread(util.DaemonThread):
             if result is None:
                 continue    
             if method == 'blockchain.scripthash.subscribe':
-                self.network.subscribe_to_scripthash(
+                self.network.get_balance_for_scripthash(
                         scripthash, self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
                 addr = self.network.h2addr.get(scripthash, None)

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -95,17 +95,17 @@ class WsClientThread(util.DaemonThread):
                 continue
             util.print_error('response', r)
             method = r.get('method')
-            params = r.get('params')
+            scripthash = r.get('params')[0]
             result = r.get('result')
             if result is None:
                 continue    
             if method == 'blockchain.scripthash.subscribe':
-                self.network.send([('blockchain.scripthash.get_balance', params)], self.response_queue.put)
+                request = self.network.subscribe_to_scripthash(scripthash)
+                self.network.send([request], self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
-                h = params[0]
-                addr = self.network.h2addr.get(h, None)
+                addr = self.network.h2addr.get(scripthash, None)
                 if addr is None:
-                    util.print_error("can't find address for scripthash: %s" % h)
+                    util.print_error("can't find address for scripthash: %s" % scripthash)
                 l = self.subscriptions.get(addr, [])
                 for ws, amount in l:
                     if not ws.closed:

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -21,7 +21,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([('blockchain.headers.subscribe',[])], callback)
+network.send([network.subscribe_to_headers()], callback)
 
 # 3. wait for results
 while network.is_connected():

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -21,7 +21,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([network.subscribe_to_headers()], callback)
+network.subscribe_to_headers(callback)
 
 # 3. wait for results
 while network.is_connected():

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_get(('blockchain.scripthash.get_history',[_hash]))
+h = n.synchronous_send(('blockchain.scripthash.get_history',[_hash]))
 print_msg(json_encode(h))

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_send(n.history_for_scripthash(_hash))
+h = n.synchronous_send(n.get_history_for_scripthash(_hash))
 print_msg(json_encode(h))

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_send(('blockchain.scripthash.get_history',[_hash]))
+h = n.synchronous_send(n.history_for_scripthash(_hash))
 print_msg(json_encode(h))

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -14,5 +14,5 @@ except Exception:
 n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
-h = n.synchronous_send(n.get_history_for_scripthash(_hash))
+h = n.get_history_for_scripthash(_hash)
 print_msg(json_encode(h))

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -26,7 +26,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([('blockchain.address.subscribe',[addr])], callback)
+network.send([network.subscribe_to_address(addr)], callback)
 
 # 3. wait for results
 while network.is_connected():

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -26,7 +26,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([network.subscribe_to_address(addr)], callback)
+network.subscribe_to_address(addr, callback)
 
 # 3. wait for results
 while network.is_connected():


### PR DESCRIPTION
This is a continuation of #4371.
The goal here was to make the code base easier to understand and more decoupled. All the ElectrumX protocol mentions are now in the network module. Except for two instances in the websockets module.

Functionally almost nothing changed. The only thing which changed is that in the commands module an optional `timeout` parameter could be passed. That parameter has been removed in favor of simpler code. 