### PR TITLE
Use NamedTuple notation for TxOutput in test_lnchannel

### DIFF
--- a/electrum/tests/test_lnchannel.py
+++ b/electrum/tests/test_lnchannel.py
@@ -173,8 +173,8 @@ class TestChannel(unittest.TestCase):
     maxDiff = 999
 
     def assertOutputExistsByValue(self, tx, amt_sat):
-        for typ, scr, val in tx.outputs():
-            if val == amt_sat:
+        for o in tx.outputs():
+            if o.value == amt_sat:
                 break
         else:
             self.assertFalse()


### PR DESCRIPTION
This makes the code more resilient in case additional members are added to TxOutput later.