### PR TITLE
Show fiat options from api.bitcoinvenezuela.com

### DIFF
--- a/lib/currencies.json
+++ b/lib/currencies.json
@@ -341,6 +341,12 @@
     "Bitcointoyou": [
         "BRL"
     ],
+    "BitcoinVenezuela": [
+        "ARS",
+        "EUR",
+        "USD",
+        "VEF"
+    ],    
     "Bitmarket": [
         "PLN"
     ],


### PR DESCRIPTION
Adding the options to be able to select BitcoinVenezuela.com fiat exchange rates in the Preferences. Certificate validation error has been fixed.