### PR TITLE
storage upgrades: make a copy of the wallet before upgrading

### DIFF
--- a/electrum/storage.py
+++ b/electrum/storage.py
@@ -23,6 +23,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
+import shutil
 import ast
 import threading
 import json
@@ -347,6 +348,10 @@ class WalletStorage(JsonDB):
     @profiler
     def upgrade(self):
         self.print_error('upgrading wallet format')
+
+        # make a copy of the file, just in case
+        if self.file_exists():
+            shutil.copy(self.path, self.path + '.old')
 
         self.convert_imported()
         self.convert_wallet_type()


### PR DESCRIPTION
This might be useful for the user should anything go wrong.

For example, in https://github.com/spesmilo/electrum/issues/4641#issue-351807160, the user ran into a problem with the newer version but could not go back to the older one, because of the upgrade.