### PR TITLE
Kivy installwizard back button fix2

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -896,6 +896,8 @@ class ElectrumWindow(App):
         # pause nfc
         if self.nfcscanner:
             self.nfcscanner.nfc_disable()
+        if self.wallet:
+            self.electrum_config.save_last_wallet(self.wallet)
         return True
 
     def on_resume(self):

--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -607,6 +607,8 @@ class WizardDialog(EventsDialog):
     def on_keyboard(self, instance, key, keycode, codepoint, modifier):
         if key == 27:
             if self.wizard.can_go_back():
+                self._on_release = True
+                self.dismiss()
                 self.wizard.go_back()
             else:
                 app = App.get_running_app()
@@ -631,7 +633,7 @@ class WizardDialog(EventsDialog):
 
     def on_release(self, button):
         self._on_release = True
-        self.close()
+        self.dismiss()
         if not button:
             self.parent.dispatch('on_wizard_complete', None)
             return


### PR DESCRIPTION
- kivy: dismiss previous wizard window on back button (additional fix on #5534)
- ~kivy: stop network on pause, save last wallet, start network on resume~