### PR TITLE
some apt-get and cleanup tweaks

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04@sha256:97b54e5692c27072234ff958a7442dde4266af21e7b688e7fca5dc5
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 RUN apt-get update -q && \
-    apt-get install -qy \
+    apt-get --no-install-recommends install -qy \
         git=1:2.7.4-0ubuntu1.7 \
         wget=1.17.1-1ubuntu1.5 \
         make=4.1-6 \

--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -4,15 +4,23 @@ ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 RUN dpkg --add-architecture i386 && \
     apt-get update -q && \
-    apt-get install -qy \
+    apt-get --no-install-recommends install -qy \
         wget=1.19.4-1ubuntu2.2 \
         gnupg2=2.2.4-1ubuntu1.2 \
         dirmngr=2.2.4-1ubuntu1.2 \
         python3-software-properties=0.96.24.32.1 \
-        software-properties-common=0.96.24.32.1
+        software-properties-common=0.96.24.32.1 && \
+    apt-get clean && \
+    rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base    
 
 RUN apt-get update -q && \
-        apt-get install -qy \
+        apt-get --no-install-recommends install -qy \
         git=1:2.17.1-1ubuntu0.5 \
         p7zip-full=16.02+dfsg-6 \
         make=4.1-9.1ubuntu1 \
@@ -20,7 +28,15 @@ RUN apt-get update -q && \
         autotools-dev=20180224.1 \
         autoconf=2.69-11 \
         libtool=2.4.6-2 \
-        gettext=0.19.8.1-6
+        gettext=0.19.8.1-6 && \
+    apt-get clean && \
+    rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base        
 
 RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
         echo "c51bcb8cc4a12abfbd7c7660eaf90f49674d15e222c262f27e6c96429111b822 Release.key" | sha256sum -c - && \
@@ -32,11 +48,19 @@ RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
         rm winehq.key && \
     apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/ && \
     apt-get update -q && \
-    apt-get install -qy \
+    apt-get --no-install-recommends install -qy \
         wine-stable-amd64:amd64=4.0.3~bionic \
         wine-stable-i386:i386=4.0.3~bionic \
         wine-stable:amd64=4.0.3~bionic \
-        winehq-stable:amd64=4.0.3~bionic
+        winehq-stable:amd64=4.0.3~bionic && \
+    apt-get clean && \
+    rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base        
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Another Cleanup tweaks using 

1. apt-get clean 

2. rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

removing downloaded packages and packages list will free up some space ,

results in smaller image size.