### PR TITLE
wallet: try detecting internal address corruption

### DIFF
--- a/electrum/gui/kivy/uix/screens.py
+++ b/electrum/gui/kivy/uix/screens.py
@@ -21,9 +21,10 @@ from kivy.utils import platform
 from electrum.util import profiler, parse_URI, format_time, InvalidPassword, NotEnoughFunds, Fiat
 from electrum import bitcoin
 from electrum.transaction import TxOutput
-from electrum.util import timestamp_to_datetime
+from electrum.util import send_exception_to_crash_reporter
 from electrum.paymentrequest import PR_UNPAID, PR_PAID, PR_UNKNOWN, PR_EXPIRED
 from electrum.plugin import run_hook
+from electrum.wallet import InternalAddressCorruption
 
 from .context_menu import ContextMenu
 
@@ -331,18 +332,24 @@ class ReceiveScreen(CScreen):
         self.screen.amount = ''
         self.screen.message = ''
 
-    def get_new_address(self):
+    def get_new_address(self) -> bool:
+        """Sets the address field, and returns whether the set address
+        is unused."""
         if not self.app.wallet:
             return False
         self.clear()
-        addr = self.app.wallet.get_unused_address()
-        if addr is None:
-            addr = self.app.wallet.get_receiving_address() or ''
-            b = False
-        else:
-            b = True
+        unused = True
+        try:
+            addr = self.app.wallet.get_unused_address()
+            if addr is None:
+                addr = self.app.wallet.get_receiving_address() or ''
+                unused = False
+        except InternalAddressCorruption as e:
+            addr = ''
+            self.app.show_error(str(e))
+            send_exception_to_crash_reporter(e)
         self.screen.address = addr
-        return b
+        return unused
 
     def on_address(self, addr):
         req = self.app.wallet.get_payment_request(addr, self.app.electrum_config)
@@ -401,8 +408,8 @@ class ReceiveScreen(CScreen):
         Clock.schedule_once(lambda dt: self.update_qr())
 
     def do_new(self):
-        addr = self.get_new_address()
-        if not addr:
+        is_unused = self.get_new_address()
+        if not is_unused:
             self.app.show_info(_('Please use the existing requests first.'))
 
     def do_save(self):

--- a/electrum/gui/qt/request_list.py
+++ b/electrum/gui/qt/request_list.py
@@ -31,6 +31,7 @@ from electrum.i18n import _
 from electrum.util import format_time, age
 from electrum.plugin import run_hook
 from electrum.paymentrequest import PR_UNKNOWN
+from electrum.wallet import InternalAddressCorruption
 
 from .util import MyTreeView, pr_tooltips, pr_icons
 
@@ -78,7 +79,11 @@ class RequestList(MyTreeView):
         # update the receive address if necessary
         current_address = self.parent.receive_address_e.text()
         domain = self.wallet.get_receiving_addresses()
-        addr = self.wallet.get_unused_address()
+        try:
+            addr = self.wallet.get_unused_address()
+        except InternalAddressCorruption as e:
+            self.parent.show_error(str(e))
+            addr = ''
         if not current_address in domain and addr:
             self.parent.set_receive_address(addr)
         self.parent.new_request_button.setEnabled(addr != current_address)

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -835,6 +835,10 @@ def setup_thread_excepthook():
     threading.Thread.__init__ = init
 
 
+def send_exception_to_crash_reporter(e: BaseException):
+    sys.excepthook(type(e), e, e.__traceback__)
+
+
 def versiontuple(v):
     return tuple(map(int, (v.split("."))))
 

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -61,6 +61,7 @@ from .paymentrequest import (PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED,
                              InvoiceStore)
 from .contacts import Contacts
 from .interface import RequestTimedOut
+from .ecc_fast import is_using_fast_ecc
 
 if TYPE_CHECKING:
     from .network import Network
