### PR TITLE
update bitcoin explorer options

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -661,20 +661,16 @@ def time_difference(distance_in_time, include_seconds):
 mainnet_block_explorers = {
     'Bitupper Explorer': ('https://bitupper.com/en/explorer/bitcoin/',
                         {'tx': 'transactions/', 'addr': 'addresses/'}),
-    'Biteasy.com': ('https://www.biteasy.com/blockchain/',
-                        {'tx': 'transactions/', 'addr': 'addresses/'}),
     'Bitflyer.jp': ('https://chainflyer.bitflyer.jp/',
                         {'tx': 'Transaction/', 'addr': 'Address/'}),
     'Blockchain.info': ('https://blockchain.info/',
                         {'tx': 'tx/', 'addr': 'address/'}),
     'blockchainbdgpzk.onion': ('https://blockchainbdgpzk.onion/',
                         {'tx': 'tx/', 'addr': 'address/'}),
-    'Blockr.io': ('https://btc.blockr.io/',
-                        {'tx': 'tx/info/', 'addr': 'address/info/'}),
     'Blockstream.info': ('https://blockstream.info/',
                         {'tx': 'tx/', 'addr': 'address/'}),
-    'Blocktrail.com': ('https://www.blocktrail.com/BTC/',
-                        {'tx': 'tx/', 'addr': 'address/'}),
+    'Bitaps.com': ('https://btc.bitaps.com/',
+                        {'tx': '', 'addr': ''}),
     'BTC.com': ('https://chain.btc.com/',
                         {'tx': 'tx/', 'addr': 'address/'}),
     'Chain.so': ('https://www.chain.so/',
@@ -698,8 +694,8 @@ mainnet_block_explorers = {
 }
 
 testnet_block_explorers = {
-    'Blocktrail.com': ('https://www.blocktrail.com/tBTC/',
-                       {'tx': 'tx/', 'addr': 'address/'}),
+    'Bitaps.com': ('https://tbtc.bitaps.com/',
+                       {'tx': '', 'addr': ''}),
     'BlockCypher.com': ('https://live.blockcypher.com/btc-testnet/',
                        {'tx': 'tx/', 'addr': 'address/'}),
     'Blockchain.info': ('https://testnet.blockchain.info/',


### PR DESCRIPTION
removed blocktrail.com, blockr.io, biteasy.com ( this explorers no longer works)
added btc.bitaps.com (mainnet explorer) tbtc.bitaps.com (testnet explorer + coin faucet)