### PR TITLE
colour 2fa billing outputs in Qt tx dialog

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -278,10 +278,15 @@ class TxDialog(QDialog, MessageBoxMixin):
         chg = QTextCharFormat()
         chg.setBackground(QBrush(ColorScheme.YELLOW.as_color(background=True)))
         chg.setToolTip(_("Wallet change address"))
+        twofactor = QTextCharFormat()
+        twofactor.setBackground(QBrush(ColorScheme.BLUE.as_color(background=True)))
+        twofactor.setToolTip(_("TrustedCoin (2FA) fee for the next batch of transactions"))
 
         def text_format(addr):
             if self.wallet.is_mine(addr):
                 return chg if self.wallet.is_change(addr) else rec
+            elif self.wallet.is_billing_address(addr):
+                return twofactor
             return ext
 
         def format_amount(amt):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1849,6 +1849,10 @@ class Abstract_Wallet(PrintError):
                 p = self.price_at_timestamp(txid, price_func)
                 return p * txin_value/Decimal(COIN)
 
+    def is_billing_address(self, addr):
+        # overloaded for TrustedCoin wallets
+        return False
+
 
 class Simple_Wallet(Abstract_Wallet):
     # wallet with a single keystore


### PR DESCRIPTION
resolves https://github.com/spesmilo/electrum/issues/3844

![tx_dialog_color_2fa](https://user-images.githubusercontent.com/29142493/42163717-dcd5a74e-7e03-11e8-8976-7236935c8ff6.PNG)

Billing addresses are persisted in the wallet file.
When receiving a new billing index from TrustedCoin, which is a counter from 0 up, we generate all missing billing addresses up to that index (to cover the case of restoring from seed).

This information is used to colour the output addresses in the Qt tx dialog; and also to make sure when RBF bumping a transaction the billing output is not decreased.

Note that when restoring from seed and disabling 2fa, i.e. keeping two xprvs in the wallet, TrustedCoin is not contacted for billing info, and hence the billing addresses will not be calculated, and e.g. the colouring will not work.