### PR TITLE
[macOS] Added optional code signing capability to the OSX build scripts.

### DIFF
--- a/contrib/build-osx/base.sh
+++ b/contrib/build-osx/base.sh
@@ -2,6 +2,7 @@
 
 RED='\033[0;31m'
 BLUE='\033[0,34m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 function info {
 	printf "\r💬 ${BLUE}INFO:${NC}  ${1}\n"
@@ -9,4 +10,26 @@ function info {
 function fail {
     printf "\r🗯 ${RED}ERROR:${NC} ${1}\n"
     exit 1
+}
+function warn {
+	printf "\r⚠️  ${YELLOW}WARNING:${NC}  ${1}\n"
+}
+
+function DoCodeSignMaybe { # ARGS: infoName fileOrDirName codesignIdentity
+    infoName="$1"
+    file="$2"
+    identity="$3"
+    deep=""
+    if [ -z "$identity" ]; then
+        # we are ok with them not passing anything -- master script calls us always even if no identity is specified
+        return
+    fi
+    if [ -d "$file" ]; then
+        deep="--deep"
+    fi
+    if [ -z "$infoName" ] || [ -z "$file" ] || [ -z "$identity" ] || [ ! -e "$file" ]; then
+        fail "Argument error to internal function DoCodeSignMaybe()"
+    fi
+    info "Code signing ${infoName}..."
+    codesign -f -v $deep -s "$identity" "$file" || fail "Could not code sign ${infoName}"
 }

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -17,6 +17,24 @@ VERSION=`git describe --tags --dirty --always`
 
 which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
 
+# Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
+APP_SIGN=""
+if [ -n "$1" ]; then
+    # Test the identity is valid for signing by doing this hack. There is no other way to do this.
+    cp -f /bin/ls ./CODESIGN_TEST
+    codesign -s "$1" --dryrun -f ./CODESIGN_TEST > /dev/null 2>&1
+    res=$?
+    rm -f ./CODESIGN_TEST
+    if ((res)); then
+        fail "Code signing identity \"$1\" appears to be invalid."
+    fi
+    unset res
+    APP_SIGN="$1"
+    info "Code signing enabled using identity \"$APP_SIGN\""
+else
+    warn "Code signing DISABLED. Specify a valid macOS Developer identity installed on the system as the first argument to this script to enable signing."
+fi
+
 info "Installing Python $PYTHON_VERSION"
 export PATH="~/.pyenv/bin:~/.pyenv/shims:~/Library/Python/3.6/bin:$PATH"
 if [ -d "~/.pyenv" ]; then
@@ -54,6 +72,7 @@ info "Downloading libusb..."
 curl https://homebrew.bintray.com/bottles/libusb-1.0.22.el_capitan.bottle.tar.gz | \
 tar xz --directory $BUILDDIR
 cp $BUILDDIR/libusb/1.0.22/lib/libusb-1.0.dylib contrib/build-osx
+DoCodeSignMaybe "libusb" "contrib/build-osx/libusb-1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 info "Building libsecp256k1"
 brew install autoconf automake libtool
@@ -66,6 +85,7 @@ git clean -f -x -q
 make
 popd
 cp $BUILDDIR/secp256k1/.libs/libsecp256k1.0.dylib contrib/build-osx
+DoCodeSignMaybe "libsecp256k1" "contrib/build-osx/libsecp256k1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 
 info "Installing requirements..."
@@ -96,5 +116,14 @@ plutil -insert 'CFBundleURLTypes' \
 	-- dist/$PACKAGE.app/Contents/Info.plist \
 	|| fail "Could not add keys to Info.plist. Make sure the program 'plutil' exists and is installed."
 
+DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+
 info "Creating .DMG"
 hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"
+
+DoCodeSignMaybe ".DMG" "dist/electrum-${VERSION}.dmg" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+
+if [ -z "$APP_SIGN" ]; then
+    warn "App was built successfully but was not code signed. Users may get security warnings from macOS."
+    warn "Specify a valid code signing identity as the first argument to this script to enable code signing."
+fi


### PR DESCRIPTION
As per a Slack conversation with @SomberNight , I am adding code signing capability to the macOS build scripts in `contrib/build-osx`.

Note that this capability is completely optional.  It is enabled by passing a "codesigning identity" as the first arg to the `make-osx` script, eg:

<img width="758" alt="screen shot 2018-11-26 at 1 40 08 pm" src="https://user-images.githubusercontent.com/266627/49012042-d6674480-f180-11e8-9875-a1dc684cfccd.png">

---

If no arg is specified it does warn the user that codesigning is disabled, but proceeds anyway.

<img width="761" alt="screen shot 2018-11-26 at 1 41 31 pm" src="https://user-images.githubusercontent.com/266627/49012091-0f9fb480-f181-11e8-98b7-87a008b590d9.png">

And at the end it warns again:

<img width="764" alt="screen shot 2018-11-26 at 1 42 22 pm" src="https://user-images.githubusercontent.com/266627/49012126-26dea200-f181-11e8-951f-0a02f92282ab.png">

---

The changes are minimal and I think will help going forward.

Note that this PR is a prerequisite for a PR I plan on submitting this week which will enable QR scanning on macOS by compiling a tiny Objective-C app at build time.   I made that using native macOS libs to do QR.  

(The helper app will be bundled with the final build .app and both need to be signed for the webcam to work on latest macOS.)

