### PR TITLE
fix json_db: _convert_version_17

### DIFF
--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -407,9 +407,12 @@ class JsonDB(Logger):
 
         self.put('pruned_txo', None)
 
-        transactions = self.get('transactions', {})  # txid -> Transaction
+        transactions = self.get('transactions', {})  # txid -> Transaction or raw_tx
         spent_outpoints = defaultdict(dict)
         for txid, tx in transactions.items():
+            if isinstance(tx, (bytes, str)):
+                from .transaction import Transaction
+                tx = Transaction(tx)
             for txin in tx.inputs():
                 if txin['type'] == 'coinbase':
                     continue


### PR DESCRIPTION
When wallet converted from stdio/text gui there is raised exception:

```python
Traceback (most recent call last):
  File "./run_electrum", line 359, in <module>
    d.init_gui(config, plugins)
  File "/home/max/tmp/electrum/electrum/electrum/daemon.py", line 349, in init_gui
    self.gui = gui.ElectrumGui(config, self, plugins)
  File "/home/max/tmp/electrum/electrum/electrum/gui/stdio.py", line 24, in __init__
    storage = WalletStorage(config.get_wallet_path())
  File "/home/max/tmp/electrum/electrum/electrum/storage.py", line 66, in __init__
    self.db = DB_Class(self.raw, manual_upgrades=manual_upgrades)
  File "/home/max/tmp/electrum/electrum/electrum/json_db.py", line 63, in __init__
    self.load_data(raw)
  File "/home/max/tmp/electrum/electrum/electrum/json_db.py", line 152, in load_data
    self.upgrade()
  File "/home/max/tmp/electrum/electrum/electrum/util.py", line 356, in <lambda>
    return lambda *args, **kw_args: do_profile(args, kw_args)
  File "/home/max/tmp/electrum/electrum/electrum/util.py", line 352, in do_profile
    o = func(*args, **kw_args)
  File "/home/max/tmp/electrum/electrum/electrum/json_db.py", line 211, in upgrade
    self._convert_version_17()
  File "/home/max/tmp/electrum/electrum/electrum/json_db.py", line 414, in _convert_version_17
    for txin in tx.inputs():
AttributeError: 'str' object has no attribute 'inputs'

```