### PR TITLE
[macOS] Add QR Reader. Uses native obj-c helper app (included). Automatic code signing also added.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ electrum/gui/kivy/theming/light.atlas
 .cache/
 .coverage
 .pytest_cache
+
+# Xcode project per-user data
+xcuserdata/
+

--- a/contrib/CalinsQRReader/CalinsQRReader.xcodeproj/project.pbxproj
+++ b/contrib/CalinsQRReader/CalinsQRReader.xcodeproj/project.pbxproj
@@ -1,0 +1,339 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		FAA6C5A221AA195800ACDD8F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA6C5A121AA195800ACDD8F /* AppDelegate.m */; };
+		FAA6C5A721AA195A00ACDD8F /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAA6C5A521AA195A00ACDD8F /* MainMenu.xib */; };
+		FAA6C5AA21AA195A00ACDD8F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA6C5A921AA195A00ACDD8F /* main.m */; };
+		FAA6C5B321AA1A4400ACDD8F /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAA6C5B221AA1A4400ACDD8F /* AVFoundation.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		FAA6C59D21AA195800ACDD8F /* CalinsQRReader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CalinsQRReader.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAA6C5A021AA195800ACDD8F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		FAA6C5A121AA195800ACDD8F /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		FAA6C5A321AA195A00ACDD8F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		FAA6C5A621AA195A00ACDD8F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		FAA6C5A821AA195A00ACDD8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FAA6C5A921AA195A00ACDD8F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		FAA6C5B221AA1A4400ACDD8F /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FAA6C59A21AA195800ACDD8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAA6C5B321AA1A4400ACDD8F /* AVFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FAA6C59421AA195800ACDD8F = {
+			isa = PBXGroup;
+			children = (
+				FAA6C59F21AA195800ACDD8F /* CalinsQRReader */,
+				FAA6C59E21AA195800ACDD8F /* Products */,
+				FAA6C5B121AA1A4400ACDD8F /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		FAA6C59E21AA195800ACDD8F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FAA6C59D21AA195800ACDD8F /* CalinsQRReader.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FAA6C59F21AA195800ACDD8F /* CalinsQRReader */ = {
+			isa = PBXGroup;
+			children = (
+				FAA6C5A021AA195800ACDD8F /* AppDelegate.h */,
+				FAA6C5A121AA195800ACDD8F /* AppDelegate.m */,
+				FAA6C5A321AA195A00ACDD8F /* Assets.xcassets */,
+				FAA6C5A521AA195A00ACDD8F /* MainMenu.xib */,
+				FAA6C5A821AA195A00ACDD8F /* Info.plist */,
+				FAA6C5A921AA195A00ACDD8F /* main.m */,
+			);
+			path = CalinsQRReader;
+			sourceTree = "<group>";
+		};
+		FAA6C5B121AA1A4400ACDD8F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FAA6C5B221AA1A4400ACDD8F /* AVFoundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		FAA6C59C21AA195800ACDD8F /* CalinsQRReader */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FAA6C5AE21AA195A00ACDD8F /* Build configuration list for PBXNativeTarget "CalinsQRReader" */;
+			buildPhases = (
+				FAA6C59921AA195800ACDD8F /* Sources */,
+				FAA6C59A21AA195800ACDD8F /* Frameworks */,
+				FAA6C59B21AA195800ACDD8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CalinsQRReader;
+			productName = CalinsQRReader;
+			productReference = FAA6C59D21AA195800ACDD8F /* CalinsQRReader.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FAA6C59521AA195800ACDD8F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "c3-soft.com";
+				TargetAttributes = {
+					FAA6C59C21AA195800ACDD8F = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = FAA6C59821AA195800ACDD8F /* Build configuration list for PBXProject "CalinsQRReader" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = FAA6C59421AA195800ACDD8F;
+			productRefGroup = FAA6C59E21AA195800ACDD8F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FAA6C59C21AA195800ACDD8F /* CalinsQRReader */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FAA6C59B21AA195800ACDD8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAA6C5A721AA195A00ACDD8F /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FAA6C59921AA195800ACDD8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAA6C5AA21AA195A00ACDD8F /* main.m in Sources */,
+				FAA6C5A221AA195800ACDD8F /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		FAA6C5A521AA195A00ACDD8F /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FAA6C5A621AA195A00ACDD8F /* Base */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		FAA6C5AC21AA195A00ACDD8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FAA6C5AD21AA195A00ACDD8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		FAA6C5AF21AA195A00ACDD8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = CalinsQRReader/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.c3-soft.CalinsQRReader";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Debug;
+		};
+		FAA6C5B021AA195A00ACDD8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = CalinsQRReader/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.c3-soft.CalinsQRReader";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FAA6C59821AA195800ACDD8F /* Build configuration list for PBXProject "CalinsQRReader" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAA6C5AC21AA195A00ACDD8F /* Debug */,
+				FAA6C5AD21AA195A00ACDD8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FAA6C5AE21AA195A00ACDD8F /* Build configuration list for PBXNativeTarget "CalinsQRReader" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAA6C5AF21AA195A00ACDD8F /* Debug */,
+				FAA6C5B021AA195A00ACDD8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = FAA6C59521AA195800ACDD8F /* Project object */;
+}

