### PR TITLE
network: handle reorg (sooner) in case of multiple forks at given height

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -892,6 +892,7 @@ class Network(util.DaemonThread):
             self.connection_down(interface.server)
             return
         height = header.get('block_height')
+        #interface.print_error('got header', height, blockchain.hash_header(header))
         if interface.request != height:
             interface.print_error("unsolicited header",interface.request, height)
             self.connection_down(interface.server)
@@ -947,7 +948,7 @@ class Network(util.DaemonThread):
                     elif branch.parent().check_header(header):
                         interface.print_error('reorg', interface.bad, interface.tip)
                         interface.blockchain = branch.parent()
-                        next_height = None
+                        next_height = interface.bad
                     else:
                         interface.print_error('checkpoint conflicts with existing fork', branch.path())
                         branch.write(b'', 0)
@@ -1081,6 +1082,7 @@ class Network(util.DaemonThread):
         except InvalidHeader:
             self.connection_down(interface.server)
             return
+        #interface.print_error('notified of header', height, blockchain.hash_header(header))
         if height < self.max_checkpoint():
             self.connection_down(interface.server)
             return


### PR DESCRIPTION
If there is already a fork at height h, and the branch we are on reorganises, we detect the reorg but will be left in a weird state, with a 50% chance.
This gets resolved, but only when the next block comes (on top of the new chain).

With this PR, it gets resolved when we detect the reorg (one block sooner).

related: https://github.com/spesmilo/electrum/commit/d5d5e8af5c77760e8e20a5565388b9acc337279b

-----

On master, if we get into the weird state, depends on whether the binary search of block headers find the checkpoint from the left or from the right.
<details>
 <summary>master, from left</summary>

```
[Network] notified of header 2328 3b5b8df46ec29ca1a25ec820e9ad72229cb0f7a136c57a088ca7d10a861f7518
[Network] got header 2327 106448c2efc98c088c5cc1a270be98d45339aa58e631624b50124d2e4ff23cf8
[Network] got header 2326 61f61b2b97c54fceea2b7ae1b28e55bad2e841cf382f0db46a28c94feb39b7fc
[Network] got header 2324 6372c8a684e615b971ab936dead33b08ff7f0afcccd98fdb8ffe6c5d22381e78
[Network] got header 2320 7317bc27795e25199de38cebf2b7e437ea8b6eae8d227e8298b28cb412d3c5e0
[Network] got header 2312 121d240601bb10be75c7ecd2fc0345348381baa550f41deed5d9fea6a41a8a0d
[Network] got header 2296 544ac1300fba43a1361c989b81f58010e380b3e26d221d39e7d70d4c58c6dd98
[127.0.0.1] binary search
[Network] got header 2304 3e329346b13a27bffcf8ec09cba2532d3fd61a37414f8f3d99c21a32eb82480c
[Network] got header 2308 3f74f8a31ccba13c6562b603ea8bab1e5835abcbdd053a11258f661f45e6334b
[Network] got header 2310 3102d835d0717681eb106952268c1399ab7b6f59eec2b1f735f2d74c899f0d85
[Network] got header 2311 372624c908dfbfec5442f542595eb8ac7f3deadccf890b29ca2c00473feb159b
[127.0.0.1] reorg 2312 2328
```
</details>
^^ weird state

<details>
 <summary>master, from right</summary>

