### PR TITLE
Remove Bitupper Explorer

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -640,8 +640,6 @@ def time_difference(distance_in_time, include_seconds):
         return "over %d years" % (round(distance_in_minutes / 525600))
 
 mainnet_block_explorers = {
-    'Bitupper Explorer': ('https://bitupper.com/en/explorer/bitcoin/',
-                        {'tx': 'transactions/', 'addr': 'addresses/'}),
     'Bitflyer.jp': ('https://chainflyer.bitflyer.jp/',
                         {'tx': 'Transaction/', 'addr': 'Address/'}),
     'Blockchain.info': ('https://blockchain.info/',


### PR DESCRIPTION
This site is unreliable. It shows a completely random unrelated transaction on each reload regardless of the transaction hash entered.