--- a/contrib/CalinsQRReader/CalinsQRReader.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/contrib/CalinsQRReader/CalinsQRReader.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:CalinsQRReader.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/contrib/CalinsQRReader/CalinsQRReader.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/contrib/CalinsQRReader/CalinsQRReader.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/contrib/CalinsQRReader/CalinsQRReader/AppDelegate.h
+++ b/contrib/CalinsQRReader/CalinsQRReader/AppDelegate.h
@@ -1,0 +1,16 @@
+//
+//  AppDelegate.h
+//  CalinsQRReader
+//
+//  Created by calin on 11/25/18.
+//  Copyright © 2018 Calin Culianu <calin.culianu@gmail.com>. MIT License.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+@property (nonatomic, weak) IBOutlet NSTextField *label;
+@property (nonatomic, weak) IBOutlet NSButton *button;
+- (IBAction) showAbout:(id)sender;
+@end
+

--- a/contrib/CalinsQRReader/CalinsQRReader/AppDelegate.m
+++ b/contrib/CalinsQRReader/CalinsQRReader/AppDelegate.m
@@ -1,0 +1,179 @@
+//
+//  AppDelegate.m
+//  CalinsQRReader
+//
+//  Created by calin on 11/25/18.
+//  Copyright © 2018 Calin Culianu <calin.culianu@gmail.com>. MIT License.
+//
+
+#import "AppDelegate.h"
+#import <AVFoundation/AVFoundation.h>
+#include <stdio.h>
+
+@interface AppDelegate () <NSWindowDelegate, AVCaptureVideoDataOutputSampleBufferDelegate> {
+    __strong dispatch_queue_t dispatchQueue;
+}
+
+@property (nonatomic, weak) IBOutlet NSWindow *window;
+@property (nonatomic, weak) IBOutlet NSView *viewForCamera;
+
+@property (nonatomic) BOOL isReading;
+@property (nonatomic, strong) AVCaptureSession *captureSession;
+@property (nonatomic, strong) AVCaptureVideoPreviewLayer *videoPreviewLayer;
+@property (nonatomic, strong) CIDetector *detector;
+
+-(BOOL)startReading;
+-(void)stopReading;
+
+-(void)windowWillClose:(NSNotification *)notification;
+-(void)windowDidResize:(NSNotification *)notification;
+
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+    self.window.level = NSFloatingWindowLevel; // make this window be rudely always on top of every other window on the desktop ;)
+    [self.window makeKeyAndOrderFront:nil];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // this is executed later on main thread after the window finishes raising itself.
+        [self startReading]; // start your engines!
+    });
+}
+
+
+- (void)applicationWillTerminate:(NSNotification *)aNotification {
+    [self stopReading];
+}
+
+- (BOOL)startReading {
+    NSError *error;
+    self.button.hidden = YES;
+
+    if (@available(macOS 10.14, *)) {
+        // macOS 10.14 or later code path -- ask user for permission to access camera
+        AVAuthorizationStatus st = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+        if (st == AVAuthorizationStatusRestricted) {
+            self.label.stringValue = @"Camera access restricted";
+            return NO;
+        } else if (st != AVAuthorizationStatusAuthorized) {
+            self.label.stringValue = @"Requesting camera authorization";
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted){
+                // below must be done on the main thread -- (this handler is not necessarily on the main thread)
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (!granted) {
+                        self.label.stringValue = @"Camera access denied";
+                    } else {
+                        [self startReading];
+                    }
+                });
+            }];
+            return NO;
+        }
+    }
+
+    AVCaptureDevice *captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+
+    if (captureDevice.position == AVCaptureDevicePositionBack) {
+        //NSLog(@"back camera");
+    } else if (captureDevice.position == AVCaptureDevicePositionFront) {
+        //NSLog(@"Front Camera");
+    } else {
+        //NSLog(@"Unspecified, %@",captureDevice);
+    }
+
+    self.label.stringValue = @"";
+
+    AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error];
+
+    if (!input) {
+        NSString *errDesc = error.description;
+        //NSLog(@"%@", errDesc);
+        if (errDesc.length) self.label.stringValue = errDesc;
+        else self.label.stringValue = @"Error initializing camera";
+        return NO;
+    }
+
+    self.captureSession = [[AVCaptureSession alloc] init];
+    [self.captureSession addInput:input];
+
+    if (!dispatchQueue) {
+        dispatchQueue = dispatch_queue_create("myQueue", NULL);
+    }
+    // add per-frame callback (see captureOutput:didOutputSampleBuffer:fromConnection method below)
+    AVCaptureVideoDataOutput *vdo = [AVCaptureVideoDataOutput new];
+    [vdo setSampleBufferDelegate:self queue:dispatchQueue];
+    [self.captureSession addOutput:vdo];
+    self.detector = [CIDetector detectorOfType:CIDetectorTypeQRCode context:nil options:nil];
+    self.videoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:_captureSession];
+
+    [self.videoPreviewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
+    [self.videoPreviewLayer setFrame:self.viewForCamera.layer.bounds];
+    [self.viewForCamera.layer addSublayer:self.videoPreviewLayer];
+
+    [_captureSession startRunning];
+
+    return YES;
+}
+
+- (void)stopReading {
+    [self.captureSession stopRunning];
+    self.captureSession = nil;
+    [self.videoPreviewLayer removeFromSuperlayer];
+    self.videoPreviewLayer = nil;
+    self.detector = nil;
+    dispatchQueue = nil;
+    //self.button.hidden = NO; // <--- uncomment this if you want the app to read more than one QR code (if you make this a standalone app)
+}
+
+- (void)windowWillClose:(NSNotification *)notif {
+    if (notif.object == self.window)
+        [[NSApplication sharedApplication] terminate:self];
+}
+- (void)windowDidResize:(NSNotification *)notif {
+    if (notif.object == self.window && self.videoPreviewLayer && self.viewForCamera) {
+        [self.videoPreviewLayer setFrame:self.viewForCamera.layer.bounds];
+    }
+}
+// This callback processes each video frame, sending it to CoreImage APIs for detecting QR Codes.
+- (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
+    //NSLog(@"sample buffer did output");
+    CIImage *img = [CIImage imageWithCVImageBuffer:CMSampleBufferGetImageBuffer(sampleBuffer)];
+    NSArray <CIFeature *> *features = [self.detector featuresInImage:img];
+    for (CIFeature *f in features) {
+        if ([f.type isEqualToString:CIFeatureTypeQRCode]) {
+            //NSLog(@"Feature %@ at %f,%f,%f,%f",f.type, f.bounds.origin.x, f.bounds.origin.y, f.bounds.size.width, f.bounds.size.height);
+            CIQRCodeFeature *qr = (CIQRCodeFeature *)f;
+            //NSLog(@"Message: %@", qr.messageString);
+            NSString *msg = qr.messageString;
+            // the below must be done on the main thread because it touches the GUI!
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                printf("%s\n",[msg UTF8String]); // tell calling process what the QR code is.
+                self.label.stringValue = msg;
+                [self stopReading];
+                [self.window close]; // this will trigger an app exit in windowWillClose: above. Comment this out if you want this app to be a standalone app.
+            });
+            return;
+        }
+    }
+}
+
+- (IBAction) onButton:(id)sender {
+    [self startReading];
+}
+
+- (IBAction) showAbout:(id)sender {
+    // this method isn't normally reached becasue we run as a background app -- but if we were to
+    // change Info.plist to make this a foreground app, then this could potentially be executed.
+    NSApplication *app = NSApplication.sharedApplication;
+    [app orderFrontStandardAboutPanel:sender];
+    NSArray<NSWindow *> *windows = app.windows;
+    for (NSWindow *w in windows) {
+        if (w != self.window) {
+            // about panel .. make sure it's on top.
+            w.level = self.window.level + 1;
+            [w orderFront:sender];
+        }
+    }
+}
+@end

