### PR TITLE
Hard fail on bad server-string

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -268,8 +268,8 @@ class Network(Logger):
             try:
                 deserialize_server(self.default_server)
             except:
-                print('Failed to parse server-string.')
-                exit()
+                self.logger.warning('failed to parse server-string; falling back to localhost.')
+                self.default_server = "localhost:50002:s"
         if not self.default_server:
             self.default_server = pick_random_server()
 

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -268,8 +268,8 @@ class Network(Logger):
             try:
                 deserialize_server(self.default_server)
             except:
-                self.logger.warning('failed to parse server-string; falling back to random.')
-                self.default_server = None
+                print('Failed to parse server-string.')
+                exit()
         if not self.default_server:
             self.default_server = pick_random_server()
 


### PR DESCRIPTION
Resolves https://github.com/spesmilo/electrum/issues/6085

I just copied the same print then exit fail style from here:

https://github.com/spesmilo/electrum/blob/da8b24d61af00109d480fe4ee5b73d130a7c1f25/electrum/gui/stdio.py#L26-L27

However this doesn't seem to actually exit the process for me, in the terminal I see the "Failed to parse server-string." text but the python process just hangs. Am I doing something wrong?