### PR TITLE
[macOS] QR scanner facility using a platform-native helper app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "contrib/deterministic-build/electrum-locale"]
 	path = contrib/deterministic-build/electrum-locale
 	url = https://github.com/spesmilo/electrum-locale
+[submodule "contrib/CalinsQRReader"]
+	path = contrib/CalinsQRReader
+	url = https://github.com/spesmilo/CalinsQRReader

--- a/contrib/build-osx/base.sh
+++ b/contrib/build-osx/base.sh
@@ -21,7 +21,7 @@ function DoCodeSignMaybe { # ARGS: infoName fileOrDirName codesignIdentity
     identity="$3"
     deep=""
     if [ -z "$identity" ]; then
-        # we are ok with them not passing anything -- master script calls us always even if no identity is specified
+        # we are ok with them not passing anything; master script calls us unconditionally even if no identity is specified
         return
     fi
     if [ -d "$file" ]; then

--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -16,6 +16,7 @@ export PYTHONHASHSEED=22
 VERSION=`git describe --tags --dirty --always`
 
 which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
+which xcodebuild > /dev/null 2>&1 || fail "Please install Xcode and xcode command line tools to continue"
 
 # Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
 APP_SIGN=""
@@ -86,6 +87,14 @@ make
 popd
 cp $BUILDDIR/secp256k1/.libs/libsecp256k1.0.dylib contrib/build-osx
 DoCodeSignMaybe "libsecp256k1" "contrib/build-osx/libsecp256k1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+
+info "Building CalinsQRReader..."
+d=contrib/CalinsQRReader
+pushd $d
+rm -fr build
+xcodebuild || fail "Could not build CalinsQRReader"
+popd
+DoCodeSignMaybe "CalinsQRReader.app" "${d}/build/Release/CalinsQRReader.app" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 
 info "Installing requirements..."

--- a/contrib/build-osx/osx.spec
+++ b/contrib/build-osx/osx.spec
@@ -41,6 +41,9 @@ datas += collect_data_files('btchip')
 datas += collect_data_files('keepkeylib')
 datas += collect_data_files('ckcc')
 
+# Add the QR Scanner helper app
+datas += [(electrum + "contrib/CalinsQRReader/build/Release/CalinsQRReader.app", "./contrib/CalinsQRReader/build/Release/CalinsQRReader.app")]
+
 # Add libusb so Trezor and Safe-T mini will work
 binaries = [(electrum + "contrib/build-osx/libusb-1.0.dylib", ".")]
 binaries += [(electrum + "contrib/build-osx/libsecp256k1.0.dylib", ".")]

--- a/electrum/qrscanner.py
+++ b/electrum/qrscanner.py
@@ -25,49 +25,72 @@
 
 import os
 import sys
-import ctypes
 
 if sys.platform == 'darwin':
-    name = 'libzbar.dylib'
-elif sys.platform in ('windows', 'win32'):
-    name = 'libzbar-0.dll'
+    import subprocess
+
+    def scan_barcode(*args, **kwargs):
+        # NOTE: This code needs to be modified if the positions of this file changes with respect to the helper app!
+        # This assumes the built macOS .app bundle which ends up putting the helper app in
+        # .app/contrib/CalinsQRReader/build/Release/CalinsQRReader.app.
+        root_ec_dir = os.path.abspath(os.path.dirname(__file__) + "/../")
+        prog = root_ec_dir + "/" + "contrib/CalinsQRReader/build/Release/CalinsQRReader.app/Contents/MacOS/CalinsQRReader"
+        if not os.path.exists(prog):
+            raise RuntimeError("Cannot start QR scanner; helper app not found.")
+        data = ''
+        try:
+            # This will run the "CalinsQRReader" helper app (which also gets bundled with the built .app)
+            # Just like the zbar implementation -- the main app will hang until the QR window returns a QR code
+            # (or is closed). Communication with the subprocess is done via stdout.
+            # See contrib/CalinsQRReader for the helper app source code.
+            with subprocess.Popen([prog], stdout=subprocess.PIPE) as p:
+                data = p.stdout.read().decode('utf-8').strip()
+            return data
+        except OSError as e:
+            raise RuntimeError("Cannot start camera helper app; {}".format(e.strerror))
+
 else:
-    name = 'libzbar.so.0'
+    import ctypes
 
-try:
-    libzbar = ctypes.cdll.LoadLibrary(name)
-except BaseException:
-    libzbar = None
-
-
-def scan_barcode(device='', timeout=-1, display=True, threaded=False, try_again=True):
-    if libzbar is None:
-        raise RuntimeError("Cannot start QR scanner; zbar not available.")
-    libzbar.zbar_symbol_get_data.restype = ctypes.c_char_p
-    libzbar.zbar_processor_create.restype = ctypes.POINTER(ctypes.c_int)
-    libzbar.zbar_processor_get_results.restype = ctypes.POINTER(ctypes.c_int)
-    libzbar.zbar_symbol_set_first_symbol.restype = ctypes.POINTER(ctypes.c_int)
-    proc = libzbar.zbar_processor_create(threaded)
-    libzbar.zbar_processor_request_size(proc, 640, 480)
-    if libzbar.zbar_processor_init(proc, device.encode('utf-8'), display) != 0:
-        if try_again:
-            # workaround for a bug in "ZBar for Windows"
-            # libzbar.zbar_processor_init always seem to fail the first time around
-            return scan_barcode(device, timeout, display, threaded, try_again=False)
-        raise RuntimeError("Can not start QR scanner; initialization failed.")
-    libzbar.zbar_processor_set_visible(proc)
-    if libzbar.zbar_process_one(proc, timeout):
-        symbols = libzbar.zbar_processor_get_results(proc)
+    if sys.platform in ('windows', 'win32'):
+        name = 'libzbar-0.dll'
     else:
-        symbols = None
-    libzbar.zbar_processor_destroy(proc)
-    if symbols is None:
-        return
-    if not libzbar.zbar_symbol_set_get_size(symbols):
-        return
-    symbol = libzbar.zbar_symbol_set_first_symbol(symbols)
-    data = libzbar.zbar_symbol_get_data(symbol)
-    return data.decode('utf8')
+        name = 'libzbar.so.0'
+
+    try:
+        libzbar = ctypes.cdll.LoadLibrary(name)
+    except BaseException:
+        libzbar = None
+
+
+    def scan_barcode(device='', timeout=-1, display=True, threaded=False, try_again=True):
+        if libzbar is None:
+            raise RuntimeError("Cannot start QR scanner; zbar not available.")
+        libzbar.zbar_symbol_get_data.restype = ctypes.c_char_p
+        libzbar.zbar_processor_create.restype = ctypes.POINTER(ctypes.c_int)
+        libzbar.zbar_processor_get_results.restype = ctypes.POINTER(ctypes.c_int)
+        libzbar.zbar_symbol_set_first_symbol.restype = ctypes.POINTER(ctypes.c_int)
+        proc = libzbar.zbar_processor_create(threaded)
+        libzbar.zbar_processor_request_size(proc, 640, 480)
+        if libzbar.zbar_processor_init(proc, device.encode('utf-8'), display) != 0:
+            if try_again:
+                # workaround for a bug in "ZBar for Windows"
+                # libzbar.zbar_processor_init always seem to fail the first time around
+                return scan_barcode(device, timeout, display, threaded, try_again=False)
+            raise RuntimeError("Can not start QR scanner; initialization failed.")
+        libzbar.zbar_processor_set_visible(proc)
+        if libzbar.zbar_process_one(proc, timeout):
+            symbols = libzbar.zbar_processor_get_results(proc)
+        else:
+            symbols = None
+        libzbar.zbar_processor_destroy(proc)
+        if symbols is None:
+            return
+        if not libzbar.zbar_symbol_set_get_size(symbols):
+            return
+        symbol = libzbar.zbar_symbol_set_first_symbol(symbols)
+        data = libzbar.zbar_symbol_get_data(symbol)
+        return data.decode('utf8')
 
 def _find_system_cameras():
     device_root = "/sys/class/video4linux"

--- a/electrum/qrscanner.py
+++ b/electrum/qrscanner.py
@@ -25,72 +25,72 @@
 
 import os
 import sys
+import ctypes
 
 if sys.platform == 'darwin':
-    import subprocess
-
-    def scan_barcode(*args, **kwargs):
-        # NOTE: This code needs to be modified if the positions of this file changes with respect to the helper app!
-        # This assumes the built macOS .app bundle which ends up putting the helper app in
-        # .app/contrib/CalinsQRReader/build/Release/CalinsQRReader.app.
-        root_ec_dir = os.path.abspath(os.path.dirname(__file__) + "/../")
-        prog = root_ec_dir + "/" + "contrib/CalinsQRReader/build/Release/CalinsQRReader.app/Contents/MacOS/CalinsQRReader"
-        if not os.path.exists(prog):
-            raise RuntimeError("Cannot start QR scanner; helper app not found.")
-        data = ''
-        try:
-            # This will run the "CalinsQRReader" helper app (which also gets bundled with the built .app)
-            # Just like the zbar implementation -- the main app will hang until the QR window returns a QR code
-            # (or is closed). Communication with the subprocess is done via stdout.
-            # See contrib/CalinsQRReader for the helper app source code.
-            with subprocess.Popen([prog], stdout=subprocess.PIPE) as p:
-                data = p.stdout.read().decode('utf-8').strip()
-            return data
-        except OSError as e:
-            raise RuntimeError("Cannot start camera helper app; {}".format(e.strerror))
-
+    name = 'libzbar.dylib'
+elif sys.platform in ('windows', 'win32'):
+    name = 'libzbar-0.dll'
 else:
-    import ctypes
+    name = 'libzbar.so.0'
 
-    if sys.platform in ('windows', 'win32'):
-        name = 'libzbar-0.dll'
+try:
+    libzbar = ctypes.cdll.LoadLibrary(name)
+except BaseException:
+    libzbar = None
+
+
+def scan_barcode_ctypes(device='', timeout=-1, display=True, threaded=False, try_again=True):
+    if libzbar is None:
+        raise RuntimeError("Cannot start QR scanner; zbar not available.")
+    libzbar.zbar_symbol_get_data.restype = ctypes.c_char_p
+    libzbar.zbar_processor_create.restype = ctypes.POINTER(ctypes.c_int)
+    libzbar.zbar_processor_get_results.restype = ctypes.POINTER(ctypes.c_int)
+    libzbar.zbar_symbol_set_first_symbol.restype = ctypes.POINTER(ctypes.c_int)
+    proc = libzbar.zbar_processor_create(threaded)
+    libzbar.zbar_processor_request_size(proc, 640, 480)
+    if libzbar.zbar_processor_init(proc, device.encode('utf-8'), display) != 0:
+        if try_again:
+            # workaround for a bug in "ZBar for Windows"
+            # libzbar.zbar_processor_init always seem to fail the first time around
+            return scan_barcode(device, timeout, display, threaded, try_again=False)
+        raise RuntimeError("Can not start QR scanner; initialization failed.")
+    libzbar.zbar_processor_set_visible(proc)
+    if libzbar.zbar_process_one(proc, timeout):
+        symbols = libzbar.zbar_processor_get_results(proc)
     else:
-        name = 'libzbar.so.0'
+        symbols = None
+    libzbar.zbar_processor_destroy(proc)
+    if symbols is None:
+        return
+    if not libzbar.zbar_symbol_set_get_size(symbols):
+        return
+    symbol = libzbar.zbar_symbol_set_first_symbol(symbols)
+    data = libzbar.zbar_symbol_get_data(symbol)
+    return data.decode('utf8')
 
+def scan_barcode_osx(*args_ignored, **kwargs_ignored):
+    import subprocess
+    # NOTE: This code needs to be modified if the positions of this file changes with respect to the helper app!
+    # This assumes the built macOS .app bundle which ends up putting the helper app in
+    # .app/contrib/CalinsQRReader/build/Release/CalinsQRReader.app.
+    root_ec_dir = os.path.abspath(os.path.dirname(__file__) + "/../")
+    prog = root_ec_dir + "/" + "contrib/CalinsQRReader/build/Release/CalinsQRReader.app/Contents/MacOS/CalinsQRReader"
+    if not os.path.exists(prog):
+        raise RuntimeError("Cannot start QR scanner; helper app not found.")
+    data = ''
     try:
-        libzbar = ctypes.cdll.LoadLibrary(name)
-    except BaseException:
-        libzbar = None
+        # This will run the "CalinsQRReader" helper app (which also gets bundled with the built .app)
+        # Just like the zbar implementation -- the main app will hang until the QR window returns a QR code
+        # (or is closed). Communication with the subprocess is done via stdout.
+        # See contrib/CalinsQRReader for the helper app source code.
+        with subprocess.Popen([prog], stdout=subprocess.PIPE) as p:
+            data = p.stdout.read().decode('utf-8').strip()
+        return data
+    except OSError as e:
+        raise RuntimeError("Cannot start camera helper app; {}".format(e.strerror))
 
-
-    def scan_barcode(device='', timeout=-1, display=True, threaded=False, try_again=True):
-        if libzbar is None:
-            raise RuntimeError("Cannot start QR scanner; zbar not available.")
-        libzbar.zbar_symbol_get_data.restype = ctypes.c_char_p
-        libzbar.zbar_processor_create.restype = ctypes.POINTER(ctypes.c_int)
-        libzbar.zbar_processor_get_results.restype = ctypes.POINTER(ctypes.c_int)
-        libzbar.zbar_symbol_set_first_symbol.restype = ctypes.POINTER(ctypes.c_int)
-        proc = libzbar.zbar_processor_create(threaded)
-        libzbar.zbar_processor_request_size(proc, 640, 480)
-        if libzbar.zbar_processor_init(proc, device.encode('utf-8'), display) != 0:
-            if try_again:
-                # workaround for a bug in "ZBar for Windows"
-                # libzbar.zbar_processor_init always seem to fail the first time around
-                return scan_barcode(device, timeout, display, threaded, try_again=False)
-            raise RuntimeError("Can not start QR scanner; initialization failed.")
-        libzbar.zbar_processor_set_visible(proc)
-        if libzbar.zbar_process_one(proc, timeout):
-            symbols = libzbar.zbar_processor_get_results(proc)
-        else:
-            symbols = None
-        libzbar.zbar_processor_destroy(proc)
-        if symbols is None:
-            return
-        if not libzbar.zbar_symbol_set_get_size(symbols):
-            return
-        symbol = libzbar.zbar_symbol_set_first_symbol(symbols)
-        data = libzbar.zbar_symbol_get_data(symbol)
-        return data.decode('utf8')
+scan_barcode = scan_barcode_osx if sys.platform == 'darwin' else scan_barcode_ctypes
 
 def _find_system_cameras():
     device_root = "/sys/class/video4linux"


### PR DESCRIPTION
Note: This PR deprecates #4870, as well as #3485.

Note 2: This PR adds a submodule in `contrib/CalinsQRReader` which basically points to [spesmilo/CalinsQRReader](https://github.com/spesmilo/CalinsQRReader) (helper app Obj-C source code).

This is similar to https://github.com/Electron-Cash/Electron-Cash/pull/977, although this Electrum version builds from source each time and does not include a compiled binary.

--- 
Sample screenshot taken from Electron Cash:

![me_ec_test](https://user-images.githubusercontent.com/266627/48979638-ba9f6800-f0c6-11e8-9f24-42d5c56e8bea.png)

---

This feature adds much-needed QR scanning capability to Electrum on macOS.

Note that zbar does **not** work on macOS for reading from the webcam.  So -- a different approach was needed.

I did some digging and most other approaches I could find have external dependencies that just make building and packaging too cumbersome.  (See: https://github.com/spesmilo/electrum/pull/3485 for an example of a cumbersome approach).

However -- macOS since 10.7 comes with very good video processing capabilities right in the OS.  This includes the ability to decode QR codes! Why bundle heavy-handed libs when the OS already provides them? (And -- they are **hardware accelerated**, to boot!).

So -- I wrote a small helper app that Electrum can execute to read QR codes from a camera.  The entire app is 80KB compiled -- so it's tiny and on the order of the size of other bundled binaries included on macOS such as `libusb.dylib`. 

The workflow for this app is identical to the 'zbar' approach used on Linux and Windows.

This PR also takes care of bundling and signing the helper app in the built .app & .DMG for macOS.  

The helper app basically creates a window and reads from the default camera device on the system. It will continue to run until either the window is closed by the user or a QR image is read.

#### Rationale for using a Helper App rather than a dylib

1. macOS Mojave and above require special Info.plist keys and annoying permissions from the user to access the camera. It was far simpler to do this as a self-contained app, than make Electrum adapt to this insanity.
2. It's far less invasive to have a standalone app than to build a dylib when it comes to creating GUI windows -- no interference with Electrum's GUI event loop. Everything is self-contained.

#### Workflow for the helper app is as follows (note this is identical to zbar):

1. If a QR image is scanned, it will print the decoded string to stdout and exit.
2. If there is an error detecting the camera, it will show an error message and wait.
3. If the user closes the window without having scanned a QR code (because of an error or s/he changed his/her mind), it will print nothing to stdout and exit.

As such, `lib/qrscanner.py` was modified to call the helper app using `subprocess.Popen` in the 'darwin' case. The 'windows' and 'linux' cases were left unmodified.

