### PR TITLE
Allow going "back" in the installwizard when in show_xpub_dialog

### DIFF
--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -549,7 +549,7 @@ class BaseWizard(Logger):
             if len(self.keystores) == 0:
                 xpub = k.get_master_public_key()
                 self.run('show_xpub_and_add_cosigners', xpub)
-                # self.reset_stack()
+                self.reset_stack()
             self.keystores.append(k)
             if len(self.keystores) < self.n:
                 self.run('choose_keystore')

--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -117,6 +117,7 @@ class BaseWizard(Logger):
             raise Exception("unknown action", action)
 
     def can_go_back(self):
+        print(self._stack)
         return len(self._stack) > 1
 
     def go_back(self, *, rerun_previous: bool = True) -> None:
@@ -546,12 +547,12 @@ class BaseWizard(Logger):
                     self.show_error(_('Cannot add this cosigner:') + '\n' + "Their key type is '%s', we are '%s'"%(t1, t2))
                     self.run('choose_keystore')
                     return
-            self.keystores.append(k)
-            if len(self.keystores) == 1:
+            if len(self.keystores) == 0:
                 xpub = k.get_master_public_key()
-                self.reset_stack()
                 self.run('show_xpub_and_add_cosigners', xpub)
-            elif len(self.keystores) < self.n:
+                # self.reset_stack()
+            self.keystores.append(k)
+            if len(self.keystores) < self.n:
                 self.run('choose_keystore')
             else:
                 self.run('create_wallet')
@@ -641,7 +642,7 @@ class BaseWizard(Logger):
         raise NotImplementedError()  # implemented by subclasses
 
     def show_xpub_and_add_cosigners(self, xpub):
-        self.show_xpub_dialog(xpub=xpub, run_next=lambda x: self.run('choose_keystore'))
+        self.show_xpub_dialog(xpub=xpub, run_next=lambda x: None)
 
     def choose_seed_type(self, message=None, choices=None):
         title = _('Choose Seed type')

--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -117,7 +117,6 @@ class BaseWizard(Logger):
             raise Exception("unknown action", action)
 
     def can_go_back(self):
-        print(self._stack)
         return len(self._stack) > 1
 
     def go_back(self, *, rerun_previous: bool = True) -> None:

--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -549,7 +549,7 @@ class BaseWizard(Logger):
             if len(self.keystores) == 0:
                 xpub = k.get_master_public_key()
                 self.run('show_xpub_and_add_cosigners', xpub)
-                self.reset_stack()
+            self.reset_stack()
             self.keystores.append(k)
             if len(self.keystores) < self.n:
                 self.run('choose_keystore')


### PR DESCRIPTION
Problem was described in https://github.com/spesmilo/electrum/issues/6145

The order of execution (before) was:
1. self.keystores.append(k)  (Because this was done first it prevented going back)
2. show_xpub_and_add_cosigners
3. choose_keystore  (called from inside show_xpub_and_add_cosigners)

Now it is:
1. show_xpub_and_add_cosigners 
2. self.keystores.append(k)
3. choose_keystore 

The neat thing is that the code of on_keystore is now actually more simple, because it removes calling choose_keystore from inside show_xpub_and_add_cosigners.

Additionally it also fixes a small bug:
- Previously: self.reset_stack() was only called if   len(self.keystores) == 1 . Therefore allows going back for all len(self.keystores) > 2. 
- Now: self.reset_stack()  is called regardless of  len(self.keystores), and therefore ensures one cannot go back after self.keystores.append(k)  is executed.

Tested on qt testnet (linux).
