### PR TITLE
First message on an interface is server.version

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -260,9 +260,7 @@ class Interface(util.PrintError):
         self.debug = False
         self.unsent_requests = []
         self.unanswered_requests = {}
-        # Set last ping to zero to ensure immediate ping
-        self.last_request = time.time()
-        self.last_ping = 0
+        self.last_send = time.time()
         self.closed_remotely = False
 
     def diagnostic_name(self):
@@ -294,6 +292,7 @@ class Interface(util.PrintError):
 
     def send_requests(self):
         '''Sends queued requests.  Returns False on failure.'''
+        self.last_send = time.time()
         make_dict = lambda m, p, i: {'method': m, 'params': p, 'id': i}
         n = self.num_requests()
         wire_requests = self.unsent_requests[0:n]
@@ -310,14 +309,8 @@ class Interface(util.PrintError):
         return True
 
     def ping_required(self):
-        '''Maintains time since last ping.  Returns True if a ping should
-        be sent.
-        '''
-        now = time.time()
-        if now - self.last_ping > 60:
-            self.last_ping = now
-            return True
-        return False
+        '''Returns True if a ping should be sent.'''
+        return time.time() - self.last_send > 300
 
     def has_timed_out(self):
         '''Returns True if the interface has timed out.'''

--- a/lib/network.py
+++ b/lib/network.py
@@ -307,9 +307,6 @@ class Network(util.DaemonThread):
         # Resend unanswered requests
         requests = self.unanswered_requests.values()
         self.unanswered_requests = {}
-        if self.interface.ping_required():
-            params = [ELECTRUM_VERSION, PROTOCOL_VERSION]
-            self.queue_request('server.version', params, self.interface)
         for request in requests:
             message_id = self.queue_request(request[0], request[1])
             self.unanswered_requests[message_id] = request
@@ -711,6 +708,9 @@ class Network(util.DaemonThread):
         interface.mode = 'default'
         interface.request = None
         self.interfaces[server] = interface
+        # server.version should be the first message
+        params = [ELECTRUM_VERSION, PROTOCOL_VERSION]
+        self.queue_request('server.version', params, interface)
         self.queue_request('blockchain.headers.subscribe', [True], interface)
         if server == self.default_server:
             self.switch_to_interface(server)
@@ -734,8 +734,7 @@ class Network(util.DaemonThread):
             if interface.has_timed_out():
                 self.connection_down(interface.server)
             elif interface.ping_required():
-                params = [ELECTRUM_VERSION, PROTOCOL_VERSION]
-                self.queue_request('server.version', params, interface)
+                self.queue_request('server.ping', [], interface)
 
         now = time.time()
         # nodes


### PR DESCRIPTION
- Use server.ping to ping (valid as of protocol version 1.2) rather
  than server.version (deprecated as a ping)
- Ping every 5 mins rather than every 1 minute.  By default servers
  don't consider a connection stale until 10 minutes of inactivity.
- Remove unused last_request member of interface

Port of https://github.com/fyookball/electrum/commit/c3f26e59db9ce6d5af6c12510f1817d2782f4928