### PR TITLE
Commands: clarify description of getservers

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -467,7 +467,7 @@ class Commands:
 
     @command('n')
     async def getservers(self):
-        """Return the list of available servers"""
+        """Return the list of known servers (candidates for connecting)."""
         return self.network.get_servers()
 
     @command('')


### PR DESCRIPTION
The previous description of `getservers` made it sound like it returned the list of currently connected servers; this clarifies that it's only a list of candidate servers to connect to (no guarantee that they are all currently connected).