### PR TITLE
purpose48 segwit multisig path

### DIFF
--- a/gui/kivy/uix/dialogs/installwizard.py
+++ b/gui/kivy/uix/dialogs/installwizard.py
@@ -720,7 +720,7 @@ class LineDialog(WizardDialog):
         self.ids.next.disabled = False
 
     def get_params(self, b):
-        return (self.ids.passphrase_input.text,)
+        return (self.ids.passphrase_input.text, {})
 
 class ShowSeedDialog(WizardDialog):
     seed_text = StringProperty('')

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -279,8 +279,9 @@ class BaseWizard(object):
             self.choose_hw_device(purpose)
             return
         if purpose == HWD_SETUP_NEW_WALLET:
-            f = lambda x: self.run('on_hw_derivation', name, device_info, str(x))
-            self.derivation_dialog(f)
+            def f(derivation, script_type):
+                self.run('on_hw_derivation', name, device_info, derivation, script_type)
+            self.derivation_and_script_type_dialogs(f)
         elif purpose == HWD_SETUP_DECRYPT_WALLET:
             derivation = get_derivation_used_for_hw_device_encryption()
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, 'standard', self)
@@ -296,6 +297,22 @@ class BaseWizard(object):
                 raise
         else:
             raise Exception('unknown purpose: %s' % purpose)
+
+    def derivation_and_script_type_dialogs(self, f):
+        derivation = None
+
+        def after_derivation(der, options):
+            nonlocal derivation
+            derivation = str(der)
+            if options.get('script_type'):
+                self.script_type_dialog(after_script_type)
+            else:
+                after_script_type(None)
+
+        def after_script_type(script_type):
+            f(derivation, script_type)
+
+        self.derivation_dialog(after_derivation)
 
     def derivation_dialog(self, f):
         message = '\n'.join([
@@ -316,19 +333,48 @@ class BaseWizard(object):
                 ('p2sh-segwit BIP49', bip44_derivation(0, bip43_purpose=49)),
                 ('native-segwit BIP84', bip44_derivation(0, bip43_purpose=84)),
             )
+        options = (
+            ('script_type', _('Customize script type')),
+        )
         while True:
             try:
                 self.line_dialog(run_next=f, title=_('Derivation'), message=message,
                                  default=default, test=bitcoin.is_bip32_derivation,
-                                 presets=presets)
+                                 presets=presets, options=options)
                 return
             except ScriptTypeNotSupported as e:
                 self.show_error(e)
                 # let the user choose again
 
-    def on_hw_derivation(self, name, device_info, derivation):
+    def script_type_dialog(self, f):
+        title = _('Script type')
+        message = (_('Choose the type of script to be derived for the addresses in your wallet.') + ' ' +
+                   _('This will override the default that would be inferred from the '
+                     'derivation path.') + '\n' +
+                   _('Warning: customizing the script type is an advanced option, '
+                     'and should only be done if you know what you are doing!'))
+        if self.wallet_type == 'multisig':
+            choices = [
+                (None,          _("I don't know.")),
+                ('standard',    'legacy multisig (p2sh)'),
+                ('p2wsh-p2sh',  'p2sh-segwit multisig (p2wsh-p2sh'),
+                ('p2wsh',       'native segwit multisig (p2wsh)'),
+            ]
+        else:
+            choices = [
+                (None,          _("I don't know.")),
+                ('standard',    'legacy (p2pkh)'),
+                ('p2wpkh-p2sh', 'p2sh-segwit (p2wpkh-p2sh)'),
+                ('p2wpkh',      'native segwit (p2wpkh)'),
+            ]
+        self.choice_dialog(title=title, message=message, choices=choices, run_next=f)
+
+    def on_hw_derivation(self, name, device_info, derivation, script_type):
         from .keystore import hardware_keystore
-        xtype = keystore.xtype_from_derivation(derivation)
+        if script_type:
+            xtype = script_type
+        else:
+            xtype = keystore.xtype_from_derivation(derivation)
         try:
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, xtype, self)
         except ScriptTypeNotSupported:
@@ -356,7 +402,8 @@ class BaseWizard(object):
             _('Note that this is NOT your encryption password.'),
             _('If you do not know what this is, leave this field empty.'),
         ])
-        self.line_dialog(title=title, message=message, warning=warning, default='', test=lambda x:True, run_next=run_next)
+        f = lambda text, opt: run_next(text)
+        self.line_dialog(title=title, message=message, warning=warning, default='', test=lambda x:True, run_next=f)
 
     def restore_from_seed(self):
         self.opt_bip39 = True
@@ -382,15 +429,16 @@ class BaseWizard(object):
             raise Exception('Unknown seed type', self.seed_type)
 
     def on_restore_bip39(self, seed, passphrase):
-        f = lambda x: self.run('on_bip43', seed, passphrase, str(x))
-        self.derivation_dialog(f)
+        def f(derivation, script_type):
+            self.run('on_bip43', seed, passphrase, derivation, script_type)
+        self.derivation_and_script_type_dialogs(f)
 
     def create_keystore(self, seed, passphrase):
         k = keystore.from_seed(seed, passphrase, self.wallet_type == 'multisig')
         self.on_keystore(k)
 
