### PR TITLE
anti-fee-sniping for lnsweep and swap claim

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -12,7 +12,7 @@ from .transaction import TxOutpoint, PartialTxInput, PartialTxOutput, PartialTra
 from .transaction import script_GetOp, match_script_against_template, OPPushDataGeneric, OPPushDataPubkey
 from .util import log_exceptions
 from .lnutil import REDEEM_AFTER_DOUBLE_SPENT_DELAY, ln_dummy_address, LN_MAX_HTLC_VALUE_MSAT
-from .bitcoin import dust_threshold
+from .bitcoin import dust_threshold, get_locktime_for_new_transaction
 from .logging import Logger
 from .lnutil import hex_to_bytes
 from .json_db import StoredObject
@@ -104,6 +104,7 @@ def create_claim_tx(
         txin.script_sig = bytes.fromhex(push_script(txin.redeem_script.hex()))
     txin.witness_script = witness_script
     txout = PartialTxOutput.from_address_and_value(address, amount_sat)
+    locktime = max(locktime, get_locktime_for_new_transaction())  # anti fee-sniping
     tx = PartialTransaction.from_io([txin], [txout], version=2, locktime=locktime)
     #tx.set_rbf(True)
     sig = bytes.fromhex(tx.sign_txin(0, privkey))

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -56,7 +56,7 @@ from .util import (NotEnoughFunds, UserCancelled, profiler,
                    Fiat, bfh, bh2u, TxMinedInfo, quantize_feerate, create_bip21_uri, OrderedDictWithIndex)
 from .util import get_backup_dir
 from .simple_config import SimpleConfig
-from .bitcoin import COIN, TYPE_ADDRESS
+from .bitcoin import COIN, TYPE_ADDRESS, get_locktime_for_new_transaction
 from .bitcoin import is_address, address_to_script, is_minikey, relayfee, dust_threshold
 from .crypto import sha256d
 from . import keystore
@@ -189,23 +189,6 @@ def sweep(privkeys, *, network: 'Network', config: 'SimpleConfig',
         tx.set_rbf(True)
     tx.sign(keypairs)
     return tx
-
-
-def get_locktime_for_new_transaction(network: 'Network') -> int:
-    # if no network or not up to date, just set locktime to zero
-    if not network:
-        return 0
-    chain = network.blockchain()
-    if chain.is_tip_stale():
-        return 0
-    # discourage "fee sniping"
-    locktime = chain.height()
-    # sometimes pick locktime a bit further back, to help privacy
-    # of setups that need more time (offline/multisig/coinjoin/...)
-    if random.randint(0, 9) == 0:
-        locktime = max(0, locktime - random.randint(0, 99))
-    return locktime
-
 
 
 class CannotBumpFee(Exception): pass


### PR DESCRIPTION
We set the locktime to the chaintip for wallet transactions.
We do this for anti-fee-sniping reasons (and to imitate Bitcoin Core):
https://github.com/bitcoin/bitcoin/blob/c27330897d84144ad128994dc51efde6084e796f/src/wallet/wallet.cpp#L2617

Currently this is only done for wallet transactions, so e.g. not lightning sweep stuff and submarine swap claim txs.

Note however that wallet transactions are made with user interaction, while ln sweeps and swap claims are automated.
Related:
https://github.com/spesmilo/electrum/issues/6254#issuecomment-647233004

