### PR TITLE
[MacOS] Fixed code signing on macos to code sign *all* embedded binaries

### DIFF
--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -75,7 +75,6 @@ tar xz --directory $BUILDDIR
 cp $BUILDDIR/libusb/1.0.22/lib/libusb-1.0.dylib contrib/osx
 echo "82c368dfd4da017ceb32b12ca885576f325503428a4966cc09302cbd62702493  contrib/osx/libusb-1.0.dylib" | \
     shasum -a 256 -c || fail "libusb checksum mismatched"
-DoCodeSignMaybe "libusb" "contrib/osx/libusb-1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 info "Building libsecp256k1"
 brew install autoconf automake libtool
@@ -88,7 +87,6 @@ git clean -f -x -q
 make
 popd
 cp $BUILDDIR/secp256k1/.libs/libsecp256k1.0.dylib contrib/osx
-DoCodeSignMaybe "libsecp256k1" "contrib/osx/libsecp256k1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 info "Building CalinsQRReader..."
 d=contrib/osx/CalinsQRReader
@@ -120,7 +118,7 @@ for d in ~/Library/Python/ ~/.pyenv .; do
 done
 
 info "Building binary"
-pyinstaller --noconfirm --ascii --clean --name $VERSION contrib/osx/osx.spec || fail "Could not build binary"
+APP_SIGN="$APP_SIGN" pyinstaller --noconfirm --ascii --clean --name $VERSION contrib/osx/osx.spec || fail "Could not build binary"
 
 info "Adding bitcoin URI types to Info.plist"
 plutil -insert 'CFBundleURLTypes' \

--- a/contrib/osx/osx.spec
+++ b/contrib/osx/osx.spec
@@ -2,13 +2,50 @@
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs
 
-import sys
-import os
+import sys, os
 
 PACKAGE='Electrum'
 PYPKG='electrum'
 MAIN_SCRIPT='run_electrum'
 ICONS_FILE='electrum.icns'
+APP_SIGN = os.environ.get('APP_SIGN', '')
+
+def fail(*msg):
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    print("\r🗯 {}ERROR:{}".format(RED, NC), *msg)
+    sys.exit(1)
+
+def codesign(identity, binary):
+    d = os.path.dirname(binary)
+    saved_dir=None
+    if d:
+        # switch to directory of the binary so codesign verbose messages don't include long path
+        saved_dir = os.path.abspath(os.path.curdir)
+        os.chdir(d)
+        binary = os.path.basename(binary)
+    os.system("codesign -v -f -s '{}' '{}'".format(identity, binary))==0 or fail("Could not code sign " + binary)
+    if saved_dir:
+        os.chdir(saved_dir)
+
+def monkey_patch_pyinstaller_for_codesigning(identity):
+    # Monkey-patch PyInstaller so that we app-sign all binaries *after* they are modified by PyInstaller
+    # If we app-sign before that point, the signature will be invalid because PyInstaller modifies
+    # @loader_path in the Mach-O loader table.
+    try:
+        import PyInstaller.depend.dylib
+        _saved_func = PyInstaller.depend.dylib.mac_set_relative_dylib_deps
+    except (ImportError, NameError, AttributeError):
+        # Hmm. Likely wrong PyInstaller version.
+        fail("Could not monkey-patch PyInstaller for code signing. Please ensure that you are using PyInstaller 3.4.")
+    _signed = set()
+    def my_func(fn, distname):
+        _saved_func(fn, distname)
+        if  (fn, distname) not in _signed:
+            codesign(identity, fn)
+            _signed.add((fn,distname)) # remember we signed it so we don't sign again
+    PyInstaller.depend.dylib.mac_set_relative_dylib_deps = my_func
+
 
 for i, x in enumerate(sys.argv):
     if x == '--name':
@@ -89,6 +126,10 @@ for x in a.binaries.copy():
         if x[0].lower().startswith(r):
             a.binaries.remove(x)
             print('----> Removed x =', x)
+
+# If code signing, monkey-patch in a code signing step to pyinstaller. See: https://github.com/spesmilo/electrum/issues/4994
+if APP_SIGN:
+    monkey_patch_pyinstaller_for_codesigning(APP_SIGN)
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 


### PR DESCRIPTION
This was pulled from Electron Cash #1110.

This addresses #4994 .

Verified to fix the problem.  Release version (note the dynamic requirements fail.. PID 598 is the subprocess that actually contains the Python interpreter):

```
528: satisfies its Designated Requirement
calin@CalinMBP2016 ~/tmp/ec/electrum $ ps -eafw | grep Electrum
  501   597     1   0 11:02AM ??         0:00.95 /Applications/Electrum.app/Contents/MacOS/Electrum
  501   598   597   0 11:02AM ??         0:01.98 /Applications/Electrum.app/Contents/MacOS/Electrum
calin@CalinMBP2016 ~/tmp/ec/electrum $ codesign -vvv 597 598
597: dynamically valid
597: valid on disk
597: satisfies its Designated Requirement
598: code identity has been invalidated
```

App built against this PR (and code signed using my developer key):

```
calin@CalinMBP2016 ~/tmp/ec/electrum $ ps -eafw | grep Electrum
  501   526     1   0 11:01AM ??         0:01.02 /Users/calin/tmp/ec/electrum/dist/Electrum.app/Contents/MacOS/Electrum
  501   528   526   0 11:01AM ??         0:02.37 /Users/calin/tmp/ec/electrum/dist/Electrum.app/Contents/MacOS/Electrum
calin@CalinMBP2016 ~/tmp/ec/electrum $ codesign -vvv 526 528
526: dynamically valid
526: valid on disk
526: satisfies its Designated Requirement
528: dynamically valid
528: valid on disk
528: satisfies its Designated Requirement
```
