### PR TITLE
Backport from Electron Cash (macOS) -- fix missing URI types

### DIFF
--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -15,7 +15,7 @@ cd $src_dir/../..
 export PYTHONHASHSEED=22
 VERSION=`git describe --tags --dirty`
 
-which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
+which brew > /dev/null 2>&1 || which port > /dev/null 2>&1 || fail "Please install either Homebrew (from https://brew.sh/) or MacPorts (from https://www.macports.org/) to continue"
 
 info "Installing Python $PYTHON_VERSION"
 export PATH="~/.pyenv/bin:~/.pyenv/shims:~/Library/Python/3.6/bin:$PATH"
@@ -89,6 +89,12 @@ done
 
 info "Building binary"
 pyinstaller --noconfirm --ascii --clean --name $VERSION contrib/build-osx/osx.spec || fail "Could not build binary"
+
+info "Adding bitcoin URI types to Info.plist"
+plutil -insert 'CFBundleURLTypes' \
+	-xml '<array><dict> <key>CFBundleURLName</key> <string>bitcoin</string> <key>CFBundleURLSchemes</key> <array><string>bitcoin</string></array> </dict></array>' \
+	-- dist/$PACKAGE.app/Contents/Info.plist \
+	|| fail "Could not add keys to Info.plist. Make sure the program 'plutil' exists and is installed."
 
 info "Creating .DMG"
 hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -15,7 +15,7 @@ cd $src_dir/../..
 export PYTHONHASHSEED=22
 VERSION=`git describe --tags --dirty`
 
-which brew > /dev/null 2>&1 || which port > /dev/null 2>&1 || fail "Please install either Homebrew (from https://brew.sh/) or MacPorts (from https://www.macports.org/) to continue"
+which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
 
 info "Installing Python $PYTHON_VERSION"
 export PATH="~/.pyenv/bin:~/.pyenv/shims:~/Library/Python/3.6/bin:$PATH"


### PR DESCRIPTION
After you guys upgraded to the new building scheme for macOS (which we ported over to our code) -- the Info.plist for macOS became spartan and bare.  One of the thing's it's missing is support for bitcoin: (or bitcoincash: in our case) URI types.

This adds that.

~Also I noticed your build system insists on Homebrew.. when it also works with either MacPorts or Homebrew - so I added supporting that too.~

~I personally use MacPorts and consider it pretty awesome so I try to add support for it to any project.  Since it's 0 cost for you guys to support it (it provides identical tools really) -- here it is, acknowledged as being a viable way to build.~

Tested and works on my macOS system.

