### PR TITLE
Add --serverfingerprint option

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1263,7 +1263,8 @@ argparse._SubParsersAction.__call__ = subparser_call
 
 
 def add_network_options(parser):
-    parser.add_argument("-f", "--serverfingerprint", dest="serverfingerprint", default=None, help="only allow connecting to servers with a matching SSL certificate SHA256 fingerprint")
+    parser.add_argument("-f", "--serverfingerprint", dest="serverfingerprint", default=None, help="only allow connecting to servers with a matching SSL certificate SHA256 fingerprint." + " " +
+                                                                                                  "To calculate this yourself: '$ openssl x509 -noout -fingerprint -sha256 -inform pem -in mycertfile.crt'. Enter as 64 hex chars.")
     parser.add_argument("-1", "--oneserver", action="store_true", dest="oneserver", default=None, help="connect to one server only")
     parser.add_argument("-s", "--server", dest="server", default=None, help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
     parser.add_argument("-p", "--proxy", dest="proxy", default=None, help="set proxy [type:]host[:port] (or 'none' to disable proxy), where type is socks4,socks5 or http")

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1263,7 +1263,7 @@ argparse._SubParsersAction.__call__ = subparser_call
 
 
 def add_network_options(parser):
-    parser.add_argument("-f", "--fingerprint", dest="fingerprint", default=None, help="only allow connecting to servers with a matching SSL certificate SHA256 fingerprint")
+    parser.add_argument("-f", "--serverfingerprint", dest="serverfingerprint", default=None, help="only allow connecting to servers with a matching SSL certificate SHA256 fingerprint")
     parser.add_argument("-1", "--oneserver", action="store_true", dest="oneserver", default=None, help="connect to one server only")
     parser.add_argument("-s", "--server", dest="server", default=None, help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
     parser.add_argument("-p", "--proxy", dest="proxy", default=None, help="set proxy [type:]host[:port] (or 'none' to disable proxy), where type is socks4,socks5 or http")

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1263,6 +1263,7 @@ argparse._SubParsersAction.__call__ = subparser_call
 
 
 def add_network_options(parser):
+    parser.add_argument("-f", "--fingerprint", dest="fingerprint", default=None, help="only allow connecting to servers with a matching SSL certificate SHA256 fingerprint")
     parser.add_argument("-1", "--oneserver", action="store_true", dest="oneserver", default=None, help="connect to one server only")
     parser.add_argument("-s", "--server", dest="server", default=None, help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
     parser.add_argument("-p", "--proxy", dest="proxy", default=None, help="set proxy [type:]host[:port] (or 'none' to disable proxy), where type is socks4,socks5 or http")

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -183,6 +183,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.checking_accounts = False
         self.qr_window = None
         self.pluginsdialog = None
+        self.showing_cert_mismatch_error = False
         self.tl_windows = []
         Logger.__init__(self)
 
@@ -267,7 +268,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                          'banner', 'verified', 'fee', 'fee_histogram', 'on_quotes',
                          'on_history', 'channel', 'channels_updated',
                          'payment_failed', 'payment_succeeded',
-                         'invoice_status', 'request_status', 'ln_gossip_sync_progress']
+                         'invoice_status', 'request_status', 'ln_gossip_sync_progress',
+                         'cert_mismatch']
             # To avoid leaking references to "self" that prevent the
             # window from being GC-ed when closed, callbacks should be
             # methods of this class only, and specifically not be
@@ -442,6 +444,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.history_model.on_fee_histogram()
         elif event == 'ln_gossip_sync_progress':
             self.update_lightning_icon()
+        elif event == 'cert_mismatch':
+            self.show_cert_mismatch_error()
         else:
             self.logger.info(f"unexpected network event: {event} {args}")
 
@@ -3118,3 +3122,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                      "to see it, you need to broadcast it."))
             win.msg_box(QPixmap(icon_path("offline_tx.png")), None, _('Success'), msg)
             return True
