### PR TITLE
Stop using deprecated RPC blockchain.block.get_chunk

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -561,8 +561,8 @@ class Network(util.DaemonThread):
             if error is None:
                 self.relay_fee = int(result * COIN) if result is not None else None
                 self.print_error("relayfee", self.relay_fee)
-        elif method == 'blockchain.block.get_chunk':
-            self.on_get_chunk(interface, response)
+        elif method == 'blockchain.block.headers':
+            self.on_block_headers(interface, response)
         elif method == 'blockchain.block.get_header':
             self.on_get_header(interface, response)
 
@@ -766,9 +766,11 @@ class Network(util.DaemonThread):
             return
         interface.print_error("requesting chunk %d" % index)
         self.requested_chunks.add(index)
-        self.queue_request('blockchain.block.get_chunk', [index], interface)
+        height = index * 2016
+        self.queue_request('blockchain.block.headers', [height, 2016],
+                           interface)
 
-    def on_get_chunk(self, interface, response):
+    def on_block_headers(self, interface, response):
         '''Handle receiving a chunk of block headers'''
         error = response.get('error')
         result = response.get('result')
@@ -777,15 +779,17 @@ class Network(util.DaemonThread):
         if result is None or params is None or error is not None:
             interface.print_error(error or 'bad response')
             return
-        index = params[0]
         # Ignore unsolicited chunks
-        if index not in self.requested_chunks:
+        height = params[0]
+        index = height // 2016
+        if index * 2016 != height or index not in self.requested_chunks:
             interface.print_error("received chunk %d (unsolicited)" % index)
             return
         else:
             interface.print_error("received chunk %d" % index)
         self.requested_chunks.remove(index)
-        connect = blockchain.connect_chunk(index, result)
+        hexdata = result['hex']
+        connect = blockchain.connect_chunk(index, hexdata)
         if not connect:
             self.connection_down(interface.server)
             return


### PR DESCRIPTION
Use blockchain.block.headers instead.  It's more flexible but
that flexibility is not used here.

Port of https://github.com/fyookball/electrum/commit/09798d6b20bb35bae745b1a74c2fac5bb24b700a