### PR TITLE
Remove test files from coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps=
 	pytest
 	coverage
 commands=
-	coverage run --source=electrum '--omit=electrum/gui/*,electrum/plugins/*,electrum/scripts/*' -m py.test -v
+	coverage run --source=electrum '--omit=electrum/gui/*,electrum/plugins/*,electrum/scripts/*,electrum/tests/*' -m py.test -v
 	coverage report
 extras=
 	fast


### PR DESCRIPTION
I'm not sure why the actual test files are included in the coverage, I can't think of a good reason why. They kind of inflate the actual coverage of the core libs.

Unfortunately this reduces your reported coverage from 56% to 46%