### PR TITLE
Fix a bug in PaymentRequest __str__() function

### DIFF
--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -111,7 +111,7 @@ class PaymentRequest:
         self.tx = None
 
     def __str__(self):
-        return self.raw
+        return str(self.raw)
 
     def parse(self, r):
         if self.error:


### PR DESCRIPTION
Hi guys,

I stumbled across this bug in the PaymentRequest class when developing Electron Cash on iOS and I figured I'd push the fix to you guys upstream.

I don't think any of your code calls this function (but my code does -- which is how I triggered it).

PaymentRequest's self.raw is a bytes object in some code paths (perhaps all code paths, actually).. but the \_\_str\_\_ function was returning it unchanged.  This causes an exception from the python runtime.

