### PR TITLE
Qt address list: add "funded or unused" filter option

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/addresses.py
+++ b/electrum/gui/kivy/uix/dialogs/addresses.py
@@ -102,9 +102,9 @@ Builder.load_string('''
                 spacing: '5dp'
                 AddressButton:
                     id: search
-                    text: {0:_('All'), 1:_('Unused'), 2:_('Funded'), 3:_('Used')}[root.show_used]
+                    text: {0:_('All'), 1:_('Unused'), 2:_('Funded'), 3:_('Used'), 4:(_('Funded')+'|'+_('Unused'))}[root.show_used]
                     on_release:
-                        root.show_used = (root.show_used + 1) % 4
+                        root.show_used = (root.show_used + 1) % 5
                         Clock.schedule_once(lambda dt: root.update())
             AddressFilter:
                 opacity: 1
@@ -270,6 +270,8 @@ class AddressesDialog(Factory.Popup):
             if self.show_used == 2 and balance == 0:
                 continue
             if self.show_used == 3 and not is_used_and_empty:
+                continue
+            if self.show_used == 4 and is_used_and_empty:
                 continue
             card = self.get_card(address, balance, is_used_and_empty, label)
             if search and not self.ext_search(card, search):

--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -43,6 +43,7 @@ class AddressUsageStateFilter(IntEnum):
     UNUSED = 1
     FUNDED = 2
     USED_AND_EMPTY = 3
+    FUNDED_OR_UNUSED = 4
 
     def ui_text(self) -> str:
         return {
@@ -50,6 +51,7 @@ class AddressUsageStateFilter(IntEnum):
             self.UNUSED: _('Unused'),
             self.FUNDED: _('Funded'),
             self.USED_AND_EMPTY: _('Used'),
+            self.FUNDED_OR_UNUSED: _('Funded or Unused'),
         }[self]
 
 
@@ -172,6 +174,8 @@ class AddressList(MyTreeView):
             if self.show_used == AddressUsageStateFilter.FUNDED and balance == 0:
                 continue
             if self.show_used == AddressUsageStateFilter.USED_AND_EMPTY and not is_used_and_empty:
+                continue
+            if self.show_used == AddressUsageStateFilter.FUNDED_OR_UNUSED and is_used_and_empty:
                 continue
             balance_text = self.parent.format_amount(balance, whitespaces=True)
             # create item


### PR DESCRIPTION
I've noticed that old used addresses can make an address list unwieldy over time. I would like a filter for "Funded & Unused" that filters out old zero balance addresses.