### PR TITLE
implement oneserver option for kivy

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -101,6 +101,14 @@ class ElectrumWindow(App):
     def toggle_auto_connect(self, x):
         self.auto_connect = not self.auto_connect
 
+    oneserver = BooleanProperty(False)
+    def on_oneserver(self, instance, x):
+        net_params = self.network.get_parameters()
+        net_params = net_params._replace(oneserver=self.oneserver)
+        self.network.run_from_another_thread(self.network.set_parameters(net_params))
+    def toggle_oneserver(self, x):
+        self.oneserver = not self.oneserver
+
     def choose_server_dialog(self, popup):
         from .uix.dialogs.choice_dialog import ChoiceDialog
         protocol = 's'
@@ -275,6 +283,7 @@ class ElectrumWindow(App):
             self.server_host = net_params.host
             self.server_port = net_params.port
             self.auto_connect = net_params.auto_connect
+            self.oneserver = net_params.oneserver
             self.proxy_config = net_params.proxy if net_params.proxy else {}
 
         self.plugins = kwargs.get('plugins', [])

--- a/electrum/gui/kivy/uix/ui_screens/network.kv
+++ b/electrum/gui/kivy/uix/ui_screens/network.kv
@@ -39,6 +39,13 @@ Popup:
 
                 CardSeparator
                 SettingsItem:
+                    title: _("One-server mode") + ': ' + ('ON' if app.oneserver else 'OFF')
+                    description: _("Only connect to a single server")
+                    action: app.toggle_oneserver
+                    disabled: app.auto_connect and not app.oneserver
+
+                CardSeparator
+                SettingsItem:
                     value: "%d blocks" % app.num_blocks
                     title: _("Blockchain") + ': ' + self.value
                     description: _('Verified block headers')

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -116,6 +116,7 @@ class NetworkParameters(NamedTuple):
     protocol: str
     proxy: Optional[dict]
     auto_connect: bool
+    oneserver: bool = False
 
 
 proxy_modes = ['socks4', 'socks5']
@@ -176,7 +177,6 @@ class Network(PrintError):
         if config is None:
             config = {}  # Do not use mutables as default values!
         self.config = SimpleConfig(config) if isinstance(config, dict) else config  # type: SimpleConfig
-        self.num_server = 10 if not self.config.get('oneserver') else 0
         blockchain.blockchains = blockchain.read_blockchains(self.config)
         self.print_error("blockchains", list(blockchain.blockchains))
         self._blockchain_preferred_block = self.config.get('blockchain_preferred_block', None)  # type: Optional[Dict]
@@ -386,7 +386,8 @@ class Network(PrintError):
                                  port=port,
                                  protocol=protocol,
                                  proxy=self.proxy,
-                                 auto_connect=self.auto_connect)
+                                 auto_connect=self.auto_connect,
+                                 oneserver=self.oneserver)
 
     def get_donation_address(self):
         if self.is_connected():
@@ -496,16 +497,18 @@ class Network(PrintError):
         except:
             return
         self.config.set_key('auto_connect', net_params.auto_connect, False)
+        self.config.set_key('oneserver', net_params.oneserver, False)
         self.config.set_key('proxy', proxy_str, False)
         self.config.set_key('server', server_str, True)
         # abort if changes were not allowed by config
         if self.config.get('server') != server_str \
-                or self.config.get('proxy') != proxy_str:
+                or self.config.get('proxy') != proxy_str \
+                or self.config.get('oneserver') != net_params.oneserver:
             return
 
         async with self.restart_lock:
             self.auto_connect = net_params.auto_connect
-            if self.proxy != proxy or self.protocol != protocol:
+            if self.proxy != proxy or self.protocol != protocol or self.oneserver != net_params.oneserver:
                 # Restart the network defaulting to the given server
                 await self._stop()
                 self.default_server = server_str
@@ -514,6 +517,10 @@ class Network(PrintError):
                 await self.switch_to_interface(server_str)
             else:
                 await self.switch_lagging_interface()
+
+    def _set_oneserver(self, oneserver: bool):
+        self.num_server = 10 if not oneserver else 0
+        self.oneserver = oneserver
 
     async def _switch_to_random_interface(self):
         '''Switch to a random connected server other than the current one'''
@@ -808,6 +815,7 @@ class Network(PrintError):
         self.protocol = deserialize_server(self.default_server)[2]
         self.server_queue = queue.Queue()
         self._set_proxy(deserialize_proxy(self.config.get('proxy')))
+        self._set_oneserver(self.config.get('oneserver'))
         self._start_interface(self.default_server)
 
         async def main():

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import subprocess
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-MIN_PYTHON_VERSION = "3.6"
+MIN_PYTHON_VERSION = "3.6.1"
 _min_python_version_tuple = tuple(map(int, (MIN_PYTHON_VERSION.split("."))))
 
 


### PR DESCRIPTION
closes #4826 

note: the min python version was deliberately bumped to 3.6.1 as [default args for NamedTuple need it](https://docs.python.org/3/library/typing.html#typing.NamedTuple)
I don't think any Linux distribution is on 3.6.0 specifically