### PR TITLE
Remove unreachable return statement

### DIFF
--- a/electrum/rsakey.py
+++ b/electrum/rsakey.py
@@ -125,7 +125,6 @@ def numBits(n):
      '8':4, '9':4, 'a':4, 'b':4,
      'c':4, 'd':4, 'e':4, 'f':4,
      }[s[0]]
-    return int(math.floor(math.log(n, 2))+1)
 
 def numBytes(n):
     if n==0:


### PR DESCRIPTION
The function `numBits` has two `return` statements.  
The second one will, of course, never get called.
This PR removes the second return `statement`.

```
def numBits(n):
    if n==0:
        return 0
    s = "%x" % n
    return ((len(s)-1)*4) + \
    {'0':0, '1':1, '2':2, '3':2,
     '4':3, '5':3, '6':3, '7':3,
     '8':4, '9':4, 'a':4, 'b':4,
     'c':4, 'd':4, 'e':4, 'f':4,
     }[s[0]]
    return int(math.floor(math.log(n, 2))+1)
```