### PR TITLE
UI: Make Coins Tab -> Details TX Dialog show TX Description (label)

### DIFF
--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -71,7 +71,7 @@ class UTXOList(MyTreeWidget):
             txid = selected[0].split(':')[0]
             tx = self.wallet.transactions.get(txid)
             if tx:
-                label = self.wallet.get_label(txid)
+                label = self.wallet.get_label(txid) or None # Prefer None if empty (None hides the Description: field in the window)
                 menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx, label))
 
         menu.exec_(self.viewport().mapToGlobal(position))

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -71,7 +71,8 @@ class UTXOList(MyTreeWidget):
             txid = selected[0].split(':')[0]
             tx = self.wallet.transactions.get(txid)
             if tx:
-                menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx))
+                label = self.wallet.get_label(txid)
+                menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx, label))
 
         menu.exec_(self.viewport().mapToGlobal(position))
 


### PR DESCRIPTION
This is a follow-up to #4775.  It turns out the UTXOList (Coins tab) has the same issue as the history screen did before #4775.

You right-click on a coin which has a label, pick "Details" and the resulting Tx Dialog lacks a tx description.

Can be useful to have it there.

---

Here is a sample screenshot of what's new with this change.

<img width="1094" alt="pr_ss" src="https://user-images.githubusercontent.com/266627/49340040-fb592d00-f642-11e8-9fc8-6089b6830f07.png">
