### PR TITLE
appimage: update openssl

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update -q && \
         autoconf=2.69-9 \
         libtool=2.4.6-0.1 \
         xz-utils=5.1.1alpha+20120614-2ubuntu2 \
-        libssl-dev=1.0.2g-1ubuntu4.15 \
-        libssl1.0.0=1.0.2g-1ubuntu4.15 \
-        openssl=1.0.2g-1ubuntu4.15 \
+        libssl-dev=1.0.2g-1ubuntu4.16 \
+        libssl1.0.0=1.0.2g-1ubuntu4.16 \
+        openssl=1.0.2g-1ubuntu4.16 \
         zlib1g-dev=1:1.2.8.dfsg-2ubuntu4.3 \
         libffi-dev=3.2.1-4 \
         libncurses5-dev=6.0+20160213-1ubuntu1 \


### PR DESCRIPTION
E: Version '1.0.2g-1ubuntu4.15' for 'libssl-dev' was not found
E: Version '1.0.2g-1ubuntu4.15' for 'libssl1.0.0' was not found
E: Version '1.0.2g-1ubuntu4.15' for 'openssl' was not found
Now version is 1.0.2g-1ubuntu4.16
https://packages.ubuntu.com/xenial/openssl