### PR TITLE
Extract electrumx module

### DIFF
--- a/electrum
+++ b/electrum
@@ -139,7 +139,7 @@ def run_non_RPC(config):
             storage.write()
             wallet = Wallet(storage)
         if not config.get('offline'):
-            network = Network(config)
+            network = ElectrumX(config)
             network.start()
             wallet.start_threads(network)
             print_msg("Recovering wallet...")

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -252,9 +252,9 @@ class Blockchain(util.PrintError):
                 os.fsync(f.fileno())
             self.update_size()
 
-    def is_after_last_checkpoint(tx_height):
+    def is_before_last_checkpoint(tx_height):
         index = tx_height // 2016
-        return index > len(self.checkpoints)
+        return index < len(self.checkpoints)
 
     def save_header(self, header):
         delta = header.get('block_height') - self.checkpoint

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -252,6 +252,10 @@ class Blockchain(util.PrintError):
                 os.fsync(f.fileno())
             self.update_size()
 
+    def is_after_last_checkpoint(tx_height):
+        index = tx_height // 2016
+        return index > len(self.checkpoints)
+
     def save_header(self, header):
         delta = header.get('block_height') - self.checkpoint
         data = bfh(serialize_header(header))

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -33,7 +33,7 @@ import jsonrpclib
 from .jsonrpc import VerifyingJSONRPCServer
 
 from .version import ELECTRUM_VERSION
-from .network import Network
+from .electrumx import ElectrumX
 from .util import json_decode, DaemonThread
 from .util import print_error, to_string
 from .wallet import Wallet
@@ -125,7 +125,7 @@ class Daemon(DaemonThread):
         if config.get('offline'):
             self.network = None
         else:
-            self.network = Network(config)
+            self.network = ElectrumX(config)
             self.network.start()
         self.fx = FxThread(config, self.network)
         if self.network:

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -36,6 +36,7 @@ class ElectrumX(network.Network):
             for x in hash2address.keys()]
         self.send(msgs, self.map_scripthash_to_address(callback))
 
+    # TODO Remove this is favor of get_history_for_scripthash
     def request_address_history(self, address, callback):
         h = bitcoin.address_to_scripthash(address)
         self.h2addr.update({h: address})
@@ -78,6 +79,7 @@ class ElectrumX(network.Network):
             invocation,
             callback)
 
