### PR TITLE
use system language by default

### DIFF
--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
 import PyQt5.QtCore as QtCore
 
-from electrum.i18n import _, set_language
+from electrum.i18n import _, set_language, get_default_language
 from electrum.plugin import run_hook
 from electrum.storage import WalletStorage
 from electrum.base_wizard import GoBack
@@ -89,7 +89,7 @@ class QNetworkUpdatedSignalObject(QObject):
 class ElectrumGui(PrintError):
 
     def __init__(self, config, daemon, plugins):
-        set_language(config.get('language'))
+        set_language(config.get('language', get_default_language()))
         # Uncomment this call to verify objects are being properly
         # GC-ed when windows are closed
         #network.add_jobs([DebugMem([Abstract_Wallet, SPV, Synchronizer,

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
 import PyQt5.QtCore as QtCore
 
-from electrum.i18n import _, set_language, get_default_language
+from electrum.i18n import _, set_language
 from electrum.plugin import run_hook
 from electrum.storage import WalletStorage
 from electrum.base_wizard import GoBack

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -10,7 +10,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 
-from electrum.i18n import _
+from electrum.i18n import _, languages
 from electrum.util import FileImportFailed, FileExportFailed
 from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_EXPIRED
 
@@ -810,6 +810,11 @@ class IconCache:
         if file_name not in self.__cache:
             self.__cache[file_name] = QIcon(file_name)
         return self.__cache[file_name]
+
+
+def get_default_language():
+    name = QLocale.system().name()
+    return name if name in languages else 'en_UK'
 
 
 if __name__ == "__main__":

--- a/electrum/i18n.py
+++ b/electrum/i18n.py
@@ -26,6 +26,8 @@ import os
 
 import gettext
 
+from PyQt5.QtCore import QLocale
+
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), 'locale')
 language = gettext.translation('electrum', LOCALE_DIR, fallback=True)
 
@@ -39,6 +41,11 @@ def set_language(x):
     global language
     if x:
         language = gettext.translation('electrum', LOCALE_DIR, fallback=True, languages=[x])
+
+
+def get_default_language():
+    system_locale = QLocale.system().name()
+    return languages.get(system_locale, 'en_UK')
 
 
 languages = {

--- a/electrum/i18n.py
+++ b/electrum/i18n.py
@@ -26,8 +26,6 @@ import os
 
 import gettext
 
-from PyQt5.QtCore import QLocale
-
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), 'locale')
 language = gettext.translation('electrum', LOCALE_DIR, fallback=True)
 
@@ -41,11 +39,6 @@ def set_language(x):
     global language
     if x:
         language = gettext.translation('electrum', LOCALE_DIR, fallback=True, languages=[x])
-
-
-def get_default_language():
-    system_locale = QLocale.system().name()
-    return languages.get(system_locale, 'en_UK')
 
 
 languages = {


### PR DESCRIPTION
Default language is english and settings menu is not available until you create first wallet. For not english speaking users it very hard to accomplish.

It would be better to use system language at first start.
My commit is applied to qt interface. I'm not sure where to set default language for kivy interface.