### PR TITLE
network: reintroduce network.debug

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -71,8 +71,16 @@ class NotificationSession(RPCSession):
         self.cache = {}
         self.in_flight_requests_semaphore = asyncio.Semaphore(100)
         self.default_timeout = NetworkTimeout.Generic.NORMAL
+        self._msg_counter = 0
+        self.interface = None  # type: Optional[Interface]
+
+    def _get_and_inc_msg_counter(self):
+        # runs in event loop thread, no need for lock
+        self._msg_counter += 1
+        return self._msg_counter
 
     async def handle_request(self, request):
+        self.maybe_log(f"--> {request}")
         # note: if server sends malformed request and we raise, the superclass
         # will catch the exception, count errors, and at some point disconnect
         if isinstance(request, Notification):
@@ -91,12 +99,17 @@ class NotificationSession(RPCSession):
             timeout = self.default_timeout
         # note: the semaphore implementation guarantees no starvation
         async with self.in_flight_requests_semaphore:
+            msg_id = self._get_and_inc_msg_counter()
+            self.maybe_log(f"<-- {args} {kwargs} (id: {msg_id})")
             try:
-                return await asyncio.wait_for(
+                response = await asyncio.wait_for(
                     super().send_request(*args, **kwargs),
                     timeout)
             except asyncio.TimeoutError as e:
-                raise RequestTimedOut('request timed out: {}'.format(args)) from e
+                raise RequestTimedOut(f'request timed out: {args} (id: {msg_id})') from e
+            else:
+                self.maybe_log(f"--> {response} (id: {msg_id})")
+                return response
 
     async def subscribe(self, method: str, params: List, queue: asyncio.Queue):
         # note: until the cache is written for the first time,
@@ -122,6 +135,11 @@ class NotificationSession(RPCSession):
     def get_hashable_key_for_rpc_call(cls, method, params):
         """Hashable index for subscriptions and cache"""
         return str(method) + repr(params)
+
+    def maybe_log(self, msg: str) -> None:
+        if not self.interface: return
+        if self.interface.debug or self.interface.network.debug:
+            self.interface.print_error(msg)
 
 
 class GracefulDisconnect(Exception): pass
@@ -172,6 +190,9 @@ class Interface(PrintError):
 
         self.tip_header = None
         self.tip = 0
+
+        # Dump network messages (only for this interface).  Set at runtime from the console.
+        self.debug = False
 
         asyncio.run_coroutine_threadsafe(
             self.network.main_taskgroup.spawn(self.run()), self.network.asyncio_loop)
@@ -370,6 +391,7 @@ class Interface(PrintError):
                                      host=self.host, port=self.port,
                                      ssl=sslc, proxy=self.proxy) as session:
             self.session = session  # type: NotificationSession
+            self.session.interface = self
             self.session.default_timeout = self.network.get_network_timeout_seconds(NetworkTimeout.Generic)
             try:
                 ver = await session.send_request('server.version', [ELECTRUM_VERSION, PROTOCOL_VERSION])

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -264,6 +264,9 @@ class Network(PrintError):
         self.server_queue = None
         self.proxy = None
 
+        # Dump network messages (all interfaces).  Set at runtime from the console.
+        self.debug = False
+
         self._set_status('disconnected')
 
     def run_from_another_thread(self, coro):


### PR DESCRIPTION
network.debug and interface.debug were removed during the asyncio-aiorpcx network-rewrite.

note that msg ids are per session