+    # NOTE: Deprecated since ElectrumX 1.2. Use subscribe_to_scripthash.
     def subscribe_to_address(self, address, callback=None):
         command = 'blockchain.address.subscribe'
         invocation = lambda c: self.send([(command, [address])], c)

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -12,6 +12,7 @@ class ElectrumX(network.Network):
     See https://electrumx.readthedocs.io/en/latest/protocol-basics.html
     """
 
+    # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
         self.queue_request('blockchain.block.get_header', [height], interface)
         interface.request = height
@@ -26,6 +27,8 @@ class ElectrumX(network.Network):
             callback(x2)
         return cb2
 
+    # TODO I believe the caller should take care of the mapping between addr<->hash
+    # Then we can rid of this silly h2addr and map_scripthash_to_address.
     def subscribe_to_addresses(self, addresses, callback):
         hash2address = {
             bitcoin.address_to_scripthash(address): address

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -119,7 +119,7 @@ class ElectrumX(network.Network):
 
     def subscribe_to_headers(self, callback=None):
         command = 'blockchain.headers.subscribe'
-        invocation = lambda c: self._send([(command, [])], c)
+        invocation = lambda c: self._send([(command, [True])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -17,6 +17,15 @@ class ElectrumX(network.Network):
 
         self.__hash2address = {}
 
+    # Deprecated in favor of headers
+    def get_chunk(self, index, callback=None):
+        command = 'blockchain.block.get_chunk'
+        invocation = lambda c: self.send([(command, [index])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
         self.queue_request('blockchain.block.get_header', [height], interface)
@@ -95,6 +104,14 @@ class ElectrumX(network.Network):
     def get_history_for_scripthash(self, hash, callback=None):
         command = 'blockchain.scripthash.get_history'
         invocation = lambda c: self.send([(command, [hash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def headers(self, start_height, count, callback=None):
+        command = 'blockchain.block.headers'
+        invocation = lambda c: self.send([(command, [start_height, count])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -1,4 +1,160 @@
+import time
+import queue
+from . import util
 from . import network
+from . import bitcoin
+from .i18n import _
+
 
 class ElectrumX(network.Network):
-        pass
+    """ The ElectrumX class defines all ElectrumX specific API calls.
+
+    See https://electrumx.readthedocs.io/en/latest/protocol-basics.html
+    """
+
+    def request_header(self, interface, height):
+        self.queue_request('blockchain.block.get_header', [height], interface)
+        interface.request = height
+        interface.req_time = time.time()
+
+    def map_scripthash_to_address(self, callback):
+        def cb2(x):
+            x2 = x.copy()
+            p = x2.pop('params')
+            addr = self.h2addr[p[0]]
+            x2['params'] = [addr]
+            callback(x2)
+        return cb2
+
+    def subscribe_to_addresses(self, addresses, callback):
+        hash2address = {
+            bitcoin.address_to_scripthash(address): address
+            for address in addresses}
+        self.h2addr.update(hash2address)
+        msgs = [
+            ('blockchain.scripthash.subscribe', [x])
+            for x in hash2address.keys()]
+        self.send(msgs, self.map_scripthash_to_address(callback))
+
+    def request_address_history(self, address, callback):
+        h = bitcoin.address_to_scripthash(address)
+        self.h2addr.update({h: address})
+        self.send(
+            [('blockchain.scripthash.get_history', [h])],
+            self.map_scripthash_to_address(callback))
+
+    # NOTE this method handles exceptions and a special edge case, counter to
+    # what the other ElectrumX methods do. This is unexpected.
+    def broadcast_transaction(self, transaction, callback=None):
+        command = 'blockchain.transaction.broadcast'
+        invocation = lambda c: self.send([(command, [str(transaction)])], c)
+
+        if callback:
+            invocation(callback)
+
+        try:
+            out = ElectrumX.__wait_for(invocation)
+        except BaseException as e:
+            return False, "error: " + str(e)
+
+        if out != transaction.txid():
+            return False, "error: " + out
+
+        return True, out
+
+    def get_history_for_scripthash(self, hash, callback=None):
+        command = 'blockchain.scripthash.get_history'
+        invocation = lambda c: self.send([(command, [hash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def subscribe_to_headers(self, callback=None):
+        command = 'blockchain.headers.subscribe'
+        invocation = lambda c: self.send([(command, [])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def subscribe_to_address(self, address, callback=None):
+        command = 'blockchain.address.subscribe'
+        invocation = lambda c: self.send([(command, [address])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
+        command = 'blockchain.transaction.get_merkle'
+        invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def subscribe_to_scripthash(self, scripthash, callback=None):
+        command = 'blockchain.scripthash.subscribe'
+        invocation = lambda c: self.send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_transaction(self, transaction_hash, callback=None):
+        command = 'blockchain.transaction.get'
+        invocation = lambda c: self.send([(command, [transaction_hash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_transactions(self, transaction_hashes, callback=None):
+        command = 'blockchain.transaction.get'
+        messages = [(command, [tx_hash]) for tx_hash in transaction_hashes]
+        invocation = lambda c: self.send(messages, c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def listunspent_for_scripthash(self, scripthash, callback=None):
+        command = 'blockchain.scripthash.listunspent'
+        invocation = lambda c: self.send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_balance_for_scripthash(self, scripthash, callback=None):
+        command = 'blockchain.scripthash.get_balance'
+        invocation = lambda c: self.send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    @staticmethod
+    def __wait_for(it):
+        """Wait for the result of calling lambda `it`."""
+        q = queue.Queue()
+        it(q.put)
+        try:
+            result = q.get(block=True, timeout=30)
+        except queue.Empty:
+            raise util.TimeoutException(_('Server did not answer'))
+
+        if result.get('error'):
+            raise Exception(result.get('error'))
+
+        return result.get('result')
+
+    @staticmethod
+    def __with_default_synchronous_callback(invocation, callback):
+        """ Use this method if you want to make the network request
+        synchronous. """
+        if not callback:
+            return ElectrumX.__wait_for(invocation)
+
+        invocation(callback)

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -55,6 +55,7 @@ class ElectrumX(network.Network):
 
         if callback:
             invocation(callback)
+            return
 
         try:
             out = ElectrumX.__wait_for(invocation)

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -1,0 +1,4 @@
+from . import network
+
+class ElectrumX(network.Network):
+        pass

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -20,7 +20,7 @@ class ElectrumX(network.Network):
     # Deprecated in favor of headers
     def get_chunk(self, index, callback=None):
         command = 'blockchain.block.get_chunk'
-        invocation = lambda c: self.send([(command, [index])], c)
+        invocation = lambda c: self._send([(command, [index])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -28,7 +28,7 @@ class ElectrumX(network.Network):
 
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
-        self.queue_request('blockchain.block.get_header', [height], interface)
+        self._queue_request('blockchain.block.get_header', [height], interface)
         interface.request = height
         interface.req_time = time.time()
 
@@ -49,7 +49,7 @@ class ElectrumX(network.Network):
     def subscribe_to_scripthashes(self, hashes, callback):
         command = 'blockchain.scripthash.subscribe'
         messages = [(command, [hash_]) for hash_ in hashes]
-        invocation = lambda c: self.send(messages, c)
+        invocation = lambda c: self._send(messages, c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -74,7 +74,7 @@ class ElectrumX(network.Network):
     # what the other ElectrumX methods do. This is unexpected.
     def broadcast_transaction(self, transaction, callback=None):
         command = 'blockchain.transaction.broadcast'
-        invocation = lambda c: self.send([(command, [str(transaction)])], c)
+        invocation = lambda c: self._send([(command, [str(transaction)])], c)
 
         if callback:
             invocation(callback)
@@ -103,7 +103,7 @@ class ElectrumX(network.Network):
 
     def get_history_for_scripthash(self, hash, callback=None):
         command = 'blockchain.scripthash.get_history'
-        invocation = lambda c: self.send([(command, [hash])], c)
+        invocation = lambda c: self._send([(command, [hash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -111,7 +111,7 @@ class ElectrumX(network.Network):
 
     def headers(self, start_height, count, callback=None):
         command = 'blockchain.block.headers'
-        invocation = lambda c: self.send([(command, [start_height, count])], c)
+        invocation = lambda c: self._send([(command, [start_height, count])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -119,7 +119,7 @@ class ElectrumX(network.Network):
 
     def subscribe_to_headers(self, callback=None):
         command = 'blockchain.headers.subscribe'
-        invocation = lambda c: self.send([(command, [])], c)
+        invocation = lambda c: self._send([(command, [])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -127,7 +127,7 @@ class ElectrumX(network.Network):
 
     def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
         command = 'blockchain.transaction.get_merkle'
-        invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)
+        invocation = lambda c: self._send([(command, [tx_hash, tx_height])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -135,7 +135,7 @@ class ElectrumX(network.Network):
 
     def subscribe_to_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.subscribe'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
+        invocation = lambda c: self._send([(command, [scripthash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -143,7 +143,7 @@ class ElectrumX(network.Network):
 
     def get_transaction(self, transaction_hash, callback=None):
         command = 'blockchain.transaction.get'
-        invocation = lambda c: self.send([(command, [transaction_hash])], c)
+        invocation = lambda c: self._send([(command, [transaction_hash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -152,7 +152,7 @@ class ElectrumX(network.Network):
     def get_transactions(self, transaction_hashes, callback=None):
         command = 'blockchain.transaction.get'
         messages = [(command, [tx_hash]) for tx_hash in transaction_hashes]
-        invocation = lambda c: self.send(messages, c)
+        invocation = lambda c: self._send(messages, c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -160,7 +160,7 @@ class ElectrumX(network.Network):
 
     def listunspent_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.listunspent'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
+        invocation = lambda c: self._send([(command, [scripthash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -168,7 +168,15 @@ class ElectrumX(network.Network):
 
     def get_balance_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.get_balance'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
+        invocation = lambda c: self._send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def server_version(self, client_name, protocol_version, callback=None):
+        command = 'server.version'
+        invocation = lambda c: self._send([(command, [client_name, protocol_version])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -82,15 +82,6 @@ class ElectrumX(network.Network):
             invocation,
             callback)
 
-    # NOTE: Deprecated since ElectrumX 1.2. Use subscribe_to_scripthash.
-    def subscribe_to_address(self, address, callback=None):
-        command = 'blockchain.address.subscribe'
-        invocation = lambda c: self.send([(command, [address])], c)
-
-        return ElectrumX.__with_default_synchronous_callback(
-            invocation,
-            callback)
-
     def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
         command = 'blockchain.transaction.get_merkle'
         invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -17,15 +17,6 @@ class ElectrumX(network.Network):
 
         self.__hash2address = {}
 
-    # Deprecated in favor of headers
-    def get_chunk(self, index, callback=None):
-        command = 'blockchain.block.get_chunk'
-        invocation = lambda c: self._send([(command, [index])], c)
-
-        return ElectrumX.__with_default_synchronous_callback(
-            invocation,
-            callback)
-
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
         self._queue_request('blockchain.block.get_header', [height], interface)

--- a/lib/network.py
+++ b/lib/network.py
@@ -41,12 +41,10 @@ import socks
 from . import util
 from .util import print_error
 from . import bitcoin
-from .bitcoin import COIN
 from . import constants
 from .interface import Connection, Interface
 from . import blockchain
 from .version import ELECTRUM_VERSION, PROTOCOL_VERSION
-from .i18n import _
 
 
 NODES_RETRY_INTERVAL = 60
@@ -640,13 +638,13 @@ class Network(util.DaemonThread):
         elif method == 'blockchain.estimatefee':
             if error is None and result > 0:
                 i = params[0]
-                fee = int(result*COIN)
+                fee = int(result*bitcoin.COIN)
                 self.config.update_fee_estimates(i, fee)
                 self.print_error("fee_estimates[%d]" % i, fee)
                 self.notify('fee')
         elif method == 'blockchain.relayfee':
             if error is None:
-                self.relay_fee = int(result * COIN) if result is not None else None
+                self.relay_fee = int(result * bitcoin.COIN) if result is not None else None
                 self.print_error("relayfee", self.relay_fee)
         elif method == 'blockchain.block.headers':
             self.on_block_headers(interface, response)
@@ -1159,138 +1157,6 @@ class Network(util.DaemonThread):
 
     def get_local_height(self):
         return self.blockchain().height()
-
-    @staticmethod
-    def __wait_for(it):
-        """Wait for the result of calling lambda `it`."""
-        q = queue.Queue()
-        it(q.put)
-        try:
-            result = q.get(block=True, timeout=30)
-        except queue.Empty:
-            raise util.TimeoutException(_('Server did not answer'))
-
-        if result.get('error'):
-            raise Exception(result.get('error'))
-
-        return result.get('result')
-
-    @staticmethod
-    def __with_default_synchronous_callback(invocation, callback):
-        """ Use this method if you want to make the network request
-        synchronous. """
-        if not callback:
-            return Network.__wait_for(invocation)
-
-        invocation(callback)
-
-    def request_header(self, interface, height):
-        self.queue_request('blockchain.block.get_header', [height], interface)
-        interface.request = height
-        interface.req_time = time.time()
-
-    def map_scripthash_to_address(self, callback):
-        def cb2(x):
-            x2 = x.copy()
-            p = x2.pop('params')
-            addr = self.h2addr[p[0]]
-            x2['params'] = [addr]
-            callback(x2)
-        return cb2
-
-    def subscribe_to_addresses(self, addresses, callback):
-        hash2address = {
-            bitcoin.address_to_scripthash(address): address
-            for address in addresses}
-        self.h2addr.update(hash2address)
-        msgs = [
-            ('blockchain.scripthash.subscribe', [x])
-            for x in hash2address.keys()]
-        self.send(msgs, self.map_scripthash_to_address(callback))
-
-    def request_address_history(self, address, callback):
-        h = bitcoin.address_to_scripthash(address)
-        self.h2addr.update({h: address})
-        self.send([('blockchain.scripthash.get_history', [h])], self.map_scripthash_to_address(callback))
-
-    # NOTE this method handles exceptions and a special edge case, counter to
-    # what the other ElectrumX methods do. This is unexpected.
-    def broadcast_transaction(self, transaction, callback=None):
-        command = 'blockchain.transaction.broadcast'
-        invocation = lambda c: self.send([(command, [str(transaction)])], c)
-
-        if callback:
-            invocation(callback)
-            return
-
-        try:
-            out = Network.__wait_for(invocation)
-        except BaseException as e:
-            return False, "error: " + str(e)
-
-        if out != transaction.txid():
-            return False, "error: " + out
-
-        return True, out
-
-    def get_history_for_scripthash(self, hash, callback=None):
-        command = 'blockchain.scripthash.get_history'
-        invocation = lambda c: self.send([(command, [hash])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def subscribe_to_headers(self, callback=None):
-        command = 'blockchain.headers.subscribe'
-        invocation = lambda c: self.send([(command, [True])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def subscribe_to_address(self, address, callback=None):
-        command = 'blockchain.address.subscribe'
-        invocation = lambda c: self.send([(command, [address])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
-        command = 'blockchain.transaction.get_merkle'
-        invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def subscribe_to_scripthash(self, scripthash, callback=None):
-        command = 'blockchain.scripthash.subscribe'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def get_transaction(self, transaction_hash, callback=None):
-        command = 'blockchain.transaction.get'
-        invocation = lambda c: self.send([(command, [transaction_hash])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def get_transactions(self, transaction_hashes, callback=None):
-        command = 'blockchain.transaction.get'
-        messages = [(command, [tx_hash]) for tx_hash in transaction_hashes]
-        invocation = lambda c: self.send(messages, c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def listunspent_for_scripthash(self, scripthash, callback=None):
-        command = 'blockchain.scripthash.listunspent'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def get_balance_for_scripthash(self, scripthash, callback=None):
-        command = 'blockchain.scripthash.get_balance'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
-
-        return Network.__with_default_synchronous_callback(invocation, callback)
-
-    def history_for_scripthash(self, hash):
-        command = 'blockchain.scripthash.get_history'
-        return (command, [hash])
 
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints

--- a/lib/network.py
+++ b/lib/network.py
@@ -219,7 +219,7 @@ class Network(util.DaemonThread):
 
         # subscriptions and requests
         self.subscribed_addresses = set()  # note: needs self.subscribed_addresses_lock
-        self.h2addr = {}
+
         # Requests from client we've not seen a response to
         self.unanswered_requests = {}
         # retry times

--- a/lib/network.py
+++ b/lib/network.py
@@ -297,10 +297,6 @@ class Network(util.DaemonThread, triggers.Triggers):
     def is_connecting(self):
         return self.connection_status == 'connecting'
 
-    # TODO unused?
-    def is_up_to_date(self):
-        return self.unanswered_requests == {}
-
     @with_interface_lock
     def _queue_request(self, method, params, interface=None):
         # If you want to queue a request on any interface it must go

--- a/lib/network.py
+++ b/lib/network.py
@@ -1283,6 +1283,10 @@ class Network(util.DaemonThread):
 
         return Network.__with_default_synchronous_callback(invocation, callback)
 
+    def history_for_scripthash(self, hash):
+        command = 'blockchain.scripthash.get_history'
+        return (command, [hash])
+
     def export_checkpoints(self, path):
         # run manually from the console to generate checkpoints
         cp = self.blockchain().get_checkpoints()

--- a/lib/network.py
+++ b/lib/network.py
@@ -78,6 +78,7 @@ def parse_servers(result):
             servers[host] = out
     return servers
 
+
 def filter_version(servers):
     def is_recent(version):
         try:
@@ -87,7 +88,7 @@ def filter_version(servers):
     return {k: v for k, v in servers.items() if is_recent(v.get('version'))}
 
 
-def filter_protocol(hostmap, protocol = 's'):
+def filter_protocol(hostmap, protocol='s'):
     '''Filters the hostmap for those implementing protocol.
     The result is a list in serialized form.'''
     eligible = []
@@ -97,11 +98,13 @@ def filter_protocol(hostmap, protocol = 's'):
             eligible.append(serialize_server(host, port, protocol))
     return eligible
 
+
 def pick_random_server(hostmap = None, protocol = 's', exclude_set = set()):
     if hostmap is None:
         hostmap = constants.net.DEFAULT_SERVERS
     eligible = list(set(filter_protocol(hostmap, protocol)) - exclude_set)
     return random.choice(eligible) if eligible else None
+
 
 from .simple_config import SimpleConfig
 
@@ -201,7 +204,7 @@ class Network(util.DaemonThread):
         self.pending_sends = []
         self.message_id = 0
         self.debug = False
-        self.irc_servers = {} # returned by interface (list from irc)
+        self.irc_servers = {}  # returned by interface (list from irc)
         self.recent_servers = self.read_recent_servers()  # note: needs self.recent_servers_lock
 
         self.banner = ''
@@ -213,7 +216,7 @@ class Network(util.DaemonThread):
         # callbacks set by the GUI
         self.callbacks = defaultdict(list)      # note: needs self.callback_lock
 
-        dir_path = os.path.join( self.config.path, 'certs')
+        dir_path = os.path.join(self.config.path, 'certs')
         util.make_dir(dir_path)
 
         # subscriptions and requests
@@ -406,7 +409,7 @@ class Network(util.DaemonThread):
                 except:
                     continue
                 if host not in out:
-                    out[host] = { protocol:port }
+                    out[host] = {protocol: port}
         return out
 
     @with_interface_lock
@@ -416,7 +419,7 @@ class Network(util.DaemonThread):
                 self.print_error("connecting to %s as new interface" % server)
                 self.set_status('connecting')
             self.connecting.add(server)
-            c = Connection(server, self.socket_queue, self.config.path)
+            Connection(server, self.socket_queue, self.config.path)
 
     def start_random_interface(self):
         with self.interface_lock:
@@ -553,7 +556,7 @@ class Network(util.DaemonThread):
         if self.server_is_lagging() and self.auto_connect:
             # switch to one that has the correct header (not height)
             header = self.blockchain().read_header(self.get_local_height())
-            filtered = list(map(lambda x:x[0], filter(lambda x: x[1].tip_header==header, self.interfaces.items())))
+            filtered = list(map(lambda x: x[0], filter(lambda x: x[1].tip_header == header, self.interfaces.items())))
             if filtered:
                 choice = random.choice(filtered)
                 self.switch_to_interface(choice)
@@ -569,6 +572,7 @@ class Network(util.DaemonThread):
             self.interface = None
             self.start_interface(server)
             return
+
         i = self.interfaces[server]
         if self.interface != i:
             self.print_error("switching to", server)
@@ -798,6 +802,7 @@ class Network(util.DaemonThread):
             server, socket = self.socket_queue.get()
             if server in self.connecting:
                 self.connecting.remove(server)
+
             if socket:
                 self.new_interface(server, socket)
             else:

--- a/lib/network.py
+++ b/lib/network.py
@@ -586,7 +586,7 @@ class Network(util.DaemonThread, triggers.Triggers):
 
     def _process_response(self, interface, response, callbacks):
         if self.debug:
-            self.print_error("<--", response)
+            self.print_error(interface.host, "<--", response)
         error = response.get('error')
         result = response.get('result')
         method = response.get('method')
@@ -993,6 +993,7 @@ class Network(util.DaemonThread, triggers.Triggers):
             interface.mode = 'default'
             interface.request = None
             self._notify('updated')
+
         # refresh network dialog
         self._notify('interfaces')
 

--- a/lib/network.py
+++ b/lib/network.py
@@ -832,7 +832,8 @@ class Network(util.DaemonThread, triggers.Triggers):
             return
 
         self.requested_chunks.add(index)
-        self.headers(tx_height, 2016)
+        self._queue_request('blockchain.block.headers', [index * 2016, 2016],
+            self.interface)
 
     def _on_block_headers(self, interface, response):
         '''Handle receiving a batch of block headers'''
@@ -859,7 +860,7 @@ class Network(util.DaemonThread, triggers.Triggers):
             return
         # If not finished, get the next chunk
         if index >= len(blockchain.checkpoints) and blockchain.height() < interface.tip:
-            self.request_chunk(interface, index+1)
+            self.fetch_missing_headers_for(height + 2016)
         else:
             interface.mode = 'default'
             interface.print_error('catch up done', blockchain.height())

--- a/lib/network.py
+++ b/lib/network.py
@@ -44,6 +44,7 @@ from . import bitcoin
 from . import constants
 from .interface import Connection, Interface
 from . import blockchain
+from . import triggers
 from .version import ELECTRUM_VERSION, PROTOCOL_VERSION
 
 
@@ -155,7 +156,7 @@ def serialize_server(host, port, protocol):
     return str(':'.join([host, port, protocol]))
 
 
-class Network(util.DaemonThread):
+class Network(util.DaemonThread, triggers.Triggers):
     """The Network class manages a set of connections to remote electrum
     servers, each connected socket is handled by an Interface() object.
     Connections are initiated by a Connection() thread which stops once
