### PR TITLE
Color-Code Addresses in Kivy UI

### DIFF
--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -69,7 +69,7 @@
 
             
 <BackgroundColor@Widget>
-    background_color: 1, 1, 1, 1
+    background_color: 0, 0, 0, 1
     canvas.before:
         Color:
             rgba: root.background_color
@@ -77,7 +77,7 @@
             size: self.size
             pos: self.pos
 <BackgroundTopLabel@TopLabel+BackgroundColor>
-    background_color: 0, 0, 0, 0            
+    background_color: 0, 0, 0, 1
 
 
 #########################

--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -100,6 +100,7 @@
     address: ''
     value: ''
     background_color: 1, 1, 1, 1
+    color: 1, 1, 1, 1
     size_hint_y: None
     height: max(lbl1.height, lbl2.height)
     BackgroundTopLabelExtended
@@ -107,6 +108,7 @@
         text: '[ref=%s]%s[/ref]'%(root.address, root.address)
         background_color: root.background_color 
         font_size: '6pt'
+        color: root.color
         shorten: True
         size_hint_x: 0.65
         on_ref_press:

--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -76,7 +76,7 @@
         Rectangle:
             size: self.size
             pos: self.pos
-<BackgroundTopLabelExtended@TopLabelExtended+BackgroundColor>
+<BackgroundTopLabel@TopLabel+BackgroundColor>
     background_color: 0, 0, 0, 0            
 
 
@@ -99,11 +99,11 @@
 <OutputItem>
     address: ''
     value: ''
-    background_color: 1, 1, 1, 1
+    background_color: 0, 0, 0, 1
     color: 1, 1, 1, 1
     size_hint_y: None
     height: max(lbl1.height, lbl2.height)
-    BackgroundTopLabelExtended
+    BackgroundTopLabel
         id: lbl1
         text: '[ref=%s]%s[/ref]'%(root.address, root.address)
         background_color: root.background_color 

--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -67,6 +67,17 @@
             size_hint_x: None
             size: '30dp', '30dp'
 
+            
+<BackgroundColor@Widget>
+    background_color: 1, 1, 1, 1
+    canvas.before:
+        Color:
+            rgba: root.background_color
+        Rectangle:
+            size: self.size
+            pos: self.pos
+<BackgroundTopLabelExtended@TopLabelExtended+BackgroundColor>
+    background_color: 0, 0, 0, 0            
 
 
 #########################
@@ -88,11 +99,13 @@
 <OutputItem>
     address: ''
     value: ''
+    background_color: 1, 1, 1, 1
     size_hint_y: None
     height: max(lbl1.height, lbl2.height)
-    TopLabel
+    BackgroundTopLabelExtended
         id: lbl1
         text: '[ref=%s]%s[/ref]'%(root.address, root.address)
+        background_color: root.background_color 
         font_size: '6pt'
         shorten: True
         size_hint_x: 0.65

--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -106,9 +106,9 @@
     BackgroundTopLabel
         id: lbl1
         text: '[ref=%s]%s[/ref]'%(root.address, root.address)
+        color: root.color
         background_color: root.background_color 
         font_size: '6pt'
-        color: root.color
         shorten: True
         size_hint_x: 0.65
         on_ref_press:

--- a/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -213,16 +213,17 @@ class OutputList(RecycleView):
         res = []
         for o in outputs:
             value = self.app.format_amount_and_units(o.value)
-            res.append({'address': o.get_ui_address_str(), 'value': value, 'background_color': (0.3, 0.3, 0.3, 1), 'color': (1, 1, 1, 1)})
+            res.append({
+                    'address': o.get_ui_address_str(),
+                    'value': value,
+                    'background_color': (0.3, 0.3, 0.3, 1),
+                    'color': (1, 1, 1, 1)})
         self.data = res
 
 
 class TopLabel(Factory.Label):
     pass
 
-
-class TopLabelExtended(TopLabel):
-    pass
 
 
 class RefLabel(TopLabel):

--- a/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -213,7 +213,7 @@ class OutputList(RecycleView):
         res = []
         for o in outputs:
             value = self.app.format_amount_and_units(o.value)
-            res.append({'address': o.get_ui_address_str(), 'value': value, 'background_color': (0.3, 0.3, 0.3, 1)})
+            res.append({'address': o.get_ui_address_str(), 'value': value, 'background_color': (0.3, 0.3, 0.3, 1), 'color': (1, 1, 1, 1)})
         self.data = res
 
 

--- a/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -213,11 +213,15 @@ class OutputList(RecycleView):
         res = []
         for o in outputs:
             value = self.app.format_amount_and_units(o.value)
-            res.append({'address': o.get_ui_address_str(), 'value': value})
+            res.append({'address': o.get_ui_address_str(), 'value': value, 'background_color': (0.3, 0.3, 0.3, 1)})
         self.data = res
 
 
 class TopLabel(Factory.Label):
+    pass
+
+
+class TopLabelExtended(TopLabel):
     pass
 
 

--- a/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -213,11 +213,7 @@ class OutputList(RecycleView):
         res = []
         for o in outputs:
             value = self.app.format_amount_and_units(o.value)
-            res.append({
-                    'address': o.get_ui_address_str(),
-                    'value': value,
-                    'background_color': (0.3, 0.3, 0.3, 1),
-                    'color': (1, 1, 1, 1)})
+            res.append({'address': o.get_ui_address_str(),'value': value})
         self.data = res
 
 

--- a/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -213,7 +213,7 @@ class OutputList(RecycleView):
         res = []
         for o in outputs:
             value = self.app.format_amount_and_units(o.value)
-            res.append({'address': o.get_ui_address_str(),'value': value})
+            res.append({'address': o.get_ui_address_str(), 'value': value})
         self.data = res
 
 

