### PR TITLE
ln: fix stored local/remote ctx'es

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -78,6 +78,8 @@ class LNWorker(PrintError):
         self.channels = {}  # type: Dict[bytes, Channel]
         for x in wallet.storage.get("channels", []):
             c = Channel(x, sweep_address=self.sweep_address, payment_completed=self.payment_completed)
+            c.set_remote_commitment()
+            c.set_local_commitment(c.current_commitment(LOCAL))
             self.channels[c.channel_id] = c
             c.lnwatcher = network.lnwatcher
         self.invoices = wallet.storage.get('lightning_invoices', {})  # type: Dict[str, Tuple[str,str]]  # RHASH -> (preimage, invoice)


### PR DESCRIPTION
This makes current_commitment_signature fit with local_commitment. The definition of current_commitment is fixed to use the current point. Fixes the sweeping of a force close by remote, which was not working before.

Dec 20 addendum: It is problematic to call set_local_commitment in `Channel.__init__` since we construct the Channel before we have the `remote_sig` in `channel_establishment_flow`. So if we were to save the `local_commitment` in the constructor of Channel, before we received the sig, we would have a state where we have a `local_commitment` but no sig for it.