### PR TITLE
keystore: stronger pbkdf for encryption

### DIFF
--- a/electrum/crypto.py
+++ b/electrum/crypto.py
@@ -32,6 +32,7 @@ from typing import Union
 import pyaes
 
 from .util import assert_bytes, InvalidPassword, to_bytes, to_string
+from .i18n import _
 
 
 try:
@@ -90,37 +91,103 @@ def aes_decrypt_with_iv(key: bytes, iv: bytes, data: bytes) -> bytes:
         raise InvalidPassword()
 
 
-def EncodeAES(secret: bytes, msg: bytes) -> bytes:
+def EncodeAES_base64(secret: bytes, msg: bytes) -> bytes:
     """Returns base64 encoded ciphertext."""
-    assert_bytes(msg)
-    iv = bytes(os.urandom(16))
-    ct = aes_encrypt_with_iv(secret, iv, msg)
-    e = iv + ct
+    e = EncodeAES_bytes(secret, msg)
     return base64.b64encode(e)
 
 
-def DecodeAES(secret: bytes, ciphertext_b64: Union[bytes, str]) -> bytes:
-    e = bytes(base64.b64decode(ciphertext_b64))
-    iv, e = e[:16], e[16:]
+def EncodeAES_bytes(secret: bytes, msg: bytes) -> bytes:
+    assert_bytes(msg)
+    iv = bytes(os.urandom(16))
+    ct = aes_encrypt_with_iv(secret, iv, msg)
+    return iv + ct
+
+
+def DecodeAES_base64(secret: bytes, ciphertext_b64: Union[bytes, str]) -> bytes:
+    ciphertext = bytes(base64.b64decode(ciphertext_b64))
+    return DecodeAES_bytes(secret, ciphertext)
+
+
+def DecodeAES_bytes(secret: bytes, ciphertext: bytes) -> bytes:
+    assert_bytes(ciphertext)
+    iv, e = ciphertext[:16], ciphertext[16:]
     s = aes_decrypt_with_iv(secret, iv, e)
     return s
 
 
-def pw_encode(data: str, password: Union[bytes, str]) -> str:
+PW_HASH_VERSION_LATEST = 2
+KNOWN_PW_HASH_VERSIONS = (1, 2)
+assert PW_HASH_VERSION_LATEST in KNOWN_PW_HASH_VERSIONS
+
+
+class UnexpectedPasswordHashVersion(InvalidPassword):
+    def __init__(self, version):
+        self.version = version
+
+    def __str__(self):
+        return "{unexpected}: {version}\n{please_update}".format(
+            unexpected=_("Unexpected password hash version"),
+            version=self.version,
+            please_update=_('You are most likely using an outdated version of Electrum. Please update.'))
+
+
+def _hash_password(password: Union[bytes, str], *, version: int, salt: bytes) -> bytes:
+    pw = to_bytes(password, 'utf8')
+    if version == 1:
+        return sha256d(pw)
+    elif version == 2:
+        if not isinstance(salt, bytes) or len(salt) < 16:
+            raise Exception('too weak salt', salt)
+        return hashlib.pbkdf2_hmac(hash_name='sha256',
+                                   password=pw,
+                                   salt=b'ELECTRUM_PW_HASH_V2'+salt,
+                                   iterations=50_000)
+    else:
+        assert version not in KNOWN_PW_HASH_VERSIONS
+        raise UnexpectedPasswordHashVersion(version)
+
+
+def pw_encode(data: str, password: Union[bytes, str, None], *, version: int) -> str:
     if not password:
         return data
-    secret = sha256d(password)
-    return EncodeAES(secret, to_bytes(data, "utf8")).decode('utf8')
+    if version not in KNOWN_PW_HASH_VERSIONS:
+        raise UnexpectedPasswordHashVersion(version)
+    # derive key from password
+    if version == 1:
+        salt = b''
+    elif version == 2:
+        salt = bytes(os.urandom(16))
+    else:
+        assert False, version
+    secret = _hash_password(password, version=version, salt=salt)
+    # encrypt given data
+    e = EncodeAES_bytes(secret, to_bytes(data, "utf8"))
+    # return base64(salt + encrypted data)
+    ciphertext = salt + e
+    ciphertext_b64 = base64.b64encode(ciphertext)
+    return ciphertext_b64.decode('utf8')
 
 
-def pw_decode(data: str, password: Union[bytes, str]) -> str:
+def pw_decode(data: str, password: Union[bytes, str, None], *, version: int) -> str:
     if password is None:
         return data
-    secret = sha256d(password)
+    if version not in KNOWN_PW_HASH_VERSIONS:
+        raise UnexpectedPasswordHashVersion(version)
+    data_bytes = bytes(base64.b64decode(data))
+    # derive key from password
+    if version == 1:
+        salt = b''
+    elif version == 2:
+        salt, data_bytes = data_bytes[:16], data_bytes[16:]
+    else:
+        assert False, version
+    secret = _hash_password(password, version=version, salt=salt)
+    # decrypt given data
     try:
-        d = to_string(DecodeAES(secret, data), "utf8")
-    except Exception:
-        raise InvalidPassword()
+        d = to_string(DecodeAES_bytes(secret, data_bytes), "utf8")
+    except Exception as e:
+        raise InvalidPassword() from e
     return d
 
 

--- a/electrum/plugins/digitalbitbox/digitalbitbox.py
+++ b/electrum/plugins/digitalbitbox/digitalbitbox.py
@@ -4,7 +4,7 @@
 #
 
 try:
