### PR TITLE
wallet: disallow fee-bumping/coinjoining ln funding tx

### DIFF
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -170,9 +170,9 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
         ptx_merge_sigs_action = QAction(_("Merge signatures from"), self)
         ptx_merge_sigs_action.triggered.connect(self.merge_sigs)
         partial_tx_actions_menu.addAction(ptx_merge_sigs_action)
-        ptx_join_txs_action = QAction(_("Join inputs/outputs"), self)
-        ptx_join_txs_action.triggered.connect(self.join_tx_with_another)
-        partial_tx_actions_menu.addAction(ptx_join_txs_action)
+        self._ptx_join_txs_action = QAction(_("Join inputs/outputs"), self)
+        self._ptx_join_txs_action.triggered.connect(self.join_tx_with_another)
+        partial_tx_actions_menu.addAction(self._ptx_join_txs_action)
         self.partial_tx_actions_button = QToolButton()
         self.partial_tx_actions_button.setText(_("Combine"))
         self.partial_tx_actions_button.setMenu(partial_tx_actions_menu)
@@ -499,6 +499,8 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
                 widget.menuAction().setVisible(show_psbt_only_widgets)
             else:
                 widget.setVisible(show_psbt_only_widgets)
+        if tx_details.is_lightning_funding_tx:
+            self._ptx_join_txs_action.setEnabled(False)  # would change txid
 
         self.save_button.setEnabled(tx_details.can_save_as_local)
         if tx_details.can_save_as_local:


### PR DESCRIPTION
related: #6127

This PR makes it explicit that funding txns cannot be fee-bumped.
It also closes the add inputs/outputs flow described in https://github.com/spesmilo/electrum/issues/6127#issuecomment-622070937. i.e. we disallow joining a partial tx that we know is a funding tx of ours

It does not seem possible to completely close down all footguns re changing the txid of a funding tx via adding inputs/outputs, as e.g. the user could
- create tx1 in wallet1, which is a funding tx for a channel open
- create tx2 in wallet2
- join them together in wallet2, through e.g. the "Load transaction" menu
- and then broadcast; resulting in most likely losing the coins intended for the channel open