### PR TITLE
lnsweep: use dicts consistently

### DIFF
--- a/electrum/lnchan.py
+++ b/electrum/lnchan.py
@@ -474,7 +474,7 @@ class Channel(PrintError):
         outpoint = self.funding_outpoint.to_str()
         ctx = self.remote_commitment_to_be_revoked  # FIXME can't we just reconstruct it?
         encumbered_sweeptxs = create_sweeptxs_for_their_just_revoked_ctx(self, ctx, per_commitment_secret, self.sweep_address)
-        for prev_txid, encumbered_tx in encumbered_sweeptxs:
+        for prev_txid, encumbered_tx in encumbered_sweeptxs.items():
             if encumbered_tx is not None:
                 self.lnwatcher.add_sweep_tx(outpoint, prev_txid, encumbered_tx.to_json())
 


### PR DESCRIPTION
follow up 7084f63ea2be17b4128d1ccbb86002f18766869a "lnchannel: store pre-signed sweep transactions after each new commitment"