### PR TITLE
synchronizer: show progress in GUI (take 1) (num_addrs, num_txs)

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -582,6 +582,13 @@ class AddressSynchronizer(Logger):
     def is_up_to_date(self):
         with self.lock: return self.up_to_date
 
+    def get_history_sync_state_details(self) -> Tuple[Optional[int], int]:
+        num_subs = None
+        if self.synchronizer:
+            num_subs = self.synchronizer.num_subscriptions
+        num_txs = self.db.num_transactions()
+        return num_subs, num_txs
+
     @with_transaction_lock
     def get_tx_delta(self, tx_hash, address):
         """effect of tx on address"""

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -744,7 +744,9 @@ class ElectrumWindow(App):
             server_height = self.network.get_server_height()
             server_lag = self.num_blocks - server_height
             if not self.wallet.up_to_date or server_height == 0:
-                status = _("Synchronizing...")
+                num_subs, num_txs = self.wallet.get_history_sync_state_details()
+                status = ("{}\n({} addrs, {} txs)"
+                          .format(_("Synchronizing..."), num_subs, num_txs))
             elif server_lag > 1:
                 status = _("Server is lagging ({} blocks)").format(server_lag)
             else:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -367,6 +367,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             wallet, tx = args
             if wallet == self.wallet:
                 self.tx_notification_queue.put(tx)
+                self.need_update.set()
         elif event in ['status', 'banner', 'verified', 'fee', 'fee_histogram']:
             # Handle in GUI thread
             self.network_signal.emit(event, args)
@@ -822,7 +823,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             # until we get a headers subscription request response.
             # Display the synchronizing message in that case.
             if not self.wallet.up_to_date or server_height == 0:
-                text = _("Synchronizing...")
+                num_subs, num_txs = self.wallet.get_history_sync_state_details()
+                text = ("{} ({} addrs, {} txs)"
+                        .format(_("Synchronizing..."), num_subs, num_txs))
                 icon = read_QIcon("status_waiting.png")
             elif server_lag > 1:
                 text = _("Server is lagging ({} blocks)").format(server_lag)

--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -606,6 +606,10 @@ class JsonDB(Logger):
         return list(self.transactions.keys())
 
     @locked
+    def num_transactions(self) -> int:
+        return len(self.transactions)
+
+    @locked
     def get_history(self):
         return list(self.history.keys())
 


### PR DESCRIPTION
I think the user should be shown some details regarding the progress/state of the history sync.
This has become even more relevant recently, with servers getting DDOS-ed and as a consequence becoming slower/less responsive.

Instead of `Synchronizing...`,
we now display `Synchronizing... ({num_subs} addrs, {num_txs} txs)`
- where `num_subs` is the number of addresses for which the client sent `blockchain.scripthash.subscribe` and received the initial scripthash status from the server,
- and `num_txs` is the number of "raw hex" transactions that are already stored in the wallet 

![sync1](https://user-images.githubusercontent.com/29142493/57188667-205c0f80-6f03-11e9-9743-b98855b3c2e4.PNG)
![sync2](https://user-images.githubusercontent.com/29142493/57188668-2225d300-6f03-11e9-84c8-faac552280e4.PNG)

(I know, the kivy version is somewhat ugly; I can try to improve it)