### PR TITLE
Fix create_menu error

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -197,7 +197,7 @@ class HistoryModel(QAbstractItemModel, Logger):
                 monospace_font = QFont(MONOSPACE_FONT)
                 return QVariant(monospace_font)
             #elif col == HistoryColumns.DESCRIPTION and role == Qt.DecorationRole and not is_lightning\
-            #        and self.parent.wallet.invoices.paid.get(tx_hash):
+            #        and self.parent.wallet.invoices.get(tx_hash):
             #    return QVariant(read_QIcon("seal"))
             elif col in (HistoryColumns.DESCRIPTION, HistoryColumns.AMOUNT) \
                     and role == Qt.ForegroundRole and not is_lightning and tx_item['value'].value < 0:
@@ -602,7 +602,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
         height = self.wallet.get_tx_height(tx_hash).height
         is_relevant, is_mine, v, fee = self.wallet.get_wallet_delta(tx)
         is_unconfirmed = height <= 0
-        pr_key = self.wallet.invoices.paid.get(tx_hash)
+        pr_key = self.wallet.invoices.get(tx_hash)
         menu = QMenu()
         if height in [TX_HEIGHT_FUTURE, TX_HEIGHT_LOCAL]:
             menu.addAction(_("Remove"), lambda: self.remove_local_tx(tx_hash))


### PR DESCRIPTION
```
Traceback
Traceback (most recent call last):
  File "/home/wakiyamap/electrum/electrum/gui/qt/history_list.py", line 605, in create_menu
    pr_key = self.wallet.invoices.paid.get(tx_hash)
AttributeError: 'dict' object has no attribute 'paid'
 
Additional information
Electrum version: 3.3.8-997-g3d7cb935f 
Python version: 3.6.8 (default, Jan 14 2019, 11:02:34) [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]] 
Operating system: Linux-4.15.0-58-generic-x86_64-with-Ubuntu-18.04-bionic 
Wallet type: imported 
Locale: ja_JP 
```