### PR TITLE
Remove unneccessary imports from the unit testing directory.

### DIFF
--- a/electrum/tests/test_bitcoin.py
+++ b/electrum/tests/test_bitcoin.py
@@ -1,5 +1,4 @@
 import base64
-import unittest
 import sys
 
 from electrum.bitcoin import (

--- a/electrum/tests/test_interface.py
+++ b/electrum/tests/test_interface.py
@@ -1,5 +1,3 @@
-import unittest
-
 from electrum import interface
 
 from . import SequentialTestCase

--- a/electrum/tests/test_mnemonic.py
+++ b/electrum/tests/test_mnemonic.py
@@ -1,4 +1,3 @@
-import unittest
 from electrum import keystore
 from electrum import mnemonic
 from electrum import old_mnemonic

--- a/electrum/tests/test_simple_config.py
+++ b/electrum/tests/test_simple_config.py
@@ -1,7 +1,6 @@
 import ast
 import sys
 import os
-import unittest
 import tempfile
 import shutil
 

--- a/electrum/tests/test_storage_upgrade.py
+++ b/electrum/tests/test_storage_upgrade.py
@@ -6,8 +6,6 @@ from electrum.wallet import Wallet
 
 from .test_wallet import WalletTestCase
 
-from . import SequentialTestCase
-
 
 # TODO add other wallet types: 2fa, xpub-only
 # TODO hw wallet with client version 2.6.x (single-, and multiacc)

--- a/electrum/tests/test_transaction.py
+++ b/electrum/tests/test_transaction.py
@@ -1,5 +1,3 @@
-import unittest
-
 from electrum import transaction
 from electrum.bitcoin import TYPE_ADDRESS
 from electrum.keystore import xpubkey_to_address

--- a/electrum/tests/test_util.py
+++ b/electrum/tests/test_util.py
@@ -1,4 +1,3 @@
-import unittest
 from electrum.util import format_satoshis, parse_URI
 
 from . import SequentialTestCase

--- a/electrum/tests/test_wallet.py
+++ b/electrum/tests/test_wallet.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 import sys
-import unittest
 import os
 import json
 

--- a/electrum/tests/test_wallet_vertical.py
+++ b/electrum/tests/test_wallet_vertical.py
@@ -1,10 +1,9 @@
-import unittest
 from unittest import mock
 import shutil
 import tempfile
 from typing import Sequence
 
-from electrum import storage, bitcoin, keystore, constants
+from electrum import storage, bitcoin, keystore
 from electrum import Transaction
 from electrum import SimpleConfig
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCONF_PARENT


### PR DESCRIPTION
Some of the imports in the unit testing directory are redundant.