### PR TITLE
Automated BIP39 Recovery

### DIFF
--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -404,7 +404,7 @@ class BaseWizard(Logger):
         else:
             raise Exception('unknown purpose: %s' % purpose)
 
-    def derivation_and_script_type_dialog(self, f, get_account_xpub=None):
+    def derivation_and_script_type_dialog(self, f, *, get_account_xpub=None):
         message1 = _('Choose the type of addresses in your wallet.')
         message2 = ' '.join([
             _('You can override the suggested derivation path.'),
@@ -516,7 +516,7 @@ class BaseWizard(Logger):
             account_node = root_node.subkey_at_private_derivation(account_path)
             account_xpub = account_node.to_xpub()
             return account_xpub
-        self.derivation_and_script_type_dialog(f, get_account_xpub)
+        self.derivation_and_script_type_dialog(f, get_account_xpub=get_account_xpub)
 
     def create_keystore(self, seed, passphrase):
         k = keystore.from_seed(seed, passphrase, self.wallet_type == 'multisig')

--- a/electrum/bip39_recovery.py
+++ b/electrum/bip39_recovery.py
@@ -2,6 +2,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file LICENCE or http://www.opensource.org/licenses/mit-license.php
 
+from typing import TYPE_CHECKING
+
 from aiorpcx import TaskGroup
 
 from . import bitcoin
@@ -10,7 +12,11 @@ from .bip32 import BIP32_PRIME, BIP32Node
 from .bip32 import convert_bip32_path_to_list_of_uint32 as bip32_str_to_ints
 from .bip32 import convert_bip32_intpath_to_strpath as bip32_ints_to_str
 
-async def account_discovery(network, get_account_xpub):
+if TYPE_CHECKING:
+    from .network import Network
+
+
+async def account_discovery(network: 'Network', get_account_xpub):
     async with TaskGroup() as group:
         account_scan_tasks = []
         for wallet_format in BIP39_WALLET_FORMATS:
@@ -21,13 +27,14 @@ async def account_discovery(network, get_account_xpub):
         active_accounts.extend(task.result())
     return active_accounts
 
-async def scan_for_active_accounts(network, get_account_xpub, wallet_format):
+
+async def scan_for_active_accounts(network: 'Network', get_account_xpub, wallet_format):
     active_accounts = []
     account_path = bip32_str_to_ints(wallet_format["derivation_path"])
     while True:
         account_xpub = get_account_xpub(account_path)
         account_node = BIP32Node.from_xkey(account_xpub)
-        has_history = await account_has_history(network, account_node, wallet_format["script_type"]);
+        has_history = await account_has_history(network, account_node, wallet_format["script_type"])
         if has_history:
             account = format_account(wallet_format, account_path)
             active_accounts.append(account)
@@ -36,7 +43,8 @@ async def scan_for_active_accounts(network, get_account_xpub, wallet_format):
         account_path[-1] = account_path[-1] + 1
     return active_accounts
 
-async def account_has_history(network, account_node, script_type):
+
+async def account_has_history(network: 'Network', account_node: BIP32Node, script_type: str) -> bool:
     gap_limit = 20
     async with TaskGroup() as group:
         get_history_tasks = []
@@ -53,6 +61,7 @@ async def account_has_history(network, account_node, script_type):
         if len(history) > 0:
             return True
     return False
+
 
 def format_account(wallet_format, account_path):
     description = wallet_format["description"]

--- a/electrum/bip39_recovery.py
+++ b/electrum/bip39_recovery.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2020 The Electrum developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENCE or http://www.opensource.org/licenses/mit-license.php
+
+from aiorpcx import TaskGroup
+
+from . import bitcoin
+from .constants import BIP39_WALLET_FORMATS
+from .bip32 import BIP32_PRIME, BIP32Node
+from .bip32 import convert_bip32_path_to_list_of_uint32 as bip32_str_to_ints
+from .bip32 import convert_bip32_intpath_to_strpath as bip32_ints_to_str
+
+async def account_discovery(network, get_account_xpub):
+    async with TaskGroup() as group:
+        account_scan_tasks = []
+        for wallet_format in BIP39_WALLET_FORMATS:
+            account_scan = scan_for_active_accounts(network, get_account_xpub, wallet_format)
+            account_scan_tasks.append(await group.spawn(account_scan))
+    active_accounts = []
+    for task in account_scan_tasks:
+        active_accounts.extend(task.result())
+    return active_accounts
+
+async def scan_for_active_accounts(network, get_account_xpub, wallet_format):
+    active_accounts = []
+    account_path = bip32_str_to_ints(wallet_format["derivation_path"])
+    while True:
+        account_xpub = get_account_xpub(account_path)
+        account_node = BIP32Node.from_xkey(account_xpub)
+        has_history = await account_has_history(network, account_node, wallet_format["script_type"]);
+        if has_history:
+            account = format_account(wallet_format, account_path)
+            active_accounts.append(account)
+        if not has_history or not wallet_format["iterate_accounts"]:
+            break
+        account_path[-1] = account_path[-1] + 1
+    return active_accounts
+
+async def account_has_history(network, account_node, script_type):
+    gap_limit = 20
+    async with TaskGroup() as group:
+        get_history_tasks = []
+        for address_index in range(gap_limit):
+            address_node = account_node.subkey_at_public_derivation("0/" + str(address_index))
+            pubkey = address_node.eckey.get_public_key_hex()
+            address = bitcoin.pubkey_to_address(script_type, pubkey)
+            script = bitcoin.address_to_script(address)
+            scripthash = bitcoin.script_to_scripthash(script)
+            get_history = network.get_history_for_scripthash(scripthash)
+            get_history_tasks.append(await group.spawn(get_history))
+    for task in get_history_tasks:
+        history = task.result()
+        if len(history) > 0:
+            return True
+    return False
+
+def format_account(wallet_format, account_path):
+    description = wallet_format["description"]
+    if wallet_format["iterate_accounts"]:
+        account_index = account_path[-1] % BIP32_PRIME
+        description = f'{description} (Account {account_index})'
+    return {
+        "description": description,
+        "derivation_path": bip32_ints_to_str(account_path),
+        "script_type": wallet_format["script_type"],
+    }

--- a/electrum/bip39_wallet_formats.json
+++ b/electrum/bip39_wallet_formats.json
@@ -1,0 +1,80 @@
+[
+    {
+        "description": "Standard BIP44 legacy",
+        "derivation_path": "m/44'/0'/0'",
+        "script_type": "p2pkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Standard BIP49 compatibility segwit",
+        "derivation_path": "m/49'/0'/0'",
+        "script_type": "p2wpkh-p2sh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Standard BIP84 native segwit",
+        "derivation_path": "m/84'/0'/0'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Non-standard legacy",
+        "derivation_path": "m/0'",
+        "script_type": "p2pkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Non-standard compatibility segwit",
+        "derivation_path": "m/0'",
+        "script_type": "p2wpkh-p2sh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Non-standard native segwit",
+        "derivation_path": "m/0'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Copay native segwit",
+        "derivation_path": "m/44'/0'/0'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Samourai Bad Bank (toxic change)",
+        "derivation_path": "m/84'/0'/2147483644'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": false
+    },
+    {
+        "description": "Samourai Whirlpool Pre Mix",
+        "derivation_path": "m/84'/0'/2147483645'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": false
+    },
+    {
+        "description": "Samourai Whirlpool Post Mix",
+        "derivation_path": "m/84'/0'/2147483646'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": false
+    },
+    {
+        "description": "Samourai Ricochet legacy",
+        "derivation_path": "m/44'/0'/2147483647'",
+        "script_type": "p2pkh",
+        "iterate_accounts": false
+    },
+    {
+        "description": "Samourai Ricochet compatibility segwit",
+        "derivation_path": "m/49'/0'/2147483647'",
+        "script_type": "p2wpkh-p2sh",
+        "iterate_accounts": false
+    },
+    {
+        "description": "Samourai Ricochet native segwit",
+        "derivation_path": "m/84'/0'/2147483647'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": false
+    }
+]

--- a/electrum/constants.py
+++ b/electrum/constants.py
@@ -42,6 +42,7 @@ def read_json(filename, default):
 
 GIT_REPO_URL = "https://github.com/spesmilo/electrum"
 GIT_REPO_ISSUES_URL = "https://github.com/spesmilo/electrum/issues"
+BIP39_WALLET_FORMATS = read_json('bip39_wallet_formats.json', [])
 
 
 class AbstractNet:

--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -1115,7 +1115,7 @@ class InstallWizard(BaseWizard, Widget):
     def multisig_dialog(self, **kwargs): WizardMultisigDialog(self, **kwargs).open()
     def show_seed_dialog(self, **kwargs): ShowSeedDialog(self, **kwargs).open()
     def line_dialog(self, **kwargs): LineDialog(self, **kwargs).open()
-    def choice_and_line_dialog(self, **kwargs): ChoiceLineDialog(self, **kwargs).open()
+    def derivation_and_script_type_gui_specific_dialog(self, **kwargs): ChoiceLineDialog(self, **kwargs).open()
 
     def confirm_seed_dialog(self, **kwargs):
         kwargs['title'] = _('Confirm Seed')

--- a/electrum/gui/qt/bip39_recovery_dialog.py
+++ b/electrum/gui/qt/bip39_recovery_dialog.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2020 The Electrum developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENCE or http://www.opensource.org/licenses/mit-license.php
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGridLayout, QLabel, QListWidget, QListWidgetItem
+
+from electrum.i18n import _
+from electrum.network import Network
+from electrum.bip39_recovery import account_discovery
+
+from .util import WindowModalDialog, MessageBoxMixin, TaskThread, Buttons, CancelButton, OkButton
+
+class Bip39RecoveryDialog(WindowModalDialog):
+    def __init__(self, parent: QWidget, get_account_xpub, on_account_select):
+        self.get_account_xpub = get_account_xpub
+        self.on_account_select = on_account_select
+        WindowModalDialog.__init__(self, parent, _('BIP39 Recovery'))
+        self.setMinimumWidth(400)
+        vbox = QVBoxLayout(self)
+        self.content = QVBoxLayout()
+        self.content.addWidget(QLabel(_('Scanning common paths for existing accounts...')))
+        vbox.addLayout(self.content)
+        self.ok_button = OkButton(self)
+        self.ok_button.clicked.connect(self.on_ok_button_click)
+        self.ok_button.setEnabled(False)
+        vbox.addLayout(Buttons(CancelButton(self), self.ok_button))
+        self.show()
+        self.thread = TaskThread(self)
+        self.thread.finished.connect(self.deleteLater) # see #3956
+        self.thread.add(self.recovery, self.on_recovery_success, None, self.on_recovery_error)
+
+    def on_ok_button_click(self):
+        item = self.list.currentItem()
+        account = item.data(Qt.UserRole)
+        self.on_account_select(account)
+
+    def recovery(self):
+        network = Network.get_instance()
+        coroutine = account_discovery(network, self.get_account_xpub)
+        return network.run_from_another_thread(coroutine)
+
+    def on_recovery_success(self, accounts):
+        self.clear_content()
+        if len(accounts) == 0:
+            self.content.addWidget(QLabel(_('No existing accounts found.')))
+            return
+        self.content.addWidget(QLabel(_('Choose an account to restore.')))
+        self.list = QListWidget()
+        for account in accounts:
+            item = QListWidgetItem(account['description'])
+            item.setData(Qt.UserRole, account)
+            self.list.addItem(item)
+        self.list.clicked.connect(lambda: self.ok_button.setEnabled(True))
+        self.content.addWidget(self.list)
+
+    def on_recovery_error(self, error):
+        self.clear_content()
+        self.content.addWidget(QLabel(_('Error: Account discovery failed.')))
+        print(error)
+
+    def clear_content(self):
+        for i in reversed(range(self.content.count())):
+            self.content.itemAt(i).widget().setParent(None)

--- a/electrum/gui/qt/installwizard.py
+++ b/electrum/gui/qt/installwizard.py
@@ -604,9 +604,18 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         return clayout.selected_index()
 
     @wizard_dialog
-    def derivation_and_script_type_gui_specific_dialog(self, title: str, message1: str, choices: List[Tuple[str, str, str]],
-                               message2: str, test_text: Callable[[str], int],
-                               run_next, default_choice_idx: int=0, get_account_xpub=None) -> Tuple[str, str]:
+    def derivation_and_script_type_gui_specific_dialog(
+            self,
+            *,
+            title: str,
+            message1: str,
+            choices: List[Tuple[str, str, str]],
+            message2: str,
+            test_text: Callable[[str], int],
+            run_next,
+            default_choice_idx: int = 0,
+            get_account_xpub=None
+    ) -> Tuple[str, str]:
         vbox = QVBoxLayout()
 
         if get_account_xpub:

--- a/electrum/scripts/bip39_recovery.py
+++ b/electrum/scripts/bip39_recovery.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+import asyncio
+
+from electrum.util import json_encode, print_msg, create_and_start_event_loop, log_exceptions
+from electrum.simple_config import SimpleConfig
+from electrum.network import Network
+from electrum.keystore import bip39_to_seed
+from electrum.bip32 import BIP32Node
+from electrum.bip39_recovery import account_discovery
+
+try:
+    mnemonic = sys.argv[1]
+    passphrase = sys.argv[2] if len(sys.argv) > 2 else ""
+except Exception:
+    print("usage: bip39_recovery <mnemonic> [<passphrase>]")
+    sys.exit(1)
+
+loop, stopping_fut, loop_thread = create_and_start_event_loop()
+
+config = SimpleConfig()
+network = Network(config)
+network.start()
+
+@log_exceptions
+async def f():
+    try:
+        def get_account_xpub(account_path):
+            root_seed = bip39_to_seed(mnemonic, passphrase)
+            root_node = BIP32Node.from_rootseed(root_seed, xtype="standard")
+            account_node = root_node.subkey_at_private_derivation(account_path)
+            account_xpub = account_node.to_xpub()
+            return account_xpub
+        active_accounts = await account_discovery(network, get_account_xpub)
+        print_msg(json_encode(active_accounts))
+    finally:
+        stopping_fut.set_result(1)
+
+asyncio.run_coroutine_threadsafe(f(), loop)


### PR DESCRIPTION
Resolves #6155 

Implements automated scanning of all known BIP32 chains that can be imported into Electrum.

I'm opening this PR for review, it's not ready to be merged yet. Account discovery is functional but still needs to be integrated in to the GUI.

Currently it's implemented as a script for easy testing, you can quickly test it out by running the `electrum/scripts/bip39_recovery.py` script with a `mnemonic` parameter and also an optional second `passphrase` parameter. It will return a list of any previously used accounts it can find. You can use this mnemonic that I've created a few test accounts in:

```
much bottom such hurt hunt welcome cushion erosion pulse admit name deer
```

e.g:

```
$ ./bip39_recovery.py "much bottom such hurt hunt welcome cushion erosion pulse admit name deer"
[
    {
        "derivation_path": "m/84'/0'/0'",
        "description": "Standard BIP84 native segwit (Account 0)",
        "script_type": "p2wpkh"
    },
    {
        "derivation_path": "m/84'/0'/1'",
        "description": "Standard BIP84 native segwit (Account 1)",
        "script_type": "p2wpkh"
    },
    {
        "derivation_path": "m/0'",
        "description": "Non-standard legacy (Account 0)",
        "script_type": "p2pkh"
    },
    {
        "derivation_path": "m/84'/0'/2147483646'",
        "description": "Samourai Whirlpool post-mix",
        "script_type": "p2wpkh"
    }
]
```

**Diversions from BIP44**

Due to the fact that at discovery we only need to check which accounts has been used, not the final balance of each account, we take a few shortcuts:
- Don't scan the change chain, if a BIP44 compliant account is used it will have received a TX in one of the first 20 (BIP44 gap limit) addresses of the external chain.
- Move on to the next account as soon as we find a single address with funds. No need to keep scanning until we exhaust the gap limit.

If one of the discovered accounts is selected by the user for recovery, then Electrum will proceed to properly scan both internal external chains and exhaust the gap limit when it creates the wallet.

**Limitations**

Electrum takes an account level import path like `m/84'/0'/0'` and derives the wallet with the non hardened `is_change/address_index` sub trees. Due to this we cannot import Bitcoin Core accounts as they use the format [`m/0'/0'/address_index'`](https://github.com/bitcoin/bitcoin/issues/13302#issuecomment-391227927), notice all sub trees use hardened derivation.

All other wallets listed on walletsrecovery.org can be successfully recovered.

---

Please let me know if this code looks ok so far. Next steps will be to migrate the account discovery code from the script to `electrum.bip39_recovery` and then integrate it in to the recovery wizard GUI.

CC @ecdsa @SomberNight @aantonop