-    def on_bip43(self, seed, passphrase, derivation):
-        k = keystore.from_bip39_seed(seed, passphrase, derivation)
+    def on_bip43(self, seed, passphrase, derivation, script_type):
+        k = keystore.from_bip39_seed(seed, passphrase, derivation, xtype=script_type)
         self.on_keystore(k)
 
     def on_keystore(self, k):
@@ -534,7 +582,7 @@ class BaseWizard(object):
         self.confirm_seed_dialog(run_next=f, test=lambda x: x==seed)
 
     def confirm_passphrase(self, seed, passphrase):
-        f = lambda x: self.run('create_keystore', seed, x)
+        f = lambda text, opt: self.run('create_keystore', seed, text)
         if passphrase:
             title = _('Confirm Seed Extension')
             message = '\n'.join([
@@ -543,7 +591,7 @@ class BaseWizard(object):
             ])
             self.line_dialog(run_next=f, title=title, message=message, default='', test=lambda x: x==passphrase)
         else:
-            f('')
+            f('', None)
 
     def create_addresses(self):
         def task():

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -279,13 +279,8 @@ class BaseWizard(object):
             self.choose_hw_device(purpose)
             return
         if purpose == HWD_SETUP_NEW_WALLET:
-            if self.wallet_type=='multisig':
-                # There is no general standard for HD multisig.
-                # This is partially compatible with BIP45; assumes index=0
-                self.on_hw_derivation(name, device_info, "m/45'/0")
-            else:
-                f = lambda x: self.run('on_hw_derivation', name, device_info, str(x))
-                self.derivation_dialog(f)
+            f = lambda x: self.run('on_hw_derivation', name, device_info, str(x))
+            self.derivation_dialog(f)
         elif purpose == HWD_SETUP_DECRYPT_WALLET:
             derivation = get_derivation_used_for_hw_device_encryption()
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, 'standard', self)
@@ -303,16 +298,24 @@ class BaseWizard(object):
             raise Exception('unknown purpose: %s' % purpose)
 
     def derivation_dialog(self, f):
-        default = bip44_derivation(0, bip43_purpose=44)
         message = '\n'.join([
             _('Enter your wallet derivation here.'),
             _('If you are not sure what this is, leave this field unchanged.')
         ])
-        presets = (
-            ('legacy BIP44', bip44_derivation(0, bip43_purpose=44)),
-            ('p2sh-segwit BIP49', bip44_derivation(0, bip43_purpose=49)),
-            ('native-segwit BIP84', bip44_derivation(0, bip43_purpose=84)),
-        )
+        if self.wallet_type == 'multisig':
+            # There is no general standard for HD multisig.
+            # This is partially compatible with BIP45; assumes index=0
+            default = "m/45'/0"
+            presets = (
+                #('legacy BIP45', "m/45'/0"),
+            )
+        else:
+            default = bip44_derivation(0, bip43_purpose=44)
+            presets = (
+                ('legacy BIP44', bip44_derivation(0, bip43_purpose=44)),
+                ('p2sh-segwit BIP49', bip44_derivation(0, bip43_purpose=49)),
+                ('native-segwit BIP84', bip44_derivation(0, bip43_purpose=84)),
+            )
         while True:
             try:
                 self.line_dialog(run_next=f, title=_('Derivation'), message=message,

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -374,10 +374,7 @@ class BaseWizard(object):
 
     def on_hw_derivation(self, name, device_info, derivation, script_type):
         from .keystore import hardware_keystore
-        if script_type:
-            xtype = script_type
-        else:
-            xtype = keystore.xtype_from_derivation(derivation)
+        xtype = script_type or keystore.xtype_from_derivation(derivation)
         try:
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, xtype, self)
         except ScriptTypeNotSupported:

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -30,7 +30,7 @@ from functools import partial
 
 from . import bitcoin
 from . import keystore
-from .keystore import bip44_derivation
+from .keystore import bip44_derivation, purpose48_derivation
 from .wallet import Imported_Wallet, Standard_Wallet, Multisig_Wallet, wallet_types, Wallet
 from .storage import STO_EV_USER_PW, STO_EV_XPUB_PW, get_derivation_used_for_hw_device_encryption
 from .i18n import _
@@ -321,10 +321,13 @@ class BaseWizard(object):
         ])
         if self.wallet_type == 'multisig':
             # There is no general standard for HD multisig.
-            # This is partially compatible with BIP45; assumes index=0
+            # For legacy, this is partially compatible with BIP45; assumes index=0
+            # For segwit, a custom path is used, as there is no standard at all.
             default = "m/45'/0"
             presets = (
-                #('legacy BIP45', "m/45'/0"),
+                ('legacy BIP45', "m/45'/0"),
+                ('p2sh-segwit', purpose48_derivation(0, xtype='p2wsh-p2sh')),
+                ('native-segwit', purpose48_derivation(0, xtype='p2wsh')),
             )
         else:
             default = bip44_derivation(0, bip43_purpose=44)

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -600,14 +600,26 @@ def from_bip39_seed(seed, passphrase, derivation, xtype=None):
     return k
 
 
