### PR TITLE
kivy: use RecycleView in history

### DIFF
--- a/gui/kivy/uix/screens.py
+++ b/gui/kivy/uix/screens.py
@@ -11,6 +11,7 @@ from kivy.compat import string_types
 from kivy.properties import (ObjectProperty, DictProperty, NumericProperty,
                              ListProperty, StringProperty)
 
+from kivy.uix.recycleview import RecycleView
 from kivy.uix.label import Label
 
 from kivy.lang import Builder
@@ -28,6 +29,8 @@ from .context_menu import ContextMenu
 
 from electrum_gui.kivy.i18n import _
 
+class HistoryRecycleView(RecycleView):
+    pass
 
 class CScreen(Factory.Screen):
     __events__ = ('on_activate', 'on_deactivate', 'on_enter', 'on_leave')
@@ -132,25 +135,22 @@ class HistoryScreen(CScreen):
         status, status_str = self.app.wallet.get_tx_status(tx_hash, height, conf, timestamp)
         icon = "atlas://gui/kivy/theming/light/" + TX_ICONS[status]
         label = self.app.wallet.get_label(tx_hash) if tx_hash else _('Pruned transaction outputs')
-        ri = self.cards.get(tx_hash)
-        if ri is None:
-            ri = Factory.HistoryItem()
-            ri.screen = self
-            ri.tx_hash = tx_hash
-            self.cards[tx_hash] = ri
-        ri.icon = icon
-        ri.date = status_str
-        ri.message = label
-        ri.confirmations = conf
+        ri = {}
+        ri['screen'] = self
+        ri['tx_hash'] = tx_hash
+        ri['icon'] = icon
+        ri['date'] = status_str
+        ri['message'] = label
+        ri['confirmations'] = conf
         if value is not None:
-            ri.is_mine = value < 0
+            ri['is_mine'] = value < 0
             if value < 0: value = - value
-            ri.amount = self.app.format_amount_and_units(value)
+            ri['amount'] = self.app.format_amount_and_units(value)
             if self.app.fiat_unit:
                 fx = self.app.fx
                 fiat_value = value / Decimal(bitcoin.COIN) * self.app.wallet.price_at_timestamp(tx_hash, fx.timestamp_rate)
                 fiat_value = Fiat(fiat_value, fx.ccy)
-                ri.quote_text = str(fiat_value)
+                ri['quote_text'] = str(fiat_value)
         return ri
 
     def update(self, see_all=False):
@@ -158,11 +158,8 @@ class HistoryScreen(CScreen):
             return
         history = reversed(self.app.wallet.get_history())
         history_card = self.screen.ids.history_container
-        history_card.clear_widgets()
         count = 0
-        for item in history:
-            ri = self.get_card(*item)
-            history_card.add_widget(ri)
+        history_card.data = [self.get_card(*item) for item in history]
 
 
 class SendScreen(CScreen):

--- a/gui/kivy/uix/ui_screens/history.kv
+++ b/gui/kivy/uix/ui_screens/history.kv
@@ -48,11 +48,19 @@
             text: root.date + '   ' + root.message
         Widget
 
+<HistoryRecycleView>:
+    viewclass: 'HistoryItem'
+    RecycleBoxLayout:
+        default_size: None, dp(56)
+        default_size_hint: 1, None
+        size_hint: 1, None
+        height: self.minimum_height
+        orientation: 'vertical'
 
 
 HistoryScreen:
     name: 'history'
-    content: content
+    content: history_container
     BoxLayout:
         orientation: 'vertical'
         Button:
@@ -64,14 +72,7 @@ HistoryScreen:
             bold: True
             size_hint: 1, 0.25
             on_release: app.is_fiat = not app.is_fiat if app.fx.is_enabled() else False
-        ScrollView:
-            id: content
-            do_scroll_x: False
-            size_hint: 1, 0.75
+        HistoryRecycleView:
+            id: history_container
             scroll_type: ['bars', 'content']
             bar_width: 15
-            GridLayout
-                id: history_container
-                cols: 1
-                size_hint: 1, None
-                height: self.minimum_height


### PR DESCRIPTION
The reduces memory consumption a lot. One wallet's RES memory usage went from 218 MB to 123 MB. The wallet is actually rather small, some wallets can't even be opened without this patch.