### PR TITLE
Qt: introduce BlockingWaitingDialog

### DIFF
--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -34,7 +34,7 @@ from electrum.transaction import Transaction, PartialTransaction
 from electrum.simple_config import FEERATE_WARNING_HIGH_FEE
 from electrum.wallet import InternalAddressCorruption
 
-from .util import WindowModalDialog, ColorScheme, HelpLabel, Buttons, CancelButton
+from .util import WindowModalDialog, ColorScheme, HelpLabel, Buttons, CancelButton, BlockingWaitingDialog
 
 from .fee_slider import FeeSlider
 
@@ -156,7 +156,7 @@ class ConfirmTxDialog(TxEditor, WindowModalDialog):
         self.send_button.clicked.connect(self.on_send)
         self.send_button.setDefault(True)
         vbox.addLayout(Buttons(CancelButton(self), self.send_button))
-        self.update_tx()
+        BlockingWaitingDialog(window, _("Preparing transaction..."), self.update_tx)
         self.update()
         self.is_send = False
 


### PR DESCRIPTION
A variant of `WaitingDialog` that runs the task in the GUI thread, blocking the GUI.
It is probably a code smell to actually use this, as operations should not block the GUI... still it provides a middle-ground between blocking the GUI without giving user-feedback and having to refactor existing code (to avoid blocking).