### PR TITLE
 contrib: bump pyinstaller to 3.4

### DIFF
--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -30,7 +30,7 @@ fail "Unable to use Python $PYTHON_VERSION"
 
 
 info "Installing pyinstaller"
-python3 -m pip install git+https://github.com/ecdsa/pyinstaller@fix_2952 -I --user || fail "Could not install pyinstaller"
+python3 -m pip install -I --user pyinstaller==3.4 || fail "Could not install pyinstaller"
 
 info "Using these versions for building $PACKAGE:"
 sw_vers

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -111,16 +111,13 @@ done
 # upgrade pip
 $PYTHON -m pip install pip --upgrade
 
-# Install pywin32-ctypes (needed by pyinstaller)
-$PYTHON -m pip install pywin32-ctypes==0.1.2
-
 # install PySocks
 $PYTHON -m pip install win_inet_pton==1.0.1
 
 $PYTHON -m pip install -r $here/../deterministic-build/requirements-binaries.txt
 
 # Install PyInstaller
-$PYTHON -m pip install https://github.com/ecdsa/pyinstaller/archive/fix_2952.zip
+$PYTHON -m pip install pyinstaller==3.4
 
 # Install ZBar
 download_if_not_exist $ZBAR_FILENAME "$ZBAR_URL"
@@ -140,9 +137,6 @@ verify_hash $LIBUSB_FILENAME "$LIBUSB_SHA256"
 7z x -olibusb $LIBUSB_FILENAME -aoa
 
 cp libusb/MS32/dll/libusb-1.0.dll $WINEPREFIX/drive_c/python$PYTHON_VERSION/
-
-# add dlls needed for pyinstaller:
-cp $WINEPREFIX/drive_c/python$PYTHON_VERSION/Lib/site-packages/PyQt5/Qt/bin/* $WINEPREFIX/drive_c/python$PYTHON_VERSION/
 
 mkdir -p $WINEPREFIX/drive_c/tmp
 cp secp256k1/libsecp256k1.dll $WINEPREFIX/drive_c/tmp/


### PR DESCRIPTION
PyInstaller 3.4 highlights from [changelog](https://pyinstaller.readthedocs.io/en/v3.4/CHANGES.html):

* patch for deterministic builds by electrum
* improved support for Qt5-based applications
* added support for Python 3.7

Contributed by FDF.