### PR TITLE
Fix electrum-env on FreeBSD

### DIFF
--- a/electrum-env
+++ b/electrum-env
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script creates a virtualenv named 'env' and installs all
 # python dependencies before activating the env and running Electrum.


### PR DESCRIPTION
On BSDs. `bash` is not located in `/bin` but in `/usr/local/bin`. This is the platform-agnostic fix.