### PR TITLE
Add AppImage to "Creating Binaries" in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,10 +83,16 @@ Create translations (optional)::
 Creating Binaries
 =================
 
-Linux
------
+Linux (tarball)
+---------------
 
 See :code:`contrib/build-linux/README.md`.
+
+
+Linux (AppImage)
+----------------
+
+See :code:`contrib/build-linux/appimage/README.md`.
 
 
 Mac OS X / macOS


### PR DESCRIPTION
The README.md docs for creating binaries didn't mention the AppImage; this PR fixes that.