### PR TITLE
Added a meaningful message on invalid public key

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2248,7 +2248,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             encrypted_e.setText(encrypted.decode('ascii'))
         except BaseException as e:
             traceback.print_exc(file=sys.stdout)
-            self.show_warning(str(e))
+            self.show_warning("Invalid Public key")
 
     def encrypt_message(self, address=''):
         d = WindowModalDialog(self, _('Encrypt/decrypt Message'))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2244,11 +2244,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         message = message.encode('utf-8')
         try:
             public_key = ecc.ECPubkey(bfh(pubkey_e.text()))
-            encrypted = public_key.encrypt_message(message)
-            encrypted_e.setText(encrypted.decode('ascii'))
         except BaseException as e:
-            traceback.print_exc(file=sys.stdout)
-            self.show_warning("Invalid Public key")
+            traceback.print_exc(file=sys.stdout)            
+            self.show_warning(_('Invalid Public key')) 
+            return
+        encrypted = public_key.encrypt_message(message)
+        encrypted_e.setText(encrypted.decode('ascii'))
 
     def encrypt_message(self, address=''):
         d = WindowModalDialog(self, _('Encrypt/decrypt Message'))


### PR DESCRIPTION
Error message is not in understandable format on entering a invalid/blank public key in Encrypt/decrypt window. Please refer the bug [#64](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/64) for description/steps