### PR TITLE
Move BIP44 coin type to net constants.

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -63,6 +63,7 @@ class BitcoinMainnet:
         'p2wpkh':      0x04b24746,  # zpub
         'p2wsh':       0x02aa7ed3,  # Zpub
     }
+    BIP44_COIN_TYPE = 0
 
 
 class BitcoinTestnet:
@@ -91,6 +92,7 @@ class BitcoinTestnet:
         'p2wpkh':      0x045f1cf6,  # vpub
         'p2wsh':       0x02575483,  # Vpub
     }
+    BIP44_COIN_TYPE = 1
 
 
 class BitcoinRegtest(BitcoinTestnet):

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -716,7 +716,7 @@ is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 
 
 def bip44_derivation(account_id, bip43_purpose=44):
-    coin = 1 if constants.net.TESTNET else 0
+    coin = constants.net.BIP44_COIN_TYPE
     return "m/%d'/%d'/%d'" % (bip43_purpose, coin, int(account_id))
 
 def from_seed(seed, passphrase, is_p2sh):


### PR DESCRIPTION
The BIP44 coin type is conceptually a per-network parameter, e.g. developers who are porting Electrum to an altcoin will usually need to change the BIP44 coin type in the same way that they change the address prefixes.  Therefore I think it makes sense to have the BIP44 coin type in the net constants, rather than burying it in the keystore logic.