### PR TITLE
storage upgrade as part of the wizard. fix storage upgrade on kivy.

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -503,7 +503,7 @@ class ElectrumWindow(App):
                 self.load_wallet(wallet)
         else:
             Logger.debug('Electrum: Wallet not found. Launching install wizard')
-            storage = WalletStorage(path)
+            storage = WalletStorage(path, manual_upgrades=True)
             wizard = Factory.InstallWizard(self.electrum_config, storage)
             wizard.bind(on_wizard_complete=self.on_wizard_complete)
             action = wizard.storage.get_action()

--- a/gui/kivy/uix/dialogs/installwizard.py
+++ b/gui/kivy/uix/dialogs/installwizard.py
@@ -744,7 +744,7 @@ class InstallWizard(BaseWizard, Widget):
         """overriden by main_window"""
         pass
 
-    def waiting_dialog(self, task, msg):
+    def waiting_dialog(self, task, msg, on_finished=None):
         '''Perform a blocking task in the background by running the passed
         method in a thread.
         '''
@@ -756,6 +756,8 @@ class InstallWizard(BaseWizard, Widget):
                 self.show_error(str(err))
             # on  completion hide message
             Clock.schedule_once(lambda dt: app.info_bubble.hide(now=True), -1)
+            if on_finished:
+                Clock.schedule_once(lambda dt: on_finished(), -1)
 
         app = App.get_running_app()
         app.show_info_bubble(

--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -284,13 +284,8 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                 self.show_warning(_('The file was removed'))
             return
 
-        if self.storage.requires_upgrade():
-            self.storage.upgrade()
-            self.wallet = Wallet(self.storage)
-            return self.wallet
-
         action = self.storage.get_action()
-        if action and action != 'new':
+        if action and action not in ('new', 'upgrade_storage'):
             self.hide()
             msg = _("The file '{}' contains an incompletely created wallet.\n"
                     "Do you want to complete its creation now?").format(path)
@@ -473,12 +468,26 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
     def terminate(self):
         self.accept_signal.emit()
 
-    def waiting_dialog(self, task, msg):
-        self.please_wait.setText(msg)
-        self.refresh_gui()
-        t = threading.Thread(target = task)
+    def waiting_dialog(self, task, msg, on_finished=None):
+        label = WWLabel(msg)
+        vbox = QVBoxLayout()
+        vbox.addSpacing(100)
+        label.setMinimumWidth(300)
+        label.setAlignment(Qt.AlignCenter)
+        vbox.addWidget(label)
+        self.set_layout(vbox, next_enabled=False)
+        self.back_button.setEnabled(False)
+
+        t = threading.Thread(target=task)
         t.start()
-        t.join()
+        while True:
+            t.join(1.0/60)
+            if t.is_alive():
+                self.refresh_gui()
+            else:
+                break
+        if on_finished:
+            on_finished()
 
     @wizard_dialog
     def choice_dialog(self, title, message, choices, run_next):

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -26,11 +26,12 @@
 import os
 import sys
 import traceback
+from functools import partial
 
 from . import bitcoin
 from . import keystore
 from .keystore import bip44_derivation
-from .wallet import Imported_Wallet, Standard_Wallet, Multisig_Wallet, wallet_types
+from .wallet import Imported_Wallet, Standard_Wallet, Multisig_Wallet, wallet_types, Wallet
 from .storage import STO_EV_USER_PW, STO_EV_XPUB_PW, get_derivation_used_for_hw_device_encryption
 from .i18n import _
 from .util import UserCancelled, InvalidPassword
@@ -99,6 +100,12 @@ class BaseWizard(object):
         ]
         choices = [pair for pair in wallet_kinds if pair[0] in wallet_types]
         self.choice_dialog(title=title, message=message, choices=choices, run_next=self.on_wallet_type)
+
+    def upgrade_storage(self):
+        def on_finished():
+            self.wallet = Wallet(self.storage)
+            self.terminate()
+        self.waiting_dialog(partial(self.storage.upgrade), _('Upgrading wallet format...'), on_finished=on_finished)
 
     def load_2fa(self):
         self.storage.put('wallet_type', '2fa')

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -238,8 +238,6 @@ class Daemon(DaemonThread):
             storage.decrypt(password)
         if storage.requires_split():
             return
-        if storage.requires_upgrade():
-            return
         if storage.get_action():
             return
         wallet = Wallet(storage)

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -578,10 +578,17 @@ class WalletStorage(PrintError):
             return True
 
     def get_action(self):
-        action = run_hook('get_action', self)
-        if action:
-            return action
-        if not self.file_exists():
+        if self.file_exists():
+            action = run_hook('get_action', self)
+            if action and self.requires_upgrade():
+                raise WalletFileException(_('Incomplete wallet files cannot be upgraded.'))
+            elif self.requires_upgrade():
+                return 'upgrade_storage'
+            elif action:
+                return action
+            else:
+                return None
+        else:
             return 'new'
 
     def get_seed_version(self):


### PR DESCRIPTION
- `upgrade_storage` is now a possible return value of `storage.get_action()`
- in the Qt and kivy GUIs, the storage upgrade is part of the wizard
- the upgrade is wrapped in a waiting_dialog, so that it does not block the GUI
- storage upgrade works reasonably on kivy too now; previously if an upgrade was needed, it happened in the background and the app opened into "No Wallet"
- refuse to touch wallet files that are both incomplete and need a storage upgrade (was previously upgraded but completion not finished, and we tried to create a wallet object from that..)