@@ -172,6 +173,7 @@ class Network(util.DaemonThread):
         if config is None:
             config = {}  # Do not use mutables as default values!
         util.DaemonThread.__init__(self)
+        triggers.Triggers.__init__(self)
         self.config = SimpleConfig(config) if isinstance(config, dict) else config
         self.num_server = 10 if not self.config.get('oneserver') else 0
         self.blockchains = blockchain.read_blockchains(self.config)  # note: needs self.blockchains_lock
@@ -211,8 +213,6 @@ class Network(util.DaemonThread):
         # callbacks passed with subscriptions
         self.subscriptions = defaultdict(list)  # note: needs self.callback_lock
         self.sub_cache = {}                     # note: needs self.interface_lock
-        # callbacks set by the GUI
-        self.callbacks = defaultdict(list)      # note: needs self.callback_lock
 
         dir_path = os.path.join(self.config.path, 'certs')
         util.make_dir(dir_path)
@@ -248,22 +248,6 @@ class Network(util.DaemonThread):
             with self.recent_servers_lock:
                 return func(self, *args, **kwargs)
         return func_wrapper
-
-    def register_callback(self, callback, events):
-        with self.callback_lock:
-            for event in events:
-                self.callbacks[event].append(callback)
-
-    def unregister_callback(self, callback):
-        with self.callback_lock:
-            for callbacks in self.callbacks.values():
-                if callback in callbacks:
-                    callbacks.remove(callback)
-
-    def trigger_callback(self, event, *args):
-        with self.callback_lock:
-            callbacks = self.callbacks[event][:]
-        [callback(event, *args) for callback in callbacks]
 
     def read_recent_servers(self):
         if not self.config.path:

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -99,7 +99,7 @@ class Synchronizer(ThreadJob):
             # there is no history
             if addr not in self.requested_histories:
                 self.requested_histories[addr] = result
