### PR TITLE
Travis CI: Use flake8 to find Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 dist: xenial
 language: python
 python:
@@ -29,7 +28,6 @@ jobs:
   include:
     - stage: binary builds
       name: "Windows build"
-      sudo: true
       language: c
       python: false
       env:
@@ -72,7 +70,6 @@ jobs:
       after_script: ls -lah dist && md5 dist/*
       after_success: true
     - name: "AppImage build"
-      sudo: true
       language: c
       python: false
       services:
@@ -82,6 +79,10 @@ jobs:
       script:
         - sudo docker run --name electrum-appimage-builder-cont -v $PWD:/opt/electrum --rm --workdir /opt/electrum/contrib/build-linux/appimage electrum-appimage-builder-img ./build.sh
       after_success: true
+    - name: "Flake8 tests"
+      language: python
+      install: pip install flake8
+      script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - stage: release check
       install:
           - git fetch --all --tags

--- a/electrum/logging.py
+++ b/electrum/logging.py
@@ -257,7 +257,7 @@ def get_logfile_path() -> Optional[pathlib.Path]:
 def describe_os_version() -> str:
     if 'ANDROID_DATA' in os.environ:
         from kivy import utils
-        if utils.platform is not "android":
+        if utils.platform != "android":
             return utils.platform
         import jnius
         bv = jnius.autoclass('android.os.Build$VERSION')

--- a/electrum/plugins/ledger/qt.py
+++ b/electrum/plugins/ledger/qt.py
@@ -47,7 +47,7 @@ class Ledger_Handler(QtHandlerBase):
         else:
             self.word = str(response[0])
         self.done.set()
-    
+
     def message_dialog(self, msg):
         self.clear_dialog()
         self.dialog = dialog = WindowModalDialog(self.top_level_window(), _("Ledger Status"))
@@ -66,18 +66,18 @@ class Ledger_Handler(QtHandlerBase):
         dialog.exec_()
         self.word = dialog.pin
         self.done.set()
-                    
+
     def get_auth(self, data):
         self.done.clear()
         self.auth_signal.emit(data)
         self.done.wait()
         return self.word
-        
+
     def get_setup(self):
         self.done.clear()
         self.setup_signal.emit()
         self.done.wait()
-        return 
-        
+        return
+
     def setup_dialog(self):
         self.show_error(_('Initialization of Ledger HW devices is currently disabled.'))

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -604,10 +604,7 @@ class Abstract_Wallet(AddressSynchronizer):
         return item
 
     def get_label(self, tx_hash):
-        label = self.labels.get(tx_hash, '')
-        if label is '':
-            label = self.get_default_label(tx_hash)
-        return label
+        return self.labels.get(tx_hash, '') or self.get_default_label(tx_hash)
 
     def get_default_label(self, tx_hash):
         if not self.db.get_txi(tx_hash):


### PR DESCRIPTION
Also the __sudo:__ tag is now deprecated in Travis CI.

Identity is not the same thing as equality in Python:

$ python
```python
>>> platform = "andr"
>>> platform += "oid"
>>> platform == "android"
True
>>> platform is "android"
False
```