### PR TITLE
wizard: script type dialog

### DIFF
--- a/gui/kivy/uix/dialogs/installwizard.py
+++ b/gui/kivy/uix/dialogs/installwizard.py
@@ -720,7 +720,7 @@ class LineDialog(WizardDialog):
         self.ids.next.disabled = False
 
     def get_params(self, b):
-        return (self.ids.passphrase_input.text,)
+        return (self.ids.passphrase_input.text, {})
 
 class ShowSeedDialog(WizardDialog):
     seed_text = StringProperty('')

--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -507,9 +507,30 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         self.exec_layout(vbox, '')
         return clayout.selected_index()
 
+    def _create_options_button_and_functionality(self, options, selected_options):
+        for option_name, option_text in options:
+            selected_options[option_name] = False
+
+        def show_options():
+            dialog = QDialog()
+            vbox = QVBoxLayout(dialog)
+            for option_name, option_text in options:
+                cb = QCheckBox(option_text)
+                cb.setChecked(selected_options[option_name])
+                def on_toggle(b):
+                    selected_options[option_name] = b
+                cb.toggled.connect(on_toggle)
+                vbox.addWidget(cb)
+            vbox.addLayout(Buttons(OkButton(dialog)))
+            if not dialog.exec_():
+                return None
+        opt_button = EnterButton(_('Options'), show_options)
+        opt_button.setMaximumWidth(100)
+        return opt_button
+
     @wizard_dialog
     def line_dialog(self, run_next, title, message, default, test, warning='',
-                    presets=()):
+                    presets=(), options=()):
         vbox = QVBoxLayout()
         vbox.addWidget(WWLabel(message))
         line = QLineEdit()
@@ -518,18 +539,26 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
             self.next_button.setEnabled(test(text))
         line.textEdited.connect(f)
         vbox.addWidget(line)
+
+        selected_options = {}
+        if options:
+            opt_button = self._create_options_button_and_functionality(options, selected_options)
+            hbox = QHBoxLayout()
+            hbox.addWidget(opt_button, alignment=Qt.AlignRight)
+            vbox.addLayout(hbox)
+
         vbox.addWidget(WWLabel(warning))
 
         for preset in presets:
             button = QPushButton(preset[0])
             button.clicked.connect(lambda __, text=preset[1]: line.setText(text))
-            button.setMaximumWidth(150)
+            button.setMinimumWidth(150)
             hbox = QHBoxLayout()
-            hbox.addWidget(button, Qt.AlignCenter)
+            hbox.addWidget(button, alignment=Qt.AlignCenter)
             vbox.addLayout(hbox)
 
         self.exec_layout(vbox, title, next_enabled=test(default))
-        return ' '.join(line.text().split())
+        return ' '.join(line.text().split()), selected_options
 
     @wizard_dialog
     def show_xpub_dialog(self, xpub, run_next):

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -279,8 +279,9 @@ class BaseWizard(object):
             self.choose_hw_device(purpose)
             return
         if purpose == HWD_SETUP_NEW_WALLET:
-            f = lambda x: self.run('on_hw_derivation', name, device_info, str(x))
-            self.derivation_dialog(f)
+            def f(derivation, script_type):
+                self.run('on_hw_derivation', name, device_info, derivation, script_type)
+            self.derivation_and_script_type_dialogs(f)
         elif purpose == HWD_SETUP_DECRYPT_WALLET:
             derivation = get_derivation_used_for_hw_device_encryption()
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, 'standard', self)
@@ -296,6 +297,22 @@ class BaseWizard(object):
                 raise
         else:
             raise Exception('unknown purpose: %s' % purpose)
+
+    def derivation_and_script_type_dialogs(self, f):
+        derivation = None
+
+        def after_derivation(der, options):
+            nonlocal derivation
+            derivation = str(der)
+            if options.get('script_type'):
+                self.script_type_dialog(after_script_type)
+            else:
+                after_script_type(None)
+
+        def after_script_type(script_type):
+            f(derivation, script_type)
+
+        self.derivation_dialog(after_derivation)
 
     def derivation_dialog(self, f):
         message = '\n'.join([
@@ -316,19 +333,48 @@ class BaseWizard(object):
                 ('p2sh-segwit BIP49', bip44_derivation(0, bip43_purpose=49)),
                 ('native-segwit BIP84', bip44_derivation(0, bip43_purpose=84)),
             )
+        options = (
+            ('script_type', _('Customize script type')),
+        )
         while True:
             try:
                 self.line_dialog(run_next=f, title=_('Derivation'), message=message,
                                  default=default, test=bitcoin.is_bip32_derivation,
-                                 presets=presets)
+                                 presets=presets, options=options)
                 return
             except ScriptTypeNotSupported as e:
                 self.show_error(e)
                 # let the user choose again
 
-    def on_hw_derivation(self, name, device_info, derivation):
+    def script_type_dialog(self, f):
+        title = _('Script type')
+        message = (_('Choose the type of script to be derived for the addresses in your wallet.') + ' ' +
+                   _('This will override the default that would be inferred from the '
+                     'derivation path.') + '\n' +
+                   _('Warning: customizing the script type is an advanced option, '
+                     'and should only be done if you know what you are doing!'))
+        if self.wallet_type == 'multisig':
+            choices = [
+                (None,          _("I don't know.")),
+                ('standard',    'legacy multisig (p2sh)'),
+                ('p2wsh-p2sh',  'p2sh-segwit multisig (p2wsh-p2sh'),
+                ('p2wsh',       'native segwit multisig (p2wsh)'),
+            ]
+        else:
+            choices = [
+                (None,          _("I don't know.")),
+                ('standard',    'legacy (p2pkh)'),
+                ('p2wpkh-p2sh', 'p2sh-segwit (p2wpkh-p2sh)'),
+                ('p2wpkh',      'native segwit (p2wpkh)'),
+            ]
+        self.choice_dialog(title=title, message=message, choices=choices, run_next=f)
+
+    def on_hw_derivation(self, name, device_info, derivation, script_type):
         from .keystore import hardware_keystore
