### PR TITLE
Add command line option to forget config on exit.

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1171,6 +1171,7 @@ def add_global_options(parser):
 
 def add_wallet_option(parser):
     parser.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
+    parser.add_argument("--forgetconfig", action="store_true", dest="forget_config", default=False, help="Forget config on exit")
 
 def get_parser():
     # create main parser

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -226,6 +226,8 @@ class SimpleConfig(Logger):
         return key not in self.cmdline_options
 
     def save_user_config(self):
+        if self.get('forget_config'):
+            return
         if not self.path:
             return
         path = os.path.join(self.path, "config")


### PR DESCRIPTION
By default, Electrum saves the last opened wallet's path as well as
recently opened wallets.

This can be damaging to plausible deniability.

Now it's possible to run Electrum with `--forgetconfig` to not
write to the config at all, which includes the wallet paths.