### PR TITLE
wallet: allow saving partial tx as local (if it has a txid)

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -216,7 +216,8 @@ class AddressSynchronizer(Logger):
     def add_transaction(self, tx: Transaction, *, allow_unrelated=False) -> bool:
         """Returns whether the tx was successfully added to the wallet history."""
         assert tx, tx
-        assert tx.is_complete()
+        # note: tx.is_complete() is not necessarily True; tx might be partial
+        # but it *needs* to have a txid:
         tx_hash = tx.txid()
         if tx_hash is None:
             raise Exception("cannot add tx without txid to wallet history")

--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -281,7 +281,6 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
 
     def sign(self):
         def sign_done(success):
-            # note: with segwit we could save partially signed tx, because they have a txid
             if self.tx.is_complete():
                 self.prompt_if_unsaved = True
                 self.saved = False

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -826,6 +826,8 @@ class LNWallet(LNWorker):
         self.save_channel(chan)
         self.lnwatcher.add_channel(chan.funding_outpoint.to_str(), chan.get_funding_address())
         self.network.trigger_callback('channels_updated', self.wallet)
+        self.wallet.add_transaction(funding_tx)  # save tx as local into the wallet
+        self.wallet.set_label(funding_tx.txid(), _('Open channel'))
         if funding_tx.is_complete():
             # TODO make more robust (timeout low? server returns error?)
             await asyncio.wait_for(self.network.broadcast_transaction(funding_tx), LN_P2P_NETWORK_TIMEOUT)


### PR DESCRIPTION
- So far we have required local txns to be complete. This requirement is now loosened such that it is sufficient for a tx to have a txid to be saved as a "local" tx into the wallet.
- In the wallet file, re the "transactions" dictionary,
    - complete txns are serialised as a hex string (no change); while partial txns are serialised as a base64 PSBT string
    - the key, as before, is the txid; so there can be only one tx saved for a given txid
        - partial txns with same txid overwrite each other (latest wins), however a complete tx cannot be overwritten
- In second commit, see the main motivation for this: save LN funding txns as local automatically
    - these are partial for watching-only wallets/multisig/etc. The user will now have time to conveniently get the funding tx signed and then broadcast it.
    - given it is a local tx and part of the history, it has side-effects on the wallet's UTXOs; so user will not accidentally double-spend the funding tx
    - even if the funding tx is already complete, I think it might be useful to save it as local, so if the electrum server returns an error the user still has it (previously user would have to abandon channel and create new one instead)