### PR TITLE
contrib: remove git describe workaround

### DIFF
--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -13,7 +13,7 @@ src_dir=$(dirname "$0")
 cd $src_dir/../..
 
 export PYTHONHASHSEED=22
-VERSION=`git describe --tags --dirty`
+VERSION=`git describe --tags --dirty --always`
 
 which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
 

--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -25,7 +25,7 @@ pushd $WINEPREFIX/drive_c/electrum
 git submodule init
 git submodule update
 
-VERSION=`git describe --tags --dirty || printf 'custom'`
+VERSION=`git describe --tags --dirty --always`
 echo "Last commit: $VERSION"
 
 pushd ./contrib/deterministic-build/electrum-locale


### PR DESCRIPTION
`git describe` fails if no tag can be found, leading to the whole build script to fail. This is not always desired. To prevent `git describe` from failing in this case the `--always` flag can be passed which causes a short commit hash to be output when a tag is not present.

Contributed by FDF.