-def xtype_from_derivation(derivation):
+def xtype_from_derivation(derivation: str) -> str:
     """Returns the script type to be used for this derivation."""
     if derivation.startswith("m/84'"):
         return 'p2wpkh'
     elif derivation.startswith("m/49'"):
         return 'p2wpkh-p2sh'
-    else:
+    elif derivation.startswith("m/44'"):
         return 'standard'
+    elif derivation.startswith("m/45'"):
+        return 'standard'
+
+    bip32_indices = list(bip32_derivation(derivation))
+    if len(bip32_indices) >= 4:
+        if bip32_indices[0] == 48 + BIP32_PRIME:
+            # m / purpose' / coin_type' / account' / script_type' / change / address_index
+            script_type_int = bip32_indices[3] - BIP32_PRIME
+            script_type = PURPOSE48_SCRIPT_TYPES_INV.get(script_type_int)
+            if script_type is not None:
+                return script_type
+    return 'standard'
 
 
 # extended pubkeys
@@ -718,6 +730,18 @@ is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 def bip44_derivation(account_id, bip43_purpose=44):
     coin = constants.net.BIP44_COIN_TYPE
     return "m/%d'/%d'/%d'" % (bip43_purpose, coin, int(account_id))
+
+
+def purpose48_derivation(account_id: int, xtype: str) -> str:
+    # m / purpose' / coin_type' / account' / script_type' / change / address_index
+    bip43_purpose = 48
+    coin = constants.net.BIP44_COIN_TYPE
+    account_id = int(account_id)
+    script_type_int = PURPOSE48_SCRIPT_TYPES.get(xtype)
+    if script_type_int is None:
+        raise Exception('unknown xtype: {}'.format(xtype))
+    return "m/%d'/%d'/%d'/%d'" % (bip43_purpose, coin, account_id, script_type_int)
+
 
 def from_seed(seed, passphrase, is_p2sh):
     t = seed_type(seed)

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -19,6 +19,7 @@ from lib.transaction import opcodes
 from lib.util import bfh, bh2u
 from lib import constants
 from lib.storage import WalletStorage
+from lib.keystore import xtype_from_derivation
 
 from . import SequentialTestCase
 from . import TestCaseForTestnet
@@ -468,6 +469,23 @@ class Test_xprv_xpub(SequentialTestCase):
         self.assertFalse(is_bip32_derivation("n/"))
         self.assertFalse(is_bip32_derivation(""))
         self.assertFalse(is_bip32_derivation("m/q8462"))
+
+    def test_xtype_from_derivation(self):
+        self.assertEqual('standard', xtype_from_derivation("m/44'"))
+        self.assertEqual('standard', xtype_from_derivation("m/44'/"))
+        self.assertEqual('standard', xtype_from_derivation("m/44'/0'/0'"))
+        self.assertEqual('standard', xtype_from_derivation("m/44'/5241'/221"))
+        self.assertEqual('standard', xtype_from_derivation("m/45'"))
+        self.assertEqual('standard', xtype_from_derivation("m/45'/56165/271'"))
+        self.assertEqual('p2wpkh-p2sh', xtype_from_derivation("m/49'"))
+        self.assertEqual('p2wpkh-p2sh', xtype_from_derivation("m/49'/134"))
+        self.assertEqual('p2wpkh', xtype_from_derivation("m/84'"))
+        self.assertEqual('p2wpkh', xtype_from_derivation("m/84'/112'/992/112/33'/0/2"))
+        self.assertEqual('p2wsh-p2sh', xtype_from_derivation("m/48'/0'/0'/1'"))
+        self.assertEqual('p2wsh-p2sh', xtype_from_derivation("m/48'/0'/0'/1'/52112/52'"))
+        self.assertEqual('p2wsh-p2sh', xtype_from_derivation("m/48'/9'/2'/1'"))
+        self.assertEqual('p2wsh', xtype_from_derivation("m/48'/0'/0'/2'"))
+        self.assertEqual('p2wsh', xtype_from_derivation("m/48'/1'/0'/2'/77'/0"))
 
     def test_version_bytes(self):
         xprv_headers_b58 = {


### PR DESCRIPTION
This PR includes https://github.com/spesmilo/electrum/pull/4443
and a further commit that adds default derivation paths for bip39/hw for segwit multisig
This supersedes https://github.com/spesmilo/electrum/pull/4354

The default paths used are as described in https://github.com/spesmilo/electrum/issues/4352#issuecomment-398028047 , i.e.
```
m / purpose' / coin_type' / account' / script_type' / change / address_index
```
where `purpose = 48`, `account = 0`, and
`script_type = 1` for p2wsh-p2sh multisig, and
`script_type = 2` for p2wsh multisig