### PR TITLE
Sync android multisig wizard with desktop

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -137,7 +137,7 @@ Builder.load_string('''
             text: _('From {} cosigners').format(n.value)
         Slider:
             id: n
-            range: 2, 5
+            range: 2, 15
             step: 1
             value: 2
         Label:


### PR DESCRIPTION
On Electrum desktop, up to 15 keys can be specified in the multisig wizard. This changes syncs android version with desktop version.