### PR TITLE
Don't discard partial sigs when loading PSBT files

### DIFF
--- a/electrum/plugins/coldcard/build_psbt.py
+++ b/electrum/plugins/coldcard/build_psbt.py
@@ -401,15 +401,15 @@ def get_xpubs_from_psbt(inp: BasicPSBTInput, psbt: BasicPSBT):
     # Get indexes for each pubkey
     for k, v in inp.bip32_paths.items():
         fingerprint, path = parse_fingerprint_and_deriv_path(v)
-        index_for_key[fingerprint] = path[-1] & 0x7FFFFFFF
+        index_for_key[fingerprint] = [path[-2] & 0x7FFFFFFF, path[-1] & 0x7FFFFFFF]
 
     xpubs = []
     for xpub in psbt.xpubs:
         fingerprint, path = parse_fingerprint_and_deriv_path(xpub[1])
-        index = index_for_key[fingerprint]
+        path = index_for_key[fingerprint]
         # Append index to xpub as per keystore get_xpubkey
-        indexed = int_to_hex(index, 2) if index < 0xffff else 'ffff' + int_to_hex(index, 4)
-        xpub_indexed = 'ff' + xpub[0][1:].hex() + ''.join(['0000', indexed])
+        indexed = int_to_hex(path[1], 2) if path[1] < 0xffff else 'ffff' + int_to_hex(path[1], 4)
+        xpub_indexed = 'ff' + xpub[0][1:].hex() + ''.join([int_to_hex(path[0], 2), indexed])
         xpubs.append(xpub_indexed)
         
     return xpubs


### PR DESCRIPTION
Currently when loading PSBT files, the Coldcard plugin's multisig support (added in #5440 by @peter-conalgo) causes any partial signatures to be discarded. This happens because the plugin sets the Transaction input field 'x_pubkeys' to the the same value as 'pubkeys', which is in turn parsed from the multisig script. The full xpubs are not contained in the script however, so this value is incorrect. This causes the following behaviour:

When loading the transaction dialog, Electrum compares the provided xpubs with the expected xpubs calculated from the MultisigWallet (see [wallet.py line 2121](https://github.com/spesmilo/electrum/blob/7c283f9cd21e372b9a324f370b5376fdfe1a628b/electrum/wallet.py#L2121)). Where these differ, any signatures provided with that input are discarded. This can be tested using any PSBT that is partially signed - once this file is loaded through Tools -> Load Transaction -> From PSBT File the transaction dialog Status field will show 'Unsigned' and the partial signature is lost.

This PR resolves this issue by setting the xpubs correctly. They are retrieved from the PSBT by parsing the values retrieved from the PSBT_GLOBAL_XPUB field, and adding the relevant address indexes as parsed from the PSBT_IN_BIP32_DERIVATION field since Electrum expects them to be appended. 

The result is that partial signatures from PSBT files are preserved, and the transaction dialog reflects the correct status - 'Partially Signed (m/n)'.