--- a/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -221,6 +221,5 @@ class TopLabel(Factory.Label):
     pass
 
 
-
 class RefLabel(TopLabel):
     pass

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -180,8 +180,22 @@ class TxDialog(Factory.Popup):
         else:
             self.fee_str = _('unknown')
             self.feerate_str = _('unknown')
-        self.ids.output_list.update(self.tx.outputs())                
-        self.ids.output_list.data[0]['background_color'] = (0.9,0,0,1)
+        self.ids.output_list.update(self.tx.outputs())        
+
+        def text_format(addr):            
+            """
+            Chooses the appropriate text color and background color to mark receiving, change and billing addresses.
+            returns: color, background_color
+            """
+            if self.wallet.is_mine(addr):
+                return ((0,0,0,1), (1, 1, 0, 1)) if self.wallet.is_change(addr) else ((0,0,0,1), (0.541, 0.95, 0.56, 1))
+            elif self.wallet.is_billing_address(addr):
+                return ((1,1,1,1), (0,0,1,1))
+            return ((1,1,1,1), (0.3,0.3,0.3,1))
+
+        for data in self.ids.output_list.data:
+            data['color'], data['background_color'] = text_format(data['address'])
+            
         self.is_local_tx = tx_mined_status.height == TX_HEIGHT_LOCAL
         self.update_action_button()
 

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -10,6 +10,7 @@ from kivy.clock import Clock
 from kivy.uix.label import Label
 from kivy.uix.dropdown import DropDown
 from kivy.uix.button import Button
+from kivy.utils import get_color_from_hex
 
 from .question import Question
 from electrum.gui.kivy.i18n import _
@@ -189,12 +190,19 @@ class TxDialog(Factory.Popup):
 
             Returns: color, background_color
             """
+            
+            # modified colors (textcolor, background_color) from electrum/gui/qt/util.py
+            GREEN = ("#000000", "#8af296")
+            YELLOW = ("#000000", "#ffff00")
+            BLUE = ("#000000", "#8cb3f2")
+            DEFAULT = ('#ffffff', '#4c4c4c')
+
+            colors = DEFAULT
             if self.wallet.is_mine(addr):
-                return (((0, 0, 0, 1), (1, 1, 0, 1)) if self.wallet.is_change(addr)
-                    else ((0, 0, 0, 1), (0.541, 0.95, 0.56, 1)))
+                colors = YELLOW if self.wallet.is_change(addr) else GREEN
             elif self.wallet.is_billing_address(addr):
-                return ((1, 1, 1, 1), (0, 0, 1, 1))
-            return ((1, 1, 1, 1), (0.3, 0.3, 0.3, 1))
+                colors = BLUE
+            return (get_color_from_hex(color) for color in colors)
 
         for data in self.ids.output_list.data:
             data['color'], data['background_color'] = text_format(data['address'])

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -180,22 +180,25 @@ class TxDialog(Factory.Popup):
         else:
             self.fee_str = _('unknown')
             self.feerate_str = _('unknown')
-        self.ids.output_list.update(self.tx.outputs())        
+        self.ids.output_list.update(self.tx.outputs())
 
-        def text_format(addr):            
+        def text_format(addr):
             """
-            Chooses the appropriate text color and background color to mark receiving, change and billing addresses.
-            returns: color, background_color
+            Chooses the appropriate text color and background color to 
+            mark receiving, change and billing addresses.
+
+            Returns: color, background_color
             """
             if self.wallet.is_mine(addr):
-                return ((0,0,0,1), (1, 1, 0, 1)) if self.wallet.is_change(addr) else ((0,0,0,1), (0.541, 0.95, 0.56, 1))
+                return (((0, 0, 0, 1), (1, 1, 0, 1)) if self.wallet.is_change(addr)
+                    else ((0, 0, 0, 1), (0.541, 0.95, 0.56, 1)))
             elif self.wallet.is_billing_address(addr):
-                return ((1,1,1,1), (0,0,1,1))
-            return ((1,1,1,1), (0.3,0.3,0.3,1))
+                return ((1, 1, 1, 1), (0, 0, 1, 1))
+            return ((1, 1, 1, 1), (0.3, 0.3, 0.3, 1))
 
         for data in self.ids.output_list.data:
             data['color'], data['background_color'] = text_format(data['address'])
-            
+
         self.is_local_tx = tx_mined_status.height == TX_HEIGHT_LOCAL
         self.update_action_button()
 

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -204,8 +204,8 @@ class TxDialog(Factory.Popup):
                 colors = BLUE
             return (get_color_from_hex(color) for color in colors)
 
-        for data in self.ids.output_list.data:
-            data['color'], data['background_color'] = text_format(data['address'])
+        for dict_entry in self.ids.output_list.data:
+            dict_entry['color'], dict_entry['background_color'] = text_format(dict_entry['address'])
 
         self.is_local_tx = tx_mined_status.height == TX_HEIGHT_LOCAL
         self.update_action_button()

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -180,7 +180,8 @@ class TxDialog(Factory.Popup):
         else:
             self.fee_str = _('unknown')
             self.feerate_str = _('unknown')
-        self.ids.output_list.update(self.tx.outputs())
+        self.ids.output_list.update(self.tx.outputs())                
+        self.ids.output_list.data[0]['background_color'] = (0.9,0,0,1)
         self.is_local_tx = tx_mined_status.height == TX_HEIGHT_LOCAL
         self.update_action_button()
 


### PR DESCRIPTION
- Created a kivy component BackgroundTopLabel, which allows custom background colors
- Transferred the logic for color coding from the qt version, which gives identical color coding of output addresses in the kivy gui

Closes: #5750