### PR TITLE
Readme: Clarify dependencies of make_libsecp256k1.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ For elliptic curve operations, `libsecp256k1`_ is a required dependency::
 Alternatively, when running from a cloned repository, a script is provided to build
 libsecp256k1 yourself::
 
+    sudo apt-get install automake libtool
     ./contrib/make_libsecp256k1.sh
 
 Due to the need for fast symmetric ciphers, either one of `pycryptodomex`_


### PR DESCRIPTION
`README.rst` lists the `apt-get` requirements for `pull_locale` (which is good) but neglects to do the same for `make_libsecp256k1.sh`.  This PR adds the relevant info for the latter.