### PR TITLE
lnrouter: speed up path-finding by caching edge cost

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -922,10 +922,7 @@ class LNWallet(LNWorker):
         success = False
         for i in range(attempts):
             try:
-                # note: this call does path-finding which takes ~1 second
-                #       -> we will BLOCK the asyncio loop... (could just run in a thread and await,
-                #       but then the graph could change while the path-finding runs on it)
-                route = self._create_route_from_invoice(decoded_invoice=lnaddr)
+                route = await run_in_thread(self._create_route_from_invoice, lnaddr)
                 self.set_payment_status(payment_hash, PR_INFLIGHT)
                 self.network.trigger_callback('invoice_status', key)
                 payment_attempt_log = await self._pay_to_route(route, lnaddr)


### PR DESCRIPTION
Turns out most of the time (~70%) for `find_path_for_payment` is spent in `_edge_cost`.
`_edge_cost` is not doing anything particularly expensive, just a whole bunch
of cheap things, and it is called many times (around once for every channel policy).
By caching `_edge_cost` like this, the runtime (wall clock) for `find_path_for_payment`
goes from ~1.2 sec to ~0.35 sec on my machine.

Not sure about all implications: underlying graph might change while path finding runs, cache can become stale, cache is using buckets for payment amount... but I think nothing horrible could happen, so maybe worth the speedup.

However, the cache is quite large (in terms of mem usage). :/ Maybe around 2.6 MB per payment amount bucket for the current graph (~55k channel policies).
So for say 10 buckets, it's already 26 MB, which is a lot for an Android phone, just for this.

Still, failed research should also be published; hence this PR.