### PR TITLE
Unit tests for Blockchain.verify_header

### DIFF
--- a/electrum/tests/test_blockchain.py
+++ b/electrum/tests/test_blockchain.py
@@ -339,3 +339,37 @@ class TestBlockchain(SequentialTestCase):
 
         for b in (chain_u, chain_l, chain_z):
             self.assertTrue(all([b.can_connect(b.read_header(i), False) for i in range(b.height())]))
+
+
+class TestVerifyHeader(SequentialTestCase):
+
+    # Data for Bitcoin block header #100.
+    valid_header = "0100000095194b8567fe2e8bbda931afd01a7acd399b9325cb54683e64129bcd00000000660802c98f18fd34fd16d61c63cf447568370124ac5f3be626c2e1c3c9f0052d19a76949ffff001d33f3c25d"
+    target = Blockchain.bits_to_target(0x1d00ffff)
+    prev_hash = "00000000cd9b12643e6854cb25939b39cd7a1ad0af31a9bd8b2efe67854b1995"
+
+    def setUp(self):
+        super().setUp()
+        self.header = deserialize_header(bfh(self.valid_header), 100)
+
+    def test_valid_header(self):
+        Blockchain.verify_header(self.header, self.prev_hash, self.target)
+
+    def test_expected_hash_mismatch(self):
+        with self.assertRaises(Exception):
+            Blockchain.verify_header(self.header, self.prev_hash, self.target,
+                                     expected_header_hash="foo")
+
+    def test_prev_hash_mismatch(self):
+        with self.assertRaises(Exception):
+            Blockchain.verify_header(self.header, "foo", self.target)
+
+    def test_target_mismatch(self):
+        with self.assertRaises(Exception):
+            other_target = Blockchain.bits_to_target(0x1d00eeee)
+            Blockchain.verify_header(self.header, self.prev_hash, other_target)
+
+    def test_insufficient_pow(self):
+        with self.assertRaises(Exception):
+            self.header["nonce"] = 42
+            Blockchain.verify_header(self.header, self.prev_hash, self.target)


### PR DESCRIPTION
The function `Blockchain.verify_header` was previously not covered by tests at all.  Even removing all the tests in it would still make the unit tests pass.  This change adds tests for this important (!) function.