### PR TITLE
wallet perf: significant speedup for make_unsigned_transaction and rel.

### DIFF
--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -369,7 +369,7 @@ class BaseWizard(Logger):
         elif purpose == HWD_SETUP_DECRYPT_WALLET:
             derivation = get_derivation_used_for_hw_device_encryption()
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, 'standard', self)
-            password = keystore.Xpub.get_pubkey_from_xpub(xpub, ())
+            password = keystore.Xpub.get_pubkey_from_xpub(xpub, ()).hex()
             try:
                 storage.decrypt(password)
             except InvalidPassword:

--- a/electrum/bip32.py
+++ b/electrum/bip32.py
@@ -273,6 +273,7 @@ class BIP32Node(NamedTuple):
         """Returns the fingerprint of this node.
         Note that self.fingerprint is of the *parent*.
         """
+        # TODO cache this
         return hash_160(self.eckey.get_public_key_bytes(compressed=True))[0:4]
 
 

--- a/run_electrum
+++ b/run_electrum
@@ -178,7 +178,7 @@ def get_connected_hw_devices(plugins):
     return devices
 
 
-def get_password_for_hw_device_encrypted_storage(plugins):
+def get_password_for_hw_device_encrypted_storage(plugins) -> str:
     devices = get_connected_hw_devices(plugins)
     if len(devices) == 0:
         print_msg("Error: No connected hw device found. Cannot decrypt this wallet.")
@@ -194,7 +194,7 @@ def get_password_for_hw_device_encrypted_storage(plugins):
         xpub = plugin.get_xpub(device_info.device.id_, derivation, 'standard', plugin.handler)
     except UserCancelled:
         sys.exit(0)
-    password = keystore.Xpub.get_pubkey_from_xpub(xpub, ())
+    password = keystore.Xpub.get_pubkey_from_xpub(xpub, ()).hex()
     return password
 
 


### PR DESCRIPTION
- keystore: cache `derive_pubkey`
- keystore: cache `BIP32Node.from_xkey(self.xpub)`
    - This results in significant performance improvements for keystore.can_sign() and wallet._add_txinout_derivation_info()