### PR TITLE
synchronizer: show progress in GUI (take 2) (req_answered/req_sent)

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -312,6 +312,9 @@ class ElectrumWindow(App):
         self._trigger_update_status = Clock.create_trigger(self.update_status, .5)
         self._trigger_update_history = Clock.create_trigger(self.update_history, .5)
         self._trigger_update_interfaces = Clock.create_trigger(self.update_interfaces, .5)
+
+        self._periodic_update_status_during_sync = Clock.schedule_interval(self.update_wallet_synchronizing_progress, .5)
+
         # cached dialogs
         self._settings_dialog = None
         self._password_dialog = None
@@ -745,7 +748,13 @@ class ElectrumWindow(App):
             server_height = self.network.get_server_height()
             server_lag = self.num_blocks - server_height
             if not self.wallet.up_to_date or server_height == 0:
-                status = _("Synchronizing...")
+                interface = self.network.interface
+                if interface:
+                    num_sent, num_answered = interface.num_requests_sent_and_answered()
+                    status = ("{} [size=18dp]({}/{})[/size]"
+                              .format(_("Synchronizing..."), num_answered, num_sent))
+                else:
+                    status = _("Synchronizing...")
             elif server_lag > 1:
                 status = _("Server is lagging ({} blocks)").format(server_lag)
             else:
@@ -760,6 +769,12 @@ class ElectrumWindow(App):
             text = self.format_amount(c+x+u)
             self.balance = str(text.strip()) + ' [size=22dp]%s[/size]'% self.base_unit
             self.fiat_balance = self.fx.format_amount(c+u+x) + ' [size=22dp]%s[/size]'% self.fx.ccy
+
+    def update_wallet_synchronizing_progress(self, *dt):
+        if not self.wallet:
+            return
+        if not self.wallet.up_to_date:
+            self._trigger_update_status()
 
     def get_max_amount(self):
         from electrum.transaction import TxOutput


### PR DESCRIPTION
This is another take on https://github.com/spesmilo/electrum/pull/5312

We display `Synchronizing... ({req_answered}/{req_sent})`,
where `req_sent` is the number of network requests ever sent to the current main interface,
and `req_answered` is the number of those network requests that have been answered.

based on idea by @bauerj

This is probably easier to understand for end-users than https://github.com/spesmilo/electrum/pull/5312

However, it's not perfect.
By nature of this metric, the state is persisted in the interface, this means
- state is shared between wallets
- counters only reset on reconnect
i.e. if you have a long running process, and open another wallet, both numbers will start with large initial values accumulated in the past.

![sync3](https://user-images.githubusercontent.com/29142493/57249348-ff033c80-7044-11e9-9307-a678273b2734.PNG)