### PR TITLE
CoinChooser: avoid NotEnoughFunds if zero buckets are sufficient

### DIFF
--- a/electrum/coinchooser.py
+++ b/electrum/coinchooser.py
@@ -405,7 +405,10 @@ class CoinChooserRandom(CoinChooserBase):
                 already_selected_buckets += bkts_choose_from
                 already_selected_buckets_value_sum += sum(bucket.value for bucket in bkts_choose_from)
         else:
-            raise NotEnoughFunds()
+            if sufficient_funds([], bucket_value_sum=0):
+                candidates = [[]]
+            else:
+                raise NotEnoughFunds()
 
         candidates = [(already_selected_buckets + c) for c in candidates]
         return [strip_unneeded(c, sufficient_funds) for c in candidates]


### PR DESCRIPTION
The coin chooser incorrectly raises `NotEnoughFunds` when the following conditions are both true when `make_tx` is called:

* `len(coins) == 0`
* The combined value of `inputs` is sufficient to fund the transaction.

This PR explicitly checks whether an empty bucket is sufficient to fund the transaction, and if so, suppresses the `NotEnoughFunds`.