### PR TITLE
Add electrum_data to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/
 .idea
 .mypy_cache
 .vscode
+electrum_data
 
 # icons
 electrum/gui/kivy/theming/light-0.png


### PR DESCRIPTION
This allows you to simply run `./run_electrum --portable` during development to get a development only wallet without worrying about accidentally committing it.