--- a/contrib/CalinsQRReader/CalinsQRReader/AppDelegate.m
+++ b/contrib/CalinsQRReader/CalinsQRReader/AppDelegate.m
@@ -9,6 +9,7 @@
 #import "AppDelegate.h"
 #import <AVFoundation/AVFoundation.h>
 #include <stdio.h>
+#include <Availability.h>
 
 @interface AppDelegate () <NSWindowDelegate, AVCaptureVideoDataOutputSampleBufferDelegate> {
     __strong dispatch_queue_t dispatchQueue;
@@ -50,6 +51,7 @@
     NSError *error;
     self.button.hidden = YES;
 
+#if defined(__MAC_10_14) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
     if (@available(macOS 10.14, *)) {
         // macOS 10.14 or later code path -- ask user for permission to access camera
         AVAuthorizationStatus st = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
@@ -71,6 +73,8 @@
             return NO;
         }
     }
+#endif
+
 
     AVCaptureDevice *captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
 

--- a/contrib/CalinsQRReader/CalinsQRReader/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/contrib/CalinsQRReader/CalinsQRReader/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/contrib/CalinsQRReader/CalinsQRReader/Assets.xcassets/Contents.json
+++ b/contrib/CalinsQRReader/CalinsQRReader/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/contrib/CalinsQRReader/CalinsQRReader/Base.lproj/MainMenu.xib
+++ b/contrib/CalinsQRReader/CalinsQRReader/Base.lproj/MainMenu.xib
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
+            <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="GzC-gU-4Uq"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
+            <connections>
+                <outlet property="button" destination="JiH-tf-zCi" id="hze-cy-v7e"/>
+                <outlet property="label" destination="cl9-HN-nEj" id="oIf-Eq-jUQ"/>
+                <outlet property="viewForCamera" destination="EiT-Mj-1SZ" id="zZX-rQ-gDs"/>
+                <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+            <items>
+                <menuItem title="Calin's QR Reader" id="1Xt-HY-uBw">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Calin's QR Reader" systemMenu="apple" id="uQy-DD-JDr">
+                        <items>
+                            <menuItem title="About CalinsQRReader" id="5kV-Vb-QxS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showAbout:" target="Voe-Tx-rLC" id="DjK-3S-psG"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="hideOtherApplications:" target="-1" id="VT4-aY-XCT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show All" id="Kd2-mp-pUS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="unhideAllApplications:" target="-1" id="Dhg-Le-xox"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                            <menuItem title="Quit CalinsQRReader" keyEquivalent="q" id="4sb-4s-VLi">
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+        </menu>
+        <window title="Calin's QR Reader" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="335" y="390" width="640" height="480"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="640" height="480"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cl9-HN-nEj">
+                        <rect key="frame" x="282" y="231" width="76" height="17"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Initializing..." id="cPd-n2-Oz4">
+                            <font key="font" usesAppearanceFont="YES"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JiH-tf-zCi">
+                        <rect key="frame" x="266" y="13" width="108" height="32"/>
+                        <buttonCell key="cell" type="push" title="Scan Again" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3aF-Gp-XtN">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="onButton:" target="Voe-Tx-rLC" id="UyF-La-4hU"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="cl9-HN-nEj" firstAttribute="centerX" secondItem="EiT-Mj-1SZ" secondAttribute="centerX" id="5LH-AZ-6Hc"/>
+                    <constraint firstItem="cl9-HN-nEj" firstAttribute="centerY" secondItem="EiT-Mj-1SZ" secondAttribute="centerY" id="zMw-5i-60k"/>
+                    <constraint firstAttribute="bottom" secondItem="JiH-tf-zCi" secondAttribute="bottom" constant="20" id="zbM-YB-d6O"/>
+                    <constraint firstItem="JiH-tf-zCi" firstAttribute="centerX" secondItem="EiT-Mj-1SZ" secondAttribute="centerX" id="znj-Xq-ZVF"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="apX-xC-24o"/>
+            </connections>
+        </window>
+    </objects>
+</document>

