### PR TITLE
new domain for luggs servers

### DIFF
--- a/electrum/servers.json
+++ b/electrum/servers.json
@@ -121,7 +121,7 @@
         "t": "50001",
         "version": "1.4"
     },
-    "elec.luggs.co": {
+    "ex.lug.gs": {
         "pruning": "-",
         "s": "443",
         "version": "1.4"


### PR DESCRIPTION
Updating server address to new domain, from elec.luggs.co to ex.lug.gs