### PR TITLE
Removed the Max button disable code in reset_max

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1206,7 +1206,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def reset_max(t):
             self.is_max = False
-            self.max_button.setEnabled(not bool(t))
         self.amount_e.textEdited.connect(reset_max)
         self.fiat_send_e.textEdited.connect(reset_max)
 


### PR DESCRIPTION
Max button gets disabled on editing the requested amount code. Please refer the bug [#40](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/40)