### PR TITLE
windows: when running from source, with py3.8+, load DLLs from '.dlls'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/
 .idea
 .mypy_cache
 .vscode
+.dlls
 
 # icons
 electrum/gui/kivy/theming/light-0.png

--- a/run_electrum
+++ b/run_electrum
@@ -51,6 +51,13 @@ os.environ['KIVY_DATA_DIR'] = os.path.abspath(os.path.dirname(__file__)) + '/ele
 if is_local or is_android:
     sys.path.insert(0, os.path.join(script_dir, 'packages'))
 
+# when running from source, on Windows, also search for DLLs in '.dlls' top-level folder
+if is_local and os.name == 'nt':
+    dll_dir = os.path.join(os.path.dirname(__file__), '.dlls')
+    if os.path.exists(dll_dir):
+        if hasattr(os, 'add_dll_directory'):  # requires python 3.8+
+            os.add_dll_directory(dll_dir)
+
 
 def check_imports():
     # pure-python dependencies need to be imported here for pyinstaller


### PR DESCRIPTION
Python 3.8 changed where DLLs are searched for.
see https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
This potentially affects our binaries when we start shipping python 3.8+, however that is not being addressed here. This commit simply addresses the usecase of running from source, on Windows, using python 3.8.

On older Python, a user could build/obtain DLLs and place them anywhere on the system %PATH%, however this no longer works with py3.8, as %PATH% is no longer checked.
With py3.8, instead, we now check if there is a folder named '.dlls' in the top-level project directory, and if so, register that as an additional search path.
A user who wants to run Electrum from source on Windows using python 3.8 or later, with their custom DLLs, should manually create the '.dlls' folder and put their DLLs there. If they also want to switch between e.g. python 3.7 and 3.8, they should also include '.dlls' in the system %PATH%.

When using Electrum, interesting DLLs include at least libsecp256k1.dll, libusb-1.0.dll, libzbar-0.dll.