### PR TITLE
Use SOCKSRandomAuth for stream isolation

### DIFF
--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -271,18 +271,21 @@ class NetworkChoiceLayout(object):
         self.proxy_password.setPlaceholderText(_("Password"))
         self.proxy_password.setEchoMode(QLineEdit.Password)
         self.proxy_password.setFixedWidth(fixed_width_port)
+        self.proxy_isolate = QCheckBox(_("Use stream isolation"))
 
         self.proxy_mode.currentIndexChanged.connect(self.set_proxy)
         self.proxy_host.editingFinished.connect(self.set_proxy)
         self.proxy_port.editingFinished.connect(self.set_proxy)
         self.proxy_user.editingFinished.connect(self.set_proxy)
         self.proxy_password.editingFinished.connect(self.set_proxy)
+        self.proxy_isolate.clicked.connect(self.set_proxy)
 
         self.proxy_mode.currentIndexChanged.connect(self.proxy_settings_changed)
         self.proxy_host.textEdited.connect(self.proxy_settings_changed)
         self.proxy_port.textEdited.connect(self.proxy_settings_changed)
         self.proxy_user.textEdited.connect(self.proxy_settings_changed)
         self.proxy_password.textEdited.connect(self.proxy_settings_changed)
+        self.proxy_isolate.clicked.connect(self.proxy_settings_changed)
 
         self.tor_cb = QCheckBox(_("Use Tor Proxy"))
         self.tor_cb.setIcon(read_QIcon("tor_logo.png"))
@@ -297,6 +300,7 @@ class NetworkChoiceLayout(object):
         grid.addWidget(self.proxy_port, 4, 3)
         grid.addWidget(self.proxy_user, 5, 2)
         grid.addWidget(self.proxy_password, 5, 3)
+        grid.addWidget(self.proxy_isolate, 6, 2)
         grid.setRowStretch(7, 1)
 
         # Blockchain Tab
@@ -342,7 +346,7 @@ class NetworkChoiceLayout(object):
     def check_disable_proxy(self, b):
         if not self.config.is_modifiable('proxy'):
             b = False
-        for w in [self.proxy_mode, self.proxy_host, self.proxy_port, self.proxy_user, self.proxy_password]:
+        for w in [self.proxy_mode, self.proxy_host, self.proxy_port, self.proxy_user, self.proxy_password, self.proxy_isolate]:
             w.setEnabled(b)
 
     def enable_set_server(self):
@@ -406,6 +410,7 @@ class NetworkChoiceLayout(object):
         self.proxy_port.setText(proxy_config.get("port"))
         self.proxy_user.setText(proxy_config.get("user", ""))
         self.proxy_password.setText(proxy_config.get("password", ""))
+        self.proxy_isolate.setChecked(proxy_config.get("isolate", True))
 
     def layout(self):
         return self.layout_
@@ -473,7 +478,8 @@ class NetworkChoiceLayout(object):
                       'host':str(self.proxy_host.text()),
                       'port':str(self.proxy_port.text()),
                       'user':str(self.proxy_user.text()),
-                      'password':str(self.proxy_password.text())}
+                      'password':str(self.proxy_password.text()),
+                      'isolate':self.proxy_isolate.isChecked()}
         else:
             proxy = None
             self.tor_cb.setChecked(False)
@@ -506,6 +512,7 @@ class NetworkChoiceLayout(object):
             self.proxy_port.setText(str(self.tor_proxy[1]))
             self.proxy_user.setText("")
             self.proxy_password.setText("")
+            self.proxy_isolate.setChecked(True)
             self.tor_cb.setChecked(True)
             self.proxy_cb.setChecked(True)
         self.check_disable_proxy(use_it)

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -237,8 +237,10 @@ class Interface(Logger):
 
     def _set_proxy(self, proxy: dict):
         if proxy:
-            username, pw = proxy.get('user'), proxy.get('password')
-            if not username or not pw:
+            username, pw, isolate = proxy.get('user'), proxy.get('password'), proxy.get('isolate')
+            if isolate:
+                auth = aiorpcx.socks.SOCKSRandomAuth()
+            elif not username or not pw:
                 auth = None
             else:
                 auth = aiorpcx.socks.SOCKSUserAuth(username, pw)

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -143,7 +143,8 @@ def serialize_proxy(p):
     if not isinstance(p, dict):
         return None
     return ':'.join([p.get('mode'), p.get('host'), p.get('port'),
-                     p.get('user', ''), p.get('password', '')])
+                     p.get('user', ''), p.get('password', ''),
+                     ('1' if p.get('isolate', True) else '0')])
 
 
 def deserialize_proxy(s: str) -> Optional[dict]:
@@ -171,6 +172,17 @@ def deserialize_proxy(s: str) -> Optional[dict]:
         n += 1
     if len(args) > n:
         proxy["password"] = args[n]
+        n += 1
+    if len(args) > n:
+        isolate = args[n]
+        if isolate == "0":
+            proxy["isolate"] = False
+        elif isolate == "1":
+            proxy["isolate"] = True
+        else:
+            raise Exception("Couldn't parse proxy isolation setting: " + isolate)
+    else:
+        proxy["isolate"] = True
     return proxy
 
 


### PR DESCRIPTION
This PR adds an optional feature (enabled by default if a SOCKS proxy is in use) that makes each outgoing connection to an Electrum server go over an isolated Tor circuit.  This improves Sybil-resistance by preventing a single Tor exit relay from having full control over Electrum's view of the network.  It may also improve anonymity (by making certain types of traffic analysis more difficult), and it may also improve performance (by avoiding bottlenecked Tor relays).

Stream isolation can be toggled in the Qt GUI's proxy dialog.  I didn't attempt to add a Kivy GUI toggle for this, as I don't have an easy way to test Kivy changes.

This PR is conceptually similar to https://github.com/bitcoin/bitcoin/pull/5911 .

This PR is dependent on https://github.com/kyuupichan/aiorpcX/pull/23 ; don't merge this PR until Electrum upgrades to a version of aiorpcX that includes that PR.