### PR TITLE
trezor: drop list of supported coins

### DIFF
--- a/plugins/trezor/qt.py
+++ b/plugins/trezor/qt.py
@@ -345,7 +345,6 @@ class SettingsDialog(WindowModalDialog):
             version = "%d.%d.%d" % (features.major_version,
                                     features.minor_version,
                                     features.patch_version)
-            coins = ", ".join(coin.coin_name for coin in features.coins)
 
             device_label.setText(features.label)
             pin_set_label.setText(noyes[features.pin_protection])
@@ -355,7 +354,6 @@ class SettingsDialog(WindowModalDialog):
             device_id_label.setText(features.device_id)
             initialized_label.setText(noyes[features.initialized])
             version_label.setText(version)
-            coins_label.setText(coins)
             clear_pin_button.setVisible(features.pin_protection)
             clear_pin_warning.setVisible(features.pin_protection)
             pin_button.setText(setchange[features.pin_protection])
@@ -456,8 +454,6 @@ class SettingsDialog(WindowModalDialog):
         device_id_label = QLabel()
         bl_hash_label = QLabel()
         bl_hash_label.setWordWrap(True)
-        coins_label = QLabel()
-        coins_label.setWordWrap(True)
         language_label = QLabel()
         initialized_label = QLabel()
         rows = [
@@ -467,7 +463,6 @@ class SettingsDialog(WindowModalDialog):
             (_("Firmware Version"), version_label),
             (_("Device ID"), device_id_label),
             (_("Bootloader Hash"), bl_hash_label),
-            (_("Supported Coins"), coins_label),
             (_("Language"), language_label),
             (_("Initialized"), initialized_label),
         ]


### PR DESCRIPTION
python-trezor 0.10.0 and up doesn't provide a list of supported coins,
and newer Trezor firmwares will not send it. This doesn't seem to be actually used anywhere, so I just removed the field entirely.