### PR TITLE
add logging whitelist option (-V)

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -836,6 +836,8 @@ def add_global_options(parser):
     group.add_argument("--testnet", action="store_true", dest="testnet", default=False, help="Use Testnet")
     group.add_argument("--regtest", action="store_true", dest="regtest", default=False, help="Use Regtest")
     group.add_argument("--simnet", action="store_true", dest="simnet", default=False, help="Use Simnet")
+    group.add_argument("-V", action="append", dest="verbose_module",
+        help="Match log source file name with this (whitelist), requires -v. Can be used multiple times.")
 
 def get_parser():
     # create main parser

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -20,6 +20,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import logging
 import binascii
 import os, sys, re, json
 from collections import defaultdict
@@ -168,8 +169,7 @@ class PrintError(object):
         return self.__class__.__name__
 
     def print_error(self, *msg):
-        # only prints with --verbose flag
-        print_error("[%s]" % self.diagnostic_name(), *msg)
+        logging.getLogger(self.diagnostic_name()).debug(" ".join(str(x) for x in msg), stack_info=True)
 
     def print_stderr(self, *msg):
         print_stderr("[%s]" % self.diagnostic_name(), *msg)
@@ -269,10 +269,8 @@ def set_verbosity(b):
     global is_verbose
     is_verbose = b
 
-
 def print_error(*args):
-    if not is_verbose: return
-    print_stderr(*args)
+    logging.getLogger("global").debug(" ".join(str(x) for x in args), stack_info=True)
 
 def print_stderr(*args):
     args = [str(item) for item in args]

--- a/run_electrum
+++ b/run_electrum
@@ -25,6 +25,7 @@
 # SOFTWARE.
 import os
 import sys
+import re
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 is_bundle = getattr(sys, 'frozen', False)
@@ -376,9 +377,6 @@ if __name__ == '__main__':
     if config_options.get('portable'):
         config_options['electrum_path'] = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum_data')
 
-    # kivy sometimes freezes when we write to sys.stderr
-    set_verbosity(config_options.get('verbose') and config_options.get('gui')!='kivy')
-
     # check uri
     uri = config_options.get('url')
     if uri:
@@ -397,6 +395,48 @@ if __name__ == '__main__':
         constants.set_regtest()
     elif config.get('simnet'):
         constants.set_simnet()
+
+    verbose = config_options.get('verbose')
+    verbose_modules = config.get('verbose_module')
+
+    if verbose_modules is not None and not verbose:
+        print_msg("Can't set -V (log whitelist) without setting -v (verbose).")
+        sys.exit(1)
+
+    set_verbosity(verbose) # set old global flag just for ledger
+
+    import logging
+    class MyLogger(logging.getLoggerClass()):
+        def getEffectiveLevel(self):
+            # kivy sometimes freezes when we write to sys.stderr
+            if not config_options.get('verbose') or config_options.get('gui') == 'kivy':
+                return logging.CRITICAL
+            if verbose_modules is None:
+                return logging.NOTSET
+            stack = self.findCaller(True)[3] # tuple is (filename, lineno, funcname, stackinfo)
+            caller = stack.split("\n")[-4]
+            if any(x in caller for x in verbose_modules):
+                return logging.NOTSET
+            return logging.CRITICAL
+    logging.setLoggerClass(MyLogger)
+
+    FORMAT = '%(filename)s:%(lineno)d %(name)s %(message)s'
+    logging.basicConfig(format=FORMAT, level=logging.DEBUG if verbose else logging.WARNING)
+
+    old_factory = logging.getLogRecordFactory()
+
+    def record_factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        if record.stack_info is None:
+            return record
+        relevant_stack_line = record.stack_info.split("\n")[-4] # skip the stack in util/PrintError
+        record.lineno = int(re.match(".* line (\d+), in [^ ]+$", relevant_stack_line).group(1))
+        full_path = relevant_stack_line.split('"')[1]
+        record.filename = os.path.basename(full_path)
+        record.stack_info = None # if we don't remove this, it would be dumped
+        return record
+
+    logging.setLogRecordFactory(record_factory)
 
     # run non-RPC commands separately
     if cmdname in ['create', 'restore']:


### PR DESCRIPTION
The stack manipulation could be avoided if we changed our logging to having a Logger instance in each class that we initialized once and repeatedly called. But this would change the API in many files.