```
[Network] notified of header 2435 4e41b3b6a274595b7e31787ea93e5daa03ee2de2892626ec9d967281fb699c87
[Network] got header 2434 762d0df4b0c223d8a36856b3a85721d351f13dc4abf2e6338ec99bf63ab722d8
[Network] got header 2433 7a41a0f614c98ba448a314720be8aee53cf73728c625ea8037c37dfb3ce90446
[Network] got header 2431 0ea44bbc1a94ba4600e9987d9abe513ae7f3d4e2a7cdb5ad3b14c945cb5bbf8a
[Network] got header 2427 3afa5a2d35b091dc4801dd7ef4be8282d4159176f83d6211b16085f640aeb884
[Network] got header 2419 158e30d9083bc9cb91de043b1b9d436acba86ff4de6ac42baaa270a95fad36aa
[Network] got header 2403 1bd8a86b7da0dbb592cf0eb49b768e1ef6177a30b6f5fdeea43fbbf052d8c05b
[Network] got header 2371 3022f44d7a9c9ecc38a2e5373ef873b9cf21b28ad520d177038c2f595e315a08
[Network] got header 2307 76602ac06d23a256005c01899d75b9de20aaad53cb5bdb29a25fe2f2e17e828e
[127.0.0.1] binary search
[Network] got header 2339 6c7144969e4ef21ff32a0c1a8f23e7dbb4af09c81c08218b8465c12cabc845ae
[Network] got header 2323 78c034aaf19289c7998867fb0307097a689e3b49c6dbc93145309a206e203d1e
[Network] got header 2315 27488e3a5eea9ecb5b4ee9771ae86af3a49ae1865d5204fc9d240185e3b1440d
[Network] got header 2311 372624c908dfbfec5442f542595eb8ac7f3deadccf890b29ca2c00473feb159b
[Network] got header 2313 2db8ed0c2562d50e6a57db3229318bed273f9730d915973cd2b10e7befa17ce7
[Network] got header 2312 7c55113d666fba270dbb92f0ddde9fa43f48ef3ee44fed26b82255f74dd0c1f6
[127.0.0.1] checkpoint conflicts with existing fork /home/user/.electrum/regtest/forks/fork_0_2312
[127.0.0.1] requesting chunk 1
[SPV] redoing b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[SPV] requested merkle b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[127.0.0.1] received chunk 1
[Blockchain] swap 2312 0
[127.0.0.1] catch up done 2435
```
</details>
^^ reorg handled

<details>
 <summary>with this PR, from left</summary>

```
[Network] notified of header 2326 5278446044c37e92c620bd437d5b4a2b46c68c0bae4bde21da037db0a4593f09
[Network] got header 2325 4219bce4b12b7fa9515dd23d979a998b08d358aaacdb50bb568df6faaa83961b
[Network] got header 2324 1f278bf47ab22c5c14fe325f887a25e349821962042605621ddcd8e4222258cb
[Network] got header 2322 308f66f7303d06c475c9482d313aac480c8d163e9f0e42c008c63889755785a8
[Network] got header 2318 228f31cd558ee5909b0a6854b65de1088d8a74e9f63bc71c827a38cc230d147b
[Network] got header 2310 3102d835d0717681eb106952268c1399ab7b6f59eec2b1f735f2d74c899f0d85
[127.0.0.1] binary search
[Network] got header 2314 643e26f6e65567a26a9e2366446d98e80729aec74249855592058dce0adcb3f2
[Network] got header 2312 122604bf600d12ea63eff7b9a0691c179ba5f1e0d96fa4fe26cd0b0dcddfc50e
[Network] got header 2311 372624c908dfbfec5442f542595eb8ac7f3deadccf890b29ca2c00473feb159b
[127.0.0.1] reorg 2312 2326
[Network] got header 2312 122604bf600d12ea63eff7b9a0691c179ba5f1e0d96fa4fe26cd0b0dcddfc50e
[127.0.0.1] checkpoint conflicts with existing fork /home/user/.electrum/regtest/forks/fork_0_2312
[SPV] redoing b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[SPV] requested merkle b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[Network] got header 2313 6038aab5b0c1042b77cee31534feef4a83eb9b32a880aa915a4aa5c894aaa9f6
[SPV] verified b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[WalletStorage] saved /home/user/.electrum/regtest/wallets/default_wallet
[profiler] write 0.0137
[Network] got header 2314 643e26f6e65567a26a9e2366446d98e80729aec74249855592058dce0adcb3f2
[Network] got header 2315 36a8d8be8af93e8d79cf22afca7db3f4768f35e268aec23abb54cc3a974dd119
[Network] got header 2316 4c4471b769cf37a5775265e963b9408c54cf4f7496603ae1990eaedfba8febfe
[Network] got header 2317 050ba4c09bb0f194b3ddd33cfdc260d919418c4c9524fa6da100dbce14d7576c
[Network] got header 2318 228f31cd558ee5909b0a6854b65de1088d8a74e9f63bc71c827a38cc230d147b
[Network] got header 2319 02b320d77e216b883071d9f9d4ab8f5c2009c500181368c3371562909a23b2bb
[Network] got header 2320 72d01b9037bcd8d24a8a8c584dc3bd58187a7bb24e4a389ce499aae63f132cde
[Network] got header 2321 5875d489510779eb45d4f3bab8c1d8a982ef8a6e4e539862bcea540f5f93c764
[Network] got header 2322 308f66f7303d06c475c9482d313aac480c8d163e9f0e42c008c63889755785a8
[Network] got header 2323 7f1ac16c6ca3427a05afe6f7fe7b3cddabb3f36ef891afb4d14ea240311f5bda
[Network] got header 2324 1f278bf47ab22c5c14fe325f887a25e349821962042605621ddcd8e4222258cb
[Network] got header 2325 4219bce4b12b7fa9515dd23d979a998b08d358aaacdb50bb568df6faaa83961b
[Network] got header 2326 5278446044c37e92c620bd437d5b4a2b46c68c0bae4bde21da037db0a4593f09
[Blockchain] swap 2312 0
[127.0.0.1] catch up done 2326
```
</details>
^^ reorg handled

