### PR TITLE
localization: fix download link + badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ Electrum - Lightweight Bitcoin client
 .. image:: https://coveralls.io/repos/github/spesmilo/electrum/badge.svg?branch=master
     :target: https://coveralls.io/github/spesmilo/electrum?branch=master
     :alt: Test coverage statistics
-.. image:: https://img.shields.io/badge/help-translating-blue.svg
+.. image:: https://d322cqt584bo4o.cloudfront.net/electrum/localized.svg
     :target: https://crowdin.com/project/electrum
-    :alt: Help translating Electrum online
+    :alt: Help translate Electrum online
 
 
 

--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -54,7 +54,7 @@ if crowdin_api_key:
 
 # Download & unzip
 print('Download translations')
-s = requests.request('GET', 'https://crowdin.com/download/project/' + crowdin_identifier + '.zip').content
+s = requests.request('GET', 'https://crowdin.com/backend/download/project/' + crowdin_identifier + '.zip').content
 zfobj = zipfile.ZipFile(io.BytesIO(s))
 
 print('Unzip translations')


### PR DESCRIPTION
The current download URL was returning a 404, I've updated it to what seems to be the functioning URL format. Additionally, Crowdin provides a "% localized" badge, which adds a bit extra information.

Fixes #4559