### PR TITLE
Increase timeout when using --oneserver and --server

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -654,6 +654,8 @@ class Network(PrintError):
     async def _run_new_interface(self, server):
         interface = Interface(self, server, self.proxy)
         timeout = 10 if not self.proxy else 20
+        if self.oneserver and not self.auto_connect:
+            timeout = 60
         try:
             await asyncio.wait_for(interface.ready, timeout)
         except BaseException as e:


### PR DESCRIPTION
Usually if an Electrum protocol message times out then the client will switch to another server, which is hopefully faster. But when --oneserver and --server are both used then the client will reconnect back to the same slow server. The timeout interrupts the protocol messages and doesn't fix the problem. What's needed is for the client to tolerate a slow server if the user specifically configured for that single server to be used.

My motivation for this patch is because of an issue with Electrum Personal Server (see https://github.com/chris-belcher/electrum-personal-server/issues/46), where many people run the software on slow hardware and/or connect via a slow tor hidden service or VPN. The patch shouldn't affect any other kind of user.

Let me know if there's a better way to do this, and I'll be happy to recode the patch. I did consider creating a new command line flag called something like `--tolerateslowserver`.