### PR TITLE
Show outgoing Lightning payments with red description

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -201,7 +201,7 @@ class HistoryModel(QAbstractItemModel, Logger):
             #        and self.parent.wallet.invoices.paid.get(tx_hash):
             #    return QVariant(read_QIcon("seal"))
             elif col in (HistoryColumns.DESCRIPTION, HistoryColumns.AMOUNT) \
-                    and role == Qt.ForegroundRole and not is_lightning and tx_item['value'].value < 0:
+                    and role == Qt.ForegroundRole and tx_item['value'].value < 0:
                 red_brush = QBrush(QColor("#BC1E1E"))
                 return QVariant(red_brush)
             elif col == HistoryColumns.FIAT_VALUE and role == Qt.ForegroundRole \


### PR DESCRIPTION
Resolves #5762 

Although looking at the code, it looks like this was intentionally disabled so maybe you don't want this. We can continue discussion in the related issue.