### PR TITLE
enable streaming full UTXOs for all types of inputs

### DIFF
--- a/electrum/plugins/trezor/trezor.py
+++ b/electrum/plugins/trezor/trezor.py
@@ -88,8 +88,8 @@ class TrezorKeyStore(Hardware_KeyStore):
         prev_tx = {}
         for txin in tx.inputs():
             tx_hash = txin.prevout.txid.hex()
-            if txin.utxo is None and not Transaction.is_segwit_input(txin):
-                raise UserFacingException(_('Missing previous tx for legacy input.'))
+            if txin.utxo is None:
+                raise UserFacingException(_('Missing previous tx.'))
             prev_tx[tx_hash] = txin.utxo
 
         self.plugin.sign_transaction(self, tx, prev_tx)

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1390,7 +1390,6 @@ class PartialTxInput(TxInput, PSBTSection):
     def convert_utxo_to_witness_utxo(self) -> None:
         if self.utxo:
             self.witness_utxo = self.utxo.outputs()[self.prevout.out_idx]
-            self.utxo = None  # type: Optional[Transaction]
 
     def is_native_segwit(self) -> Optional[bool]:
         """Whether this input is native segwit. None means inconclusive."""

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1381,15 +1381,15 @@ class PartialTxInput(TxInput, PSBTSection):
         self.finalize()
 
     def ensure_there_is_only_one_utxo(self):
+        # we prefer having the full previous tx, even for segwit inputs. see #6198
+        # for witness v1, witness_utxo will be enough though
         if self.utxo is not None and self.witness_utxo is not None:
-            if Transaction.is_segwit_input(self):
-                self.utxo = None
-            else:
-                self.witness_utxo = None
+            self.witness_utxo = None
 
     def convert_utxo_to_witness_utxo(self) -> None:
         if self.utxo:
             self.witness_utxo = self.utxo.outputs()[self.prevout.out_idx]
+            self.utxo = None  # type: Optional[Transaction]
 
     def is_native_segwit(self) -> Optional[bool]:
         """Whether this input is native segwit. None means inconclusive."""

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1409,23 +1409,14 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
         pass  # implemented by subclasses
 
     def _add_input_utxo_info(self, txin: PartialTxInput, address: str) -> None:
-        if Transaction.is_segwit_input(txin):
-            if txin.witness_utxo is None:
-                received, spent = self.get_addr_io(address)
-                item = received.get(txin.prevout.to_str())
-                if item:
-                    txin_value = item[1]
-                    txin.witness_utxo = TxOutput.from_address_and_value(address, txin_value)
-        else:  # legacy input
-            if txin.utxo is None:
-                # note: for hw wallets, for legacy inputs, ignore_network_issues used to be False
-                txin.utxo = self.get_input_tx(txin.prevout.txid.hex(), ignore_network_issues=True)
+        if txin.utxo is None:
+            # note: for hw wallets, for legacy inputs, ignore_network_issues used to be False
+            txin.utxo = self.get_input_tx(txin.prevout.txid.hex(), ignore_network_issues=True)
         # If there is a NON-WITNESS UTXO, but we know input is segwit, add a WITNESS UTXO, based on it.
         # This could have happened if previously another wallet had put a NON-WITNESS UTXO for txin,
         # as they did not know if it was segwit. This switch is needed to interop with bitcoin core.
         if txin.utxo and Transaction.is_segwit_input(txin):
             txin.convert_utxo_to_witness_utxo()
-        txin.ensure_there_is_only_one_utxo()
 
     def _learn_derivation_path_for_address_from_txinout(self, txinout: Union[PartialTxInput, PartialTxOutput],
                                                         address: str) -> bool:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1412,11 +1412,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
         if txin.utxo is None:
             # note: for hw wallets, for legacy inputs, ignore_network_issues used to be False
             txin.utxo = self.get_input_tx(txin.prevout.txid.hex(), ignore_network_issues=True)
-        # If there is a NON-WITNESS UTXO, but we know input is segwit, add a WITNESS UTXO, based on it.
-        # This could have happened if previously another wallet had put a NON-WITNESS UTXO for txin,
-        # as they did not know if it was segwit. This switch is needed to interop with bitcoin core.
-        if txin.utxo and Transaction.is_segwit_input(txin):
-            txin.convert_utxo_to_witness_utxo()
+        txin.ensure_there_is_only_one_utxo()
 
     def _learn_derivation_path_for_address_from_txinout(self, txinout: Union[PartialTxInput, PartialTxOutput],
                                                         address: str) -> bool:


### PR DESCRIPTION
A security issue* in the design of BIP-143 allows an attacker to lie about segwit input amounts and get the user to pay an unexpectedly high transaction fee. The problem affects all HWW vendors.

We are fixing this by making Trezor require the full UTXO for all types of inputs, so we can validate that the input amount is correct.

To facilitate that, we need Electrum to provide full UTXOs for all input types. (This goes against the recommendation in BIP-174, saying that `NON_WITNESS_UTXO` should not be provided for SegWit inputs. Nevertheless, the resulting PSBT is still valid AFAICT.)

This PR enables that for Trezor, modifications for other HWW vendors will most likely also be required. Also I'm not sure whether this is a complete PR, perhaps my modifications to the data model are breaking something?

Without this modification, it will be impossible to sign SegWit transactions on Trezor firmwares starting with 1.9.1 and 2.3.1.

*) Details in our blogpost: https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-1-and-trezor-model-t-version-2-3-1-1eba8f60f2dd