### PR TITLE
[OSX] Switch PyInstaller to a patched version: AppleEvents+CodeSign (deep code signing + URL bugfix)

### DIFF
--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -48,8 +48,8 @@ pyenv global $PYTHON_VERSION || \
 fail "Unable to use Python $PYTHON_VERSION"
 
 
-info "Installing pyinstaller"
-python3 -m pip install -I --user pyinstaller==3.4 || fail "Could not install pyinstaller"
+info "Installing PyInstaller"
+python3 -m pip install https://github.com/cculianu/pyinstaller/releases/download/3.4AppleEventsCodeSign/PyInstaller_3.4+AppleEvents+CodeSign.zip -I --user && pyenv rehash || fail "Could not install PyInstaller"
 
 info "Using these versions for building $PACKAGE:"
 sw_vers
@@ -118,7 +118,11 @@ for d in ~/Library/Python/ ~/.pyenv .; do
 done
 
 info "Building binary"
-APP_SIGN="$APP_SIGN" pyinstaller --noconfirm --ascii --clean --name $VERSION contrib/osx/osx.spec || fail "Could not build binary"
+if [ -n "$APP_SIGN" ]; then
+    pyinstaller --osx-codesign-identity "$APP_SIGN" --noconfirm --ascii --clean --name $VERSION contrib/osx/osx.spec || fail "Could not build binary"
+else
+    pyinstaller --noconfirm --ascii --clean --name $VERSION contrib/osx/osx.spec || fail "Could not build binary"
+fi
 
 info "Adding bitcoin URI types to Info.plist"
 plutil -insert 'CFBundleURLTypes' \
@@ -126,7 +130,7 @@ plutil -insert 'CFBundleURLTypes' \
 	-- dist/$PACKAGE.app/Contents/Info.plist \
 	|| fail "Could not add keys to Info.plist. Make sure the program 'plutil' exists and is installed."
 
-DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app" "$APP_SIGN" # must force a codesign again because Info.plist modified above
 
 info "Creating .DMG"
 hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"

--- a/contrib/osx/osx.spec
+++ b/contrib/osx/osx.spec
@@ -8,44 +8,6 @@ PACKAGE='Electrum'
 PYPKG='electrum'
 MAIN_SCRIPT='run_electrum'
 ICONS_FILE='electrum.icns'
-APP_SIGN = os.environ.get('APP_SIGN', '')
-
-def fail(*msg):
-    RED='\033[0;31m'
-    NC='\033[0m' # No Color
-    print("\r🗯 {}ERROR:{}".format(RED, NC), *msg)
-    sys.exit(1)
-
-def codesign(identity, binary):
-    d = os.path.dirname(binary)
-    saved_dir=None
-    if d:
-        # switch to directory of the binary so codesign verbose messages don't include long path
-        saved_dir = os.path.abspath(os.path.curdir)
-        os.chdir(d)
-        binary = os.path.basename(binary)
-    os.system("codesign -v -f -s '{}' '{}'".format(identity, binary))==0 or fail("Could not code sign " + binary)
-    if saved_dir:
-        os.chdir(saved_dir)
-
-def monkey_patch_pyinstaller_for_codesigning(identity):
-    # Monkey-patch PyInstaller so that we app-sign all binaries *after* they are modified by PyInstaller
-    # If we app-sign before that point, the signature will be invalid because PyInstaller modifies
-    # @loader_path in the Mach-O loader table.
-    try:
-        import PyInstaller.depend.dylib
-        _saved_func = PyInstaller.depend.dylib.mac_set_relative_dylib_deps
-    except (ImportError, NameError, AttributeError):
-        # Hmm. Likely wrong PyInstaller version.
-        fail("Could not monkey-patch PyInstaller for code signing. Please ensure that you are using PyInstaller 3.4.")
-    _signed = set()
-    def my_func(fn, distname):
-        _saved_func(fn, distname)
-        if  (fn, distname) not in _signed:
-            codesign(identity, fn)
-            _signed.add((fn,distname)) # remember we signed it so we don't sign again
-    PyInstaller.depend.dylib.mac_set_relative_dylib_deps = my_func
-
 
 for i, x in enumerate(sys.argv):
     if x == '--name':
@@ -126,10 +88,6 @@ for x in a.binaries.copy():
         if x[0].lower().startswith(r):
             a.binaries.remove(x)
             print('----> Removed x =', x)
-
-# If code signing, monkey-patch in a code signing step to pyinstaller. See: https://github.com/spesmilo/electrum/issues/4994
-if APP_SIGN:
-    monkey_patch_pyinstaller_for_codesigning(APP_SIGN)
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 


### PR DESCRIPTION
This is in reference to issue #4994 ,  @ecdsa suggested we go with this approach rather than monkey patching which is sensitive to PyInstaller version changes.

So we hard-code a patched pyinstaller and make_osx downloads that when it is doing its setup.

The patched PyInstaller is identical to 3.4 release except it has the following additional features:

- Allows for AppleEvents to get forwarded to Electrum slave process (python interpreter).  This means bitcoin: URLs work even AFTER the app is already running (at present they do not). (EDIT: PR for this feature is here: https://github.com/pyinstaller/pyinstaller/pull/3832).

- Has the addition of the command-line option --osx-codesign-identity with allows for code signing of *all* embedded binaries and libs as the .app is built. The PR to PyInstaller has been submitted here: https://github.com/pyinstaller/pyinstaller/pull/3991 but has not yet beed accepted

This commit also undoes the monkey patching of pyinstaller to achieve deep codesigning because it can now leverage the --osx-codesign-identity option described above.

Note: I am currently hosting the custom PyIntstaller.zip on my repo here:

https://github.com/cculianu/pyinstaller/releases/tag/3.4AppleEventsCodeSign

but feel free to fork/copy this repo under the ecdsa or spesmilo account.  I can update this PR to reflect the new link whenever that's done.  Let me know!

FWIW, this was already merged into Electron Cash. Tested and works for Electrum as well.
