### PR TITLE
Show description (label) in TxDialog screen when opened from History

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -297,10 +297,14 @@ class HistoryList(MyTreeWidget, AcceptFileDragDrop):
             super(HistoryList, self).on_doubleclick(item, column)
         else:
             tx_hash = item.data(0, Qt.UserRole)
-            tx = self.wallet.transactions.get(tx_hash)
-            if not tx:
-                return
-            self.parent.show_transaction(tx)
+            self.show_transaction(tx_hash)
+
+    def show_transaction(self, tx_hash):
+        tx = self.wallet.transactions.get(tx_hash)
+        if not tx:
+            return
+        label = self.wallet.get_label(tx_hash) or None # prefer 'None' if not defined (force tx dialog to hide Description field is missing)
+        self.parent.show_transaction(tx, label)
 
     def update_labels(self):
         root = self.invisibleRootItem()
@@ -354,7 +358,7 @@ class HistoryList(MyTreeWidget, AcceptFileDragDrop):
         for c in self.editable_columns:
             menu.addAction(_("Edit {}").format(self.headerItem().text(c)),
                            lambda bound_c=c: self.editItem(item, bound_c))
-        menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx))
+        menu.addAction(_("Details"), lambda: self.show_transaction(tx_hash))
         if is_unconfirmed and tx:
             # note: the current implementation of RBF *needs* the old tx fee
             rbf = is_mine and not tx.is_final() and fee is not None

--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -303,7 +303,7 @@ class HistoryList(MyTreeWidget, AcceptFileDragDrop):
         tx = self.wallet.transactions.get(tx_hash)
         if not tx:
             return
-        label = self.wallet.get_label(tx_hash) or None # prefer 'None' if not defined (force tx dialog to hide Description field is missing)
+        label = self.wallet.get_label(tx_hash) or None # prefer 'None' if not defined (force tx dialog to hide Description field if missing)
         self.parent.show_transaction(tx, label)
 
     def update_labels(self):


### PR DESCRIPTION
This was a pet peeve of mine that we fixed on Electron Cash.

Basically, the TxDialog window never gets the 'label' when a user double-clicks a tx in the History List.  They see the historical tx, but no "Description:" field, even if a label is defined for the tx.

This PR fixes that.

See screenshots:

### User selects transaction from History ###
<img width="1021" alt="screen shot 2018-10-15 at 11 35 27 am" src="https://user-images.githubusercontent.com/266627/46939488-18c04080-d06f-11e8-9c11-1c99be9700c0.png">

### Notice how the TxDialog now has the correct tx `Description:`.  (If it lacks a description, then the behavior is as it was before -- no `Description:` field shown). ###

<img width="1118" alt="screen shot 2018-10-15 at 11 35 51 am" src="https://user-images.githubusercontent.com/266627/46939498-1d84f480-d06f-11e8-8327-8c1c50d0d5f7.png">
