### PR TITLE
qt StatusBarButton: use QToolButton instead of QPushButton

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -46,7 +46,7 @@ from PyQt5.QtWidgets import (QMessageBox, QComboBox, QSystemTrayIcon, QTabWidget
                              QHBoxLayout, QPushButton, QScrollArea, QTextEdit,
                              QShortcut, QMainWindow, QCompleter, QInputDialog,
                              QWidget, QSizePolicy, QStatusBar, QToolTip, QDialog,
-                             QMenu, QAction, QStackedWidget)
+                             QMenu, QAction, QStackedWidget, QToolButton)
 
 import electrum
 from electrum import (keystore, ecc, constants, util, bitcoin, commands,
@@ -104,11 +104,14 @@ if TYPE_CHECKING:
 
 LN_NUM_PAYMENT_ATTEMPTS = 10
 
-class StatusBarButton(QPushButton):
+class StatusBarButton(QToolButton):
     def __init__(self, icon, tooltip, func):
-        QPushButton.__init__(self, icon, '')
+        QToolButton.__init__(self)
+        self.setText('')
+        self.setIcon(icon)
         self.setToolTip(tooltip)
-        self.setFlat(True)
+        self.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.setAutoRaise(True)
         self.setMaximumWidth(25)
         self.clicked.connect(self.onPress)
         self.func = func
@@ -2239,7 +2242,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.lightning_button.setText('')
             self.lightning_button.setToolTip(_("The Lightning Network graph is fully synced."))
         else:
-            self.lightning_button.setMaximumWidth(25 + 4 * char_width_in_lineedit())
+            self.lightning_button.setMaximumWidth(25 + 5 * char_width_in_lineedit())
             self.lightning_button.setText(progress_str)
             self.lightning_button.setToolTip(_("The Lightning Network graph is syncing...\n"
                                                "Payments are more likely to succeed with a more complete graph."))

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -104,7 +104,9 @@ if TYPE_CHECKING:
 
 LN_NUM_PAYMENT_ATTEMPTS = 10
 
+
 class StatusBarButton(QToolButton):
+    # note: this class has a custom stylesheet applied in stylesheet_patcher.py
     def __init__(self, icon, tooltip, func):
         QToolButton.__init__(self)
         self.setText('')

--- a/electrum/gui/qt/stylesheet_patcher.py
+++ b/electrum/gui/qt/stylesheet_patcher.py
@@ -2,32 +2,68 @@
 It reads the current stylesheet, appends our modifications and sets the new stylesheet.
 """
 
+import sys
+
 from PyQt5 import QtWidgets
 
 
+CUSTOM_PATCH_FOR_DARK_THEME = '''
+/* PayToEdit text was being clipped */
+QAbstractScrollArea {
+    padding: 0px;
+}
+/* In History tab, labels while edited were being clipped (Windows) */
+QAbstractItemView QLineEdit {
+    padding: 0px;
+    show-decoration-selected: 1;
+}
+/* Checked item in dropdowns have way too much height...
+   see #6281 and https://github.com/ColinDuquesnoy/QDarkStyleSheet/issues/200
+   */
+QComboBox::item:checked {
+    font-weight: bold;
+    max-height: 30px;
+}
+'''
+
+CUSTOM_PATCH_FOR_DEFAULT_THEME_MACOS = '''
+/* On macOS, main window status bar icons have ugly frame (see #6300) */
+StatusBarButton {
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    margin: 0px;
+    padding: 2px;
+}
+StatusBarButton:checked {
+  background-color: transparent;
+  border: 1px solid #1464A0;
+}
+StatusBarButton:checked:disabled {
+  border: 1px solid #14506E;
+}
+StatusBarButton:pressed {
+  margin: 1px;
+  background-color: transparent;
+  border: 1px solid #1464A0;
+}
+StatusBarButton:disabled {
+  border: none;
+}
+StatusBarButton:hover {
+  border: 1px solid #148CD2;
+}
+'''
+
+
 def patch_qt_stylesheet(use_dark_theme: bool) -> None:
-    if not use_dark_theme:
-        return
+    custom_patch = ""
+    if use_dark_theme:
+        custom_patch = CUSTOM_PATCH_FOR_DARK_THEME
+    else:  # default theme (typically light)
+        if sys.platform == 'darwin':
+            custom_patch = CUSTOM_PATCH_FOR_DEFAULT_THEME_MACOS
 
     app = QtWidgets.QApplication.instance()
-
-    style_sheet = app.styleSheet()
-    style_sheet = style_sheet + '''
-    /* PayToEdit text was being clipped */
-    QAbstractScrollArea {
-        padding: 0px;
-    }
-    /* In History tab, labels while edited were being clipped (Windows) */
-    QAbstractItemView QLineEdit {
-        padding: 0px;
-        show-decoration-selected: 1;
-    }
-    /* Checked item in dropdowns have way too much height...
-       see #6281 and https://github.com/ColinDuquesnoy/QDarkStyleSheet/issues/200
-       */
-    QComboBox::item:checked {
-        font-weight: bold;
-        max-height: 30px;
-    }
-    '''
+    style_sheet = app.styleSheet() + custom_patch
     app.setStyleSheet(style_sheet)

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -126,9 +126,10 @@ class HelpLabel(QLabel):
         return QLabel.leaveEvent(self, event)
 
 
-class HelpButton(QPushButton):
+class HelpButton(QToolButton):
     def __init__(self, text):
-        QPushButton.__init__(self, '?')
+        QToolButton.__init__(self)
+        self.setText('?')
         self.help_text = text
         self.setFocusPolicy(Qt.NoFocus)
         self.setFixedWidth(round(2.2 * char_width_in_lineedit()))


### PR DESCRIPTION
see: #6299

I think in general it would look better with this change;
except on macOS with the light theme :( There the status bar buttons have an outline/background, which makes it ugly...

-----

Pics before:
<details>
 <summary>Ubuntu GNOME</summary>

  ![ubuntu_light](https://user-images.githubusercontent.com/29142493/85954070-6e806d80-b964-11ea-93b2-66f698d4f793.PNG)
  ![ubuntu_dark](https://user-images.githubusercontent.com/29142493/85954072-6fb19a80-b964-11ea-8628-4c003473820a.PNG)
</details>

<details>
 <summary>Windows</summary>

  ![win_light](https://user-images.githubusercontent.com/29142493/85954095-9cfe4880-b964-11ea-980d-e9f152877f0f.PNG)
  ![win_dark](https://user-images.githubusercontent.com/29142493/85954096-9e2f7580-b964-11ea-93f9-41cb3ac80f97.PNG)
</details>

<details>
 <summary>macOS</summary>

  ![mac_light](https://user-images.githubusercontent.com/29142493/85954102-a982a100-b964-11ea-8b97-e06ad70698fc.PNG)
  ![mac_dark](https://user-images.githubusercontent.com/29142493/85954105-aab3ce00-b964-11ea-9e7f-60a64ba9ab81.PNG)
</details>

-----

Pics after:
<details>
 <summary>Ubuntu GNOME</summary>

  ![ubuntu_light](https://user-images.githubusercontent.com/29142493/85954123-c28b5200-b964-11ea-9dc4-cc6aaca5f981.PNG)
  ![ubuntu_dark](https://user-images.githubusercontent.com/29142493/85954125-c3bc7f00-b964-11ea-8064-2c3b78a7c012.PNG)
</details>

<details>
 <summary>Windows</summary>

  ![win_light](https://user-images.githubusercontent.com/29142493/85954131-cc14ba00-b964-11ea-9859-d1ff0540ef51.PNG)
  ![win_dark](https://user-images.githubusercontent.com/29142493/85954133-cd45e700-b964-11ea-98c5-69702b10a5de.PNG)
</details>

<details>
 <summary>macOS</summary>

  ![mac_light](https://user-images.githubusercontent.com/29142493/85954137-d1720480-b964-11ea-8020-e3514ce0b3fe.PNG)
  ![mac_dark](https://user-images.githubusercontent.com/29142493/85954139-d2a33180-b964-11ea-9686-40c4a3d0002b.PNG)
</details>