-                self.network.request_address_history(addr, self.on_address_history)
+                self.network.get_history_for_address(addr, self.on_address_history)
         # remove addr from list only after it is added to requested_histories
         if addr in self.requested_addrs:  # Notifications won't be in
             self.requested_addrs.remove(addr)

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -124,6 +124,10 @@ class Synchronizer(ThreadJob):
         # tx_fees
         tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
         tx_fees = dict(filter(lambda x:x[1] is not None, tx_fees))
+
+        # Note if the server hasn't been patched to sort the items properly
+        if hist != sorted(hist, key=lambda x:x[1]):
+            self.print_error("error: serving improperly sorted address histories")
         # Check that txids are unique
         if len(hashes) != len(result):
             self.print_error("error: server history has non-unique txids: %s"% addr)

--- a/lib/triggers.py
+++ b/lib/triggers.py
@@ -1,0 +1,29 @@
+""" This module allows for the registration of callbacks.
+Allowing interested objects to be notified of certain events.
+"""
+
+from collections import defaultdict
+import threading
+
+
+class Triggers:
+    def __init__(self):
+        # callbacks set by the GUI
+        self.callbacks = defaultdict(list)
+        self.trigger_lock = threading.Lock()
+
+    def register_callback(self, callback, events):
+        with self.trigger_lock:
+            for event in events:
+                self.callbacks[event].append(callback)
+
+    def unregister_callback(self, callback):
+        with self.trigger_lock:
+            for callbacks in self.callbacks.values():
+                if callback in callbacks:
+                    callbacks.remove(callback)
+
+    def trigger_callback(self, event, *args):
+        with self.trigger_lock:
+            callbacks = self.callbacks[event][:]
+        [callback(event, *args) for callback in callbacks]

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -52,7 +52,11 @@ class SPV(ThreadJob):
 
             header = blockchain.read_header(tx_height)
             if header is None:
