### PR TITLE
Add electrumx class

### DIFF
--- a/electrum
+++ b/electrum
@@ -139,7 +139,7 @@ def run_non_RPC(config):
             storage.write()
             wallet = Wallet(storage)
         if not config.get('offline'):
-            network = Network(config)
+            network = ElectrumX(config)
             network.start()
             wallet.start_threads(network)
             print_msg("Recovering wallet...")

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -138,9 +138,10 @@ class Blockchain(util.PrintError):
         return self.get_hash(self.get_checkpoint()).lstrip('00')[0:10]
 
     def check_header(self, header):
-        header_hash = hash_header(header)
-        height = header.get('block_height')
-        return header_hash == self.get_hash(height)
+        """ check_header returns True iff the passed header is part of the
+        chain represented by this Blockchain instance.
+        """
+        return hash_header(header) == self.get_hash(header.get('block_height'))
 
     def fork(parent, header):
         checkpoint = header.get('block_height')

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -252,6 +252,10 @@ class Blockchain(util.PrintError):
                 os.fsync(f.fileno())
             self.update_size()
 
+    def is_before_last_checkpoint(tx_height):
+        index = tx_height // 2016
+        return index < len(self.checkpoints)
+
     def save_header(self, header):
         delta = header.get('block_height') - self.checkpoint
         data = bfh(serialize_header(header))

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -68,6 +68,7 @@ def hash_header(header):
     return hash_encode(Hash(bfh(serialize_header(header))))
 
 
+# This dict contains a mapping between a checkpoint and a blockchain
 blockchains = {}
 
 def read_blockchains(config):
@@ -90,9 +91,11 @@ def read_blockchains(config):
 def check_header(header):
     if type(header) is not dict:
         return False
+
     for b in blockchains.values():
         if b.check_header(header):
             return b
+
     return False
 
 def can_connect(header):
@@ -180,8 +183,13 @@ class Blockchain(util.PrintError):
             prev_hash = hash_header(header)
 
     def path(self):
-        d = util.get_headers_dir(self.config)
-        filename = 'blockchain_headers' if self.parent_id is None else os.path.join('forks', 'fork_%d_%d'%(self.parent_id, self.checkpoint))
+        d = util.get_headers_dir (self.config)
+        filename = 'blockchain_headers'
+        if self.parent_id is not None:
+            filename = os.path.join(
+                'forks',
+                'fork_%d_%d'%(self.parent_id, self.checkpoint))
+
         return os.path.join(d, filename)
 
     def save_chunk(self, index, chunk):
@@ -197,9 +205,11 @@ class Blockchain(util.PrintError):
     def swap_with_parent(self):
         if self.parent_id is None:
             return
+
         parent_branch_size = self.parent().height() - self.checkpoint + 1
         if parent_branch_size >= self.size():
             return
+
         self.print_error("swap", self.checkpoint, self.parent_id)
         parent_id = self.parent_id
         checkpoint = self.checkpoint
@@ -342,26 +352,32 @@ class Blockchain(util.PrintError):
     def can_connect(self, header, check_height=True):
         if header is None:
             return False
+
         height = header['block_height']
         if check_height and self.height() != height - 1:
             #self.print_error("cannot connect at height", height)
             return False
+
         if height == 0:
             return hash_header(header) == constants.net.GENESIS
+
         try:
             prev_hash = self.get_hash(height - 1)
         except:
             return False