example:
```
[i][testnet.qtornado.com] <-- ('blockchain.transaction.broadcast', ['02000000000103e765267e94c7fae4316fba0b5dd99b0680f3f9086e6ec227db75220143a1305c0000000000fdffffff7e5b33b952ee177973eee1763eaa113557c2dc07a050e2d8b28a06649ab6ebab0000000000fdffffff92cc9dfe88bc742c7c12e5f4f79a42c15d8562bf3b1e5fc42f2cf012951fdadd0300000000fdffffff03a086010000000000160014337d48cf02b91b8e6914f3c2b9c9dea549e46812a0860100000000001600146aec431285e8872b0974b0c5778ef50274cc5e6ea64e070000000000160014f735528beef7f8c4f4adfc3028014a2cb6bf496302483045022100e2aa1664f15fe78935747415a9cdefc318d8eaf702ea98ed31e1fda780cbf29f02207c407c70b9781d80388c58628533aaf52cc2e3fbb0bf276a50001f5c2abdd17f012103739cb2395f00274293c8c4bcad0a2522694012b393122a5ffa4e8ecfba2e368e02483045022100aee4caf8a70c34d835edc77b480082738a5a885db6590e8bdddc8a207b7466a0022046e43d002a712dae2cdd2eb0981dfe13daedab9b8ab2216ec00294acad3c835b012102ae14c7b6fecd6b54ce56a7b79c443d4bffa5a1fef72c6eae3745c87d5fd3b7d002473044022049ca9262a11735d740195bbba1416bfe32ff0f59a897d349ee783e815b61aa3e02201c036ef5f9d4966f39263bff246cbcfd21a2cbc17559dfb9e04894722689e81f0121030ac18e7df5e7d9b69924df9925d88a3b98fd58bb430b79f64e2b381cc9002eb965391600']) {} (id: 890)
[i][testnet.qtornado.com] --> 09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7 (id: 890)
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['9e45fa7c384f736f196b5785c659376ec0979dcb8e00a19c1097db1329b44a81', '74f259bb2fda5bfb8850d0086d3a974b9e699f1718aa38d3ca1563b088e3931d'])
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['bfde73d472ec3724182c795f41225900786afb6b2f27f358d72807f7d48037a7', '74f259bb2fda5bfb8850d0086d3a974b9e699f1718aa38d3ca1563b088e3931d'])
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['5ae0fee451072940d85c2e515818f98f061db4f6465d9d5ccfcd0ddc652f75bd', 'b067962d1ced1ccec5d1bbd46942f223d26cd37688c00fbfb8b39bfa17e9a35b'])
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['74e85580dc4dfe634d7aea7eb13df97041f482bd7148e7b4ff4594bd772aaad9', '694a4b754c9783cd6246dd615c9ae2f7530567fcd12e98f53312b3fde65c7aac'])
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['baba787752bebcf121f9a4f3aa0da2d0c245da8c5dabfdecbb521353b84de68b', '37f1b62d9e88fb9524364d8594f527a8928a3de537a0b337825407be0b9d2d58'])
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['dc71e21b963116562a3bbe766b1c6e74aad81022d270a5a1c802b008f6708b79', '74f259bb2fda5bfb8850d0086d3a974b9e699f1718aa38d3ca1563b088e3931d'])
[i][testnet.qtornado.com] --> Notification('blockchain.scripthash.subscribe', ['0f44d456f60ad66319ddbc8172f51c276b66a20bb9dc9c03e096bf43aeb66a2b', None])
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['9e45fa7c384f736f196b5785c659376ec0979dcb8e00a19c1097db1329b44a81']) {} (id: 891)
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['bfde73d472ec3724182c795f41225900786afb6b2f27f358d72807f7d48037a7']) {} (id: 892)
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['5ae0fee451072940d85c2e515818f98f061db4f6465d9d5ccfcd0ddc652f75bd']) {} (id: 893)
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['74e85580dc4dfe634d7aea7eb13df97041f482bd7148e7b4ff4594bd772aaad9']) {} (id: 894)
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['baba787752bebcf121f9a4f3aa0da2d0c245da8c5dabfdecbb521353b84de68b']) {} (id: 895)
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['dc71e21b963116562a3bbe766b1c6e74aad81022d270a5a1c802b008f6708b79']) {} (id: 896)
[i][testnet.qtornado.com] <-- ('blockchain.scripthash.get_history', ['0f44d456f60ad66319ddbc8172f51c276b66a20bb9dc9c03e096bf43aeb66a2b']) {} (id: 897)
[i][testnet.qtornado.com] --> [{'tx_hash': '09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7', 'height': 0, 'fee': 517}] (id: 891)
[Synchronizer][Synchronizer:test_segwit_asdasd] receiving history tb1q7u649zlw7luvfa9dlsczsq229jmt7jtr0yg540 1
[i][testnet.qtornado.com] <-- ('blockchain.transaction.get', ['09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7']) {} (id: 898)
[i][testnet.qtornado.com] --> [{'tx_hash': '09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7', 'height': 0, 'fee': 517}] (id: 892)
[i][testnet.qtornado.com] --> [{'tx_hash': '09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7', 'height': 0, 'fee': 517}] (id: 896)
[i][testnet.qtornado.com] --> [{'tx_hash': '5c30a143012275db27c26e6e08f9f380069bd95d0bba6f31e4fac7947e2665e7', 'height': 1442695}, {'tx_hash': '09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7', 'height': 0, 'fee': 517}] (id: 893)
[i][testnet.qtornado.com] --> [] (id: 897)
[i][testnet.qtornado.com] --> [{'tx_hash': 'ddda1f9512f02c2fc45f1e3bbf62855dc1429af7f4e5127c2c74bc88fe9dcc92', 'height': 1452843}, {'tx_hash': '09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7', 'height': 0, 'fee': 517}] (id: 895)
[i][testnet.qtornado.com] --> [{'tx_hash': 'abebb69a64068ab2d8e250a007dcc2573511aa3e76e1ee737917ee52b9335b7e', 'height': 1326430}, {'tx_hash': '09a4c03e3bdf83bbe3955f907ee52da4fc12f4813d459bc75228b64ad08617c7', 'height': 0, 'fee': 517}] (id: 894)

```

@chris-belcher 