### PR TITLE
minikeys: import with uncompressed pubkey instead of compressed

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -420,7 +420,7 @@ def serialize_privkey(secret: bytes, compressed: bool, txin_type: str,
 
 def deserialize_privkey(key: str) -> (str, bytes, bool):
     if is_minikey(key):
-        return 'p2pkh', minikey_to_private_key(key), True
+        return 'p2pkh', minikey_to_private_key(key), False
 
     txin_type = None
     if ':' in key:

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -568,14 +568,14 @@ class Test_keyImport(SequentialTestCase):
             'scripthash': '242f02adde84ebb2a7dd778b2f3a81b3826f111da4d8960d826d7a4b816cb261'},
            # from http://bitscan.com/articles/security/spotlight-on-mini-private-keys
            {'priv': 'SzavMBLoXU6kDrqtUVmffv',
-            'exported_privkey': 'p2pkh:L53fCHmQhbNp1B4JipfBtfeHZH7cAibzG9oK19XfiFzxHgAkz6JK',
-            'pub': '02588d202afcc1ee4ab5254c7847ec25b9a135bbda0f2bc69ee1a714749fd77dc9',
-            'address': '19GuvDvMMUZ8vq84wT79fvnvhMd5MnfTkR',
+            'exported_privkey': 'p2pkh:5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF',
+            'pub': '04588d202afcc1ee4ab5254c7847ec25b9a135bbda0f2bc69ee1a714749fd77dc9f88ff2a00d7e752d44cbe16e1ebcf0890b76ec7c78886109dee76ccfc8445424',
+            'address': '1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj',
             'minikey': True,
             'txin_type': 'p2pkh',
-            'compressed': True,  # this is actually ambiguous... issue #2748
+            'compressed': False,  # this is actually ambiguous... issue #2748
             'addr_encoding': 'base58',
-            'scripthash': '60ad5a8b922f758cd7884403e90ee7e6f093f8d21a0ff24c9a865e695ccefdf1'},
+            'scripthash': '5b07ddfde826f5125ee823900749103cea37808038ecead5505a766a07c34445'},
     )
 
     @needs_test_with_all_ecc_implementations


### PR DESCRIPTION
When importing minikeys, I would like to change the behaviour to derive an uncompressed public key, instead of compressed.

Before this commit https://github.com/spesmilo/electrum/commit/e8b564c0e728e1ca15d39f48a0153c984e2acc3c that first appeared in 3.0, the default was uncompressed; since then we've been deriving compressed keys.
Every so often there is a user on IRC complaining that importing does not work.
Sweeping works as then we try both compressed and uncompressed p2pkh (https://github.com/spesmilo/electrum/pull/3268).

The original Casascius coins used uncompressed public keys.
Also, @AbdussamadA emailed an active seller of physical bitcoins (Denarium Bitcoin), and was told that "uncompressed" is part of the "spec for mini private keys".
@kyuupichan also seems to agree in https://github.com/fyookball/electrum/commit/92e74d1cc9097b9330450854a68f3bd119713cf7

Unless someone actually derives compressed pubkeys from minikeys, we should just do this simple change. Otherwise, maybe we could import both addresses....

related: https://github.com/spesmilo/electrum/issues/2748