### PR TITLE
add logging whitelist option (-V), second approach

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -836,6 +836,8 @@ def add_global_options(parser):
     group.add_argument("--testnet", action="store_true", dest="testnet", default=False, help="Use Testnet")
     group.add_argument("--regtest", action="store_true", dest="regtest", default=False, help="Use Regtest")
     group.add_argument("--simnet", action="store_true", dest="simnet", default=False, help="Use Simnet")
+    group.add_argument("-V", action="append", dest="verbose_module",
+        help="Match log source file name with this (whitelist), requires -v. Can be used multiple times.")
 
 def get_parser():
     # create main parser

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -239,6 +239,7 @@ class Network(util.DaemonThread):
         self.socket_queue = queue.Queue()
         self.start_network(deserialize_server(self.default_server)[2],
                            deserialize_proxy(self.config.get('proxy')))
+        self.log_label = "N"
 
     def with_interface_lock(func):
         def func_wrapper(self, *args, **kwargs):

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -56,6 +56,7 @@ class Plugins(DaemonThread):
         self.device_manager = DeviceMgr(config)
         self.load_plugins()
         self.add_jobs(self.device_manager.thread_jobs())
+        self.log_label = "P"
         self.start()
 
     def load_plugins(self):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -192,6 +192,8 @@ class Abstract_Wallet(AddressSynchronizer):
 
         self.coin_price_cache = {}
 
+        self.log_label = "W"
+
     def diagnostic_name(self):
         return self.basename()
 

--- a/run_electrum
+++ b/run_electrum
@@ -25,6 +25,7 @@
 # SOFTWARE.
 import os
 import sys
+import logging
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 is_bundle = getattr(sys, 'frozen', False)
@@ -72,7 +73,7 @@ from electrum.wallet import Wallet, Imported_Wallet
 from electrum import bitcoin, util, constants
 from electrum.storage import WalletStorage, get_derivation_used_for_hw_device_encryption
 from electrum.util import print_msg, print_stderr, json_encode, json_decode, UserCancelled
-from electrum.util import set_verbosity, InvalidPassword
+from electrum.util import set_verbosity, InvalidPassword, ElectrumLogFilter
 from electrum.commands import get_parser, known_commands, Commands, config_variables
 from electrum import daemon
 from electrum import keystore
@@ -376,9 +377,6 @@ if __name__ == '__main__':
     if config_options.get('portable'):
         config_options['electrum_path'] = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum_data')
 
-    # kivy sometimes freezes when we write to sys.stderr
-    set_verbosity(config_options.get('verbose') and config_options.get('gui')!='kivy')
-
     # check uri
     uri = config_options.get('url')
     if uri:
@@ -397,6 +395,21 @@ if __name__ == '__main__':
         constants.set_regtest()
     elif config.get('simnet'):
         constants.set_simnet()
+
+    verbose = config_options.get('verbose')
+    verbose_modules = config.get('verbose_module')
+    is_kivy = config_options.get('gui') == 'kivy'
+
+    if verbose_modules is not None and not verbose:
+        print_msg("Can't set -V (log whitelist) without setting -v (verbose).")
+        sys.exit(1)
+
+    set_verbosity(verbose and not is_kivy)
+
+    hand = logging.StreamHandler()
+    hand.addFilter(ElectrumLogFilter(verbose_modules, is_kivy))
+
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING, handlers=(hand,))
 
     # run non-RPC commands separately
     if cmdname in ['create', 'restore']:


### PR DESCRIPTION
This approach makes it possible for PrintError descendents to opt in to having their logs filtered by setting `log_label`. This will overwrite the print_error method to one that respects the filtering.

There are four log_labels defined: Wallet, Network, DaemonThread, and Plugins. Each of them use the first letter of their respective names. 