### PR TITLE
android: disable backups

### DIFF
--- a/gui/kivy/Readme.md
+++ b/gui/kivy/Readme.md
@@ -33,9 +33,11 @@ cd /opt
 git clone https://github.com/kivy/python-for-android
 cd python-for-android
 git remote add agilewalker https://github.com/agilewalker/python-for-android
+git remote add sombernight https://github.com/SomberNight/python-for-android
 git fetch --all
 git checkout 93759f36ba45c7bbe0456a4b3e6788622924cbac
-git merge a2fb5ecbc09c4847adbcfd03c6b1ca62b3d09b8d
+git cherry-pick a2fb5ecbc09c4847adbcfd03c6b1ca62b3d09b8d  # openssl-fix
+git cherry-pick a0ef2007bc60ed642fbd8b61937995dbed0ddd24  # disable backups
 ```
 
 ## 4. Install buildozer


### PR DESCRIPTION
Add instruction to readme to manually cherry-pick https://github.com/SomberNight/python-for-android/commit/a0ef2007bc60ed642fbd8b61937995dbed0ddd24
The referenced commit disables backups, which means
- [manual adb backups](https://gist.github.com/SomberNight/295cd950ee4fb2b3768f1ae538babe7e) will not be possible
- google automatic cloud backups will not be made of the app's data

The second point is the main concern of course.
Apps need to opt-out of automatic backups, and we had not been doing that.
Luckily, we target API level 19 (4.4), which is lower than the "participation threshold" but I actually could not find during a casual search where this value is specified (I believe it is a default somewhere in python-for-android), so we should not rely on this.

https://developer.android.com/guide/topics/data/autobackup#EnablingAutoBackup
> Apps that target Android 6.0 (API level 23) or higher automatically participate in Auto Backup. In your app manifest file, set the boolean value android:allowBackup to enable or disable backup. The default value is true
