### PR TITLE
Display exported txn compatibility information to the user

### DIFF
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -183,6 +183,7 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
             vbox.addWidget(self.feecontrol_fields)
         self.hbox = hbox = QHBoxLayout()
         hbox.addLayout(Buttons(*self.sharing_buttons))
+        hbox.addWidget(QLabel(_("Electrum 3.2.0 or newer required to import.")))
         hbox.addStretch(1)
         hbox.addLayout(Buttons(*self.buttons))
         vbox.addLayout(hbox)


### PR DESCRIPTION

![txdialog](https://user-images.githubusercontent.com/60500523/73563029-07e13d00-4422-11ea-9f02-de17b3cd0241.png)

The serialized transaction format was changed here #4405

The change occurred in Electrum 3.2.0.

(
  before: https://github.com/spesmilo/electrum/blob/624fa4769d9f02fa71696b3d69030ae114ccf573/lib/transaction.py#L891
  after: https://github.com/spesmilo/electrum/blob/0119ab9ee1c4b07255442c7c91a7119ca989b64c/lib/transaction.py#L1013
)

I ran into this myself, here: #5924

Personally I believe that users should be notified of breaking changes.  Users should not have to make educated guesses, ask online, or be python programmers in order to be able to tell whats going on / why doesn't it work.

If you don't like this verbiage (for example, if you think that the user should be instructed to always use the exact same electrum version when importing / exporting)  

Then an alternative verbiage would be appropriate, such as "Always use the exact same Electrum version to import any exported transactions."

If that doesn't fit there the label can be moved. Or it could be  `'Electrum ' + current_electrum_version + ' required to import.'` Or Something. Point is that there should be some indication of this fact of life to the user.