### PR TITLE
docker: ignore .buildozer folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.buildozer


### PR DESCRIPTION
The `.buildozer` folder is not needed for the Windows build. Moreover, it causes the `touch` command to fail. Therefore, it should be ignored from docker's context.