### PR TITLE
appimage: update libudev-dev

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -q && \
         libncurses5-dev=6.0+20160213-1ubuntu1 \
         libsqlite3-dev=3.11.0-1ubuntu1.3 \
         libusb-1.0-0-dev=2:1.0.20-1 \
-        libudev-dev=229-4ubuntu21.23 \
+        libudev-dev=229-4ubuntu21.27 \
         gettext=0.19.7-2ubuntu3.1 \
         libzbar0=0.10+doc-10ubuntu1  \
         libdbus-1-3=1.10.6-1ubuntu3.4 \


### PR DESCRIPTION
https://travis-ci.org/spesmilo/electrum/jobs/647090064
E: Version '229-4ubuntu21.23' for 'libudev-dev' was not found
Now version is 229-4ubuntu21.27
https://packages.ubuntu.com/xenial/libudev-dev