### PR TITLE
mac: build qr scanner using old xcode

### DIFF
--- a/contrib/osx/README.md
+++ b/contrib/osx/README.md
@@ -8,12 +8,13 @@ This guide explains how to build Electrum binaries for macOS systems.
 
 This needs to be done on a system running macOS or OS X. We use El Capitan (10.11.6) as building it
 on High Sierra (or later)
-makes the binaries incompatible with older versions. 
+makes the binaries [incompatible with older versions](https://github.com/pyinstaller/pyinstaller/issues/1191).
 
+Before starting, make sure that the Xcode command line tools are installed (e.g. you have `git`).
 
-#### 1.1 Get Xcode
+#### 1.1a Get Xcode
 
-Building the QR code reader (CalinsQRReader) requires full Xcode (not just command line tools).
+Building the QR scanner (CalinsQRReader) requires full Xcode (not just command line tools).
 
 The last Xcode version compatible with El Capitan is Xcode 8.2.1
 
@@ -26,6 +27,17 @@ After downloading, uncompress it.
 Make sure it is the "selected" xcode (e.g.):
 
     sudo xcode-select -s $HOME/Downloads/Xcode.app/Contents/Developer/
+
+#### 1.1b Build QR scanner separately on newer Mac
+
+Alternatively, you can try building just the QR scanner on newer macOS.
+
+On newer Mac, run:
+
+    pushd contrib/osx/CalinsQRReader; xcodebuild; popd
+    cp -r contrib/osx/CalinsQRReader/build prebuilt_qr
+
+Move `prebuilt_qr` to El Capitan: `contrib/osx/CalinsQRReader/prebuilt_qr`.
 
 
 #### 1.2 Build Electrum

--- a/contrib/osx/README.md
+++ b/contrib/osx/README.md
@@ -3,22 +3,40 @@ Building Mac OS binaries
 
 This guide explains how to build Electrum binaries for macOS systems.
 
-The build process consists of two steps:
 
 ## 1. Building the binary
 
-This needs to be done on a system running macOS or OS X. We use El Capitan (10.11.6) as building it on High Sierra
+This needs to be done on a system running macOS or OS X. We use El Capitan (10.11.6) as building it
+on High Sierra (or later)
 makes the binaries incompatible with older versions. 
 
-Before starting, make sure that the Xcode command line tools are installed (e.g. you have `git`).
 
+#### 1.1 Get Xcode
+
+Building the QR code reader (CalinsQRReader) requires full Xcode (not just command line tools).
+
+The last Xcode version compatible with El Capitan is Xcode 8.2.1
+
+Get it from [here](https://developer.apple.com/download/more/).
+
+Unfortunately, you need an "Apple ID" account.
+
+After downloading, uncompress it.
+
+Make sure it is the "selected" xcode (e.g.):
+
+    sudo xcode-select -s $HOME/Downloads/Xcode.app/Contents/Developer/
+
+
+#### 1.2 Build Electrum
 
     cd electrum
     ./contrib/osx/make_osx
     
-This creates a folder named Electrum.app.
+This creates both a folder named Electrum.app and the .dmg file.
 
-## 2. Building the image 
+
+## 2. Building the image deterministically (WIP)
 The usual way to distribute macOS applications is to use image files containing the 
 application. Although these images can be created on a Mac with the built-in `hdiutil`,
 they are not deterministic.

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -94,7 +94,8 @@ info "Building CalinsQRReader..."
 d=contrib/osx/CalinsQRReader
 pushd $d
 rm -fr build
-xcodebuild || fail "Could not build CalinsQRReader"
+# prefer building using xcode ourselves. otherwise fallback to prebuilt binary
+xcodebuild || cp -r prebuilt_qr build || fail "Could not build CalinsQRReader"
 popd
 DoCodeSignMaybe "CalinsQRReader.app" "${d}/build/Release/CalinsQRReader.app" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Parameterize
-PYTHON_VERSION=3.6.4
+PYTHON_VERSION=3.6.7
 BUILDDIR=/tmp/electrum-build
 PACKAGE=Electrum
 GIT_REPO=https://github.com/spesmilo/electrum
@@ -73,6 +73,8 @@ info "Downloading libusb..."
 curl https://homebrew.bintray.com/bottles/libusb-1.0.22.el_capitan.bottle.tar.gz | \
 tar xz --directory $BUILDDIR
 cp $BUILDDIR/libusb/1.0.22/lib/libusb-1.0.dylib contrib/osx
+echo "82c368dfd4da017ceb32b12ca885576f325503428a4966cc09302cbd62702493  contrib/osx/libusb-1.0.dylib" | \
+    shasum -a 256 -c || fail "libusb checksum mismatched"
 DoCodeSignMaybe "libusb" "contrib/osx/libusb-1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 info "Building libsecp256k1"


### PR DESCRIPTION
use old xcode to build qr scanner on El Capitan