### PR TITLE
RPC client: exit code 1 if RPC server returned error

### DIFF
--- a/run_electrum
+++ b/run_electrum
@@ -433,6 +433,7 @@ if __name__ == '__main__':
         print_msg(result)
     elif type(result) is dict and result.get('error'):
         print_stderr(result.get('error'))
+        sys_exit(1)
     elif result is not None:
         print_msg(json_encode(result))
     sys_exit(0)


### PR DESCRIPTION
The RPC client was returning an exit code of 0 (success) if the server returned an error; this was confusing to tools that expect an error to be reflected in the exit code.  (If you prefer a different nonzero exit code, let me know; it just definitely shouldn't be 0.)