-    from electrum.crypto import sha256d, EncodeAES, DecodeAES
+    from electrum.crypto import sha256d, EncodeAES_base64, DecodeAES_base64
     from electrum.bitcoin import (TYPE_ADDRESS, push_script, var_int, public_key_to_p2pkh,
                                   is_address)
     from electrum.bip32 import serialize_xpub, deserialize_xpub
@@ -396,10 +396,10 @@ class DigitalBitbox_Client():
         reply = ""
         try:
             secret = sha256d(self.password)
-            msg = EncodeAES(secret, msg)
+            msg = EncodeAES_base64(secret, msg)
             reply = self.hid_send_plain(msg)
             if 'ciphertext' in reply:
-                reply = DecodeAES(secret, ''.join(reply["ciphertext"]))
+                reply = DecodeAES_base64(secret, ''.join(reply["ciphertext"]))
                 reply = to_string(reply, 'utf8')
                 reply = json.loads(reply)
             if 'error' in reply:
@@ -716,7 +716,7 @@ class DigitalBitboxPlugin(HW_PluginBase):
         key_s = base64.b64decode(self.digitalbitbox_config['encryptionprivkey'])
         args = 'c=data&s=0&dt=0&uuid=%s&pl=%s' % (
             self.digitalbitbox_config['comserverchannelid'],
-            EncodeAES(key_s, json.dumps(payload).encode('ascii')).decode('ascii'),
+            EncodeAES_base64(key_s, json.dumps(payload).encode('ascii')).decode('ascii'),
         )
         try:
             requests.post(url, args)

--- a/electrum/tests/test_bitcoin.py
+++ b/electrum/tests/test_bitcoin.py
@@ -11,11 +11,11 @@ from electrum.bitcoin import (public_key_to_p2pkh, address_from_private_key,
 from electrum.bip32 import (bip32_root, bip32_public_derivation, bip32_private_derivation,
                             xpub_from_xprv, xpub_type, is_xprv, is_bip32_derivation,
                             is_xpub, convert_bip32_path_to_list_of_uint32)
-from electrum.crypto import sha256d
+from electrum.crypto import sha256d, KNOWN_PW_HASH_VERSIONS
 from electrum import ecc, crypto, constants
 from electrum.ecc import number_to_string, string_to_number
 from electrum.transaction import opcodes
-from electrum.util import bfh, bh2u
+from electrum.util import bfh, bh2u, InvalidPassword
 from electrum.storage import WalletStorage
 from electrum.keystore import xtype_from_derivation
 
@@ -219,23 +219,26 @@ class Test_bitcoin(SequentialTestCase):
         """Make sure AES is homomorphic."""
         payload = u'\u66f4\u7a33\u5b9a\u7684\u4ea4\u6613\u5e73\u53f0'
         password = u'secret'
-        enc = crypto.pw_encode(payload, password)
-        dec = crypto.pw_decode(enc, password)
-        self.assertEqual(dec, payload)
+        for version in KNOWN_PW_HASH_VERSIONS:
+            enc = crypto.pw_encode(payload, password, version=version)
+            dec = crypto.pw_decode(enc, password, version=version)
+            self.assertEqual(dec, payload)
 
     @needs_test_with_all_aes_implementations
     def test_aes_encode_without_password(self):
         """When not passed a password, pw_encode is noop on the payload."""
         payload = u'\u66f4\u7a33\u5b9a\u7684\u4ea4\u6613\u5e73\u53f0'
-        enc = crypto.pw_encode(payload, None)
-        self.assertEqual(payload, enc)
+        for version in KNOWN_PW_HASH_VERSIONS:
+            enc = crypto.pw_encode(payload, None, version=version)
+            self.assertEqual(payload, enc)
 
     @needs_test_with_all_aes_implementations
     def test_aes_deencode_without_password(self):
         """When not passed a password, pw_decode is noop on the payload."""
         payload = u'\u66f4\u7a33\u5b9a\u7684\u4ea4\u6613\u5e73\u53f0'
-        enc = crypto.pw_decode(payload, None)
-        self.assertEqual(payload, enc)
+        for version in KNOWN_PW_HASH_VERSIONS:
+            enc = crypto.pw_decode(payload, None, version=version)
+            self.assertEqual(payload, enc)
 
     @needs_test_with_all_aes_implementations
     def test_aes_decode_with_invalid_password(self):
@@ -243,8 +246,10 @@ class Test_bitcoin(SequentialTestCase):
         payload = u"blah"
         password = u"uber secret"
         wrong_password = u"not the password"
-        enc = crypto.pw_encode(payload, password)
-        self.assertRaises(Exception, crypto.pw_decode, enc, wrong_password)
+        for version in KNOWN_PW_HASH_VERSIONS:
+            enc = crypto.pw_encode(payload, password, version=version)
+            with self.assertRaises(InvalidPassword):
+                crypto.pw_decode(enc, wrong_password, version=version)
 
     def test_sha256d(self):
         self.assertEqual(b'\x95MZI\xfdp\xd9\xb8\xbc\xdb5\xd2R&x)\x95\x7f~\xf7\xfalt\xf8\x84\x19\xbd\xc5\xe8"\t\xf4',


### PR DESCRIPTION
Currently, when keystore encryption is enabled, the symmetric key used to encrypt the seed/private keys is `sha256d(password)`. (If storage encryption is also enabled, then the whole wallet file is encrypted again, there the key derivation uses PBKDF2 with 1024 iterations of sha512)

This PR introduces versioning for the keystore encryption, and the existing behaviour becomes version 1.
Version 2 uses PBKDF2 with 50k iterations of hmac-sha256 with a random 16 byte salt.

Newly created wallets will use version 2 automatically; and for existing wallets, if they change the password, they will get upgraded to version 2.

see: https://github.com/spesmilo/electrum/issues/3147