### PR TITLE
fix ecc_fast.py for win64

### DIFF
--- a/electrum/ecc_fast.py
+++ b/electrum/ecc_fast.py
@@ -72,6 +72,9 @@ def load_library():
         secp256k1.secp256k1_ecdsa_signature_parse_compact.argtypes = [c_void_p, c_char_p, c_char_p]
         secp256k1.secp256k1_ecdsa_signature_parse_compact.restype = c_int
 
+        secp256k1.secp256k1_ecdsa_signature_normalize.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_normalize.restype = c_int
+
         secp256k1.secp256k1_ecdsa_signature_serialize_compact.argtypes = [c_void_p, c_char_p, c_char_p]
         secp256k1.secp256k1_ecdsa_signature_serialize_compact.restype = c_int
 


### PR DESCRIPTION
This patch fixes next error on win64:
```ctypes.ArgumentError: argument 1: <class 'OverflowError'>: int too long to convert```
When trying to make signature or sweep master key to new wallet.