### PR TITLE
Empty Message Field validation added in Sign/Verify

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2143,6 +2143,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def do_sign(self, address, message, signature, password):
         address  = address.text().strip()
         message = message.toPlainText().strip()
+        if message=='':
+          self.show_message(_("Please enter Message"))
+          return
         if not bitcoin.is_address(address):
             self.show_message(_('Invalid Bitcoin address.'))
             return


### PR DESCRIPTION
Signature gets generated with Blank Message field in sign/verify window. Please see the bug [#60](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/60) for steps