-        xtype = keystore.xtype_from_derivation(derivation)
+        if script_type:
+            xtype = script_type
+        else:
+            xtype = keystore.xtype_from_derivation(derivation)
         try:
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, xtype, self)
         except ScriptTypeNotSupported:
@@ -356,7 +402,8 @@ class BaseWizard(object):
             _('Note that this is NOT your encryption password.'),
             _('If you do not know what this is, leave this field empty.'),
         ])
-        self.line_dialog(title=title, message=message, warning=warning, default='', test=lambda x:True, run_next=run_next)
+        f = lambda text, opt: run_next(text)
+        self.line_dialog(title=title, message=message, warning=warning, default='', test=lambda x:True, run_next=f)
 
     def restore_from_seed(self):
         self.opt_bip39 = True
@@ -382,15 +429,16 @@ class BaseWizard(object):
             raise Exception('Unknown seed type', self.seed_type)
 
     def on_restore_bip39(self, seed, passphrase):
-        f = lambda x: self.run('on_bip43', seed, passphrase, str(x))
-        self.derivation_dialog(f)
+        def f(derivation, script_type):
+            self.run('on_bip43', seed, passphrase, derivation, script_type)
+        self.derivation_and_script_type_dialogs(f)
 
     def create_keystore(self, seed, passphrase):
         k = keystore.from_seed(seed, passphrase, self.wallet_type == 'multisig')
         self.on_keystore(k)
 
-    def on_bip43(self, seed, passphrase, derivation):
-        k = keystore.from_bip39_seed(seed, passphrase, derivation)
+    def on_bip43(self, seed, passphrase, derivation, script_type):
+        k = keystore.from_bip39_seed(seed, passphrase, derivation, xtype=script_type)
         self.on_keystore(k)
 
     def on_keystore(self, k):
@@ -534,7 +582,7 @@ class BaseWizard(object):
         self.confirm_seed_dialog(run_next=f, test=lambda x: x==seed)
 
     def confirm_passphrase(self, seed, passphrase):
-        f = lambda x: self.run('create_keystore', seed, x)
+        f = lambda text, opt: self.run('create_keystore', seed, text)
         if passphrase:
             title = _('Confirm Seed Extension')
             message = '\n'.join([
@@ -543,7 +591,7 @@ class BaseWizard(object):
             ])
             self.line_dialog(run_next=f, title=title, message=message, default='', test=lambda x: x==passphrase)
         else:
-            f('')
+            f('', None)
 
     def create_addresses(self):
         def task():

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -279,13 +279,8 @@ class BaseWizard(object):
             self.choose_hw_device(purpose)
             return
         if purpose == HWD_SETUP_NEW_WALLET:
-            if self.wallet_type=='multisig':
-                # There is no general standard for HD multisig.
-                # This is partially compatible with BIP45; assumes index=0
-                self.on_hw_derivation(name, device_info, "m/45'/0")
-            else:
-                f = lambda x: self.run('on_hw_derivation', name, device_info, str(x))
-                self.derivation_dialog(f)
+            f = lambda x: self.run('on_hw_derivation', name, device_info, str(x))
+            self.derivation_dialog(f)
         elif purpose == HWD_SETUP_DECRYPT_WALLET:
             derivation = get_derivation_used_for_hw_device_encryption()
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, 'standard', self)
@@ -303,16 +298,24 @@ class BaseWizard(object):
             raise Exception('unknown purpose: %s' % purpose)
 
     def derivation_dialog(self, f):
-        default = bip44_derivation(0, bip43_purpose=44)
         message = '\n'.join([
             _('Enter your wallet derivation here.'),
             _('If you are not sure what this is, leave this field unchanged.')
         ])
-        presets = (
-            ('legacy BIP44', bip44_derivation(0, bip43_purpose=44)),
-            ('p2sh-segwit BIP49', bip44_derivation(0, bip43_purpose=49)),
-            ('native-segwit BIP84', bip44_derivation(0, bip43_purpose=84)),
-        )
+        if self.wallet_type == 'multisig':
+            # There is no general standard for HD multisig.
+            # This is partially compatible with BIP45; assumes index=0
+            default = "m/45'/0"
+            presets = (
+                #('legacy BIP45', "m/45'/0"),
+            )
+        else:
+            default = bip44_derivation(0, bip43_purpose=44)
+            presets = (
+                ('legacy BIP44', bip44_derivation(0, bip43_purpose=44)),
+                ('p2sh-segwit BIP49', bip44_derivation(0, bip43_purpose=49)),
+                ('native-segwit BIP84', bip44_derivation(0, bip43_purpose=84)),
+            )
         while True:
             try:
                 self.line_dialog(run_next=f, title=_('Derivation'), message=message,


### PR DESCRIPTION
Allow advanced users to specify the script type independently of the derivation path for bip39/hw wallets.
Also, show the derivation dialog for multisig wallets too; and offer the same advanced script type option.

![wizard_script_type_dialog1](https://user-images.githubusercontent.com/29142493/41514237-ab4306e0-72a5-11e8-8fee-b68ce29070c6.png)
![wizard_script_type_dialog2](https://user-images.githubusercontent.com/29142493/41514238-abd3516e-72a5-11e8-89c9-bbac7a1a3b52.png)
![wizard_script_type_dialog3](https://user-images.githubusercontent.com/29142493/41514300-fdb8471e-72a5-11e8-81a6-6c0c33477324.png)
