### PR TITLE
Daemon: Fix preflight CORS request handling

### DIFF
--- a/lib/jsonrpc.py
+++ b/lib/jsonrpc.py
@@ -58,6 +58,9 @@ class VerifyingJSONRPCServer(SimpleJSONRPCServer):
                 # first, call the original implementation which returns
                 # True if all OK so far
                 if SimpleJSONRPCRequestHandler.parse_request(myself):
+                    # Do not authenticate OPTIONS-requests
+                    if myself.command.strip() == 'OPTIONS':
+                        return True
                     try:
                         self.authenticate(myself.headers)
                         return True


### PR DESCRIPTION
Problem:
When Electrum is started in daemon mode it calls an authenticate method for every incoming request. However, when a POST request from another domain is conducted, the actual POST request is always preceded by an OPTIONS request (Cross-Origin Resource Sharing; CORS, see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). This OPTIONS request should/can not contain any credential information. Thus, in the current state the Electrum daemon is not accessible from other domains.

Fix:
Circumvent the authentication method when the request method is "OPTIONS".