### PR TITLE
Fix travis appimage

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -q && \
         libssl-dev=1.0.2g-1ubuntu4.15 \
         libssl1.0.0=1.0.2g-1ubuntu4.15 \
         openssl=1.0.2g-1ubuntu4.15 \
-        zlib1g-dev=1:1.2.8.dfsg-2ubuntu4.1 \
+        zlib1g-dev=1:1.2.8.dfsg-2ubuntu4.3 \
         libffi-dev=3.2.1-4 \
         libncurses5-dev=6.0+20160213-1ubuntu1 \
         libsqlite3-dev=3.11.0-1ubuntu1.3 \


### PR DESCRIPTION
https://travis-ci.org/spesmilo/electrum/jobs/640576201
``E: Version '1:1.2.8.dfsg-2ubuntu4.1' for 'zlib1g-dev' was not found``
Now version is `1:1.2.8.dfsg-2ubuntu4.3`
https://packages.ubuntu.com/xenial/zlib1g-dev