--- a/contrib/CalinsQRReader/CalinsQRReader/Info.plist
+++ b/contrib/CalinsQRReader/CalinsQRReader/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2018 Calin Culianu. MIT License.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Need to use camera to read QR Codes</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/contrib/CalinsQRReader/CalinsQRReader/main.m
+++ b/contrib/CalinsQRReader/CalinsQRReader/main.m
@@ -1,0 +1,13 @@
+//
+//  main.m
+//  CalinsQRReader
+//
+//  Created by calin on 11/25/18.
+//  Copyright © 2018 Calin Culianu <calin.culianu@gmail.com>. MIT License.
+//
+
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char * argv[]) {
+    return NSApplicationMain(argc, argv);
+}

--- a/contrib/CalinsQRReader/README.md
+++ b/contrib/CalinsQRReader/README.md
@@ -1,0 +1,39 @@
+# Calin's QR Reader
+
+Author: Calin Culianu <calin.culianu@gmail.com>
+
+---
+
+A helper app for Electrum. This app emulates the 'zbar' functionality present on Windows and Linux for Electrum.
+
+It is a very small and lightweight app with no external dependencies other than what macOS provides in its own system libs for
+reading from the camera and detecting QR codes in video.
+
+The app basically creates a window and reads from the default camera device on the system. It will continue to run until either
+the window is closed by the user or a QR image is read.
+
+1. If a QR image is scanned, it will print the decoded string to stdout and exit.
+2. If there is an error detecting the camera, it will show an error message and wait.
+3. If the user closes the window without having scanned a QR code (because of an error or s/he changed his/her mind),
+it will print nothing to stdout and exit.
+
+---
+
+### Building
+
+In order to build the app and have it actually work on deployed machines other than your developer machine, you need an Apple Developer Certificate (you have to join the Apple developer program), and you need to sign the app. Otherwise on newer macOS, camera access won't be granted to the app.
+
+1. Load included source code in Xcode.
+2. Hit build.
+
+Or, if you prefer the command-line:
+
+1. Chdir to sources
+2. `xcodebuild`
+3. `codesign -v -f -s MY_DEVELOPER_CERT build/Release/CalinsQRReader.app`
+
+
+### See Also
+
+- `electrum/qrscanner.py` - for how it is integrated into Electrum.
+- `contrib/build-osx/osx.spec` - for how it's collected and put into the final Electrum.app.

