### PR TITLE
config: introduce ConfigVar enum. default values are no longer duped

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -36,7 +36,6 @@ from .logging import describe_os_version, Logger
 
 class BaseCrashReporter(Logger):
     report_server = "https://crashhub.electrum.org"
-    config_key = "show_crash_reporter"
     issue_template = """<h2>Traceback</h2>
 <pre>
 {traceback}

--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -45,6 +45,7 @@ from .simple_config import SimpleConfig
 from .plugin import Plugins, HardwarePluginLibraryUnavailable
 from .logging import Logger
 from .plugins.hw_wallet.plugin import OutdatedHwFirmwareException, HW_PluginBase
+from .simple_config import ConfigVar
 
 if TYPE_CHECKING:
     from .plugin import DeviceInfo
@@ -86,7 +87,7 @@ class BaseWizard(Logger):
         self._stack = []  # type: List[WizardStackItem]
         self.plugin = None
         self.keystores = []
-        self.is_kivy = config.get('gui') == 'kivy'
+        self.is_kivy = config.get(ConfigVar.GUI) == 'kivy'
         self.seed_type = None
 
     def set_icon(self, icon):

--- a/electrum/coinchooser.py
+++ b/electrum/coinchooser.py
@@ -24,13 +24,14 @@
 # SOFTWARE.
 from collections import defaultdict
 from math import floor, log10
-from typing import NamedTuple, List, Callable
+from typing import NamedTuple, List, Callable, TYPE_CHECKING
 from decimal import Decimal
 
 from .bitcoin import sha256, COIN, TYPE_ADDRESS, is_address
 from .transaction import Transaction, TxOutput
 from .util import NotEnoughFunds
 from .logging import Logger
+from .simple_config import SimpleConfig, ConfigVar
 
 
 # A simple deterministic PRNG.  Used to deterministically shuffle a
@@ -463,15 +464,17 @@ class CoinChooserPrivacy(CoinChooserRandom):
 COIN_CHOOSERS = {
     'Privacy': CoinChooserPrivacy,
 }
+assert ConfigVar.WALLET_COIN_CHOOSER_POLICY.get_default_value() in COIN_CHOOSERS
 
-def get_name(config):
-    kind = config.get('coin_chooser')
-    if not kind in COIN_CHOOSERS:
-        kind = 'Privacy'
+
+def get_name(config: 'SimpleConfig') -> str:
+    kind = config.get(ConfigVar.WALLET_COIN_CHOOSER_POLICY)
+    if kind not in COIN_CHOOSERS:
+        kind = ConfigVar.WALLET_COIN_CHOOSER_POLICY.get_default_value()
     return kind
 
 def get_coin_chooser(config):
     klass = COIN_CHOOSERS[get_name(config)]
     coinchooser = klass()
-    coinchooser.enable_output_value_rounding = config.get('coin_chooser_output_rounding', False)
+    coinchooser.enable_output_value_rounding = config.get(ConfigVar.WALLET_COIN_CHOOSER_OUTPUT_ROUNDING)
     return coinchooser

--- a/electrum/gui/kivy/uix/dialogs/crash_reporter.py
+++ b/electrum/gui/kivy/uix/dialogs/crash_reporter.py
@@ -1,5 +1,6 @@
 import sys
 import json
+from typing import TYPE_CHECKING
 
 from aiohttp.client_exceptions import ClientError
 from kivy import base, utils
@@ -14,6 +15,10 @@ from electrum.gui.kivy.i18n import _
 
 from electrum.base_crash_reporter import BaseCrashReporter
 from electrum.logging import Logger
+from electrum.simple_config import ConfigVar
+
+if TYPE_CHECKING:
+    from electrum.gui.kivy.main_window import ElectrumWindow
 
 
 Builder.load_string('''
@@ -95,7 +100,7 @@ class CrashReporter(BaseCrashReporter, Factory.Popup):
  * Locale: {locale}
         """
 
-    def __init__(self, main_window, exctype, value, tb):
+    def __init__(self, main_window: 'ElectrumWindow', exctype, value, tb):
         BaseCrashReporter.__init__(self, exctype, value, tb)
         Factory.Popup.__init__(self)
         self.main_window = main_window
@@ -150,7 +155,7 @@ class CrashReporter(BaseCrashReporter, Factory.Popup):
         currentActivity.startActivity(browserIntent)
 
     def show_never(self):
-        self.main_window.electrum_config.set_key(BaseCrashReporter.config_key, False)
+        self.main_window.electrum_config.set_key(ConfigVar.SHOW_CRASH_REPORTER, False)
         self.dismiss()
 
     def get_user_description(self):
@@ -169,11 +174,11 @@ class CrashReportDetails(Factory.Popup):
 
 
 class ExceptionHook(base.ExceptionHandler, Logger):
-    def __init__(self, main_window):
+    def __init__(self, main_window: 'ElectrumWindow'):
         base.ExceptionHandler.__init__(self)
         Logger.__init__(self)
         self.main_window = main_window
-        if not main_window.electrum_config.get(BaseCrashReporter.config_key, default=True):
+        if not main_window.electrum_config.get(ConfigVar.SHOW_CRASH_REPORTER):
             return
         # For exceptions in Kivy:
         base.ExceptionManager.add_handler(self)

--- a/electrum/gui/kivy/uix/dialogs/fee_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/fee_dialog.py
@@ -5,6 +5,9 @@ from kivy.lang import Builder
 
 from electrum.gui.kivy.i18n import _
 