+
+    def show_cert_mismatch_error(self):
+        if self.showing_cert_mismatch_error:
+            return
+        self.showing_cert_mismatch_error = True
+        self.show_critical(title=_("Certificate mismatch"),
+                           msg="\n\n" +
+                               _("The SSL certificate provided by the main server did not match the fingerprint passed in with the --serverfingerprint option.") + "\n\n" +
+                               _("Electrum will now exit."))
+        self.showing_cert_mismatch_error = False
+        self.close()

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -3128,8 +3128,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             return
         self.showing_cert_mismatch_error = True
         self.show_critical(title=_("Certificate mismatch"),
-                           msg="\n\n" +
-                               _("The SSL certificate provided by the main server did not match the fingerprint passed in with the --serverfingerprint option.") + "\n\n" +
+                           msg=_("The SSL certificate provided by the main server did not match the fingerprint passed in with the --serverfingerprint option.") + "\n\n" +
                                _("Electrum will now exit."))
         self.showing_cert_mismatch_error = False
         self.close()

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -508,6 +508,7 @@ class Interface(Logger):
         fingerprint = hashlib.sha256(certificate).hexdigest()
         fingerprints_match = fingerprint.lower() == expected_fingerprint.lower()
         if not fingerprints_match:
+            util.trigger_callback('cert_mismatch')
             raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to cert fingerprint mismatch')
         self.logger.info("cert fingerprint verification passed")
 

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -429,7 +429,9 @@ class Interface(Logger):
     @handle_disconnect
     async def run(self):
         expected_fingerprint = self.network.config.get("serverfingerprint")
-        if expected_fingerprint and not await self.verify_server_certificate(expected_fingerprint):
+        if (expected_fingerprint
+                and self.is_main_server()
+                and not await self.verify_server_certificate(expected_fingerprint)):
             raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to SSL certificate fingerprint mismatch')
         try:
             ssl_context = await self._get_ssl_context()

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -428,7 +428,7 @@ class Interface(Logger):
     @log_exceptions
     @handle_disconnect
     async def run(self):
-        expected_fingerprint = self.network.config.get("fingerprint")
+        expected_fingerprint = self.network.config.get("serverfingerprint")
         if expected_fingerprint and not await self.verify_server_certificate(expected_fingerprint):
             raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to SSL certificate fingerprint mismatch')
         try:

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -191,6 +191,7 @@ class RequestCorrupted(GracefulDisconnect): pass
 
 class ErrorParsingSSLCert(Exception): pass
 class ErrorGettingSSLCertFromServer(Exception): pass
+class ErrorSSLCertFingerprintMismatch(Exception): pass
 class ConnectError(NetworkException): pass
 
 
@@ -429,8 +430,7 @@ class Interface(Logger):
     async def run(self):
         expected_fingerprint = self.network.config.get("fingerprint")
         if expected_fingerprint and not await self.verify_server_certificate(expected_fingerprint):
-            self.logger.warning(f'Refusing to connect to server due to SSL certificate fingerprint mismatch')
-            return
+            raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to SSL certificate fingerprint mismatch')
         try:
             ssl_context = await self._get_ssl_context()
         except (ErrorParsingSSLCert, ErrorGettingSSLCertFromServer) as e:

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -429,10 +429,11 @@ class Interface(Logger):
     @handle_disconnect
     async def run(self):
         expected_fingerprint = self.network.config.get("serverfingerprint")
-        if (expected_fingerprint
-                and self.is_main_server()
-                and not await self.verify_server_certificate(expected_fingerprint)):
-            raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to SSL certificate fingerprint mismatch')
+        if (expected_fingerprint and self.is_main_server()):
+            if self.protocol is not 's':
+                raise Error(f'cannot use --serverfingerprint with non-SSL servers')
+            if not await self.verify_server_certificate(expected_fingerprint):
+                raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to SSL certificate fingerprint mismatch')
         try:
             ssl_context = await self._get_ssl_context()
         except (ErrorParsingSSLCert, ErrorGettingSSLCertFromServer) as e:

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -428,11 +428,9 @@ class Interface(Logger):
     @handle_disconnect
     async def run(self):
         expected_fingerprint = self.network.config.get("fingerprint")
