### PR TITLE
Anti-Phishing: It appears loading tx from blockchain was vulnerable.

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2494,7 +2494,18 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 raw_tx = self.network.run_from_another_thread(
                     self.network.get_transaction(txid, timeout=10))
             except Exception as e:
-                self.show_message(_("Error getting transaction from network") + ":\n" + str(e))
+                msg = str(e).lower().strip()
+                if 'should be a transaction hash' in msg:
+                    msg = _("Input data is not a transaction hash.")
+                elif 'no such' in msg:
+                    msg = _("No such mempool or blockchain transaction exists.")
+                elif 'no interface' in msg:
+                    msg = _("The network may be down.")
+                else:
+                    # fall back to something generic.
+                    msg = _("Could not retrieve transaction for the specified hash.")
+                self.print_error("Exception retrieving transaction for '{}': {}".format(txid, repr(e)))
+                self.show_message(_("Error getting transaction from network") + ":\n" + msg)
                 return
             tx = transaction.Transaction(raw_tx)
             self.show_transaction(tx)


### PR DESCRIPTION
It printed server messages to client.  See screenshot:

<img width="425" alt="screen shot 2019-02-12 at 5 15 00 pm" src="https://user-images.githubusercontent.com/266627/52645605-c17d9000-2ee9-11e9-851b-841c0273ca58.png">


This hole has now been plugged using the normal scheme: transalate server messages into user messages, falling back to something generic if not recognized.

<img width="428" alt="screen shot 2019-02-12 at 5 15 42 pm" src="https://user-images.githubusercontent.com/266627/52645653-d9551400-2ee9-11e9-82f9-0d408ec0d6ee.png">