<details>
 <summary>with this PR, from right</summary>

```
[Network] notified of header 2427 7a593ce3f8248ab6a464111c20ec1257b5a1ea99986479be3ace37d0b1808e34
[Network] got header 2426 3de5765f33429f57aca4c19b0783d6075350598b4cf7612f12f89d7d7782911d
[Network] got header 2425 6149a1caf1a49cc140eb89d8e454b1c8ffc0a64d3ceec42787124e529b417e81
[Network] got header 2423 554a99774192b9bfaeb66a9710cef430b5b065aae7c2acaa5867d9512a43ed64
[Network] got header 2419 31cc108e9b57563095ae437fb6b0f9d4587c4b1029b7297f721eea6f100762ba
[Network] got header 2411 4fbfbd8c6b46558f2fc8e594d7152f120cdc5e46cbe6f12572ed1b57192ac862
[Network] got header 2395 167292d9bda7e3c853df8b7895c3e6534c6f7c26200e9f683210203f73587baf
[Network] got header 2363 2a8c2892c6a11fb1120980ec3bf765c7f1f95ef63b52dbfc798990f7d44298c1
[Network] got header 2299 06c4346bd77fda0094e8a092929f39c723f1a997d181eceae1ab08f0b419304f
[127.0.0.1] binary search
[Network] got header 2331 50ba9e4e800726c3b8ac17bd081687ced5e3ff1e5db7afa2a37d1097eed18cfa
[Network] got header 2315 5395f0ab044ca6121d70a27f94f4b5897f438af5f168f15051a2c30a1da47053
[Network] got header 2307 76602ac06d23a256005c01899d75b9de20aaad53cb5bdb29a25fe2f2e17e828e
[Network] got header 2311 372624c908dfbfec5442f542595eb8ac7f3deadccf890b29ca2c00473feb159b
[Network] got header 2313 338ade84486223e43be8f33cee454c69682a22db7ad6eff37e6ec5c1c6594a26
[Network] got header 2312 186a104c085c82fa516795d8186fe37e937b4e24aafd272132b4c7bba8f2c27e
[127.0.0.1] checkpoint conflicts with existing fork /home/user/.electrum/regtest/forks/fork_0_2312
[127.0.0.1] requesting chunk 1
[SPV] redoing b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[SPV] requested merkle b0060af54d831077251e2be6663e848909bdeddaa555974416ad59bab69eed2f
[127.0.0.1] received chunk 1
[Blockchain] swap 2312 0
[127.0.0.1] catch up done 2427
```
</details>
^^ reorg handled

-----

I left two commented out debug prints in as I think they can be useful.