### PR TITLE
Fix missing wallet argument to _resolver

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -34,6 +34,7 @@ import operator
 import asyncio
 import inspect
 from functools import wraps, partial
+from itertools import repeat
 from decimal import Decimal
 from typing import Optional, TYPE_CHECKING, Dict
 
@@ -536,7 +537,7 @@ class Commands:
             raise Exception("Cannot specify both 'fee' and 'feerate' at the same time!")
         self.nocheck = nocheck
         change_addr = self._resolver(change_addr, wallet)
-        domain_addr = None if domain_addr is None else map(self._resolver, domain_addr)
+        domain_addr = None if domain_addr is None else map(self._resolver, domain_addr, repeat(wallet))
         final_outputs = []
         for address, amount in outputs:
             address = self._resolver(address, wallet)


### PR DESCRIPTION
`_mktx` wasn't properly passing the `wallet` argument to `_resolver`; this caused errors when it was called with non-`None` values for `domain_addr`.  This PR fixes that.