### PR TITLE
Add minimum confirmations for balance

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -322,7 +322,8 @@ class Commands:
         server query, results are not checked by SPV.
         """
         sh = bitcoin.address_to_scripthash(address)
-        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh]))
+        minconf = self.config.get('minconf', 1)
+        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh, int(minconf)]))
         out["confirmed"] =  str(Decimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(Decimal(out["unconfirmed"])/COIN)
         return out

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -695,16 +695,17 @@ class Abstract_Wallet(PrintError):
     def get_addr_balance(self, address):
         received, sent = self.get_addr_io(address)
         c = u = x = 0
+        minconf = config.get('minconf', 1)
         local_height = self.get_local_height()
         for txo, (tx_height, v, is_cb) in received.items():
             if is_cb and tx_height + COINBASE_MATURITY > local_height:
                 x += v
-            elif tx_height > 0:
+            elif tx_height >= minconf:
                 c += v
             else:
                 u += v
             if txo in sent:
-                if sent[txo] > 0:
+                if sent[txo] >= minconf:
                     c -= v
                 else:
                     u -= v
@@ -723,7 +724,7 @@ class Abstract_Wallet(PrintError):
         for addr in domain:
             utxos = self.get_addr_utxo(addr)
             for x in utxos.values():
-                if confirmed_only and x['height'] <= 0:
+                if confirmed_only and x['height'] < config.get('minconf', 1):
                     continue
                 if mature and x['coinbase'] and x['height'] + COINBASE_MATURITY > self.get_local_height():
                     continue


### PR DESCRIPTION
I think it would be good if users were able to decide how many confirmations they need in order to declare a transaction actually confirmed (recommended is 6, Electrum uses 1).

This also required a PR on ElectrumX server as well (kyuupichan/electrumx#482) and shall not be accepted if ElectrumX PR does not get accepted. Unfortunately I don't have enough storage for deploying and testing my PR to Electrum and therefore I wasn't able to test this as well, so please consider this as an untested idea.

Related: #3779 