### PR TITLE
Add block explorer support for mynode.local

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -743,6 +743,8 @@ mainnet_block_explorers = {
                         {'tx': 'transaction/', 'addr': 'address/'}),
     'smartbit.com.au': ('https://www.smartbit.com.au/',
                         {'tx': 'tx/', 'addr': 'address/'}),
+    'mynode.local': ('http://mynode.local:3002/',
+                        {'tx': 'tx/', 'addr': 'address/'}),
     'system default': ('blockchain:/',
                         {'tx': 'tx/', 'addr': 'address/'}),
 }


### PR DESCRIPTION
Very minor change which adds support for loading mynode.local when the user selects "View on block explorer" option on a transaction or address.

User can select "mynode.local" entry in the "Online Block Explorer" in the preferences window to enable this.

Tested and working fine on addresses or transactions being selected without issue.

This only works when the user has a mynode installation on their network (website here: http://www.mynodebtc.com/ ) and have turned on the electrum server option. If this has not been done, then the mynode.local domain will not resolve and loading will fail.

This allows users to run electrum on their own node, but also interface with a friendly block explorer which is hosted locally.

Only appears in mainnet as testnet isn't really supported by mynode without modification.