### PR TITLE
network: auto-switch servers to preferred fork (or longest chain)

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -120,7 +120,7 @@ class ElectrumWindow(App):
             with blockchain.blockchains_lock: blockchain_items = list(blockchain.blockchains.items())
             for index, b in blockchain_items:
                 if name == b.get_name():
-                    self.network.run_from_another_thread(self.network.follow_chain(index))
+                    self.network.run_from_another_thread(self.network.follow_chain_given_id(index))
         names = [blockchain.blockchains[b].get_name() for b in chains]
         if len(names) > 1:
             cur_chain = self.network.blockchain().get_name()
@@ -664,7 +664,7 @@ class ElectrumWindow(App):
         self.num_nodes = len(self.network.get_interfaces())
         self.num_chains = len(self.network.get_blockchains())
         chain = self.network.blockchain()
-        self.blockchain_forkpoint = chain.get_forkpoint()
+        self.blockchain_forkpoint = chain.get_max_forkpoint()
         self.blockchain_name = chain.get_name()
         interface = self.network.interface
         if interface:

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -107,7 +107,7 @@ class NodesListWidget(QTreeWidget):
             b = blockchain.blockchains[k]
             name = b.get_name()
             if n_chains >1:
-                x = QTreeWidgetItem([name + '@%d'%b.get_forkpoint(), '%d'%b.height()])
+                x = QTreeWidgetItem([name + '@%d'%b.get_max_forkpoint(), '%d'%b.height()])
                 x.setData(0, Qt.UserRole, 1)
                 x.setData(1, Qt.UserRole, b.forkpoint)
             else:
@@ -364,7 +364,7 @@ class NetworkChoiceLayout(object):
         chains = self.network.get_blockchains()
         if len(chains) > 1:
             chain = self.network.blockchain()
-            forkpoint = chain.get_forkpoint()
+            forkpoint = chain.get_max_forkpoint()
             name = chain.get_name()
             msg = _('Chain split detected at block {0}').format(forkpoint) + '\n'
             msg += (_('You are following branch') if auto_connect else _('Your server is on branch'))+ ' ' + name
@@ -411,14 +411,11 @@ class NetworkChoiceLayout(object):
         self.set_server()
 
     def follow_branch(self, index):
-        self.network.run_from_another_thread(self.network.follow_chain(index))
+        self.network.run_from_another_thread(self.network.follow_chain_given_id(index))
         self.update()
 
     def follow_server(self, server):
-        net_params = self.network.get_parameters()
-        host, port, protocol = deserialize_server(server)
-        net_params = net_params._replace(host=host, port=port, protocol=protocol)
-        self.network.run_from_another_thread(self.network.set_parameters(net_params))
+        self.network.run_from_another_thread(self.network.follow_chain_given_server(server))
         self.update()
 
     def server_changed(self, x):

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -384,6 +384,7 @@ class Interface(PrintError):
             self.mark_ready()
             await self._process_header_at_tip()
             self.network.trigger_callback('network_updated')
+            await self.network.switch_unwanted_fork_interface()
             await self.network.switch_lagging_interface()
 
     async def _process_header_at_tip(self):

--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -156,7 +156,7 @@ class SPV(NetworkJobOnDefaultServer):
 
     async def _maybe_undo_verifications(self):
         def undo_verifications():
-            height = self.blockchain.get_forkpoint()
+            height = self.blockchain.get_max_forkpoint()
             self.print_error("undoing verifications back to height {}".format(height))
             tx_hashes = self.wallet.undo_verifications(self.blockchain, height)
             for tx_hash in tx_hashes:


### PR DESCRIPTION
If auto_connect is enabled, allow jumping between forks too.
(Previously auto_connect was only switching between servers on a given fork, not across forks)
If there is a preferred fork set, jump to that (and stay);
if there isn't, always jump to the longest fork.