### PR TITLE
plugins/bitbox02: fix compatibility with bitbox02-4.0.0

### DIFF
--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -13,5 +13,5 @@ safet>=0.1.5
 keepkey>=6.3.1
 btchip-python>=0.1.26
 ckcc-protocol>=0.7.7
-bitbox02>=3.0.0
+bitbox02>=4.0.0
 hidapi

--- a/electrum/plugins/bitbox02/bitbox02.py
+++ b/electrum/plugins/bitbox02/bitbox02.py
@@ -394,6 +394,7 @@ class BitBox02Client(HardwareClientBase):
                     "prev_out_value": txin.value_sats(),
                     "sequence": txin.nsequence,
                     "keypath": full_path,
+                    "script_config_index": 0,
                     "prev_tx": {
                         "version": prev_tx.version,
                         "locktime": prev_tx.locktime,
@@ -437,7 +438,7 @@ class BitBox02Client(HardwareClientBase):
                 my_pubkey, change_pubkey_path = keystore.find_my_pubkey_in_txinout(txout)
                 outputs.append(
                     bitbox02.BTCOutputInternal(
-                        keypath=change_pubkey_path, value=txout.value,
+                        keypath=change_pubkey_path, value=txout.value, script_config_index=0,
                     )
                 )
             else:
@@ -475,8 +476,10 @@ class BitBox02Client(HardwareClientBase):
 
         sigs = self.bitbox02_device.btc_sign(
             coin,
-            tx_script_type,
-            keypath_account=keypath_account,
+            [bitbox02.btc.BTCScriptConfigWithKeypath(
+                script_config=tx_script_type,
+                keypath=keypath_account,
+            )],
             inputs=inputs,
             outputs=outputs,
             locktime=tx.locktime,
@@ -565,7 +568,7 @@ class BitBox02_KeyStore(Hardware_KeyStore):
 
 class BitBox02Plugin(HW_PluginBase):
     keystore_class = BitBox02_KeyStore
-    minimum_library = (3, 0, 0)
+    minimum_library = (4, 0, 0)
     DEVICE_IDS = [(0x03EB, 0x2403)]
 
     SUPPORTED_XTYPES = ("p2wpkh-p2sh", "p2wpkh", "p2wsh")


### PR DESCRIPTION
It would be great if this made it into the next beta release (or real release :crossed_fingers:).

Edit: since the bb02 plugin is now released with Electrum, we will be careful to preserve backwards compatibility as best as we can going forward. Thanks and congrats on Electrum 4! :rocket: 