@@ -148,6 +149,11 @@ def sweep(privkeys, network: 'Network', config: 'SimpleConfig', recipient, fee=N
 
 class CannotBumpFee(Exception): pass
 
+
+class InternalAddressCorruption(Exception):
+    def __str__(self):
+        return _("Internal address database inconsistency detected. "
+                 "You should restore from seed.")
 
 
 
@@ -632,6 +638,10 @@ class Abstract_Wallet(AddressSynchronizer):
                 # if there are none, take one randomly from the last few
                 addrs = self.get_change_addresses()[-self.gap_limit_for_change:]
                 change_addrs = [random.choice(addrs)] if addrs else []
+        for addr in change_addrs:
+            # note that change addresses are not necessarily ismine
+            # in which case this is a no-op
+            self.raise_if_cannot_rederive_address(addr)
 
         # Fee estimator
         if fixed_fee is None:
@@ -887,17 +897,33 @@ class Abstract_Wallet(AddressSynchronizer):
                 continue
         return tx
 
+    @profiler
+    def try_detecting_internal_addresses_corruption(self):
+        pass
+
+    def raise_if_cannot_rederive_address(self, addr):
+        pass
+
+    def try_rederiving_returned_address(func):
+        def wrapper(self, *args, **kwargs):
+            addr = func(self, *args, **kwargs)
+            self.raise_if_cannot_rederive_address(addr)
+            return addr
+        return wrapper
+
     def get_unused_addresses(self):
         # fixme: use slots from expired requests
         domain = self.get_receiving_addresses()
         return [addr for addr in domain if not self.history.get(addr)
                 and addr not in self.receive_requests.keys()]
 
+    @try_rederiving_returned_address
     def get_unused_address(self):
         addrs = self.get_unused_addresses()
         if addrs:
             return addrs[0]
 
+    @try_rederiving_returned_address
     def get_receiving_address(self):
         # always return an address
         domain = self.get_receiving_addresses()
@@ -1462,6 +1488,29 @@ class Deterministic_Wallet(Abstract_Wallet):
     def get_change_addresses(self):
         return self.change_addresses
 
+    @profiler
+    def try_detecting_internal_addresses_corruption(self):
+        if not is_using_fast_ecc():
+            self.print_error("internal address corruption test skipped due to missing libsecp256k1")
+            return
+        addresses_all = self.get_addresses()
+        # sample 1: first few
+        addresses_sample1 = addresses_all[:10]
+        # sample2: a few more randomly selected
+        addresses_rand = addresses_all[10:]
+        addresses_sample2 = random.sample(addresses_rand, min(len(addresses_rand), 10))
+        for addr_found in addresses_sample1 + addresses_sample2:
+            self.raise_if_cannot_rederive_address(addr_found)
+
+    def raise_if_cannot_rederive_address(self, addr):
+        if not addr:
+            return
+        if not self.is_mine(addr):
+            return
+        addr_derived = self.derive_address(*self.get_address_index(addr))
+        if addr != addr_derived:
+            raise InternalAddressCorruption()
+
     def get_seed(self, password):
         return self.keystore.get_seed(password)
 
@@ -1515,13 +1564,17 @@ class Deterministic_Wallet(Abstract_Wallet):
         for i, addr in enumerate(self.change_addresses):
             self._addr_to_addr_index[addr] = (True, i)
 
+    def derive_address(self, for_change, n):
+        x = self.derive_pubkeys(for_change, n)
+        address = self.pubkeys_to_address(x)
+        return address
+
     def create_new_address(self, for_change=False):
         assert type(for_change) is bool
         with self.lock:
             addr_list = self.change_addresses if for_change else self.receiving_addresses
             n = len(addr_list)
-            x = self.derive_pubkeys(for_change, n)
-            address = self.pubkeys_to_address(x)
+            address = self.derive_address(for_change, n)
             addr_list.append(address)
             self._addr_to_addr_index[address] = (for_change, n)
             self.save_addresses()


### PR DESCRIPTION
It looks like there might be malware out there which modifies wallet files of users, injecting foreign bitcoin addresses in hope of the user receiving coins there [0]
This is intended as naive defense against that.

- try to re-derive (from xpub) the first 10 addresses of the wallet, plus 10 additional random ones on every wallet-open (only if libsecp256k1 is available as otherwise it would be too slow)
- try to re-derive address (from xpub) in following cases
  - address shown in `Receive` tab
  - address to sweep to
  - user right-click copies address in `Addresses` tab
  - "change" addresses used in newly created transactions

The idea is that now the malware author needs to also change the xpub saved in the wallet to pass these checks; as well as changing most of the addresses stored in the wallet (to the ones actually derived from the foreign xpub). If the original wallet has any history at all, the transactions will disappear from the history, and the user SHOULD notice that something is going on.

-----

[0] see issues:
- https://github.com/spesmilo/electrum/issues/4790
- https://github.com/spesmilo/electrum/issues/4462
- https://bitcoin.stackexchange.com/questions/78813/same-seed-from-electrum-but-generate-different-bitcoin-addresses
- https://github.com/spesmilo/electrum/issues/4891

Also, I see many transactions failing on my server with the following error:
`'the transaction was rejected by network rules.\n\n16: mandatory-script-verify-flag-failed (Script failed an OP_EQUALVERIFY operation)`
which might point to this type of attack