### PR TITLE
Kivy: Adding address coloring to AddressPopup (Address Details)

### DIFF
--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -151,6 +151,7 @@
     text: self.data if self.data else _('Tap to show')
     touched: False
     padding: '10dp', '10dp'
+    background_color: .3, .3, .3, 1
     on_touch_down:
         touch = args[1]
         touched = bool(self.collide_point(*touch.pos))
@@ -158,7 +159,7 @@
         if touched: self.touched = True
     canvas.before:
         Color:
-            rgb: .3, .3, .3
+            rgba: root.background_color
         Rectangle:
             size: self.size
             pos: self.pos

--- a/electrum/gui/kivy/uix/dialogs/addresses.py
+++ b/electrum/gui/kivy/uix/dialogs/addresses.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from kivy.uix.popup import Popup
 
 from electrum.gui.kivy.i18n import _
+from ...util import address_colors
 
 if TYPE_CHECKING:
     from ...main_window import ElectrumWindow
@@ -111,6 +112,8 @@ Builder.load_string('''
     status: ''
     script_type: ''
     pk: ''
+    address_color: 1, 1, 1, 1
+    address_background_color: 0.3, 0.3, 0.3, 1
     BoxLayout:
         orientation: 'vertical'
         ScrollView:
@@ -123,6 +126,8 @@ Builder.load_string('''
                 TopLabel:
                     text: _('Address')
                 RefLabel:
+                    color: root.address_color
+                    background_color: root.address_background_color
                     data: root.address
                     name: _('Address')
                 GridLayout:
@@ -175,6 +180,7 @@ class AddressPopup(Popup):
         self.status = status
         self.script_type = self.app.wallet.get_txin_type(self.address)
         self.balance = self.app.format_amount_and_units(balance)
+        self.address_color, self.address_background_color = address_colors(self.app.wallet, address)
 
     def receive_at(self):
         self.dismiss()

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -10,7 +10,6 @@ from kivy.clock import Clock
 from kivy.uix.label import Label
 from kivy.uix.dropdown import DropDown
 from kivy.uix.button import Button
-from kivy.utils import get_color_from_hex
 
 from .question import Question
 from electrum.gui.kivy.i18n import _
@@ -19,6 +18,7 @@ from electrum.util import InvalidPassword
 from electrum.address_synchronizer import TX_HEIGHT_LOCAL
 from electrum.wallet import CannotBumpFee
 from electrum.transaction import Transaction, PartialTransaction
+from ...util import address_colors
 
 if TYPE_CHECKING:
     from ...main_window import ElectrumWindow
@@ -183,29 +183,8 @@ class TxDialog(Factory.Popup):
             self.feerate_str = _('unknown')
         self.ids.output_list.update(self.tx.outputs())
 
-        def text_format(addr):
-            """
-            Chooses the appropriate text color and background color to 
-            mark receiving, change and billing addresses.
-
-            Returns: color, background_color
-            """
-            
-            # modified colors (textcolor, background_color) from electrum/gui/qt/util.py
-            GREEN = ("#000000", "#8af296")
-            YELLOW = ("#000000", "#ffff00")
-            BLUE = ("#000000", "#8cb3f2")
-            DEFAULT = ('#ffffff', '#4c4c4c')
-
-            colors = DEFAULT
-            if self.wallet.is_mine(addr):
-                colors = YELLOW if self.wallet.is_change(addr) else GREEN
-            elif self.wallet.is_billing_address(addr):
-                colors = BLUE
-            return (get_color_from_hex(color) for color in colors)
-
         for dict_entry in self.ids.output_list.data:
-            dict_entry['color'], dict_entry['background_color'] = text_format(dict_entry['address'])
+            dict_entry['color'], dict_entry['background_color'] = address_colors(self.wallet, dict_entry['address'])
 
         self.is_local_tx = tx_mined_status.height == TX_HEIGHT_LOCAL
         self.update_action_button()

--- a/electrum/gui/kivy/util.py
+++ b/electrum/gui/kivy/util.py
@@ -1,0 +1,23 @@
+from kivy.utils import get_color_from_hex
+
+
+def address_colors(wallet, addr):
+    """
+    Chooses the appropriate text color and background color to 
+    mark receiving, change and billing addresses.
+
+    Returns: color, background_color
+    """
+    
+    # modified colors (textcolor, background_color) from electrum/gui/qt/util.py
+    GREEN = ("#000000", "#8af296")
+    YELLOW = ("#000000", "#ffff00")
+    BLUE = ("#000000", "#8cb3f2")
+    DEFAULT = ('#ffffff', '#4c4c4c')
+
+    colors = DEFAULT
+    if wallet.is_mine(addr):
+        colors = YELLOW if wallet.is_change(addr) else GREEN
+    elif wallet.is_billing_address(addr):
+        colors = BLUE
+    return (get_color_from_hex(color) for color in colors)


### PR DESCRIPTION
I added coloring (green, yellow, blue) to the AddressPopup dialog in Kivy to be consistent with coloring done in the tx_dialog.
The necessary coloring function was moved into a new file electrum/gui/kivy/util.py

![Screenshot_20200126_211202](https://user-images.githubusercontent.com/1935665/73141106-86378b00-4080-11ea-879b-8073424a214e.png)

![Screenshot_20200126_211300](https://user-images.githubusercontent.com/1935665/73141119-a404f000-4080-11ea-87a9-1df6af2893b6.png)


Open Issues:
- The colored background in AddressPopup is significantly larger than the address text. In the tx_dialog the colored background is only as large as the address text.
- In a future PR the 2 coloring format functions (1. electrum/gui/kivy/util.py  and 2. electrum/gui/qt/util.py) could be perhaps united.