### PR TITLE
Aiohttp must be lower than 4.0.0

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -5,7 +5,7 @@ protobuf
 dnspython
 qdarkstyle<2.7
 aiorpcx>=0.18,<0.19
-aiohttp>=3.3.0
+aiohttp>=3.3.0,<4.0.0
 aiohttp_socks
 certifi
 bitstring


### PR DESCRIPTION
In regards to issue #5753, the error just popped up for me. This PR fixes the error