### PR TITLE
set more restrictive file permissions for exported private keys

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2729,6 +2729,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
     def do_export_privkeys(self, fileName, pklist, is_csv):
         with open(fileName, "w+") as f:
+            os.chmod(fileName, 0o600)
             if is_csv:
                 transaction = csv.writer(f)
                 transaction.writerow(["address", "private_key"])


### PR DESCRIPTION
When you export private keys to a file (electrum-private-keys.csv or .json), it's created with default file permissions (644 on my system), which is not very secure for private keys I think. Let's use 600 instead.