--- a/contrib/build-osx/base.sh
+++ b/contrib/build-osx/base.sh
@@ -2,6 +2,7 @@
 
 RED='\033[0;31m'
 BLUE='\033[0,34m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 function info {
 	printf "\r💬 ${BLUE}INFO:${NC}  ${1}\n"
@@ -9,4 +10,26 @@ function info {
 function fail {
     printf "\r🗯 ${RED}ERROR:${NC} ${1}\n"
     exit 1
+}
+function warn {
+	printf "\r⚠️  ${YELLOW}WARNING:${NC}  ${1}\n"
+}
+
+function DoCodeSignMaybe { # ARGS: infoName fileOrDirName codesignIdentity
+    infoName="$1"
+    file="$2"
+    identity="$3"
+    deep=""
+    if [ -z "$identity" ]; then
+        # we are ok with them not passing anything -- master script calls us always even if no identity is specified
+        return
+    fi
+    if [ -d "$file" ]; then
+        deep="--deep"
+    fi
+    if [ -z "$infoName" ] || [ -z "$file" ] || [ -z "$identity" ] || [ ! -e "$file" ]; then
+        fail "Argument error to internal function DoCodeSignMaybe()"
+    fi
+    info "Code signing ${infoName}..."
+    codesign -f -v $deep -s "$identity" "$file" || fail "Could not code sign ${infoName}"
 }

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -17,6 +17,24 @@ VERSION=`git describe --tags --dirty --always`
 
 which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
 
+# Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
+APP_SIGN=""
+if [ -n "$1" ]; then
+    # Test the identity is valid for signing by doing this hack. There is no other way to do this.
+    cp -f /bin/ls ./CODESIGN_TEST
+    codesign -s "$1" --dryrun -f ./CODESIGN_TEST > /dev/null 2>&1
+    res=$?
+    rm -f ./CODESIGN_TEST
+    if ((res)); then
+        fail "Code signing identity \"$1\" appears to be invalid."
+    fi
+    unset res
+    APP_SIGN="$1"
+    info "Code signing enabled using identity \"$APP_SIGN\""
+else
+    warn "Code signing DISABLED. Specify a valid macOS Developer identity installed on the system as the first argument to this script to enable signing."
+fi
+
 info "Installing Python $PYTHON_VERSION"
 export PATH="~/.pyenv/bin:~/.pyenv/shims:~/Library/Python/3.6/bin:$PATH"
 if [ -d "~/.pyenv" ]; then
@@ -54,6 +72,7 @@ info "Downloading libusb..."
 curl https://homebrew.bintray.com/bottles/libusb-1.0.22.el_capitan.bottle.tar.gz | \
 tar xz --directory $BUILDDIR
 cp $BUILDDIR/libusb/1.0.22/lib/libusb-1.0.dylib contrib/build-osx
+DoCodeSignMaybe "libusb" "contrib/build-osx/libusb-1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 info "Building libsecp256k1"
 brew install autoconf automake libtool
@@ -66,6 +85,7 @@ git clean -f -x -q
 make
 popd
 cp $BUILDDIR/secp256k1/.libs/libsecp256k1.0.dylib contrib/build-osx
+DoCodeSignMaybe "libsecp256k1" "contrib/build-osx/libsecp256k1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 
 info "Installing requirements..."
@@ -96,5 +116,14 @@ plutil -insert 'CFBundleURLTypes' \
 	-- dist/$PACKAGE.app/Contents/Info.plist \
 	|| fail "Could not add keys to Info.plist. Make sure the program 'plutil' exists and is installed."
 
+DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+
 info "Creating .DMG"
 hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"
+
+DoCodeSignMaybe ".DMG" "dist/electrum-${VERSION}.dmg" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+
+if [ -z "$APP_SIGN" ]; then
+    warn "App was built successfully but was not code signed. Users may get security warnings from macOS."
+    warn "Specify a valid code signing identity as the first argument to this script to enable code signing."
+fi

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -15,7 +15,8 @@ cd $src_dir/../..
 export PYTHONHASHSEED=22
 VERSION=`git describe --tags --dirty --always`
 
-which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
+#which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
+which xcodebuild > /dev/null 2>&1 || fail "Please install Xcode and xcode command line tools to continue"
 
 # Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
 APP_SIGN=""
@@ -96,6 +97,14 @@ fail "Could not install requirements"
 info "Installing hardware wallet requirements..."
 python3 -m pip install -Ir ./contrib/deterministic-build/requirements-hw.txt --user || \
 fail "Could not install hardware wallet requirements"
+
+info "Building CalinsQRReader..."
+d=contrib/CalinsQRReader
+pushd $d
+rm -fr build
+xcodebuild || fail "Could not build CalinsQRReader"
+popd
+DoCodeSignMaybe "CalinsQRReader.app" "${d}/build/Release/CalinsQRReader.app" "$APP_SIGN"
 
 info "Building $PACKAGE..."
 python3 setup.py install --user > /dev/null || fail "Could not build $PACKAGE"

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -15,7 +15,7 @@ cd $src_dir/../..
 export PYTHONHASHSEED=22
 VERSION=`git describe --tags --dirty --always`
 
-#which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
+which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
 which xcodebuild > /dev/null 2>&1 || fail "Please install Xcode and xcode command line tools to continue"
 
 # Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html

--- a/contrib/build-osx/osx.spec
+++ b/contrib/build-osx/osx.spec
@@ -41,6 +41,9 @@ datas += collect_data_files('btchip')
 datas += collect_data_files('keepkeylib')
 datas += collect_data_files('ckcc')
 
+# Add the QR Scanner helper app
+datas += [(electrum + "contrib/CalinsQRReader/build/Release/CalinsQRReader.app", "./contrib/CalinsQRReader/build/Release/CalinsQRReader.app")]
+
 # Add libusb so Trezor and Safe-T mini will work
 binaries = [(electrum + "contrib/build-osx/libusb-1.0.dylib", ".")]
 binaries += [(electrum + "contrib/build-osx/libsecp256k1.0.dylib", ".")]

--- a/electrum/qrscanner.py
+++ b/electrum/qrscanner.py
@@ -25,49 +25,71 @@
 
 import os
 import sys
-import ctypes
 
 if sys.platform == 'darwin':
-    name = 'libzbar.dylib'
-elif sys.platform in ('windows', 'win32'):
-    name = 'libzbar-0.dll'
+    import subprocess
+
+    def scan_barcode(*args, **kwargs):
+        # NOTE: This code needs to be modified if the positions of this file changes with respect to the helper app!
+        # This assumes the built macOS .app bundle which ends up putting the helper app in .app/contrib/CalinsQRReader/build/Release/CalinsQRReader.app.
+        root_ec_dir = os.path.abspath(os.path.dirname(__file__) + "/../")
+        prog = root_ec_dir + "/" + "contrib/CalinsQRReader/build/Release/CalinsQRReader.app/Contents/MacOS/CalinsQRReader"
+        if not os.path.exists(prog):
+            raise RuntimeError("Cannot start camera helper app; app not available.")
+        data = ''
+        try:
+            # This will run the "CalinsQRReader" helper app (which also gets bundled with the built .app)
+            # Just like the zbar implementation -- the main app will hang until the QR window returns a QR code
+            # (or is closed). Communication with the subprocess is done via stdout.
+            # See contrib/CalinsQRReader for the helper app source code.
+            with subprocess.Popen([prog], stdout=subprocess.PIPE) as p:
+                data = p.stdout.read().decode('utf-8').strip()
+            return data
+        except OSError as e:
+            raise RuntimeError("Cannot start camera helper app; {}".format(e.strerror))
+
 else:
-    name = 'libzbar.so.0'
+    import ctypes
 
-try:
-    libzbar = ctypes.cdll.LoadLibrary(name)
-except BaseException:
-    libzbar = None
-
-
-def scan_barcode(device='', timeout=-1, display=True, threaded=False, try_again=True):
-    if libzbar is None:
-        raise RuntimeError("Cannot start QR scanner; zbar not available.")
-    libzbar.zbar_symbol_get_data.restype = ctypes.c_char_p
-    libzbar.zbar_processor_create.restype = ctypes.POINTER(ctypes.c_int)
-    libzbar.zbar_processor_get_results.restype = ctypes.POINTER(ctypes.c_int)
-    libzbar.zbar_symbol_set_first_symbol.restype = ctypes.POINTER(ctypes.c_int)
-    proc = libzbar.zbar_processor_create(threaded)
-    libzbar.zbar_processor_request_size(proc, 640, 480)
-    if libzbar.zbar_processor_init(proc, device.encode('utf-8'), display) != 0:
-        if try_again:
-            # workaround for a bug in "ZBar for Windows"
-            # libzbar.zbar_processor_init always seem to fail the first time around
-            return scan_barcode(device, timeout, display, threaded, try_again=False)
-        raise RuntimeError("Can not start QR scanner; initialization failed.")
-    libzbar.zbar_processor_set_visible(proc)
-    if libzbar.zbar_process_one(proc, timeout):
-        symbols = libzbar.zbar_processor_get_results(proc)
+    if sys.platform in ('windows', 'win32'):
+        name = 'libzbar-0.dll'
     else:
-        symbols = None
-    libzbar.zbar_processor_destroy(proc)
-    if symbols is None:
-        return
-    if not libzbar.zbar_symbol_set_get_size(symbols):
-        return
-    symbol = libzbar.zbar_symbol_set_first_symbol(symbols)
-    data = libzbar.zbar_symbol_get_data(symbol)
-    return data.decode('utf8')
+        name = 'libzbar.so.0'
+
+    try:
+        libzbar = ctypes.cdll.LoadLibrary(name)
+    except BaseException:
+        libzbar = None
+
+
+    def scan_barcode(device='', timeout=-1, display=True, threaded=False, try_again=True):
+        if libzbar is None:
+            raise RuntimeError("Cannot start QR scanner; zbar not available.")
+        libzbar.zbar_symbol_get_data.restype = ctypes.c_char_p
+        libzbar.zbar_processor_create.restype = ctypes.POINTER(ctypes.c_int)
+        libzbar.zbar_processor_get_results.restype = ctypes.POINTER(ctypes.c_int)
+        libzbar.zbar_symbol_set_first_symbol.restype = ctypes.POINTER(ctypes.c_int)
+        proc = libzbar.zbar_processor_create(threaded)
+        libzbar.zbar_processor_request_size(proc, 640, 480)
+        if libzbar.zbar_processor_init(proc, device.encode('utf-8'), display) != 0:
+            if try_again:
+                # workaround for a bug in "ZBar for Windows"
+                # libzbar.zbar_processor_init always seem to fail the first time around
+                return scan_barcode(device, timeout, display, threaded, try_again=False)
+            raise RuntimeError("Can not start QR scanner; initialization failed.")
+        libzbar.zbar_processor_set_visible(proc)
+        if libzbar.zbar_process_one(proc, timeout):
+            symbols = libzbar.zbar_processor_get_results(proc)
+        else:
+            symbols = None
+        libzbar.zbar_processor_destroy(proc)
+        if symbols is None:
+            return
+        if not libzbar.zbar_symbol_set_get_size(symbols):
+            return
+        symbol = libzbar.zbar_symbol_set_first_symbol(symbols)
+        data = libzbar.zbar_symbol_get_data(symbol)
+        return data.decode('utf8')
 
 def _find_system_cameras():
     device_root = "/sys/class/video4linux"


### PR DESCRIPTION
Note this PR includes within it #4869.  As far as I know it's impossible to make PR's depend on one another so I submitted #4869 first, then this (which requires it).

This is similar to https://github.com/Electron-Cash/Electron-Cash/pull/977, although this Electrum version builds from source each time and does not include a compiled binary.

--- 
Sample screenshot taken from Electron Cash:

![me_ec_test](https://user-images.githubusercontent.com/266627/48979638-ba9f6800-f0c6-11e8-9f24-42d5c56e8bea.png)

---

This feature adds much-needed QR scanning capability to Electrum on macOS.

Note that zbar does **not** work on macOS for reading from the webcam.  So -- a different approach was needed.

I did some digging and most other approaches I could find have external dependencies that just make building and packaging too cumbersome.  (See: https://github.com/spesmilo/electrum/pull/3485 for an example of a cumbersome approach).

However -- macOS since 10.7 comes with very good video processing capabilities right in the OS.  This includes the ability to decode QR codes! Why bundle heavy-handed libs when the OS already provides them? (And -- they are **hardware accelerated**, to boot!).

So -- I wrote a small helper app that Electrum can execute to read QR codes from a camera.  The entire app is 80KB compiled -- so it's tiny and on the order of the size of other bundled binaries included on macOS such as `libusb.dylib`. 

The workflow for this app is identical to the 'zbar' approach used on Linux and Windows.

This PR also takes care of bundling and signing the helper app in the built .app & .DMG for macOS.  

The helper app basically creates a window and reads from the default camera device on the system. It will continue to run until either the window is closed by the user or a QR image is read.

#### Rationale for using a Helper App rather than a dylib

1. macOS Mojave and above require special Info.plist keys and annoying permissions from the user to access the camera. It was far simpler to do this as a self-contained app, than make Electrum adapt to this insanity.
2. It's far less invasive to have a standalone app than to build a dylib when it comes to creating GUI windows -- no interference with Electrum's GUI event loop. Everything is self-contained.

#### Workflow for the helper app is as follows (note this is identical to zbar):

1. If a QR image is scanned, it will print the decoded string to stdout and exit.
2. If there is an error detecting the camera, it will show an error message and wait.
3. If the user closes the window without having scanned a QR code (because of an error or s/he changed his/her mind), it will print nothing to stdout and exit.

As such, `lib/qrscanner.py` was modified to call the helper app using `subprocess.Popen` in the 'darwin' case. The 'windows' and 'linux' cases were left unmodified.

