### PR TITLE
contrib/make_tgz: small improvements

### DIFF
--- a/contrib/make_tgz
+++ b/contrib/make_tgz
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-contrib=$(dirname "$0")
-packages="$contrib"/../packages/
+set -e
 
-if [ ! -d "$packages" ]; then
-  echo "Run make_packages first!"
-  exit 1
-fi
+CONTRIB="$(dirname "$(readlink -e "$0")")"
+ROOT_FOLDER="$CONTRIB"/..
+PACKAGES="$ROOT_FOLDER"/packages/
+LOCALE="$ROOT_FOLDER"/electrum/locale/
 
-python3 setup.py sdist --format=zip,gztar
+(
+    cd "$ROOT_FOLDER"
+
+    if [ ! -d "$LOCALE" ]; then
+      echo "Run make_locale first!"
+      exit 1
+    fi
+
+    if [ ! -d "$PACKAGES" ]; then
+      echo "Run make_packages first!"
+      exit 1
+    fi
+
+    echo "'git clean -fx' would delete the following files: >>>"
+    git clean -fx --dry-run
+    echo "<<<"
+
+    # we could build the kivy atlas potentially?
+    #(cd electrum/gui/kivy/; make theming) || echo "building kivy atlas failed! skipping."
+
+    python3 setup.py --quiet sdist --format=zip,gztar
+)


### PR DESCRIPTION
~~The release tarballs should contain the compiled Qt icons file.
The need for this was previously not articulated anywhere AFAICT.~~
 
Also, occasionally some garbage files from the build machine get included into the tarball (https://github.com/spesmilo/electrum/issues/5033#issuecomment-457930965 and https://github.com/spesmilo/electrum/issues/4424), so dry-run a `git clean` and show the user the results.

related: https://github.com/spesmilo/electrum/issues/5030