### PR TITLE
fix potential vulnerability with get_sorted_pubkeys

### DIFF
--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -638,7 +638,7 @@ class Transaction:
             return [], []
         x_pubkeys = txin['x_pubkeys']
         pubkeys = txin.get('pubkeys')
-        if pubkeys is None:
+        if pubkeys is None or len(pubkeys) == 0:
             pubkeys = [xpubkey_to_pubkey(x) for x in x_pubkeys]
             pubkeys, x_pubkeys = zip(*sorted(zip(pubkeys, x_pubkeys)))
             txin['pubkeys'] = pubkeys = list(pubkeys)


### PR DESCRIPTION
txin['pubkeys'] is not always None it is sometimes == [] where len(pubkeys) == 0, so catch it as such. Note it is set up as an array here:
https://github.com/spesmilo/electrum/blob/master/electrum/transaction.py#L454