### PR TITLE
Add flag --skipmerklecheck

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -909,6 +909,7 @@ def add_network_options(parser):
     parser.add_argument("-s", "--server", dest="server", default=None, help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
     parser.add_argument("-p", "--proxy", dest="proxy", default=None, help="set proxy [type:]host[:port], where type is socks4,socks5 or http")
     parser.add_argument("--noonion", action="store_true", dest="noonion", default=None, help="do not try to connect to onion servers")
+    parser.add_argument("--skipmerklecheck", action="store_true", dest="skipmerklecheck", default=False, help="Tolerate invalid merkle proofs from server")
 
 def add_global_options(parser):
     group = parser.add_argument_group('global options')

--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -116,8 +116,11 @@ class SPV(NetworkJobOnDefaultServer):
         try:
             verify_tx_is_in_block(tx_hash, merkle_branch, pos, header, tx_height)
         except MerkleVerificationFailure as e:
-            self.print_error(str(e))
-            raise GracefulDisconnect(e)
+            if self.network.config.get("skipmerklecheck"):
+                self.print_error("skipping merkle proof check %s" % tx_hash)
+            else:
+                self.print_error(str(e))
+                raise GracefulDisconnect(e)
         # we passed all the tests
         self.merkle_roots[tx_hash] = header.get('merkle_root')
         try: self.requested_merkle.remove(tx_hash)


### PR DESCRIPTION
The `--skipmerklecheck` optional flag makes Electrum tolerate invalid merkle proofs from the server. This is useful for building Electrum servers that need a minimum amount of storage, though of course users should only enable it if they completely trust the connected server.

This is primarily motivated so that Electrum Personal Server can be compatible with pruning. Users who have a pruned full node would enable `--skipmerklecheck`. Also it would make it much easier to create a "no history" mode where the rpc call `scantxoutset` (https://github.com/chris-belcher/electrum-personal-server/issues/27) is used to find a wallet balance without needing a long rescan.

The way this works is based on an IRC conversation with ghost43 who suggested this method, saying it's a little bit hacky but is easy to test and maintain, and is preferable to modifying the code in 10 different places for something that wouldn't be tested very often.