+
         if prev_hash != header.get('prev_block_hash'):
             return False
         try:
             target = self.get_target(height // 2016 - 1)
         except MissingHeader:
             return False
+
         try:
             self.verify_header(header, prev_hash, target)
         except BaseException as e:
             return False
+
         return True
 
     def connect_chunk(self, idx, hexdata):

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -33,7 +33,7 @@ import jsonrpclib
 from .jsonrpc import VerifyingJSONRPCServer
 
 from .version import ELECTRUM_VERSION
-from .network import Network
+from .electrumx import ElectrumX
 from .util import json_decode, DaemonThread
 from .util import print_error, to_string
 from .wallet import Wallet
@@ -125,7 +125,7 @@ class Daemon(DaemonThread):
         if config.get('offline'):
             self.network = None
         else:
-            self.network = Network(config)
+            self.network = ElectrumX(config)
             self.network.start()
         self.fx = FxThread(config, self.network)
         if self.network:

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -17,6 +17,15 @@ class ElectrumX(network.Network):
 
         self.__hash2address = {}
 
+    # Deprecated in favor of headers
+    def get_chunk(self, index, callback=None):
+        command = 'blockchain.block.get_chunk'
+        invocation = lambda c: self.send([(command, [index])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
         self.queue_request('blockchain.block.get_header', [height], interface)
@@ -95,6 +104,14 @@ class ElectrumX(network.Network):
     def get_history_for_scripthash(self, hash, callback=None):
         command = 'blockchain.scripthash.get_history'
         invocation = lambda c: self.send([(command, [hash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def headers(self, start_height, count, callback=None):
+        command = 'blockchain.block.headers'
+        invocation = lambda c: self.send([(command, [start_height, count])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -83,15 +83,6 @@ class ElectrumX(network.Network):
             invocation,
             callback)
 
-    # NOTE: Deprecated since ElectrumX 1.2. Use subscribe_to_scripthash.
-    def subscribe_to_address(self, address, callback=None):
-        command = 'blockchain.address.subscribe'
-        invocation = lambda c: self.send([(command, [address])], c)
-
-        return ElectrumX.__with_default_synchronous_callback(
-            invocation,
-            callback)
-
     def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
         command = 'blockchain.transaction.get_merkle'
         invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -1,0 +1,4 @@
+from . import network
+
+class ElectrumX(network.Network):
+        pass

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -17,15 +17,6 @@ class ElectrumX(network.Network):
 
         self.__hash2address = {}
 
-    # Deprecated in favor of headers
-    def get_chunk(self, index, callback=None):
-        command = 'blockchain.block.get_chunk'
-        invocation = lambda c: self._send([(command, [index])], c)
-
-        return ElectrumX.__with_default_synchronous_callback(
-            invocation,
-            callback)
-
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
         self._queue_request('blockchain.block.get_header', [height], interface)

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -12,6 +12,11 @@ class ElectrumX(network.Network):
     See https://electrumx.readthedocs.io/en/latest/protocol-basics.html
     """
 
+    def __init__(self, config=None):
+        super().__init__(config)
+
+        self.hash2address = {}
+
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
         self.queue_request('blockchain.block.get_header', [height], interface)
@@ -19,32 +24,41 @@ class ElectrumX(network.Network):
         interface.req_time = time.time()
 
     def map_scripthash_to_address(self, callback):
-        def cb2(x):
-            x2 = x.copy()
-            p = x2.pop('params')
-            addr = self.h2addr[p[0]]
-            x2['params'] = [addr]
-            callback(x2)
-        return cb2
+        """ This method takes a callback and wraps it in an other callback.
+        The new callback modifies the response passed to the original callback
+        by replacing the scripthash returned by the backend server with the
+        address which initially yielded this scripthash
+        """
+        def replacing_callback(original_response):
+            new_response = original_response.copy()
+            params = new_response.pop('params')
+            address = self.hash2address[params[0]]
+            new_response['params'] = [address]
+            callback(new_response)
+        return replacing_callback
 
-    # TODO I believe the caller should take care of the mapping between addr<->hash
-    # Then we can rid of this silly h2addr and map_scripthash_to_address.
-    def subscribe_to_addresses(self, addresses, callback):
-        hash2address = {
+    def subscribe_to_scripthashes(self, hashes, callback=None):
+        command = 'blockchain.scripthash.subscribe'
+        messages = [(command, [hash_]) for hash_ in hashes]
+        invocation = lambda c: self.send(messages, c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def subscribe_to_addresses(self, addresses, callback=None):
+        """ Converts the list of addresses to scripthashes and delegates to
+        subscribe_to_scripthashes. """
+        scripthashes = {
             bitcoin.address_to_scripthash(address): address
             for address in addresses}
-        self.h2addr.update(hash2address)
-        msgs = [
-            ('blockchain.scripthash.subscribe', [x])
-            for x in hash2address.keys()]
-        self.send(msgs, self.map_scripthash_to_address(callback))
+        self.hash2address.update(scripthashes)
 
-    # TODO Remove this is favor of get_history_for_scripthash
-    def request_address_history(self, address, callback):
-        h = bitcoin.address_to_scripthash(address)
-        self.h2addr.update({h: address})
-        self.send(
-            [('blockchain.scripthash.get_history', [h])],
+        if not callback:
+            callback = ElectrumX.__wait_for
+
+        return self.subscribe_to_scripthashes(
+            scripthashes,
             self.map_scripthash_to_address(callback))
 
     # NOTE this method handles exceptions and a special edge case, counter to
@@ -66,6 +80,17 @@ class ElectrumX(network.Network):
             return False, "error: " + out
 
         return True, out
+
+    def get_history_for_address(self, address, callback=None):
+        scripthash = bitcoin.address_to_scripthash(address)
+        self.hash2address.update({scripthash: address})
+
+        if not callback:
+            callback = ElectrumX.__wait_for
+
+        return self.get_history_for_scripthash(
+            scripthash,
+            self.map_scripthash_to_address(callback))
 
     def get_history_for_scripthash(self, hash, callback=None):
         command = 'blockchain.scripthash.get_history'

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -20,7 +20,7 @@ class ElectrumX(network.Network):
     # Deprecated in favor of headers
     def get_chunk(self, index, callback=None):
         command = 'blockchain.block.get_chunk'
-        invocation = lambda c: self.send([(command, [index])], c)
+        invocation = lambda c: self._send([(command, [index])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -28,7 +28,7 @@ class ElectrumX(network.Network):
 
     # TODO clean this method up. It should have no reference to interface.
     def request_header(self, interface, height):
-        self.queue_request('blockchain.block.get_header', [height], interface)
+        self._queue_request('blockchain.block.get_header', [height], interface)
         interface.request = height
         interface.req_time = time.time()
 
@@ -49,7 +49,7 @@ class ElectrumX(network.Network):
     def subscribe_to_scripthashes(self, hashes, callback=None):
         command = 'blockchain.scripthash.subscribe'
         messages = [(command, [hash_]) for hash_ in hashes]
-        invocation = lambda c: self.send(messages, c)
+        invocation = lambda c: self._send(messages, c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -74,7 +74,7 @@ class ElectrumX(network.Network):
     # what the other ElectrumX methods do. This is unexpected.
     def broadcast_transaction(self, transaction, callback=None):
         command = 'blockchain.transaction.broadcast'
-        invocation = lambda c: self.send([(command, [str(transaction)])], c)
+        invocation = lambda c: self._send([(command, [str(transaction)])], c)
 
         if callback:
             invocation(callback)
@@ -103,7 +103,7 @@ class ElectrumX(network.Network):
 
     def get_history_for_scripthash(self, hash, callback=None):
         command = 'blockchain.scripthash.get_history'
-        invocation = lambda c: self.send([(command, [hash])], c)
+        invocation = lambda c: self._send([(command, [hash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -111,7 +111,7 @@ class ElectrumX(network.Network):
 
     def headers(self, start_height, count, callback=None):
         command = 'blockchain.block.headers'
-        invocation = lambda c: self.send([(command, [start_height, count])], c)
+        invocation = lambda c: self._send([(command, [start_height, count])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -119,7 +119,7 @@ class ElectrumX(network.Network):
 
     def subscribe_to_headers(self, callback=None):
         command = 'blockchain.headers.subscribe'
-        invocation = lambda c: self.send([(command, [True])], c)
+        invocation = lambda c: self._send([(command, [True])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -127,7 +127,7 @@ class ElectrumX(network.Network):
 
     def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
         command = 'blockchain.transaction.get_merkle'
-        invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)
+        invocation = lambda c: self._send([(command, [tx_hash, tx_height])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -135,7 +135,7 @@ class ElectrumX(network.Network):
 
     def subscribe_to_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.subscribe'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
+        invocation = lambda c: self._send([(command, [scripthash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -143,7 +143,7 @@ class ElectrumX(network.Network):
 
     def get_transaction(self, transaction_hash, callback=None):
         command = 'blockchain.transaction.get'
-        invocation = lambda c: self.send([(command, [transaction_hash])], c)
+        invocation = lambda c: self._send([(command, [transaction_hash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -152,7 +152,7 @@ class ElectrumX(network.Network):
     def get_transactions(self, transaction_hashes, callback=None):
         command = 'blockchain.transaction.get'
         messages = [(command, [tx_hash]) for tx_hash in transaction_hashes]
-        invocation = lambda c: self.send(messages, c)
+        invocation = lambda c: self._send(messages, c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -160,7 +160,7 @@ class ElectrumX(network.Network):
 
     def listunspent_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.listunspent'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
+        invocation = lambda c: self._send([(command, [scripthash])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,
@@ -168,7 +168,15 @@ class ElectrumX(network.Network):
 
     def get_balance_for_scripthash(self, scripthash, callback=None):
         command = 'blockchain.scripthash.get_balance'
-        invocation = lambda c: self.send([(command, [scripthash])], c)
+        invocation = lambda c: self._send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def server_version(self, client_name, protocol_version, callback=None):
+        command = 'server.version'
+        invocation = lambda c: self._send([(command, [client_name, protocol_version])], c)
 
         return ElectrumX.__with_default_synchronous_callback(
             invocation,

--- a/lib/electrumx.py
+++ b/lib/electrumx.py
@@ -1,4 +1,166 @@
+import time
+import queue
+from . import util
 from . import network
+from . import bitcoin
+from .i18n import _
+
 
 class ElectrumX(network.Network):
-        pass
+    """ The ElectrumX class defines all ElectrumX specific API calls.
+
+    See https://electrumx.readthedocs.io/en/latest/protocol-basics.html
+    """
+
+    # TODO clean this method up. It should have no reference to interface.
+    def request_header(self, interface, height):
+        self.queue_request('blockchain.block.get_header', [height], interface)
+        interface.request = height
+        interface.req_time = time.time()
+
+    def map_scripthash_to_address(self, callback):
+        def cb2(x):
+            x2 = x.copy()
+            p = x2.pop('params')
+            addr = self.h2addr[p[0]]
+            x2['params'] = [addr]
+            callback(x2)
+        return cb2
+
+    # TODO I believe the caller should take care of the mapping between addr<->hash
+    # Then we can rid of this silly h2addr and map_scripthash_to_address.
+    def subscribe_to_addresses(self, addresses, callback):
+        hash2address = {
+            bitcoin.address_to_scripthash(address): address
+            for address in addresses}
+        self.h2addr.update(hash2address)
+        msgs = [
+            ('blockchain.scripthash.subscribe', [x])
+            for x in hash2address.keys()]
+        self.send(msgs, self.map_scripthash_to_address(callback))
+
+    # TODO Remove this is favor of get_history_for_scripthash
+    def request_address_history(self, address, callback):
+        h = bitcoin.address_to_scripthash(address)
+        self.h2addr.update({h: address})
+        self.send(
+            [('blockchain.scripthash.get_history', [h])],
+            self.map_scripthash_to_address(callback))
+
+    # NOTE this method handles exceptions and a special edge case, counter to
+    # what the other ElectrumX methods do. This is unexpected.
+    def broadcast_transaction(self, transaction, callback=None):
+        command = 'blockchain.transaction.broadcast'
+        invocation = lambda c: self.send([(command, [str(transaction)])], c)
+
+        if callback:
+            invocation(callback)
+            return
+
+        try:
+            out = ElectrumX.__wait_for(invocation)
+        except BaseException as e:
+            return False, "error: " + str(e)
+
+        if out != transaction.txid():
+            return False, "error: " + out
+
+        return True, out
+
+    def get_history_for_scripthash(self, hash, callback=None):
+        command = 'blockchain.scripthash.get_history'
+        invocation = lambda c: self.send([(command, [hash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def subscribe_to_headers(self, callback=None):
+        command = 'blockchain.headers.subscribe'
+        invocation = lambda c: self.send([(command, [True])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    # NOTE: Deprecated since ElectrumX 1.2. Use subscribe_to_scripthash.
+    def subscribe_to_address(self, address, callback=None):
+        command = 'blockchain.address.subscribe'
+        invocation = lambda c: self.send([(command, [address])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_merkle_for_transaction(self, tx_hash, tx_height, callback=None):
+        command = 'blockchain.transaction.get_merkle'
+        invocation = lambda c: self.send([(command, [tx_hash, tx_height])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def subscribe_to_scripthash(self, scripthash, callback=None):
+        command = 'blockchain.scripthash.subscribe'
+        invocation = lambda c: self.send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_transaction(self, transaction_hash, callback=None):
+        command = 'blockchain.transaction.get'
+        invocation = lambda c: self.send([(command, [transaction_hash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_transactions(self, transaction_hashes, callback=None):
+        command = 'blockchain.transaction.get'
+        messages = [(command, [tx_hash]) for tx_hash in transaction_hashes]
+        invocation = lambda c: self.send(messages, c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def listunspent_for_scripthash(self, scripthash, callback=None):
+        command = 'blockchain.scripthash.listunspent'
+        invocation = lambda c: self.send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    def get_balance_for_scripthash(self, scripthash, callback=None):
+        command = 'blockchain.scripthash.get_balance'
+        invocation = lambda c: self.send([(command, [scripthash])], c)
+
+        return ElectrumX.__with_default_synchronous_callback(
+            invocation,
+            callback)
+
+    @staticmethod
+    def __wait_for(it):
+        """Wait for the result of calling lambda `it`."""
+        q = queue.Queue()
+        it(q.put)
+        try:
+            result = q.get(block=True, timeout=30)
+        except queue.Empty:
+            raise util.TimeoutException(_('Server did not answer'))
+
+        if result.get('error'):
+            raise Exception(result.get('error'))
+
+        return result.get('result')
+
+    @staticmethod
+    def __with_default_synchronous_callback(invocation, callback):
+        """ Use this method if you want to make the network request
+        synchronous. """
+        if not callback:
+            return ElectrumX.__wait_for(invocation)
+
+        invocation(callback)

--- a/lib/network.py
+++ b/lib/network.py
@@ -219,7 +219,7 @@ class Network(util.DaemonThread):
 
         # subscriptions and requests
         self.subscribed_addresses = set()  # note: needs self.subscribed_addresses_lock
-        self.h2addr = {}
+
         # Requests from client we've not seen a response to
         self.unanswered_requests = {}
         # retry times

--- a/lib/network.py
+++ b/lib/network.py
@@ -134,6 +134,7 @@ def deserialize_proxy(s):
         proxy["port"] = args[n]
         n += 1
     else:
+
         proxy["port"] = "8080" if proxy["mode"] == "http" else "1080"
     if len(args) > n:
         proxy["user"] = args[n]
@@ -896,11 +897,13 @@ class Network(util.DaemonThread):
             interface.print_error(response)
             self._connection_down(interface.server)
             return
+
         height = header.get('block_height')
         if interface.request != height:
             interface.print_error("unsolicited header",interface.request, height)
             self._connection_down(interface.server)
             return
+
         chain = blockchain.check_header(header)
         if interface.mode == 'backward':
             can_connect = blockchain.can_connect(header)
@@ -937,6 +940,7 @@ class Network(util.DaemonThread):
             else:
                 interface.bad = height
                 interface.bad_header = header
+
             if interface.bad != interface.good + 1:
                 next_height = (interface.bad + interface.good) // 2
                 assert next_height >= self.max_checkpoint()

--- a/lib/network.py
+++ b/lib/network.py
@@ -41,12 +41,10 @@ import socks
 from . import util
 from .util import print_error
 from . import bitcoin
-from .bitcoin import COIN
 from . import constants
 from .interface import Connection, Interface
 from . import blockchain
 from .version import ELECTRUM_VERSION, PROTOCOL_VERSION
-from .i18n import _
 
 
 NODES_RETRY_INTERVAL = 60
@@ -637,13 +635,13 @@ class Network(util.DaemonThread):
         elif method == 'blockchain.estimatefee':
             if error is None and result > 0:
                 i = params[0]
-                fee = int(result*COIN)
+                fee = int(result*bitcoin.COIN)
                 self.config.update_fee_estimates(i, fee)
                 self.print_error("fee_estimates[%d]" % i, fee)
                 self.notify('fee')
         elif method == 'blockchain.relayfee':
             if error is None:
-                self.relay_fee = int(result * COIN) if result is not None else None
+                self.relay_fee = int(result * bitcoin.COIN) if result is not None else None
                 self.print_error("relayfee", self.relay_fee)
         elif method == 'blockchain.block.headers':
             self.on_block_headers(interface, response)

--- a/lib/network.py
+++ b/lib/network.py
@@ -840,17 +840,23 @@ class Network(util.DaemonThread):
                 if self.config.is_fee_estimates_update_required():
                     self.request_fee_estimates()
 
-    def request_chunk(self, interface, index):
+    def fetch_missing_headers_around(self, tx_height):
+        """ This method fetches blocks in batches of 2016 block around a specific
+        height. The number 2016 is the same interval the checkpoints are using and
+        appear to be the maximum an ElectrumX server will return.
+        """
+        index = tx_height // 2016
         if index in self.requested_chunks:
             return
-        interface.print_error("requesting chunk %d" % index)
+
         self.requested_chunks.add(index)
-        height = index * 2016
-        self.queue_request('blockchain.block.headers', [height, 2016],
-                           interface)
+        self._queue_request(
+            'blockchain.block.headers',
+            [index * 2016, 2016],
+            self.interface)
 
     def on_block_headers(self, interface, response):
-        '''Handle receiving a chunk of block headers'''
+        '''Handle receiving a batch of block headers'''
         error = response.get('error')
         result = response.get('result')
         params = response.get('params')
@@ -858,6 +864,7 @@ class Network(util.DaemonThread):
         if result is None or params is None or error is not None:
             interface.print_error(error or 'bad response')
             return
+
         # Ignore unsolicited chunks
         height = params[0]
         index = height // 2016
@@ -867,14 +874,13 @@ class Network(util.DaemonThread):
         else:
             interface.print_error("received chunk %d" % index)
         self.requested_chunks.remove(index)
-        hexdata = result['hex']
-        connect = blockchain.connect_chunk(index, hexdata)
+        connect = blockchain.connect_chunk(index, result['hex'])
         if not connect:
             self.connection_down(interface.server)
             return
         # If not finished, get the next chunk
         if index >= len(blockchain.checkpoints) and blockchain.height() < interface.tip:
-            self.request_chunk(interface, index+1)
+            self.fetch_missing_headers_around(height + 2016)
         else:
             interface.mode = 'default'
             interface.print_error('catch up done', blockchain.height())
@@ -1001,7 +1007,7 @@ class Network(util.DaemonThread):
         # If not finished, get the next header
         if next_height is not None:
             if interface.mode == 'catch_up' and interface.tip > next_height + 50:
-                self.request_chunk(interface, next_height // 2016)
+                self.fetch_missing_headers_around(next_height)
             else:
                 self.request_header(interface, next_height)
         else:

--- a/lib/network.py
+++ b/lib/network.py
@@ -164,7 +164,7 @@ class Network(util.DaemonThread):
     Our external API:
 
     - Member functions get_header(), get_interfaces(), get_local_height(),
-          get_parameters(), get_server_height(), get_status_value(),
+          get_parameters(), get_server_height(),
           is_connected(), set_parameters(), stop()
     """
 
@@ -203,7 +203,7 @@ class Network(util.DaemonThread):
         self.message_id = 0
         self.debug = False
         self.irc_servers = {}  # returned by interface (list from irc)
-        self.recent_servers = self.read_recent_servers()  # note: needs self.recent_servers_lock
+        self.recent_servers = self._read_recent_servers()  # note: needs self.recent_servers_lock
 
         self.banner = ''
         self.donation_address = ''
@@ -234,7 +234,7 @@ class Network(util.DaemonThread):
         self.connecting = set()
         self.requested_chunks = set()
         self.socket_queue = queue.Queue()
-        self.start_network(deserialize_server(self.default_server)[2],
+        self._start_network(deserialize_server(self.default_server)[2],
                            deserialize_proxy(self.config.get('proxy')))
 
     def with_interface_lock(func):
@@ -265,7 +265,7 @@ class Network(util.DaemonThread):
             callbacks = self.callbacks[event][:]
         [callback(event, *args) for callback in callbacks]
 
-    def read_recent_servers(self):
+    def _read_recent_servers(self):
         if not self.config.path:
             return []
         path = os.path.join(self.config.path, "recent_servers")
@@ -277,7 +277,7 @@ class Network(util.DaemonThread):
             return []
 
     @with_recent_servers_lock
-    def save_recent_servers(self):
+    def _save_recent_servers(self):
         if not self.config.path:
             return
         path = os.path.join(self.config.path, "recent_servers")
@@ -292,7 +292,7 @@ class Network(util.DaemonThread):
     def get_server_height(self):
         return self.interface.tip if self.interface else 0
 
-    def server_is_lagging(self):
+    def _server_is_lagging(self):
         sh = self.get_server_height()
         if not sh:
             self.print_error('no height for main interface')
@@ -303,9 +303,9 @@ class Network(util.DaemonThread):
             self.print_error('%s is lagging (%d vs %d)' % (self.default_server, sh, lh))
         return result
 
-    def set_status(self, status):
+    def _set_status(self, status):
         self.connection_status = status
-        self.notify('status')
+        self._notify('status')
 
     def is_connected(self):
         return self.interface is not None
@@ -314,7 +314,7 @@ class Network(util.DaemonThread):
         return self.connection_status == 'connecting'
 
     @with_interface_lock
-    def queue_request(self, method, params, interface=None):
+    def _queue_request(self, method, params, interface=None):
         # If you want to queue a request on any interface it must go
         # through this function so message ids are properly tracked
         if interface is None:
@@ -330,7 +330,7 @@ class Network(util.DaemonThread):
         return message_id
 
     @with_interface_lock
-    def send_subscriptions(self):
+    def _send_subscriptions(self):
         assert self.interface
         self.print_error('sending subscriptions to', self.interface.server, len(self.unanswered_requests), len(self.subscribed_addresses))
         self.sub_cache.clear()
@@ -338,25 +338,26 @@ class Network(util.DaemonThread):
         requests = self.unanswered_requests.values()
         self.unanswered_requests = {}
         for request in requests:
-            message_id = self.queue_request(request[0], request[1])
+            message_id = self._queue_request(request[0], request[1])
             self.unanswered_requests[message_id] = request
-        self.queue_request('server.banner', [])
-        self.queue_request('server.donation_address', [])
-        self.queue_request('server.peers.subscribe', [])
-        self.request_fee_estimates()
-        self.queue_request('blockchain.relayfee', [])
-        with self.subscribed_addresses_lock:
-            for h in self.subscribed_addresses:
-                self.queue_request('blockchain.scripthash.subscribe', [h])
 
-    def request_fee_estimates(self):
+        self._queue_request('server.banner', [])
+        self._queue_request('server.donation_address', [])
+        self._queue_request('server.peers.subscribe', [])
+        self._request_fee_estimates()
+        self._queue_request('blockchain.relayfee', [])
+        with self.subscribed_addresses_lock:
+            for h in list(self.subscribed_addresses):
+                self._queue_request('blockchain.scripthash.subscribe', [h])
+
+    def _request_fee_estimates(self):
         from .simple_config import FEE_ETA_TARGETS
         self.config.requested_fee_estimates()
-        self.queue_request('mempool.get_fee_histogram', [])
+        self._queue_request('mempool.get_fee_histogram', [])
         for i in FEE_ETA_TARGETS:
-            self.queue_request('blockchain.estimatefee', [i])
+            self._queue_request('blockchain.estimatefee', [i])
 
-    def get_status_value(self, key):
+    def _get_status_value(self, key):
         if key == 'status':
             value = self.connection_status
         elif key == 'banner':
@@ -373,11 +374,11 @@ class Network(util.DaemonThread):
             value = self.get_interfaces()
         return value
 
-    def notify(self, key):
+    def _notify(self, key):
         if key in ['status', 'updated']:
             self.trigger_callback(key)
         else:
-            self.trigger_callback(key, self.get_status_value(key))
+            self.trigger_callback(key, self._get_status_value(key))
 
     def get_parameters(self):
         host, port, protocol = deserialize_server(self.default_server)
@@ -408,27 +409,27 @@ class Network(util.DaemonThread):
         return out
 
     @with_interface_lock
-    def start_interface(self, server):
+    def _start_interface(self, server):
         if (not server in self.interfaces and not server in self.connecting):
             if server == self.default_server:
                 self.print_error("connecting to %s as new interface" % server)
-                self.set_status('connecting')
+                self._set_status('connecting')
             self.connecting.add(server)
             Connection(server, self.socket_queue, self.config.path)
 
-    def start_random_interface(self):
+    def _start_random_interface(self):
         with self.interface_lock:
             exclude_set = self.disconnected_servers.union(set(self.interfaces))
         server = pick_random_server(self.get_servers(), self.protocol, exclude_set)
         if server:
-            self.start_interface(server)
+            self._start_interface(server)
 
-    def start_interfaces(self):
-        self.start_interface(self.default_server)
+    def _start_interfaces(self):
+        self._start_interface(self.default_server)
         for i in range(self.num_server - 1):
-            self.start_random_interface()
+            self._start_random_interface()
 
-    def set_proxy(self, proxy):
+    def _set_proxy(self, proxy):
         self.proxy = proxy
         # Store these somewhere so we can un-monkey-patch
         if not hasattr(socket, "_socketobject"):
@@ -485,22 +486,23 @@ class Network(util.DaemonThread):
         return socket._getaddrinfo(addr, *args, **kwargs)
 
     @with_interface_lock
-    def start_network(self, protocol, proxy):
+    def _start_network(self, protocol, proxy):
         assert not self.interface and not self.interfaces
         assert not self.connecting and self.socket_queue.empty()
         self.print_error('starting network')
         self.disconnected_servers = set([])  # note: needs self.interface_lock
         self.protocol = protocol
-        self.set_proxy(proxy)
-        self.start_interfaces()
+        self._set_proxy(proxy)
+        self._start_interfaces()
 
     @with_interface_lock
-    def stop_network(self):
+    def _stop_network(self):
+
         self.print_error("stopping network")
         for interface in list(self.interfaces.values()):
-            self.close_interface(interface)
+            self._close_interface(interface)
         if self.interface:
-            self.close_interface(self.interface)
+            self._close_interface(self.interface)
         assert self.interface is None
         assert not self.interfaces
         self.connecting = set()
@@ -528,16 +530,16 @@ class Network(util.DaemonThread):
         if self.proxy != proxy or self.protocol != protocol:
             # Restart the network defaulting to the given server
             with self.interface_lock:
-                self.stop_network()
+                self._stop_network()
                 self.default_server = server
-                self.start_network(protocol, proxy)
+                self._start_network(protocol, proxy)
         elif self.default_server != server:
             self.switch_to_interface(server)
         else:
-            self.switch_lagging_interface()
-            self.notify('updated')
+            self._switch_lagging_interface()
+            self._notify('updated')
 
-    def switch_to_random_interface(self):
+    def _switch_to_random_interface(self):
         '''Switch to a random connected server other than the current one'''
         servers = self.get_interfaces()    # Those in connected state
         if self.default_server in servers:
@@ -546,9 +548,9 @@ class Network(util.DaemonThread):
             self.switch_to_interface(random.choice(servers))
 
     @with_interface_lock
-    def switch_lagging_interface(self):
+    def _switch_lagging_interface(self):
         '''If auto_connect and lagging, switch interface'''
-        if self.server_is_lagging() and self.auto_connect:
+        if self._server_is_lagging() and self.auto_connect:
             # switch to one that has the correct header (not height)
             header = self.blockchain().read_header(self.get_local_height())
             filtered = list(map(lambda x: x[0], filter(lambda x: x[1].tip_header == header, self.interfaces.items())))
@@ -565,7 +567,7 @@ class Network(util.DaemonThread):
         self.default_server = server
         if server not in self.interfaces:
             self.interface = None
-            self.start_interface(server)
+            self._start_interface(server)
             return
 
         i = self.interfaces[server]
@@ -573,15 +575,15 @@ class Network(util.DaemonThread):
             self.print_error("switching to", server)
             # stop any current interface in order to terminate subscriptions
             # fixme: we don't want to close headers sub
-            #self.close_interface(self.interface)
+            #self._close_interface(self.interface)
             self.interface = i
-            self.send_subscriptions()
-            self.set_status('connected')
-            self.notify('updated')
-            self.notify('interfaces')
+            self._send_subscriptions()
+            self._set_status('connected')
+            self._notify('updated')
+            self._notify('interfaces')
 
     @with_interface_lock
-    def close_interface(self, interface):
+    def _close_interface(self, interface):
         if interface:
             if interface.server in self.interfaces:
                 self.interfaces.pop(interface.server)
@@ -590,15 +592,15 @@ class Network(util.DaemonThread):
             interface.close()
 
     @with_recent_servers_lock
-    def add_recent_server(self, server):
+    def _add_recent_server(self, server):
         # list is ordered
         if server in self.recent_servers:
             self.recent_servers.remove(server)
         self.recent_servers.insert(0, server)
         self.recent_servers = self.recent_servers[0:20]
-        self.save_recent_servers()
+        self._save_recent_servers()
 
-    def process_response(self, interface, response, callbacks):
+    def _process_response(self, interface, response, callbacks):
         if self.debug:
             self.print_error(interface.host, "<--", response)
         error = response.get('error')
@@ -611,7 +613,7 @@ class Network(util.DaemonThread):
             interface.server_version = result
         elif method == 'blockchain.headers.subscribe':
             if error is None:
-                self.on_notify_header(interface, result)
+                self._on_notify_header(interface, result)
             else:
                 # no point in keeping this connection without headers sub
                 self.connection_down(interface.server)
@@ -619,11 +621,11 @@ class Network(util.DaemonThread):
         elif method == 'server.peers.subscribe':
             if error is None:
                 self.irc_servers = parse_servers(result)
-                self.notify('servers')
+                self._notify('servers')
         elif method == 'server.banner':
             if error is None:
                 self.banner = result
-                self.notify('banner')
+                self._notify('banner')
         elif method == 'server.donation_address':
             if error is None:
                 self.donation_address = result
@@ -631,38 +633,38 @@ class Network(util.DaemonThread):
             if error is None:
                 self.print_error('fee_histogram', result)
                 self.config.mempool_fees = result
-                self.notify('fee_histogram')
+                self._notify('fee_histogram')
         elif method == 'blockchain.estimatefee':
             if error is None and result > 0:
                 i = params[0]
                 fee = int(result*bitcoin.COIN)
                 self.config.update_fee_estimates(i, fee)
                 self.print_error("fee_estimates[%d]" % i, fee)
-                self.notify('fee')
+                self._notify('fee')
         elif method == 'blockchain.relayfee':
             if error is None:
                 self.relay_fee = int(result * bitcoin.COIN) if result is not None else None
                 self.print_error("relayfee", self.relay_fee)
         elif method == 'blockchain.block.headers':
-            self.on_block_headers(interface, response)
+            self._on_block_headers(interface, response)
         elif method == 'blockchain.block.get_header':
-            self.on_get_header(interface, response)
+            self._on_get_header(interface, response)
 
         for callback in callbacks:
             callback(response)
 
     @classmethod
-    def get_index(cls, method, params):
+    def _get_index(cls, method, params):
         """ hashable index for subscriptions and cache"""
         return str(method) + (':' + str(params[0]) if params else '')
 
-    def process_responses(self, interface):
+    def _process_responses(self, interface):
         responses = interface.get_responses()
         for request, response in responses:
             if request:
                 method, params, message_id = request
-                k = self.get_index(method, params)
-                # client requests go through self.send() with a
+                k = self._get_index(method, params)
+                # client requests go through self._send() with a
                 # callback, are only sent to the current interface,
                 # and are placed in the unanswered_requests dictionary
                 client_req = self.unanswered_requests.pop(message_id, None)
@@ -674,7 +676,7 @@ class Network(util.DaemonThread):
                     callbacks = [client_req[2]]
                 else:
                     # fixme: will only work for subscriptions
-                    k = self.get_index(method, params)
+                    k = self._get_index(method, params)
                     callbacks = list(self.subscriptions.get(k, []))
 
                 # Copy the request method and params to the response
@@ -687,12 +689,12 @@ class Network(util.DaemonThread):
                         self.subscribed_addresses.add(params[0])
             else:
                 if not response:  # Closed remotely / misbehaving
-                    self.connection_down(interface.server)
+                    self._connection_down(interface.server)
                     break
                 # Rewrite response shape to match subscription request response
                 method = response.get('method')
                 params = response.get('params')
-                k = self.get_index(method, params)
+                k = self._get_index(method, params)
                 if method == 'blockchain.headers.subscribe':
                     response['result'] = params[0]
                     response['params'] = []
@@ -706,16 +708,16 @@ class Network(util.DaemonThread):
                 with self.interface_lock:
                     self.sub_cache[k] = response
             # Response is now in canonical form
-            self.process_response(interface, response, callbacks)
+            self._process_response(interface, response, callbacks)
 
-    def send(self, messages, callback):
+    def _send(self, messages, callback):
         '''Messages is a list of (method, params) tuples'''
         messages = list(messages)
         with self.pending_sends_lock:
             self.pending_sends.append((messages, callback))
 
     @with_interface_lock
-    def process_pending_sends(self):
+    def _process_pending_sends(self):
         # Requests needs connectivity.  If we don't have an interface,
         # we cannot process them.
         if not self.interface:
@@ -729,7 +731,7 @@ class Network(util.DaemonThread):
             for method, params in messages:
                 r = None
                 if method.endswith('.subscribe'):
-                    k = self.get_index(method, params)
+                    k = self._get_index(method, params)
                     # add callback to list
                     l = list(self.subscriptions.get(k, []))
                     if callback not in l:
@@ -743,13 +745,13 @@ class Network(util.DaemonThread):
                     self.print_error("cache hit", k)
                     callback(r)
                 else:
-                    message_id = self.queue_request(method, params)
+                    message_id = self._queue_request(method, params)
                     self.unanswered_requests[message_id] = method, params, callback
 
     def unsubscribe(self, callback):
         '''Unsubscribe a callback to free object references to enable GC.'''
         # Note: we can't unsubscribe from the server, so if we receive
-        # subsequent notifications process_response() will emit a harmless
+        # subsequent notifications _process_response() will emit a harmless
         # "received unexpected notification" warning
         with self.callback_lock:
             for v in self.subscriptions.values():
@@ -757,23 +759,23 @@ class Network(util.DaemonThread):
                     v.remove(callback)
 
     @with_interface_lock
-    def connection_down(self, server):
+    def _connection_down(self, server):
         '''A connection to server either went down, or was never made.
         We distinguish by whether it is in self.interfaces.'''
         self.disconnected_servers.add(server)
         if server == self.default_server:
-            self.set_status('disconnected')
+            self._set_status('disconnected')
         if server in self.interfaces:
-            self.close_interface(self.interfaces[server])
-            self.notify('interfaces')
+            self._close_interface(self.interfaces[server])
+            self._notify('interfaces')
         with self.blockchains_lock:
             for b in self.blockchains.values():
                 if b.catch_up == server:
                     b.catch_up = None
 
-    def new_interface(self, server, socket):
+    def _new_interface(self, server, socket):
         # todo: get tip first, then decide which checkpoint to use.
-        self.add_recent_server(server)
+        self._add_recent_server(server)
         interface = Interface(server, socket)
         interface.blockchain = None
         interface.tip_header = None
@@ -784,13 +786,13 @@ class Network(util.DaemonThread):
             self.interfaces[server] = interface
         # server.version should be the first message
         params = [ELECTRUM_VERSION, PROTOCOL_VERSION]
-        self.queue_request('server.version', params, interface)
-        self.queue_request('blockchain.headers.subscribe', [True], interface)
+        self._queue_request('server.version', params, interface)
+        self._queue_request('blockchain.headers.subscribe', [True], interface)
         if server == self.default_server:
             self.switch_to_interface(server)
-        #self.notify('interfaces')
+        #self._notify('interfaces')
 
-    def maintain_sockets(self):
+    def _maintain_sockets(self):
         '''Socket maintenance.'''
         # Responses to connection attempts?
         while not self.socket_queue.empty():
@@ -799,9 +801,9 @@ class Network(util.DaemonThread):
                 self.connecting.remove(server)
 
             if socket:
-                self.new_interface(server, socket)
+                self._new_interface(server, socket)
             else:
-                self.connection_down(server)
+                self._connection_down(server)
 
         # Send pings and shut down stale interfaces
         # must use copy of values
@@ -809,15 +811,15 @@ class Network(util.DaemonThread):
             interfaces = list(self.interfaces.values())
         for interface in interfaces:
             if interface.has_timed_out():
-                self.connection_down(interface.server)
+                self._connection_down(interface.server)
             elif interface.ping_required():
-                self.queue_request('server.ping', [], interface)
+                self._queue_request('server.ping', [], interface)
 
         now = time.time()
         # nodes
         with self.interface_lock:
             if len(self.interfaces) + len(self.connecting) < self.num_server:
-                self.start_random_interface()
+                self._start_random_interface()
                 if now - self.nodes_retry_time > NODES_RETRY_INTERVAL:
                     self.print_error('network: retrying connections')
                     self.disconnected_servers = set([])
@@ -828,7 +830,7 @@ class Network(util.DaemonThread):
             if not self.is_connected():
                 if self.auto_connect:
                     if not self.is_connecting():
-                        self.switch_to_random_interface()
+                        self._switch_to_random_interface()
                 else:
                     if self.default_server in self.disconnected_servers:
                         if now - self.server_retry_time > SERVER_RETRY_INTERVAL:
@@ -838,7 +840,7 @@ class Network(util.DaemonThread):
                         self.switch_to_interface(self.default_server)
             else:
                 if self.config.is_fee_estimates_update_required():
-                    self.request_fee_estimates()
+                    self._request_fee_estimates()
 
     def fetch_missing_headers_around(self, tx_height):
         """ This method fetches blocks in batches of 2016 block around a specific
@@ -855,7 +857,7 @@ class Network(util.DaemonThread):
             [index * 2016, 2016],
             self.interface)
 
-    def on_block_headers(self, interface, response):
+    def _on_block_headers(self, interface, response):
         '''Handle receiving a batch of block headers'''
         error = response.get('error')
         result = response.get('result')
@@ -876,7 +878,7 @@ class Network(util.DaemonThread):
         self.requested_chunks.remove(index)
         connect = blockchain.connect_chunk(index, result['hex'])
         if not connect:
-            self.connection_down(interface.server)
+            self._connection_down(interface.server)
             return
         # If not finished, get the next chunk
         if index >= len(blockchain.checkpoints) and blockchain.height() < interface.tip:
@@ -885,19 +887,19 @@ class Network(util.DaemonThread):
             interface.mode = 'default'
             interface.print_error('catch up done', blockchain.height())
             blockchain.catch_up = None
-        self.notify('updated')
+        self._notify('updated')
 
-    def on_get_header(self, interface, response):
+    def _on_get_header(self, interface, response):
         '''Handle receiving a single block header'''
         header = response.get('result')
         if not header:
             interface.print_error(response)
-            self.connection_down(interface.server)
+            self._connection_down(interface.server)
             return
         height = header.get('block_height')
         if interface.request != height:
             interface.print_error("unsolicited header",interface.request, height)
-            self.connection_down(interface.server)
+            self._connection_down(interface.server)
             return
         chain = blockchain.check_header(header)
         if interface.mode == 'backward':
@@ -917,7 +919,7 @@ class Network(util.DaemonThread):
                 assert next_height >= self.max_checkpoint(), (interface.bad, interface.good)
             else:
                 if height == 0:
-                    self.connection_down(interface.server)
+                    self._connection_down(interface.server)
                     next_height = None
                 else:
                     interface.bad = height
@@ -939,7 +941,7 @@ class Network(util.DaemonThread):
                 next_height = (interface.bad + interface.good) // 2
                 assert next_height >= self.max_checkpoint()
             elif not interface.blockchain.can_connect(interface.bad_header, check_height=False):
-                self.connection_down(interface.server)
+                self._connection_down(interface.server)
                 next_height = None
             else:
                 branch = self.blockchains.get(interface.bad)
@@ -980,7 +982,7 @@ class Network(util.DaemonThread):
                             next_height = bh + 1
                             interface.blockchain.catch_up = interface.server
 
-                self.notify('updated')
+                self._notify('updated')
 
         elif interface.mode == 'catch_up':
             can_connect = interface.blockchain.can_connect(header)
@@ -999,8 +1001,8 @@ class Network(util.DaemonThread):
                 # exit catch_up state
                 interface.print_error('catch up done', interface.blockchain.height())
                 interface.blockchain.catch_up = None
-                self.switch_lagging_interface()
-                self.notify('updated')
+                self._switch_lagging_interface()
+                self._notify('updated')
 
         else:
             raise Exception(interface.mode)
@@ -1013,21 +1015,21 @@ class Network(util.DaemonThread):
         else:
             interface.mode = 'default'
             interface.request = None
-            self.notify('updated')
+            self._notify('updated')
 
         # refresh network dialog
-        self.notify('interfaces')
+        self._notify('interfaces')
 
-    def maintain_requests(self):
+    def _maintain_requests(self):
         with self.interface_lock:
             interfaces = list(self.interfaces.values())
         for interface in interfaces:
             if interface.request and time.time() - interface.request_time > 20:
                 interface.print_error("blockchain request timed out")
-                self.connection_down(interface.server)
+                self._connection_down(interface.server)
                 continue
 
-    def wait_on_sockets(self):
+    def _wait_on_sockets(self):
         # Python docs say Windows doesn't like empty selects.
         # Sleep to prevent busy looping
         if not self.interfaces:
@@ -1047,9 +1049,9 @@ class Network(util.DaemonThread):
         for interface in wout:
             interface.send_requests()
         for interface in rout:
-            self.process_responses(interface)
+            self._process_responses(interface)
 
-    def init_headers_file(self):
+    def _init_headers_file(self):
         b = self.blockchains[0]
         filename = b.path()
         length = 80 * len(constants.net.CHECKPOINTS) * 2016
@@ -1062,26 +1064,27 @@ class Network(util.DaemonThread):
             b.update_size()
 
     def run(self):
-        self.init_headers_file()
+        self._init_headers_file()
         while self.is_running():
-            self.maintain_sockets()
-            self.wait_on_sockets()
-            self.maintain_requests()
+            self._maintain_sockets()
+            self._wait_on_sockets()
+            self._maintain_requests()
             self.run_jobs()    # Synchronizer and Verifier
-            self.process_pending_sends()
-        self.stop_network()
+            self._process_pending_sends()
+        self._stop_network()
         self.on_stop()
 
-    def on_notify_header(self, interface, header_dict):
+    def _on_notify_header(self, interface, header_dict):
         try:
             header_hex, height = header_dict['hex'], header_dict['height']
         except KeyError:
             # no point in keeping this connection without headers sub
             self.connection_down(interface.server)
             return
+
         header = blockchain.deserialize_header(util.bfh(header_hex), height)
         if height < self.max_checkpoint():
-            self.connection_down(interface.server)
+            self._connection_down(interface.server)
             return
         interface.tip_header = header
         interface.tip = height
@@ -1090,17 +1093,17 @@ class Network(util.DaemonThread):
         b = blockchain.check_header(header)
         if b:
             interface.blockchain = b
-            self.switch_lagging_interface()
-            self.notify('updated')
-            self.notify('interfaces')
+            self._switch_lagging_interface()
+            self._notify('updated')
+            self._notify('interfaces')
             return
         b = blockchain.can_connect(header)
         if b:
             interface.blockchain = b
             b.save_header(header)
-            self.switch_lagging_interface()
-            self.notify('updated')
-            self.notify('interfaces')
+            self._switch_lagging_interface()
+            self._notify('updated')
+            self._notify('interfaces')
             return
         with self.blockchains_lock:
             tip = max([x.height() for x in self.blockchains.values()])

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -99,7 +99,7 @@ class Synchronizer(ThreadJob):
             # there is no history
             if addr not in self.requested_histories:
                 self.requested_histories[addr] = result
-                self.network.request_address_history(addr, self.on_address_history)
+                self.network.get_history_for_address(addr, self.on_address_history)
         # remove addr from list only after it is added to requested_histories
         if addr in self.requested_addrs:  # Notifications won't be in
             self.requested_addrs.remove(addr)

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -124,6 +124,10 @@ class Synchronizer(ThreadJob):
         # tx_fees
         tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
         tx_fees = dict(filter(lambda x:x[1] is not None, tx_fees))
+
+        # Note if the server hasn't been patched to sort the items properly
+        if hist != sorted(hist, key=lambda x:x[1]):
+            self.print_error("error: serving improperly sorted address histories")
         # Check that txids are unique
         if len(hashes) != len(result):
             self.print_error("error: server history has non-unique txids: %s"% addr)

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -39,11 +39,10 @@ class SPV(ThreadJob):
         self.requested_merkle = set()  # txid set of pending requests
 
     def run(self):
-        interface = self.network.interface
-        if not interface:
+        if not self.network.is_connected():
             return
 
-        blockchain = interface.blockchain
+        blockchain = self.network.blockchain()
         if not blockchain:
             return
 
@@ -56,9 +55,12 @@ class SPV(ThreadJob):
 
             header = blockchain.read_header(tx_height)
             if header is None:
-                index = tx_height // 2016
-                if index < len(blockchain.checkpoints):
-                    self.network.request_chunk(interface, index)
+                # Retreive headers when the transaction height is before the
+                # last checkpoint. As a rule we don't fetch headers before
+                # checkpoints as we assume the chain is correct up until that
+                # point.
+                if blockchain.is_before_last_checkpoint(tx_height):
+                    self.network.fetch_missing_headers_around(tx_height)
             elif (tx_hash not in self.requested_merkle
                     and tx_hash not in self.merkle_roots):
                 self.network.get_merkle_for_transaction(

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -23,7 +23,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import queue
-import threading, os, json
+import threading
+import os
+import json
 from collections import defaultdict
 try:
     from SimpleWebSocketServer import WebSocket, SimpleSSLWebSocketServer
@@ -34,7 +36,9 @@ except ImportError:
 from . import util
 from . import bitcoin
 
+
 request_queue = queue.Queue()
+
 
 class ElectrumWebSocket(WebSocket):
 
@@ -51,7 +55,6 @@ class ElectrumWebSocket(WebSocket):
         util.print_error("closed", self.address)
 
 
-
 class WsClientThread(util.DaemonThread):
 
     def __init__(self, config, network):
@@ -60,6 +63,7 @@ class WsClientThread(util.DaemonThread):
         self.config = config
         self.response_queue = queue.Queue()
         self.subscriptions = defaultdict(list)
+        self.hash2address = {}
 
     def make_request(self, request_id):
         # read json file
@@ -70,7 +74,9 @@ class WsClientThread(util.DaemonThread):
         d = json.loads(s)
         addr = d.get('address')
         amount = d.get('amount')
-        return addr, amount
+        scripthash = bitcoin.address_to_scripthash(addr)
+        self.hash2address[scripthash] = addr
+        return scripthash, amount
 
     def reading_thread(self):
         while self.is_running():
@@ -78,14 +84,17 @@ class WsClientThread(util.DaemonThread):
                 ws, request_id = request_queue.get()
             except queue.Empty:
                 continue
+
             try:
-                addr, amount = self.make_request(request_id)
-            except:
+                scripthash, amount = self.make_request(request_id)
+            except OSError:
                 continue
-            l = self.subscriptions.get(addr, [])
-            l.append((ws, amount))
-            self.subscriptions[addr] = l
-            self.network.subscribe_to_addresses([addr], self.response_queue.put)
+            except json.JSONDecodeError:
+                continue
+            subscription = self.subscriptions.get(scripthash, [])
+            subscription.append((ws, amount))
+            self.subscriptions[scripthash] = subscription
+            self.network.subscribe_to_scripthash(scripthash, self.response_queue.put)
 
     def run(self):
         threading.Thread(target=self.reading_thread).start()
@@ -98,7 +107,7 @@ class WsClientThread(util.DaemonThread):
             method = r.get('method')
             result = r.get('result')
             if result is None:
-                continue    
+                continue
             if method == 'blockchain.scripthash.subscribe':
                 addr = r.get('params')[0]
                 scripthash = bitcoin.address_to_scripthash(addr)
@@ -106,16 +115,16 @@ class WsClientThread(util.DaemonThread):
                         scripthash, self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
                 scripthash = r.get('params')[0]
-                addr = self.network.h2addr.get(scripthash, None)
+                addr = self.hash2address.get(scripthash, None)
                 if addr is None:
                     util.print_error(
                         "can't find address for scripthash: %s" % scripthash)
-                l = self.subscriptions.get(addr, [])
-                for ws, amount in l:
-                    if not ws.closed:
-                        if sum(result.values()) >=amount:
-                            ws.sendMessage('paid')
 
+                subscription = self.subscriptions.get(scripthash, [])
+                for ws, amount in subscription:
+                    if not ws.closed:
+                        if sum(result.values()) >= amount:
+                            ws.sendMessage('paid')
 
 
 class WebSocketServer(threading.Thread):

--- a/lib/websockets.py
+++ b/lib/websockets.py
@@ -34,7 +34,6 @@ except ImportError:
     sys.exit("install SimpleWebSocketServer")
 
 from . import util
-from . import bitcoin
 
 
 request_queue = queue.Queue()
@@ -105,16 +104,14 @@ class WsClientThread(util.DaemonThread):
                 continue
             util.print_error('response', r)
             method = r.get('method')
+            scripthash = r.get('params')[0]
             result = r.get('result')
             if result is None:
                 continue
             if method == 'blockchain.scripthash.subscribe':
-                addr = r.get('params')[0]
-                scripthash = bitcoin.address_to_scripthash(addr)
                 self.network.get_balance_for_scripthash(
                         scripthash, self.response_queue.put)
             elif method == 'blockchain.scripthash.get_balance':
-                scripthash = r.get('params')[0]
                 addr = self.hash2address.get(scripthash, None)
                 if addr is None:
                     util.print_error(

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -21,7 +21,7 @@ if not network.is_connected():
 
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.send([('server.version',["block_headers script", "1.2"])], callback)
+network.server_version("block_headers script", "1.2", callback)
 network.subscribe_to_headers(callback)
 
 # 3. wait for results

--- a/scripts/block_headers
+++ b/scripts/block_headers
@@ -8,7 +8,7 @@ from electrum.util import print_msg, json_encode
 
 # start network
 c = SimpleConfig()
-network = Network(c)
+network = ElectrumX(c)
 network.start()
 
 # wait until connected

--- a/scripts/get_history
+++ b/scripts/get_history
@@ -11,7 +11,7 @@ except Exception:
     print("usage: get_history <bitcoin_address>")
     sys.exit(1)
 
-n = Network()
+n = ElectrumX()
 n.start()
 _hash = bitcoin.address_to_scripthash(addr)
 h = n.get_history_for_scripthash(_hash)

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -12,8 +12,6 @@ except Exception:
     print("usage: watch_address <bitcoin_address>")
     sys.exit(1)
 
-sh = bitcoin.address_to_scripthash(addr)
-
 # start network
 c = SimpleConfig()
 network = ElectrumX(c)

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -16,7 +16,7 @@ sh = bitcoin.address_to_scripthash(addr)
 
 # start network
 c = SimpleConfig()
-network = Network(c)
+network = ElectrumX(c)
 network.start()
 
 # wait until connected

--- a/scripts/watch_address
+++ b/scripts/watch_address
@@ -25,9 +25,13 @@ if not network.is_connected():
     print_msg("daemon is not connected")
     sys.exit(1)
 
+# 1. translate the Bitcoin address to a scripthash
+scripthash = bitcoin.address_to_scripthash(addr)
+print_msg("Address '{}' becomes scripthash '{}'".format(addr, scripthash))
+
 # 2. send the subscription
 callback = lambda response: print_msg(json_encode(response.get('result')))
-network.subscribe_to_address(addr, callback)
+network.subscribe_to_scripthash(scripthash, callback)
 
 # 3. wait for results
 while network.is_connected():


### PR DESCRIPTION
This PR (once part of #4427) introduces the ElectrumX class. This class deal solely with API calls to the ElectrumX backend thus splitting responsibilities between:
- actual calls (now ElectrumX class)
- network socket maintenance (still Network class)
- trigger sending (still Network class)
- local blockchain management (still Network class)

It also holds the odd new docstring and linter fixes.