### PR TITLE
Logic change in setup and fixed icon location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,9 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
     parser.add_argument('--root=', dest='root_path', metavar='dir', default='/')
     opts, _ = parser.parse_known_args(sys.argv[1:])
     usr_share = os.path.join(sys.prefix, "share")
-    icons_dirname = 'pixmaps'
-    if not os.access(opts.root_path + usr_share, os.W_OK) and \
+    icons_dirname = 'icons/hicolor/128x128/apps'
+    if not os.access(opts.root_path + usr_share, os.W_OK) or \
        not os.access(opts.root_path, os.W_OK):
-        icons_dirname = 'icons'
         if 'XDG_DATA_HOME' in os.environ.keys():
             usr_share = os.environ['XDG_DATA_HOME']
         else:


### PR DESCRIPTION
This should be `or` since in some cases only one of the dirs is read only, e.g. for `root_path=/`, `usr_share=/usr/share` in flatpak-builder.

The correct path for icons is one of `{XDG_DATA_HOME,/usr/share,~/.local/share}/icons/hicolor/RESOLUTION/apps` according to freedeskop standars https://www.freedesktop.org/wiki/Specifications/.