### PR TITLE
Update Johoe's server address

### DIFF
--- a/electrum/servers.json
+++ b/electrum/servers.json
@@ -82,10 +82,10 @@
         "t": "50001",
         "version": "1.4"
     },
-    "dedi.jochen-hoenicke.de": {
+    "electrum.jochen-hoenicke.de": {
         "pruning": "-",
-        "s": "50002",
-        "t": "50001",
+        "s": "50005",
+        "t": "50003",
         "version": "1.4"
     },
     "dragon085.startdedicated.de": {


### PR DESCRIPTION
Port and hostname changed, since the other port is heavily ddos'ed. The original port is still open but errors on subscription requests.

Note that this server was only added in December to default list and changed from self-signed to letsencrypt certificate two months later, so it doesn't help much in disabling old clients.

