### PR TITLE
Fix for onchain_history summary building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ env/
 bin/
 /app.fil
 .idea
+.mypy_cache
+.vscode
 
 # icons
 electrum/gui/kivy/theming/light-0.png

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -587,9 +587,9 @@ class Abstract_Wallet(AddressSynchronizer):
             out.append(item)
         # add summary
         if out:
-            b, v = out[0]['balance'].value, out[0]['bc_value'].value
+            b, v = out[0]['bc_balance'].value, out[0]['bc_value'].value
             start_balance = None if b is None or v is None else b - v
-            end_balance = out[-1]['balance'].value
+            end_balance = out[-1]['bc_balance'].value
             if from_timestamp is not None and to_timestamp is not None:
                 start_date = timestamp_to_datetime(from_timestamp)
                 end_date = timestamp_to_datetime(to_timestamp)


### PR DESCRIPTION
This pull request fixes `onchain_history` command.
When building summary, it encountered the following error:
```
Traceback (most recent call last):
  File "daemons/btc.py", line 240, in xpub_func
    result = await result
  File "/home/alex/envs/bitcart/lib/python3.6/site-packages/electrum/commands.py", line 605, in onchain_history
    return json_encode(self.wallet.get_detailed_history(**kwargs))
  File "/home/alex/envs/bitcart/lib/python3.6/site-packages/electrum/util.py", line 394, in <lambda>
    return lambda *args, **kw_args: do_profile(args, kw_args)
  File "/home/alex/envs/bitcart/lib/python3.6/site-packages/electrum/util.py", line 390, in do_profile
    o = func(*args, **kw_args)
  File "/home/alex/envs/bitcart/lib/python3.6/site-packages/electrum/wallet.py", line 591, in get_detailed_history
    b, v = out[0]['balance'].value, out[0]['bc_value'].value
KeyError: 'balance'
```
I changed keys from balance to bc_balance as in out data