### PR TITLE
logging: '-V' cli option can blacklist/whitelist classes with short names

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -934,7 +934,8 @@ def add_network_options(parser):
 
 def add_global_options(parser):
     group = parser.add_argument_group('global options')
-    group.add_argument("-v", dest="verbosity", help="Set verbosity filter", default='')
+    group.add_argument("-v", dest="verbosity", help="Set verbosity (log levels)", default='')
+    group.add_argument("-V", dest="verbosity_shortcuts", help="Set verbosity (shortcut-filter list)", default='')
     group.add_argument("-D", "--dir", dest="electrum_path", help="electrum directory")
     group.add_argument("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electrum_data' directory")
     group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -179,6 +179,8 @@ def serialize_server(host: str, port: Union[str, int], protocol: str) -> str:
 
 class Interface(Logger):
 
+    LOGGING_SHORTCUT = 'i'
+
     def __init__(self, network: 'Network', server: str, proxy: Optional[dict]):
         self.ready = asyncio.Future()
         self.got_disconnected = asyncio.Future()

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -224,6 +224,8 @@ class Network(Logger):
     servers, each connected socket is handled by an Interface() object.
     """
 
+    LOGGING_SHORTCUT = 'n'
+
     def __init__(self, config: SimpleConfig=None):
         global INSTANCE
         INSTANCE = self

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -48,6 +48,8 @@ hooks = {}
 
 class Plugins(DaemonThread):
 
+    LOGGING_SHORTCUT = 'p'
+
     @profiler
     def __init__(self, config: SimpleConfig, gui_name):
         DaemonThread.__init__(self)

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -260,6 +260,8 @@ class DebugMem(ThreadJob):
 class DaemonThread(threading.Thread, Logger):
     """ daemon thread that terminates cleanly """
 
+    LOGGING_SHORTCUT = 'd'
+
     def __init__(self):
         threading.Thread.__init__(self)
         Logger.__init__(self)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -201,6 +201,7 @@ class Abstract_Wallet(AddressSynchronizer):
     Completion states (watching-only, single account, no seed, etc) are handled inside classes.
     """
 
+    LOGGING_SHORTCUT = 'w'
     max_change_outputs = 3
     gap_limit_for_change = 6
 


### PR DESCRIPTION
for example, `-V ni` will whitelist the `Network` and `Interface` classes (`-Vni` and `-V=ni` also works)
`-V ^ni` will blacklist those instead

This is introduced in addition to the existing `-v` syntax.