+from electrum.simple_config import ConfigVar
+
+
 Builder.load_string('''
 <FeeDialog@Popup>
     id: popup
@@ -116,15 +119,15 @@ class FeeDialog(Factory.Popup):
     def on_ok(self):
         value = int(self.ids.slider.value)
         dynfees, mempool = self.get_method()
-        self.config.set_key('dynamic_fees', dynfees, False)
-        self.config.set_key('mempool_fees', mempool, False)
+        self.config.set_key(ConfigVar.FEE_EST_DYNAMIC, dynfees, False)
+        self.config.set_key(ConfigVar.FEE_EST_USE_MEMPOOL, mempool, False)
         if dynfees:
             if mempool:
-                self.config.set_key('depth_level', value, True)
+                self.config.set_key(ConfigVar.FEE_EST_DYNAMIC_MEMPOOL_SLIDERPOS, value, True)
             else:
-                self.config.set_key('fee_level', value, True)
+                self.config.set_key(ConfigVar.FEE_EST_DYNAMIC_ETA_SLIDERPOS, value, True)
         else:
-            self.config.set_key('fee_per_kb', self.config.static_fee(value), True)
+            self.config.set_key(ConfigVar.FEE_EST_STATIC_FEERATE_FALLBACK, self.config.static_fee(value), True)
         self.callback()
 
     def on_slider(self, value):

--- a/electrum/gui/kivy/uix/dialogs/settings.py
+++ b/electrum/gui/kivy/uix/dialogs/settings.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from kivy.app import App
 from kivy.factory import Factory
 from kivy.properties import ObjectProperty
@@ -8,8 +10,13 @@ from electrum.i18n import languages
 from electrum.gui.kivy.i18n import _
 from electrum.plugin import run_hook
 from electrum import coinchooser
+from electrum.simple_config import ConfigVar
 
 from .choice_dialog import ChoiceDialog
+
+if TYPE_CHECKING:
+    from electrum.gui.kivy.main_window import ElectrumWindow
+
 
 Builder.load_string('''
 #:import partial functools.partial
@@ -96,7 +103,7 @@ Builder.load_string('''
 
 class SettingsDialog(Factory.Popup):
 
-    def __init__(self, app):
+    def __init__(self, app: 'ElectrumWindow'):
         self.app = app
         self.plugins = self.app.plugins
         self.config = self.app.electrum_config
@@ -116,16 +123,16 @@ class SettingsDialog(Factory.Popup):
         self.use_encryption = self.wallet.has_password() if self.wallet else False
 
     def get_language_name(self):
-        return languages.get(self.config.get('language', 'en_UK'), '')
+        return languages.get(self.config.get(ConfigVar.LOCALIZATION_LANGUAGE), '')
 
     def change_password(self, item, dt):
         self.app.change_password(self.update)
 
     def language_dialog(self, item, dt):
         if self._language_dialog is None:
-            l = self.config.get('language', 'en_UK')
+            l = self.config.get(ConfigVar.LOCALIZATION_LANGUAGE)
             def cb(key):
-                self.config.set_key("language", key, True)
+                self.config.set_key(ConfigVar.LOCALIZATION_LANGUAGE, key, True)
                 item.lang = self.get_language_name()
                 self.app.language = key
             self._language_dialog = ChoiceDialog(_('Language'), languages, l, cb)
@@ -148,7 +155,7 @@ class SettingsDialog(Factory.Popup):
             choosers = sorted(coinchooser.COIN_CHOOSERS.keys())
             chooser_name = coinchooser.get_name(self.config)
             def cb(text):
-                self.config.set_key('coin_chooser', text)
+                self.config.set_key(ConfigVar.WALLET_COIN_CHOOSER_POLICY, text)
                 item.status = text
             self._coinselect_dialog = ChoiceDialog(_('Coin selection'), choosers, chooser_name, cb)
         self._coinselect_dialog.open()

--- a/electrum/gui/kivy/uix/screens.py
+++ b/electrum/gui/kivy/uix/screens.py
@@ -34,6 +34,7 @@ from electrum.wallet import InternalAddressCorruption
 from electrum import simple_config
 from electrum.lnaddr import lndecode
 from electrum.lnutil import RECEIVED, SENT, PaymentFailure
+from electrum.simple_config import ConfigVar
 
 from .dialogs.question import Question
 from .dialogs.lightning_open_channel import LightningOpenChannelDialog
@@ -343,7 +344,7 @@ class SendScreen(CScreen):
             outputs = invoice['outputs']  # type: List[TxOutput]
             amount = sum(map(lambda x: x.value, outputs))
             do_pay = lambda rbf: self._do_send_onchain(amount, message, outputs, rbf)
-            if self.app.electrum_config.get('use_rbf'):
+            if self.app.electrum_config.get(ConfigVar.WALLET_USE_RBF):
                 d = Question(_('Should this transaction be replaceable?'), do_pay)
                 d.open()
             else:
@@ -413,7 +414,7 @@ class ReceiveScreen(CScreen):
         Clock.schedule_interval(lambda dt: self.update(), 5)
 
     def expiry(self):
-        return self.app.electrum_config.get('request_expiry', 3600) # 1 hour
+        return self.app.electrum_config.get(ConfigVar.PAYMENT_REQUEST_EXPIRY_SECONDS)
 
     def clear(self):
         self.screen.address = ''
@@ -503,7 +504,7 @@ class ReceiveScreen(CScreen):
     def expiration_dialog(self, obj):
         from .dialogs.choice_dialog import ChoiceDialog
         def callback(c):
-            self.app.electrum_config.set_key('request_expiry', c)
+            self.app.electrum_config.set_key(ConfigVar.PAYMENT_REQUEST_EXPIRY_SECONDS, c)
         d = ChoiceDialog(_('Expiration date'), pr_expiration_values, self.expiry(), callback)
         d.open()
 

--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -34,6 +34,7 @@ from electrum.util import block_explorer_URL, profiler
 from electrum.plugin import run_hook
 from electrum.bitcoin import is_address
 from electrum.wallet import InternalAddressCorruption
+from electrum.simple_config import ConfigVar
 
 from .util import MyTreeView, MONOSPACE_FONT, ColorScheme, webopen
 
@@ -104,11 +105,11 @@ class AddressList(MyTreeView):
         self.update()
 
     def save_toolbar_state(self, state, config):
-        config.set_key('show_toolbar_addresses', state)
+        config.set_key(ConfigVar.GUI_QT_ADDRESSES_TAB_SHOW_TOOLBAR, state)
 
     def refresh_headers(self):
         fx = self.parent.fx
-        if fx and fx.get_fiat_address_config():
+        if fx and self.config.get(ConfigVar.FX_SHOW_FIAT_BALANCE_FOR_ADDRESSES):
             ccy = fx.get_currency()
         else:
             ccy = _('Fiat')
@@ -162,7 +163,7 @@ class AddressList(MyTreeView):
                 continue
             balance_text = self.parent.format_amount(balance, whitespaces=True)
             # create item
-            if fx and fx.get_fiat_address_config():
+            if fx and self.config.get(ConfigVar.FX_SHOW_FIAT_BALANCE_FOR_ADDRESSES):
                 rate = fx.exchange_rate()
                 fiat_balance = fx.value_str(balance, rate)
             else:
@@ -197,7 +198,7 @@ class AddressList(MyTreeView):
                 set_address = QPersistentModelIndex(address_idx)
         self.set_current_idx(set_address)
         # show/hide columns
-        if fx and fx.get_fiat_address_config():
+        if fx and self.config.get(ConfigVar.FX_SHOW_FIAT_BALANCE_FOR_ADDRESSES):
             self.showColumn(self.Columns.FIAT_BALANCE)
         else:
             self.hideColumn(self.Columns.FIAT_BALANCE)

--- a/electrum/gui/qt/exception_window.py
+++ b/electrum/gui/qt/exception_window.py
@@ -34,6 +34,7 @@ from electrum.i18n import _
 from electrum.base_crash_reporter import BaseCrashReporter
 from electrum.logging import Logger
 from electrum import constants
+from electrum.simple_config import ConfigVar
 
 from .util import MessageBoxMixin, read_QIcon, WaitingDialog
 
@@ -126,7 +127,7 @@ class Exception_Window(BaseCrashReporter, QWidget, MessageBoxMixin, Logger):
         self.close()
 
     def show_never(self):
-        self.main_window.config.set_key(BaseCrashReporter.config_key, False)
+        self.main_window.config.set_key(ConfigVar.SHOW_CRASH_REPORTER, False)
         self.close()
 
     def closeEvent(self, event):
@@ -151,7 +152,7 @@ class Exception_Hook(QObject, Logger):
     def __init__(self, main_window, *args, **kwargs):
         QObject.__init__(self, *args, **kwargs)
         Logger.__init__(self)
-        if not main_window.config.get(BaseCrashReporter.config_key, default=True):
+        if not main_window.config.get(ConfigVar.SHOW_CRASH_REPORTER):
             return
         self.main_window = main_window
         sys.excepthook = self.handler

--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -45,6 +45,7 @@ from electrum.util import (block_explorer_URL, profiler, TxMinedInfo,
                            OrderedDictWithIndex, timestamp_to_datetime,
                            Satoshis, format_time)
 from electrum.logging import get_logger, Logger
+from electrum.simple_config import ConfigVar
 
 from .util import (read_QIcon, MONOSPACE_FONT, Buttons, CancelButton, OkButton,
                    filename_field, MyTreeView, AcceptFileDragDrop, WindowModalDialog,
@@ -52,6 +53,7 @@ from .util import (read_QIcon, MONOSPACE_FONT, Buttons, CancelButton, OkButton,
 
 if TYPE_CHECKING:
     from electrum.wallet import Abstract_Wallet
+    from .main_window import ElectrumWindow
 
 
 _logger = get_logger(__name__)
@@ -107,7 +109,7 @@ def get_item_key(tx_item):
 
 class HistoryModel(QAbstractItemModel, Logger):
 
-    def __init__(self, parent):
+    def __init__(self, parent: 'ElectrumWindow'):
         QAbstractItemModel.__init__(self, parent)
         Logger.__init__(self)
         self.parent = parent
@@ -304,7 +306,7 @@ class HistoryModel(QAbstractItemModel, Logger):
         set_visible(HistoryColumns.TXID, False)
         # fiat
         history = self.parent.fx.show_history()
-        cap_gains = self.parent.fx.get_history_capital_gains_config()
+        cap_gains = self.parent.config.get(ConfigVar.FX_HISTORY_RATES_CAPITAL_GAINS)
         set_visible(HistoryColumns.FIAT_VALUE, history)
         set_visible(HistoryColumns.FIAT_ACQ_PRICE, history and cap_gains)
         set_visible(HistoryColumns.FIAT_CAP_GAINS, history and cap_gains)
@@ -467,7 +469,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
         self.hide_rows()
 
     def save_toolbar_state(self, state, config):
-        config.set_key('show_toolbar_history', state)
+        config.set_key(ConfigVar.GUI_QT_HISTORY_TAB_SHOW_TOOLBAR, state)
 
     def select_start_date(self):
         self.start_timestamp = self.select_date(self.start_button)

--- a/electrum/gui/qt/installwizard.py
+++ b/electrum/gui/qt/installwizard.py
@@ -19,6 +19,7 @@ from electrum.storage import WalletStorage, StorageReadWriteError
 from electrum.util import UserCancelled, InvalidPassword, WalletFileException
 from electrum.base_wizard import BaseWizard, HWD_SETUP_DECRYPT_WALLET, GoBack
 from electrum.i18n import _
+from electrum.simple_config import ConfigVar
 
 from .seed_dialog import SeedLayout, KeysLayout
 from .network_dialog import NetworkChoiceLayout
@@ -620,7 +621,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                 nlayout.accept()
         else:
             network.auto_connect = True
-            self.config.set_key('auto_connect', True, True)
+            self.config.set_key(ConfigVar.NETWORK_AUTO_CONNECT, True, True)
 
     @wizard_dialog
     def multisig_dialog(self, run_next):

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -39,6 +39,7 @@ from electrum import constants, blockchain
 from electrum.interface import serialize_server, deserialize_server
 from electrum.network import Network
 from electrum.logging import get_logger
+from electrum.simple_config import ConfigVar, SimpleConfig
 
 from .util import Buttons, CloseButton, HelpButton, read_QIcon, char_width_in_lineedit
 
@@ -201,7 +202,7 @@ class ServerListWidget(QTreeWidget):
 
 class NetworkChoiceLayout(object):
 
-    def __init__(self, network: Network, config, wizard=False):
+    def __init__(self, network: Network, config: SimpleConfig, wizard=False):
         self.network = network
         self.config = config
         self.protocol = None
@@ -227,7 +228,7 @@ class NetworkChoiceLayout(object):
         self.server_port = QLineEdit()
         self.server_port.setFixedWidth(fixed_width_port)
         self.autoconnect_cb = QCheckBox(_('Select server automatically'))
-        self.autoconnect_cb.setEnabled(self.config.is_modifiable('auto_connect'))
+        self.autoconnect_cb.setEnabled(self.config.is_modifiable(ConfigVar.NETWORK_AUTO_CONNECT))
 
         self.server_host.editingFinished.connect(self.set_server)
         self.server_port.editingFinished.connect(self.set_server)
@@ -340,13 +341,13 @@ class NetworkChoiceLayout(object):
         self.update()
 
     def check_disable_proxy(self, b):
-        if not self.config.is_modifiable('proxy'):
+        if not self.config.is_modifiable(ConfigVar.NETWORK_PROXY):
             b = False
         for w in [self.proxy_mode, self.proxy_host, self.proxy_port, self.proxy_user, self.proxy_password]:
             w.setEnabled(b)
 
     def enable_set_server(self):
-        if self.config.is_modifiable('server'):
+        if self.config.is_modifiable(ConfigVar.NETWORK_SERVER):
             enabled = not self.autoconnect_cb.isChecked()
             self.server_host.setEnabled(enabled)
             self.server_port.setEnabled(enabled)

--- a/electrum/gui/qt/paytoedit.py
+++ b/electrum/gui/qt/paytoedit.py
@@ -247,7 +247,6 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit, Logger):
         self.setText(new_url)
         self.previous_payto = new_url
 
-        #if self.win.config.get('openalias_autoadd') == 'checked':
         self.win.contacts[key] = ('openalias', name)
         self.win.contact_list.update()
 

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -25,6 +25,7 @@ from PyQt5.QtWidgets import (QPushButton, QLabel, QMessageBox, QHBoxLayout,
 from electrum.i18n import _, languages
 from electrum.util import FileImportFailed, FileExportFailed, make_aiohttp_session, resource_path
 from electrum.util import PR_UNPAID, PR_PAID, PR_EXPIRED, PR_INFLIGHT, PR_UNKNOWN
+from electrum.simple_config import SimpleConfig, ConfigVar
 
 if TYPE_CHECKING:
     from .main_window import ElectrumWindow
@@ -391,7 +392,7 @@ def address_field(addresses):
     return hbox, address_e
 
 
-def filename_field(parent, config, defaultname, select_msg):
+def filename_field(parent, config: 'SimpleConfig', defaultname, select_msg):
 
     vbox = QVBoxLayout()
     vbox.addWidget(QLabel(_("Format")))
@@ -406,7 +407,7 @@ def filename_field(parent, config, defaultname, select_msg):
 
     hbox = QHBoxLayout()
 
-    directory = config.get('io_dir', os.path.expanduser('~'))
+    directory = config.get(ConfigVar.IO_DIRECTORY)
     path = os.path.join( directory, defaultname )
     filename_e = QLineEdit()
     filename_e.setText(path)

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -6,6 +6,7 @@ import locale
 from decimal import Decimal
 import getpass
 import logging
+from typing import TYPE_CHECKING
 
 import electrum
 from electrum.util import format_satoshis
@@ -16,13 +17,19 @@ from electrum.storage import WalletStorage
 from electrum.network import NetworkParameters, TxBroadcastError, BestEffortRequestFailed
 from electrum.interface import deserialize_server
 from electrum.logging import console_stderr_handler
+from electrum.simple_config import ConfigVar, SimpleConfig
+
+if TYPE_CHECKING:
+    from electrum.daemon import Daemon
+    from electrum.plugin import Plugins
+
 
 _ = lambda x:x  # i18n
 
 
 class ElectrumGui:
 
-    def __init__(self, config, daemon, plugins):
+    def __init__(self, config: SimpleConfig, daemon: 'Daemon', plugins: 'Plugins'):
 
         self.config = config
         self.network = daemon.network
@@ -404,7 +411,7 @@ class ElectrumGui:
         srv = 'auto-connect' if auto_connect else self.network.default_server
         out = self.run_dialog('Network', [
             {'label':'server', 'type':'str', 'value':srv},
-            {'label':'proxy', 'type':'str', 'value':self.config.get('proxy', '')},
+            {'label':'proxy', 'type':'str', 'value':self.config.get(ConfigVar.NETWORK_PROXY)},
             ], buttons = 1)
         if out:
             if out.get('server'):
@@ -429,7 +436,7 @@ class ElectrumGui:
         if out:
             if out.get('Default fee'):
                 fee = int(Decimal(out['Default fee']) * COIN)
-                self.config.set_key('fee_per_kb', fee, True)
+                self.config.set_key(ConfigVar.FEE_EST_STATIC_FEERATE_FALLBACK, fee, True)
 
 
     def password_dialog(self):

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -46,6 +46,7 @@ from .lntransport import LNTransport, LNTransportBase
 from .lnmsg import encode_msg, decode_msg
 from .interface import GracefulDisconnect, NetworkException
 from .lnrouter import fee_for_edge_msat
+from .simple_config import ConfigVar
 
 if TYPE_CHECKING:
     from .lnworker import LNWorker
@@ -976,7 +977,7 @@ class Peer(Logger):
         self.network.trigger_callback('channel', chan)
         self.add_own_channel(chan)
         self.logger.info(f"CHANNEL OPENING COMPLETED for {scid}")
-        forwarding_enabled = self.network.config.get('lightning_forward_payments', False)
+        forwarding_enabled = self.network.config.get(ConfigVar.LIGHTNING_FORWARD_PAYMENTS)
         if forwarding_enabled:
             # send channel_update of outgoing edge to peer,
             # so that channel can be used to to receive payments
@@ -1324,7 +1325,7 @@ class Peer(Logger):
         # Forward HTLC
         # FIXME: this is not robust to us going offline before payment is fulfilled
         # FIXME: there are critical safety checks MISSING here
-        forwarding_enabled = self.network.config.get('lightning_forward_payments', False)
+        forwarding_enabled = self.network.config.get(ConfigVar.LIGHTNING_FORWARD_PAYMENTS)
         if not forwarding_enabled:
             self.logger.info(f"forwarding is disabled. failing htlc.")
             reason = OnionRoutingFailureMessage(code=OnionFailureCode.PERMANENT_CHANNEL_FAILURE, data=b'')

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -52,6 +52,7 @@ from .lnrouter import RouteEdge, is_route_sane_to_use
 from .address_synchronizer import TX_HEIGHT_LOCAL
 from . import lnsweep
 from .lnwatcher import LNWatcher
+from .simple_config import ConfigVar
 
 if TYPE_CHECKING:
     from .network import Network
@@ -97,7 +98,7 @@ class LNWorker(Logger):
         return {}
 
     async def maybe_listen(self):
-        listen_addr = self.config.get('lightning_listen')
+        listen_addr = self.config.get(ConfigVar.LIGHTNING_LISTEN)
         if listen_addr:
             addr, port = listen_addr.rsplit(':', 2)
             if addr[0] == '[':
@@ -152,7 +153,7 @@ class LNWorker(Logger):
         asyncio.run_coroutine_threadsafe(self.network.main_taskgroup.spawn(self.main_loop()), self.network.asyncio_loop)
 
     def _add_peers_from_config(self):
-        peer_list = self.config.get('lightning_peers', [])
+        peer_list = self.config.get('lightning_peers') or []
         for host, port, pubkey in peer_list:
             asyncio.run_coroutine_threadsafe(
                 self._add_peer(host, int(port), bfh(pubkey)),
@@ -345,7 +346,7 @@ class LNWallet(LNWorker):
                 r = await super().request(*args, **kwargs)
                 return r.data.result
         while True:
-            watchtower_url = self.config.get('watchtower_url')
+            watchtower_url = self.config.get(ConfigVar.REMOTE_WATCHTOWER_URL)
             if watchtower_url:
                 try:
                     async with aiohttp.ClientSession(loop=asyncio.get_event_loop()) as session:

--- a/electrum/logging.py
+++ b/electrum/logging.py
@@ -8,8 +8,11 @@ import sys
 import pathlib
 import os
 import platform
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 import copy
+
+if TYPE_CHECKING:
+    from .simple_config import SimpleConfig
 
 
 class LogFormatterForFiles(logging.Formatter):
@@ -227,13 +230,13 @@ class Logger:
         return ''
 
 
-def configure_logging(config):
+def configure_logging(config: 'SimpleConfig'):
     verbosity = config.get('verbosity')
     verbosity_shortcuts = config.get('verbosity_shortcuts')
     _configure_verbosity(verbosity=verbosity, verbosity_shortcuts=verbosity_shortcuts)
 
     is_android = 'ANDROID_DATA' in os.environ
-    if is_android or not config.get('log_to_file', False):
+    if is_android or not config.get(config.ConfigVar.WRITE_LOGS_TO_DISK):
         pass  # disable file logging
     else:
         log_directory = pathlib.Path(config.path) / "logs"

--- a/electrum/paymentrequest.py
+++ b/electrum/paymentrequest.py
@@ -46,6 +46,7 @@ from .bitcoin import TYPE_ADDRESS
 from .transaction import TxOutput
 from .network import Network
 from .logging import get_logger, Logger
+from .simple_config import ConfigVar
 
 
 _logger = get_logger(__name__)
@@ -404,8 +405,8 @@ def verify_cert_chain(chain):
 
 def check_ssl_config(config):
     from . import pem
-    key_path = config.get('ssl_keyfile')
-    cert_path = config.get('ssl_certfile')
+    key_path = config.get(ConfigVar.SSL_PRIVKEY_PATH)
+    cert_path = config.get(ConfigVar.SSL_CERTFILE_PATH)
     with open(key_path, 'r', encoding='utf-8') as f:
         params = pem.parse_private_key(f.read())
     with open(cert_path, 'r', encoding='utf-8') as f:
@@ -455,8 +456,8 @@ def serialize_request(req):
 
 def make_request(config, req):
     pr = make_unsigned_request(req)
-    key_path = config.get('ssl_keyfile')
-    cert_path = config.get('ssl_certfile')
+    key_path = config.get(ConfigVar.SSL_PRIVKEY_PATH)
+    cert_path = config.get(ConfigVar.SSL_CERTFILE_PATH)
     if key_path and cert_path:
         sign_request_with_x509(pr, key_path, cert_path)
     return pr

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -34,7 +34,7 @@ from .i18n import _
 from .util import (profiler, DaemonThread, UserCancelled, ThreadJob, UserFacingException)
 from . import bip32
 from . import plugins
-from .simple_config import SimpleConfig
+from .simple_config import SimpleConfig, ConfigVar
 from .logging import get_logger, Logger
 
 if TYPE_CHECKING:
@@ -232,7 +232,7 @@ def run_hook(name, *args):
 
 class BasePlugin(Logger):
 
-    def __init__(self, parent, config, name):
+    def __init__(self, parent, config: SimpleConfig, name):
         self.parent = parent  # The plugins object
         self.name = name
         self.config = config
@@ -370,7 +370,7 @@ class DeviceMgr(ThreadJob):
         thread.'''
         with self.lock:
             clients = list(self.clients.keys())
-        cutoff = time.time() - self.config.get_session_timeout()
+        cutoff = time.time() - self.config.get(ConfigVar.HWD_SESSION_TIMEOUT)
         for client in clients:
             client.timeout(cutoff)
 

--- a/electrum/plugins/digitalbitbox/digitalbitbox.py
+++ b/electrum/plugins/digitalbitbox/digitalbitbox.py
@@ -31,6 +31,7 @@ from electrum.util import to_string, UserCancelled, UserFacingException
 from electrum.base_wizard import ScriptTypeNotSupported, HWD_SETUP_NEW_WALLET
 from electrum.network import Network
 from electrum.logging import get_logger
+from electrum.simple_config import ConfigVar
 
 
 _logger = get_logger(__name__)
@@ -309,7 +310,7 @@ class DigitalBitbox_Client():
             # import pairing from dbb app
             self.plugin.digitalbitbox_config[ENCRYPTION_PRIVKEY_KEY] = dbb_config[ENCRYPTION_PRIVKEY_KEY]
             self.plugin.digitalbitbox_config[CHANNEL_ID_KEY] = dbb_config[CHANNEL_ID_KEY]
-        self.plugin.config.set_key('digitalbitbox', self.plugin.digitalbitbox_config)
+        self.plugin.config.set_key(ConfigVar.PLUGIN_DIGITALBITBOX_SETTINGS, self.plugin.digitalbitbox_config)
 
     def dbb_generate_wallet(self):
         key = self.stretch_key(self.password)
@@ -704,7 +705,7 @@ class DigitalBitboxPlugin(HW_PluginBase):
         if self.libraries_available:
             self.device_manager().register_devices(self.DEVICE_IDS)
 
-        self.digitalbitbox_config = self.config.get('digitalbitbox', {})
+        self.digitalbitbox_config = self.config.get(ConfigVar.PLUGIN_DIGITALBITBOX_SETTINGS) or {}
 
 
     def get_dbb_device(self, device):

--- a/electrum/plugins/email_requests/qt.py
+++ b/electrum/plugins/email_requests/qt.py
@@ -48,6 +48,7 @@ from electrum.plugin import BasePlugin, hook
 from electrum.paymentrequest import PaymentRequest
 from electrum.i18n import _
 from electrum.logging import Logger
+from electrum.simple_config import ConfigVar
 
 
 class Processor(threading.Thread, Logger):
@@ -142,9 +143,9 @@ class Plugin(BasePlugin):
 
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
-        self.imap_server = self.config.get('email_server', '')
-        self.username = self.config.get('email_username', '')
-        self.password = self.config.get('email_password', '')
+        self.imap_server = self.config.get(ConfigVar.REMOTE_EMAIL_SERVER)
+        self.username = self.config.get(ConfigVar.REMOTE_EMAIL_USERNAME)
+        self.password = self.config.get(ConfigVar.REMOTE_EMAIL_PASSWORD)
         if self.imap_server and self.username and self.password:
             self.processor = Processor(self.imap_server, self.username, self.password, self.on_receive)
             self.processor.start()
@@ -236,15 +237,15 @@ class Plugin(BasePlugin):
             return
 
         server = str(server_e.text())
-        self.config.set_key('email_server', server)
+        self.config.set_key(ConfigVar.REMOTE_EMAIL_SERVER, server)
         self.imap_server = server
 
         username = str(username_e.text())
-        self.config.set_key('email_username', username)
+        self.config.set_key(ConfigVar.REMOTE_EMAIL_USERNAME, username)
         self.username = username
 
         password = str(password_e.text())
-        self.config.set_key('email_password', password)
+        self.config.set_key(ConfigVar.REMOTE_EMAIL_PASSWORD, password)
         self.password = password
 
         check_connection = CheckConnectionThread(server, username, password)

--- a/electrum/plugins/keepkey/qt.py
+++ b/electrum/plugins/keepkey/qt.py
@@ -13,6 +13,7 @@ from electrum.gui.qt.util import (WindowModalDialog, WWLabel, Buttons, CancelBut
 from electrum.i18n import _
 from electrum.plugin import hook
 from electrum.util import bh2u
+from electrum.simple_config import ConfigVar
 
 from ..hw_wallet.qt import QtHandlerBase, QtPluginBase
 from ..hw_wallet.plugin import only_hook_if_libraries_available
@@ -417,7 +418,7 @@ class SettingsDialog(WindowModalDialog):
             timeout_minutes.setText(_("{:2d} minutes").format(mins))
 
         def slider_released():
-            config.set_session_timeout(timeout_slider.sliderPosition() * 60)
+            config.set_key(ConfigVar.HWD_SESSION_TIMEOUT, timeout_slider.sliderPosition() * 60)
 
         # Information tab
         info_tab = QWidget()
@@ -502,7 +503,7 @@ class SettingsDialog(WindowModalDialog):
               "your PIN and passphrase (if enabled) must be "
               "re-entered to use the device."))
         timeout_msg.setWordWrap(True)
-        timeout_slider.setSliderPosition(config.get_session_timeout() // 60)
+        timeout_slider.setSliderPosition(config.get(ConfigVar.HWD_SESSION_TIMEOUT) // 60)
         slider_moved()
         timeout_slider.valueChanged.connect(slider_moved)
         timeout_slider.sliderReleased.connect(slider_released)

--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -564,7 +564,6 @@ class LedgerPlugin(HW_PluginBase):
     SUPPORTED_XTYPES = ('standard', 'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')
 
     def __init__(self, parent, config, name):
-        self.segwit = config.get("segwit")
         HW_PluginBase.__init__(self, parent, config, name)
         if self.libraries_available:
             self.device_manager().register_devices(self.DEVICE_IDS)

--- a/electrum/plugins/revealer/qt.py
+++ b/electrum/plugins/revealer/qt.py
@@ -27,6 +27,7 @@ from PyQt5.QtWidgets import (QGridLayout, QVBoxLayout, QHBoxLayout, QLabel,
 from electrum.plugin import hook
 from electrum.i18n import _
 from electrum.util import make_dir, InvalidPassword, UserCancelled
+from electrum.simple_config import ConfigVar
 from electrum.gui.qt.util import (read_QIcon, EnterButton, WWLabel, icon_path,
                                   WindowModalDialog, Buttons, CloseButton, OkButton)
 from electrum.gui.qt.qrtextedit import ScanQRTextEdit
@@ -43,13 +44,8 @@ class Plugin(RevealerPlugin):
         RevealerPlugin.__init__(self, parent, config, name)
         self.base_dir = os.path.join(config.electrum_path(), 'revealer')
 
-        if self.config.get('calibration_h') is None:
-            self.config.set_key('calibration_h', 0)
-        if self.config.get('calibration_v') is None:
-            self.config.set_key('calibration_v', 0)
-
-        self.calibration_h = self.config.get('calibration_h')
-        self.calibration_v = self.config.get('calibration_v')
+        self.calibration_h = self.config.get(ConfigVar.PLUGIN_REVEALER_CALIBRATION_H)
+        self.calibration_v = self.config.get(ConfigVar.PLUGIN_REVEALER_CALIBRATION_V)
 
         self.f_size = QSize(1014*2, 642*2)
         self.abstand_h = 21
@@ -727,8 +723,6 @@ class Plugin(RevealerPlugin):
         vbox.addWidget(QLabel(''.join(["<br/>", _("If you have an old printer, or want optimal precision"),"<br/>",
                                        _("print the calibration pdf and follow the instructions "), "<br/>","<br/>",
                                     ])))
-        self.calibration_h = self.config.get('calibration_h')
-        self.calibration_v = self.config.get('calibration_v')
         cprint = QPushButton(_("Open calibration pdf"))
         cprint.clicked.connect(self.calibration)
         vbox.addWidget(cprint)
@@ -754,8 +748,8 @@ class Plugin(RevealerPlugin):
             return
 
         self.calibration_h = int(Decimal(horizontal.text()))
-        self.config.set_key('calibration_h', self.calibration_h)
+        self.config.set_key(ConfigVar.PLUGIN_REVEALER_CALIBRATION_H, self.calibration_h)
         self.calibration_v = int(Decimal(vertical.text()))
-        self.config.set_key('calibration_v', self.calibration_v)
+        self.config.set_key(ConfigVar.PLUGIN_REVEALER_CALIBRATION_V, self.calibration_v)
 
 

--- a/electrum/plugins/safe_t/qt.py
+++ b/electrum/plugins/safe_t/qt.py
@@ -13,6 +13,7 @@ from electrum.gui.qt.util import (WindowModalDialog, WWLabel, Buttons, CancelBut
 from electrum.i18n import _
 from electrum.plugin import hook
 from electrum.util import bh2u
+from electrum.simple_config import ConfigVar
 
 from ..hw_wallet.qt import QtHandlerBase, QtPluginBase
 from ..hw_wallet.plugin import only_hook_if_libraries_available
@@ -327,7 +328,7 @@ class SettingsDialog(WindowModalDialog):
             timeout_minutes.setText(_("{:2d} minutes").format(mins))
 
         def slider_released():
-            config.set_session_timeout(timeout_slider.sliderPosition() * 60)
+            config.set_key(ConfigVar.HWD_SESSION_TIMEOUT, timeout_slider.sliderPosition() * 60)
 
         # Information tab
         info_tab = QWidget()
@@ -432,7 +433,7 @@ class SettingsDialog(WindowModalDialog):
               "your PIN and passphrase (if enabled) must be "
               "re-entered to use the device."))
         timeout_msg.setWordWrap(True)
-        timeout_slider.setSliderPosition(config.get_session_timeout() // 60)
+        timeout_slider.setSliderPosition(config.get(ConfigVar.HWD_SESSION_TIMEOUT) // 60)
         slider_moved()
         timeout_slider.valueChanged.connect(slider_moved)
         timeout_slider.sliderReleased.connect(slider_released)

--- a/electrum/plugins/trezor/qt.py
+++ b/electrum/plugins/trezor/qt.py
@@ -12,6 +12,7 @@ from electrum.gui.qt.util import (WindowModalDialog, WWLabel, Buttons, CancelBut
 from electrum.i18n import _
 from electrum.plugin import hook
 from electrum.util import bh2u
+from electrum.simple_config import ConfigVar
 
 from ..hw_wallet.qt import QtHandlerBase, QtPluginBase
 from ..hw_wallet.plugin import only_hook_if_libraries_available
@@ -454,7 +455,7 @@ class SettingsDialog(WindowModalDialog):
             timeout_minutes.setText(_("{:2d} minutes").format(mins))
 
         def slider_released():
-            config.set_session_timeout(timeout_slider.sliderPosition() * 60)
+            config.set_key(ConfigVar.HWD_SESSION_TIMEOUT, timeout_slider.sliderPosition() * 60)
 
         # Information tab
         info_tab = QWidget()
@@ -559,7 +560,7 @@ class SettingsDialog(WindowModalDialog):
               "your PIN and passphrase (if enabled) must be "
               "re-entered to use the device."))
         timeout_msg.setWordWrap(True)
-        timeout_slider.setSliderPosition(config.get_session_timeout() // 60)
+        timeout_slider.setSliderPosition(config.get(ConfigVar.HWD_SESSION_TIMEOUT) // 60)
         slider_moved()
         timeout_slider.valueChanged.connect(slider_moved)
         timeout_slider.sliderReleased.connect(slider_released)

--- a/electrum/plugins/trustedcoin/qt.py
+++ b/electrum/plugins/trustedcoin/qt.py
@@ -44,6 +44,7 @@ from electrum.plugin import hook
 from electrum.util import is_valid_email
 from electrum.logging import Logger
 from electrum.base_wizard import GoBack
+from electrum.simple_config import ConfigVar
 
 from .trustedcoin import TrustedCoinPlugin, server
 
@@ -202,7 +203,7 @@ class Plugin(TrustedCoinPlugin):
             grid.addWidget(QLabel(window.format_amount(v/k) + ' ' + window.base_unit() + "/tx"), i, 1)
             b = QRadioButton()
             b.setChecked(k == n_prepay)
-            b.clicked.connect(lambda b, k=k: self.config.set_key('trustedcoin_prepay', k, True))
+            b.clicked.connect(lambda b, k=k: self.config.set_key(ConfigVar.PLUGIN_TRUSTEDCOIN_NUM_PREPAY, k, True))
             grid.addWidget(b, i, 2)
             i += 1
 

--- a/electrum/plugins/trustedcoin/trustedcoin.py
+++ b/electrum/plugins/trustedcoin/trustedcoin.py
@@ -49,6 +49,7 @@ from electrum.storage import StorageEncryptionVersion
 from electrum.network import Network
 from electrum.base_wizard import BaseWizard, WizardWalletPasswordSetting
 from electrum.logging import Logger
+from electrum.simple_config import ConfigVar
 
 
 def get_signing_xpub(xtype):
@@ -293,7 +294,7 @@ class Wallet_2fa(Multisig_Wallet):
 
     def num_prepay(self):
         default = self.min_prepay()
-        n = self.config.get('trustedcoin_prepay', default)
+        n = self.config.get(ConfigVar.PLUGIN_TRUSTEDCOIN_NUM_PREPAY, override_default=default)
         if n not in self.price_per_tx:
             n = default
         return n

--- a/electrum/tests/test_commands.py
+++ b/electrum/tests/test_commands.py
@@ -6,6 +6,7 @@ from electrum.util import create_and_start_event_loop
 from electrum.commands import Commands, eval_bool
 from electrum import storage
 from electrum.wallet import restore_wallet_from_text
+from electrum.simple_config import ConfigVar
 
 from . import TestCaseForTestnet
 
@@ -40,12 +41,12 @@ class TestCommands(unittest.TestCase):
             Commands._setconfig_normalize_value('url_rewrite', '["file:///var/www/","https://electrum.org"]'))
 
     def test_setconfig_auth(self):
-        self.assertEqual("7777", Commands._setconfig_normalize_value('rpcuser', "7777"))
-        self.assertEqual("7777", Commands._setconfig_normalize_value('rpcuser', '7777'))
-        self.assertEqual("7777", Commands._setconfig_normalize_value('rpcpassword', '7777'))
-        self.assertEqual("2asd", Commands._setconfig_normalize_value('rpcpassword', '2asd'))
+        self.assertEqual("7777", Commands._setconfig_normalize_value(ConfigVar.RPC_USERNAME.get_key_str(), "7777"))
+        self.assertEqual("7777", Commands._setconfig_normalize_value(ConfigVar.RPC_USERNAME.get_key_str(), '7777'))
+        self.assertEqual("7777", Commands._setconfig_normalize_value(ConfigVar.RPC_PASSWORD.get_key_str(), '7777'))
+        self.assertEqual("2asd", Commands._setconfig_normalize_value(ConfigVar.RPC_PASSWORD.get_key_str(), '2asd'))
         self.assertEqual("['file:///var/www/','https://electrum.org']",
-            Commands._setconfig_normalize_value('rpcpassword', "['file:///var/www/','https://electrum.org']"))
+                         Commands._setconfig_normalize_value(ConfigVar.RPC_PASSWORD.get_key_str(), "['file:///var/www/','https://electrum.org']"))
 
     def test_eval_bool(self):
         self.assertFalse(eval_bool("False"))

--- a/electrum/tests/test_wallet_vertical.py
+++ b/electrum/tests/test_wallet_vertical.py
@@ -7,7 +7,7 @@ import asyncio
 
 from electrum import storage, bitcoin, keystore, bip32
 from electrum import Transaction
-from electrum import SimpleConfig
+from electrum.simple_config import SimpleConfig, ConfigVar
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCONF_PARENT
 from electrum.wallet import sweep, Multisig_Wallet, Standard_Wallet, Imported_Wallet, restore_wallet_from_text
 from electrum.util import bfh, bh2u
@@ -1144,7 +1144,7 @@ class TestWalletSending(TestCaseForTestnet):
 
     def _rbf_batching(self, *, simulate_moving_txs):
         wallet = self.create_standard_wallet_from_seed('frost repair depend effort salon ring foam oak cancel receive save usage')
-        wallet.config.set_key('batch_rbf', True)
+        wallet.config.set_key(ConfigVar.WALLET_BATCH_RBF, True)
 
         # bootstrap wallet (incoming funding_tx1)
         funding_tx1 = Transaction('01000000000102acd6459dec7c3c51048eb112630da756f5d4cb4752b8d39aa325407ae0885cba020000001716001455c7f5e0631d8e6f5f05dddb9f676cec48845532fdffffffd146691ef6a207b682b13da5f2388b1f0d2a2022c8cfb8dc27b65434ec9ec8f701000000171600147b3be8a7ceaf15f57d7df2a3d216bc3c259e3225fdffffff02a9875b000000000017a914ea5a99f83e71d1c1dfc5d0370e9755567fe4a141878096980000000000160014d4ca56fcbad98fb4dcafdc573a75d6a6fffb09b702483045022100dde1ba0c9a2862a65791b8d91295a6603207fb79635935a67890506c214dd96d022046c6616642ef5971103c1db07ac014e63fa3b0e15c5729eacdd3e77fcb7d2086012103a72410f185401bb5b10aaa30989c272b554dc6d53bda6da85a76f662723421af024730440220033d0be8f74e782fbcec2b396647c7715d2356076b442423f23552b617062312022063c95cafdc6d52ccf55c8ee0f9ceb0f57afb41ea9076eb74fe633f59c50c6377012103b96a4954d834fbcfb2bbf8cf7de7dc2b28bc3d661c1557d1fd1db1bfc123a94abb391400')
@@ -1955,7 +1955,7 @@ class TestWalletHistory_EvilGapLimit(TestCaseForTestnet):
         cls.electrum_path = tempfile.mkdtemp()
         cls.config = SimpleConfig({
             'electrum_path': cls.electrum_path,
-            'skipmerklecheck': True,  # needed for Synchronizer to generate new addresses without SPV
+            ConfigVar.NETWORK_SKIPMERKLECHECK.get_key_str(): True,  # needed for Synchronizer to generate new addresses without SPV
         })
 
     @classmethod

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -743,11 +743,9 @@ def block_explorer_info():
     return mainnet_block_explorers if not constants.net.TESTNET else testnet_block_explorers
 
 def block_explorer(config: 'SimpleConfig') -> str:
-    from . import constants
-    default_ = 'Blockstream.info'
-    be_key = config.get('block_explorer', default_)
+    be_key = config.get(config.ConfigVar.BLOCK_EXPLORER)
     be = block_explorer_info().get(be_key)
-    return be_key if be is not None else default_
+    return be_key if be is not None else config.ConfigVar.BLOCK_EXPLORER.get_default_value()
 
 def block_explorer_tuple(config: 'SimpleConfig') -> Optional[Tuple[str, dict]]:
     return block_explorer_info().get(block_explorer(config))

--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -33,6 +33,7 @@ from .transaction import Transaction
 from .blockchain import hash_header
 from .interface import GracefulDisconnect
 from .network import UntrustedServerReturnedError
+from .simple_config import ConfigVar
 from . import constants
 
 if TYPE_CHECKING:
@@ -118,7 +119,7 @@ class SPV(NetworkJobOnDefaultServer):
         try:
             verify_tx_is_in_block(tx_hash, merkle_branch, pos, header, tx_height)
         except MerkleVerificationFailure as e:
-            if self.network.config.get("skipmerklecheck"):
+            if self.network.config.get(ConfigVar.NETWORK_SKIPMERKLECHECK):
                 self.logger.info(f"skipping merkle proof check {tx_hash}")
             else:
                 self.logger.info(repr(e))

--- a/run_electrum
+++ b/run_electrum
@@ -89,6 +89,7 @@ from electrum.commands import get_parser, known_commands, Commands, config_varia
 from electrum import daemon
 from electrum import keystore
 from electrum.util import create_and_start_event_loop
+from electrum.simple_config import ConfigVar
 
 _logger = get_logger(__name__)
 
@@ -107,6 +108,9 @@ def prompt_password(prompt, confirm=True):
 
 
 def init_cmdline(config_options, wallet_path, server):
+    # FIXME config is used all-over in this method.
+    #       do we mean config_options instead maybe?
+    #       or maybe config should be passed. really not intuitive that this works.
     cmdname = config.get('cmd')
     cmd = known_commands[cmdname]
 
@@ -302,8 +306,8 @@ if __name__ == '__main__':
         config_options = args.__dict__
         f = lambda key: config_options[key] is not None and key not in config_variables.get(args.cmd, {}).keys()
         config_options = {key: config_options[key] for key in filter(f, config_options.keys())}
-        if config_options.get('server'):
-            config_options['auto_connect'] = False
+        if config_options.get(ConfigVar.NETWORK_SERVER.get_key_str()):
+            config_options[ConfigVar.NETWORK_AUTO_CONNECT.get_key_str()] = False
 
     config_options['cwd'] = os.getcwd()
 
@@ -333,10 +337,10 @@ if __name__ == '__main__':
         constants.set_regtest()
     elif config.get('simnet'):
         constants.set_simnet()
-    elif config.get('lightning') and not config.get('reckless'):
+    elif config.get(ConfigVar.LIGHTNING) and not config.get('reckless'):
         raise Exception('lightning option not available on mainnet')
 
-    if config.get('lightning'):
+    if config.get(ConfigVar.LIGHTNING):
         from electrum.ecc_fast import is_using_fast_ecc
         if not is_using_fast_ecc():
             raise Exception('libsecp256k1 library not available. '
@@ -367,7 +371,7 @@ if __name__ == '__main__':
         configure_logging(config)
         fd = daemon.get_file_descriptor(config)
         if fd is not None:
-            plugins = init_plugins(config, config.get('gui', 'qt'))
+            plugins = init_plugins(config, config.get(ConfigVar.GUI))
             d = daemon.Daemon(config, fd)
             d.run_gui(config, plugins)
             sys_exit(0)
@@ -391,9 +395,9 @@ if __name__ == '__main__':
         # command line
         cmd = known_commands[cmdname]
         wallet_path = config.get_wallet_path()
-        if not config.get('offline'):
+        if not config.get(ConfigVar.NETWORK_OFFLINE):
             init_cmdline(config_options, wallet_path, True)
-            timeout = config.get('timeout', 60)
+            timeout = config.get(ConfigVar.CLI_TIMEOUT)
             if timeout: timeout = int(timeout)
             try:
                 result = daemon.request(config, 'run_cmdline', (config_options,), timeout)


### PR DESCRIPTION
On current master, every time we lookup the value of a config variable, we potentially duplicate the corresponding default value:
https://github.com/spesmilo/electrum/blob/c7346c1eb8f790ad71d14c634097fa67d2839ac5/electrum/simple_config.py#L184
Further, almost every time we get/set a config variable, we use a new inline string literal for the config key; which means the config keys are also duplicated all over the place.

This PR introduces a `ConfigVar` enum, which lists almost all configuration variables in a single place in the code, along with default values and config key strings on the same line for each.