-        if expected_fingerprint:
-            has_matching_certificate = await self.verify_server_certificate(expected_fingerprint)
-            if not has_matching_certificate:
-                self.logger.warning(f'Refusing to connect to main server due to SSL certificate fingerprint mismatch')
-                return
+        if expected_fingerprint and not await self.verify_server_certificate(expected_fingerprint):
+            self.logger.warning(f'Refusing to connect to main server due to SSL certificate fingerprint mismatch')
+            return
         try:
             ssl_context = await self._get_ssl_context()
         except (ErrorParsingSSLCert, ErrorGettingSSLCertFromServer) as e:

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -429,7 +429,7 @@ class Interface(Logger):
     async def run(self):
         expected_fingerprint = self.network.config.get("fingerprint")
         if expected_fingerprint and not await self.verify_server_certificate(expected_fingerprint):
-            self.logger.warning(f'Refusing to connect to main server due to SSL certificate fingerprint mismatch')
+            self.logger.warning(f'Refusing to connect to server due to SSL certificate fingerprint mismatch')
             return
         try:
             ssl_context = await self._get_ssl_context()

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -192,6 +192,7 @@ class RequestCorrupted(GracefulDisconnect): pass
 class ErrorParsingSSLCert(Exception): pass
 class ErrorGettingSSLCertFromServer(Exception): pass
 class ErrorSSLCertFingerprintMismatch(Exception): pass
+class InvalidOptionCombination(Exception): pass
 class ConnectError(NetworkException): pass
 
 
@@ -430,8 +431,8 @@ class Interface(Logger):
     async def run(self):
         expected_fingerprint = self.network.config.get("serverfingerprint")
         if (expected_fingerprint and self.is_main_server()):
-            if self.protocol is not 's':
-                raise Error(f'cannot use --serverfingerprint with non-SSL servers')
+            if self.protocol != 's':
+                raise InvalidOptionCombination(f'cannot use --serverfingerprint with non-SSL servers')
             if not await self.verify_server_certificate(expected_fingerprint):
                 raise ErrorSSLCertFingerprintMismatch('Refusing to connect to server due to SSL certificate fingerprint mismatch')
         try:

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -353,6 +353,8 @@ class Interface(Logger):
     async def _try_saving_ssl_cert_for_first_time(self, ca_ssl_context):
         ca_signed = await self.is_server_ca_signed(ca_ssl_context)
         if ca_signed:
+            if self.network.config.get("serverfingerprint"):
+                raise InvalidOptionCombination("cannot use --serverfingerprint with CA signed servers")
             with open(self.cert_path, 'w') as f:
                 # empty file means this is CA signed, not self-signed
                 f.write('')
@@ -365,6 +367,8 @@ class Interface(Logger):
         with open(self.cert_path, 'r') as f:
             contents = f.read()
         if contents == '':  # CA signed
+            if self.network.config.get("serverfingerprint"):
+                raise InvalidOptionCombination("cannot use --serverfingerprint with CA signed servers")
             return True
         # pinned self-signed cert
         try:


### PR DESCRIPTION
Resolves #6084 

Needs a bit more work but it's fully functional and testable now.

If you want to test against my server you can run:

```
$ ./run_electrum --oneserver --server bitcoin.lukechilds.co:50002:s --serverfingerprint ED1FE28B21A5943A8810747B2A6DDFC0E3089115D6205125E5C4D3EE8E126F80
```

This should connect as normal.

If you run:

```
$ ./run_electrum --oneserver --server bitcoin.lukechilds.co:50002:s --serverfingerprint DEADBEEF
```

Then an `ErrorSSLCertFingerprintMismatch` error should be thrown.

Two questions:

1. `ErrorSSLCertFingerprintMismatch` is being caught somewhere so it doesn't kill the app, the connection keeps being retried. It's not entirely clear to me where this is getting handled. Instead I want the error handler to exit the application if it encounters an `ErrorSSLCertFingerprintMismatch`. Where should I add this logic?

2. I need to display an error dialog to GUI users before exit, informing them of the fingerprint mismatch. Is it ok to do Qt stuff directly inside `interface.py`? It seems like maybe that's not the right place. What's the best way to structure that?