### PR TITLE
Add Bylls BTC/CAD rates 

### DIFF
--- a/electrum/currencies.json
+++ b/electrum/currencies.json
@@ -386,6 +386,9 @@
         "TWD",
         "USD"
     ],
+    "Bylls": [
+        "CAD"
+    ],
     "CoinCap": [
         "USD"
     ],

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -238,6 +238,13 @@ class BlockchainInfo(ExchangeBase):
         return dict([(r, Decimal(json[r]['15m'])) for r in json])
 
 
+class Bylls(ExchangeBase):
+
+    async def get_rates(self, ccy):
+        json = await self.get_json('bylls.com', 'api/price?from_currency=BTC&to_currency=CAD')
+        return {'CAD': Decimal(json['public_price']['to_price'])}
+
+
 class Coinbase(ExchangeBase):
 
     async def get_rates(self, ccy):

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -241,7 +241,7 @@ class BlockchainInfo(ExchangeBase):
 class Bylls(ExchangeBase):
 
     async def get_rates(self, ccy):
-        json = await self.get_json('bylls.com', 'api/price?from_currency=BTC&to_currency=CAD')
+        json = await self.get_json('bylls.com', '/api/price?from_currency=BTC&to_currency=CAD')
         return {'CAD': Decimal(json['public_price']['to_price'])}
 
 


### PR DESCRIPTION
The bylls cad/BTC rate has become one of the dr facto Bitcoin price indexes do to its stability (not an order-book) and trustworthiness (5+ years running).

It queries the Bull Bitcoin (Bylls) servers in Canada, we do not log requests.

I'm not a dev, actually trying to learn python while doing this. Your patience and feedback is appreciated!

Unfortunately still too much of a job to test this myself. Just good old copy pasta.

Thanks !