### PR TITLE
test_bitcoin: fix decorators for running tests twice

### DIFF
--- a/electrum/tests/test_bitcoin.py
+++ b/electrum/tests/test_bitcoin.py
@@ -48,10 +48,10 @@ def needs_test_with_all_ecc_implementations(func):
             # first test without libsecp
             func(*args, **kwargs)
         finally:
-            # if libsecp is not available, we are done
-            if not ecc_fast._libsecp256k1:
-                return
             ecc_fast.do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1()
+        # if libsecp is not available, we are done
+        if not ecc_fast._libsecp256k1:
+            return
         # if libsecp is available, test again now
         func(*args, **kwargs)
     return run_test
@@ -74,10 +74,10 @@ def needs_test_with_all_aes_implementations(func):
             # first test without pycryptodomex
             func(*args, **kwargs)
         finally:
-            # if pycryptodomex is not available, we are done
-            if not _aes:
-                return
             crypto.AES = _aes
+        # if pycryptodomex is not available, we are done
+        if not _aes:
+            return
         # if pycryptodomex is available, test again now
         func(*args, **kwargs)
     return run_test


### PR DESCRIPTION
This bug is triggered if `ecc_fast._libsecp256k1` and/or `crypto.AES` are not present.

Before, if the first test would have raised an exception it would have been implicitly caught by returning from the `finally` block and hence this effectively masks the test's outcome. Now, the exception is properly propagated causing the test to fail if an exception is raised.

The effect of the `return` statement in a `finally` block can be observed using the following snippet.
```py
def foo():
   try:
       raise Exception()
   finally:
       return

try:
    foo()
except:
    print("Exception?")
else:
    print("No exception!!!")
```
Contributed by FDF.