### PR TITLE
Trezor: fix spending coinbase outputs

### DIFF
--- a/electrum/plugins/keepkey/keepkey.py
+++ b/electrum/plugins/keepkey/keepkey.py
@@ -288,7 +288,7 @@ class KeepKeyPlugin(HW_PluginBase):
         for txin in tx.inputs():
             txinputtype = self.types.TxInputType()
             if txin['type'] == 'coinbase':
-                prev_hash = "\0"*32
+                prev_hash = b"\x00"*32
                 prev_index = 0xffffffff  # signed int -1
             else:
                 if for_sig:

--- a/electrum/plugins/trezor/trezor.py
+++ b/electrum/plugins/trezor/trezor.py
@@ -362,7 +362,7 @@ class TrezorPlugin(HW_PluginBase):
         for txin in tx.inputs():
             txinputtype = self.types.TxInputType()
             if txin['type'] == 'coinbase':
-                prev_hash = "\0"*32
+                prev_hash = b"\x00"*32
                 prev_index = 0xffffffff  # signed int -1
             else:
                 if for_sig:


### PR DESCRIPTION
Attempt to spend coinbase output results in error:
a bytes-like object is required, not 'str'

Note: I have not tested this with Bitcoin since obtaining coinbase outputs is not easy even on Bitcoin testnet. Originally I have found, tested and fixed this problem in Zcoin fork of Electrum and just backporting this fix back to upstream.