-                if not blockchain.is_after_last_checkpoint(tx_height):
+                # Retreive headers when the transaction height is before the
+                # last checkpoint. As a rule we don't fetch headers before
+                # checkpoints as we assume the chain is correct up until that
+                # point.
+                if blockchain.is_before_last_checkpoint(tx_height):
                     self.network.fetch_missing_headers_for(tx_height)
             elif (tx_hash not in self.requested_merkle
                     and tx_hash not in self.merkle_roots):

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -50,7 +50,7 @@ class SPV(ThreadJob):
         unverified = self.wallet.get_unverified_txs()
         for tx_hash, tx_height in unverified.items():
             # do not request merkle branch before headers are available
-            if tx_height == 0 or tx_height > local_height:
+            if tx_height <= 0 or tx_height > local_height:
                 continue
 
             header = blockchain.read_header(tx_height)

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -60,7 +60,7 @@ class SPV(ThreadJob):
                 # checkpoints as we assume the chain is correct up until that
                 # point.
                 if blockchain.is_before_last_checkpoint(tx_height):
-                    self.network.fetch_missing_headers_for(tx_height)
+                    self.network.fetch_missing_headers_around(tx_height)
             elif (tx_hash not in self.requested_merkle
                     and tx_hash not in self.merkle_roots):
                 self.network.get_merkle_for_transaction(

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -42,29 +42,31 @@ class SPV(ThreadJob):
         interface = self.network.interface
         if not interface:
             return
+
         blockchain = interface.blockchain
         if not blockchain:
             return
-        lh = self.network.get_local_height()
+
+        local_height = self.network.get_local_height()
         unverified = self.wallet.get_unverified_txs()
         for tx_hash, tx_height in unverified.items():
             # do not request merkle branch before headers are available
-            if (tx_height > 0) and (tx_height <= lh):
-                header = blockchain.read_header(tx_height)
-                if header is None:
-                    index = tx_height // 2016
-                    if index < len(blockchain.checkpoints):
-                        self.network.request_chunk(interface, index)
-                else:
-                    if (tx_hash not in self.requested_merkle
-                            and tx_hash not in self.merkle_roots):
+            if tx_height == 0 or tx_height > local_height:
+                continue
 
-                        self.network.get_merkle_for_transaction(
-                                tx_hash,
-                                tx_height,
-                                self.verify_merkle)
-                        self.print_error('requested merkle', tx_hash)
-                        self.requested_merkle.add(tx_hash)
+            header = blockchain.read_header(tx_height)
+            if header is None:
+                index = tx_height // 2016
+                if index < len(blockchain.checkpoints):
+                    self.network.request_chunk(interface, index)
+            elif (tx_hash not in self.requested_merkle
+                    and tx_hash not in self.merkle_roots):
+                self.network.get_merkle_for_transaction(
+                        tx_hash,
+                        tx_height,
+                        self.verify_merkle)
+                self.print_error('requested merkle', tx_hash)
+                self.requested_merkle.add(tx_hash)
 
         if self.network.blockchain() != self.blockchain:
             self.blockchain = self.network.blockchain()

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -39,6 +39,9 @@ class SPV(ThreadJob):
         self.requested_merkle = set()  # txid set of pending requests
 
     def run(self):
+        if not self.network.is_connected():
+            return
+
         blockchain = self.network.blockchain()
         if not blockchain:
             return

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -72,14 +72,14 @@ class SPV(ThreadJob):
             self.blockchain = self.network.blockchain()
             self.undo_verifications()
 
-    def verify_merkle(self, r):
+    def verify_merkle(self, response):
         if self.wallet.verifier is None:
             return  # we have been killed, this was just an orphan callback
-        if r.get('error'):
-            self.print_error('received an error:', r)
+        if response.get('error'):
+            self.print_error('received an error:', response)
             return
-        params = r['params']
-        merkle = r['result']
+        params = response['params']
+        merkle = response['result']
         # Verify the hash of the server-provided merkle branch to a
         # transaction matches the merkle root of its block
         tx_hash = params[0]

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -218,10 +218,7 @@ class Abstract_Wallet(PrintError):
         self.load_unverified_transactions()
         self.remove_local_transactions_we_dont_have()
 
-        # There is a difference between wallet.up_to_date and network.is_up_to_date().
-        # network.is_up_to_date() returns true when all requests have been answered and processed
-        # wallet.up_to_date is true when the wallet is synchronized (stronger requirement)
-        # Neither of them considers the verifier.
+        # wallet.up_to_date is true when the wallet is synchronized
         self.up_to_date = False
 
         # save wallet type the first time

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -36,6 +36,7 @@ except ImportError:
 from . import util
 from . import bitcoin
 
+
 request_queue = queue.Queue()
 
 
@@ -74,7 +75,7 @@ class WsClientThread(util.DaemonThread):
         addr = d.get('address')
         amount = d.get('amount')
         scripthash = bitcoin.address_to_scripthash(addr)
-        hash2address[scripthash] = address
+        self.hash2address[scripthash] = addr
         return scripthash, amount
 
     def reading_thread(self):

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -23,7 +23,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import queue
-import threading, os, json
+import threading
+import os
+import json
 from collections import defaultdict
 try:
     from SimpleWebSocketServer import WebSocket, SimpleSSLWebSocketServer
@@ -35,6 +37,7 @@ from . import util
 from . import bitcoin
 
 request_queue = queue.Queue()
+
 
 class ElectrumWebSocket(WebSocket):
 
@@ -51,7 +54,6 @@ class ElectrumWebSocket(WebSocket):
         util.print_error("closed", self.address)
 
 
-
 class WsClientThread(util.DaemonThread):
 
     def __init__(self, config, network):
@@ -60,6 +62,7 @@ class WsClientThread(util.DaemonThread):
         self.config = config
         self.response_queue = queue.Queue()
         self.subscriptions = defaultdict(list)
+        self.hash2address = {}
 
     def make_request(self, request_id):
         # read json file
@@ -70,7 +73,9 @@ class WsClientThread(util.DaemonThread):
         d = json.loads(s)
         addr = d.get('address')
         amount = d.get('amount')
-        return addr, amount
+        scripthash = bitcoin.address_to_scripthash(addr)
+        hash2address[scripthash] = address
+        return scripthash, amount
 
     def reading_thread(self):
         while self.is_running():
@@ -78,14 +83,17 @@ class WsClientThread(util.DaemonThread):
                 ws, request_id = request_queue.get()
             except queue.Empty:
                 continue
+
             try:
-                addr, amount = self.make_request(request_id)
-            except:
+                scripthash, amount = self.make_request(request_id)
+            except OSError:
                 continue
-            l = self.subscriptions.get(addr, [])
-            l.append((ws, amount))
-            self.subscriptions[addr] = l
-            self.network.subscribe_to_addresses([addr], self.response_queue.put)
+            except json.JSONDecodeError:
+                continue
+            subscription = self.subscriptions.get(scripthash, [])
+            subscription.append((ws, amount))
+            self.subscriptions[scripthash] = subscription
+            self.network.subscribe_to_scripthash(scripthash, self.response_queue.put)
 
     def run(self):
         threading.Thread(target=self.reading_thread).start()
@@ -98,7 +106,7 @@ class WsClientThread(util.DaemonThread):
             method = r.get('method')
             result = r.get('result')
             if result is None:
-                continue    
+                continue
             if method == 'blockchain.scripthash.subscribe':
                 addr = r.get('params')[0]
                 scripthash = bitcoin.address_to_scripthash(addr)
@@ -106,16 +114,16 @@ class WsClientThread(util.DaemonThread):
                         scripthash, self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
                 scripthash = r.get('params')[0]
-                addr = self.network.h2addr.get(scripthash, None)
+                addr = self.hash2address.get(scripthash, None)
                 if addr is None:
                     util.print_error(
                         "can't find address for scripthash: %s" % scripthash)
-                l = self.subscriptions.get(addr, [])
-                for ws, amount in l:
-                    if not ws.closed:
-                        if sum(result.values()) >=amount:
-                            ws.sendMessage('paid')
 
+                subscription = self.subscriptions.get(scripthash, [])
+                for ws, amount in subscription:
+                    if not ws.closed:
+                        if sum(result.values()) >= amount:
+                            ws.sendMessage('paid')
 
 
 class WebSocketServer(threading.Thread):

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -21,7 +21,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([('server.version',["block_headers script", "1.2"])], callback)
+network.server_version("block_headers script", "1.2", callback)
 network.subscribe_to_headers(callback)
 
 # 3. wait for results

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -8,7 +8,7 @@ from electrum.util import print_msg, json_encode
 
 # start network
 c = SimpleConfig()
-network = Network(c)
+network = ElectrumX(c)
 network.start()
 
 # wait until connected

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -15,4 +15,5 @@ n = Network()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
 h = n.get_history_for_scripthash(_hash)
+
 print_msg(json_encode(h))

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -11,7 +11,7 @@ except Exception:
     print("usage: get_history <bitcoin_address>")
     sys.exit(1)
 
-n = Network()
+n = ElectrumX()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
 h = n.get_history_for_scripthash(_hash)

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -12,8 +12,6 @@ except Exception:
     print("usage: watch_address <bitcoin_address>")
     sys.exit(1)
 
-sh = bitcoin.address_to_scripthash(addr)
-
 # start network
 c = SimpleConfig()
 network = ElectrumX(c)

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -27,9 +27,13 @@ if not network.is_connected():
     print_msg("daemon is not connected")
     sys.exit(1)
 
+# 1. translate the Bitcoin address to a scripthash
+scripthash = bitcoin.address_to_scripthash(addr)
+print_msg("Address '{}' becomes scripthash '{}'".format(addr, scripthash))
+
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.subscribe_to_address(addr, callback)
+network.subscribe_to_scripthash(scripthash, callback)
 
 # 3. wait for results
 while network.is_connected():

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -16,7 +16,7 @@ sh = bitcoin.address_to_scripthash(addr)
 
 # start network
 c = SimpleConfig()
-network = Network(c)
+network = ElectrumX(c)
 network.start()
 
 # wait until connected


### PR DESCRIPTION
This pull request further clarifies the network module API.

A couple of major things have happened here (non of which impacts functionality):
- A class Triggers is defined and used as a mixin in the network module. This class deals with GUI notifications.
- A class ElectrumX is defined and used *instead of* the Network class. This class holds (almost) all the previously defined ElectrumX specific API calls. The methods therein are just copied over from the Network class.
- All of the helper methods in the Network class have been prefixed with an underscore as to communicate their private nature.

I would understand if these changes are considered controversial. Read with care.