### PR TITLE
option to set a dark theme for Qt

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -7,3 +7,4 @@ protobuf
 dnspython
 jsonrpclib-pelix
 PySocks>=1.6.6
+qdarkstyle<3.0

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -117,8 +117,22 @@ class ElectrumGui:
         self.build_tray_menu()
         self.tray.show()
         self.app.new_window_signal.connect(self.start_new_window)
+        self.set_dark_theme_if_needed()
         run_hook('init_qt', self)
-        ColorScheme.update_from_widget(QWidget())
+
+    def set_dark_theme_if_needed(self):
+        use_dark_theme = self.config.get('qt_gui_color_theme', 'default') == 'dark'
+        if use_dark_theme:
+            try:
+                import qdarkstyle
+                self.app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
+            except BaseException as e:
+                use_dark_theme = False
+                print_error('Error setting dark theme: {}'.format(e))
+        # Even if we ourselves don't set the dark theme,
+        # the OS/window manager/etc might set *a dark theme*.
+        # Hence, try to choose colors accordingly:
+        ColorScheme.update_from_widget(QWidget(), force_dark=use_dark_theme)
 
     def build_tray_menu(self):
         # Avoid immediate GC of old menu when window closed via its action

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2790,6 +2790,18 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         qr_combo.currentIndexChanged.connect(on_video_device)
         gui_widgets.append((qr_label, qr_combo))
 
+        colortheme_combo = QComboBox()
+        colortheme_combo.addItem(_('Light'), 'default')
+        colortheme_combo.addItem(_('Dark'), 'dark')
+        index = colortheme_combo.findData(self.config.get('qt_gui_color_theme', 'default'))
+        colortheme_combo.setCurrentIndex(index)
+        colortheme_label = QLabel(_('Color theme') + ':')
+        def on_colortheme(x):
+            self.config.set_key('qt_gui_color_theme', colortheme_combo.itemData(x), True)
+            self.need_restart = True
+        colortheme_combo.currentIndexChanged.connect(on_colortheme)
+        gui_widgets.append((colortheme_label, colortheme_combo))
+
         usechange_cb = QCheckBox(_('Use change addresses'))
         usechange_cb.setChecked(self.wallet.use_change)
         if not self.config.is_modifiable('use_change'): usechange_cb.setEnabled(False)

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -706,8 +706,8 @@ class ColorScheme:
         return brightness < (255*3/2)
 
     @staticmethod
-    def update_from_widget(widget):
-        if ColorScheme.has_dark_background(widget):
+    def update_from_widget(widget, force_dark=False):
+        if force_dark or ColorScheme.has_dark_background(widget):
             ColorScheme.dark_scheme = True
 
 


### PR DESCRIPTION
qdarkstyle is now a new dependency - note that it is only for qt and qt is not strictly a dependency, but it is pure python and relatively small

![dark_theme](https://user-images.githubusercontent.com/29142493/41857941-e91158f2-7898-11e8-9c53-2f8768ae1008.PNG)
![dark_theme2](https://user-images.githubusercontent.com/29142493/41858116-57d455d2-7899-11e8-8f49-44657e562495.PNG)
