### PR TITLE
[Docker] fix gnupg2 and dirmngr

### DIFF
--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -6,8 +6,8 @@ RUN dpkg --add-architecture i386 && \
     apt-get update -q && \
     apt-get install -qy \
         wget=1.19.4-1ubuntu2.1 \
-        gnupg2=2.2.4-1ubuntu1.1 \
-        dirmngr=2.2.4-1ubuntu1.1 \
+        gnupg2=2.2.4-1ubuntu1.2 \
+        dirmngr=2.2.4-1ubuntu1.2 \
         python3-software-properties=0.96.24.32.1 \
         software-properties-common=0.96.24.32.1 \
         && \


### PR DESCRIPTION
Fixes for docker

```E: Version '2.2.4-1ubuntu1.1' for 'gnupg2' was not found```
```E: Version '2.2.4-1ubuntu1.1' for 'dirmngr' was not found```