### PR TITLE
wizard: extend derivation dialog to also let user select script type

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -600,14 +600,26 @@ def from_bip39_seed(seed, passphrase, derivation, xtype=None):
     return k
 
 
-def xtype_from_derivation(derivation):
+def xtype_from_derivation(derivation: str) -> str:
     """Returns the script type to be used for this derivation."""
     if derivation.startswith("m/84'"):
         return 'p2wpkh'
     elif derivation.startswith("m/49'"):
         return 'p2wpkh-p2sh'
-    else:
+    elif derivation.startswith("m/44'"):
         return 'standard'
+    elif derivation.startswith("m/45'"):
+        return 'standard'
+
+    bip32_indices = list(bip32_derivation(derivation))
+    if len(bip32_indices) >= 4:
+        if bip32_indices[0] == 48 + BIP32_PRIME:
+            # m / purpose' / coin_type' / account' / script_type' / change / address_index
+            script_type_int = bip32_indices[3] - BIP32_PRIME
+            script_type = PURPOSE48_SCRIPT_TYPES_INV.get(script_type_int)
+            if script_type is not None:
+                return script_type
+    return 'standard'
 
 
 # extended pubkeys
@@ -718,6 +730,18 @@ is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 def bip44_derivation(account_id, bip43_purpose=44):
     coin = constants.net.BIP44_COIN_TYPE
     return "m/%d'/%d'/%d'" % (bip43_purpose, coin, int(account_id))
+
+
+def purpose48_derivation(account_id: int, xtype: str) -> str:
+    # m / purpose' / coin_type' / account' / script_type' / change / address_index
+    bip43_purpose = 48
+    coin = constants.net.BIP44_COIN_TYPE
+    account_id = int(account_id)
+    script_type_int = PURPOSE48_SCRIPT_TYPES.get(xtype)
+    if script_type_int is None:
+        raise Exception('unknown xtype: {}'.format(xtype))
+    return "m/%d'/%d'/%d'/%d'" % (bip43_purpose, coin, account_id, script_type_int)
+
 
 def from_seed(seed, passphrase, is_p2sh):
     t = seed_type(seed)

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -19,6 +19,7 @@ from lib.transaction import opcodes
 from lib.util import bfh, bh2u
 from lib import constants
 from lib.storage import WalletStorage
+from lib.keystore import xtype_from_derivation
 
 from . import SequentialTestCase
 from . import TestCaseForTestnet
@@ -468,6 +469,23 @@ class Test_xprv_xpub(SequentialTestCase):
         self.assertFalse(is_bip32_derivation("n/"))
         self.assertFalse(is_bip32_derivation(""))
         self.assertFalse(is_bip32_derivation("m/q8462"))
+
+    def test_xtype_from_derivation(self):
+        self.assertEqual('standard', xtype_from_derivation("m/44'"))
+        self.assertEqual('standard', xtype_from_derivation("m/44'/"))
+        self.assertEqual('standard', xtype_from_derivation("m/44'/0'/0'"))
+        self.assertEqual('standard', xtype_from_derivation("m/44'/5241'/221"))
+        self.assertEqual('standard', xtype_from_derivation("m/45'"))
+        self.assertEqual('standard', xtype_from_derivation("m/45'/56165/271'"))
+        self.assertEqual('p2wpkh-p2sh', xtype_from_derivation("m/49'"))
+        self.assertEqual('p2wpkh-p2sh', xtype_from_derivation("m/49'/134"))
+        self.assertEqual('p2wpkh', xtype_from_derivation("m/84'"))
+        self.assertEqual('p2wpkh', xtype_from_derivation("m/84'/112'/992/112/33'/0/2"))
+        self.assertEqual('p2wsh-p2sh', xtype_from_derivation("m/48'/0'/0'/1'"))
+        self.assertEqual('p2wsh-p2sh', xtype_from_derivation("m/48'/0'/0'/1'/52112/52'"))
+        self.assertEqual('p2wsh-p2sh', xtype_from_derivation("m/48'/9'/2'/1'"))
+        self.assertEqual('p2wsh', xtype_from_derivation("m/48'/0'/0'/2'"))
+        self.assertEqual('p2wsh', xtype_from_derivation("m/48'/1'/0'/2'/77'/0"))
 
     def test_version_bytes(self):
         xprv_headers_b58 = {


### PR DESCRIPTION
- extend derivation dialog to also let user select script type
- enable segwit multisig for bip39/hw wallets

The default paths for segwit multisig are as described in https://github.com/spesmilo/electrum/issues/4352#issuecomment-398028047 , i.e.
```
m / purpose' / coin_type' / account' / script_type' / change / address_index
```
where `purpose = 48`, `account = 0`, and
`script_type = 1` for p2wsh-p2sh multisig, and
`script_type = 2` for p2wsh multisig

This supersedes https://github.com/spesmilo/electrum/pull/4464 and https://github.com/spesmilo/electrum/pull/4443

![wizard_script_and_der1](https://user-images.githubusercontent.com/29142493/41929326-fd14d2cc-7977-11e8-936b-367f0b8fa3a4.png)
![wizard_script_and_der2](https://user-images.githubusercontent.com/29142493/41929331-fe61a628-7977-11e8-8bcf-e3f2631dd3f6.png)
