### PR TITLE
interface: check server response for some methods

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -816,7 +816,13 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
                     if success_fut.exception():
                         try:
                             raise success_fut.exception()
-                        except (RequestTimedOut, RequestCorrupted):
+                        except RequestTimedOut:
+                            await iface.close()
+                            await iface.got_disconnected
+                            continue  # try again
+                        except RequestCorrupted as e:
+                            # TODO ban server?
+                            iface.logger.exception(f"RequestCorrupted: {e}")
                             await iface.close()
                             await iface.got_disconnected
                             continue  # try again
@@ -836,11 +842,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
     @best_effort_reliable
     @catch_server_exceptions
     async def get_merkle_for_transaction(self, tx_hash: str, tx_height: int) -> dict:
-        if not is_hash256_str(tx_hash):
-            raise Exception(f"{repr(tx_hash)} is not a txid")
-        if not is_non_negative_integer(tx_height):
-            raise Exception(f"{repr(tx_height)} is not a block height")
-        return await self.interface.session.send_request('blockchain.transaction.get_merkle', [tx_hash, tx_height])
+        return await self.interface.get_merkle_for_transaction(tx_hash=tx_hash, tx_height=tx_height)
 
     @best_effort_reliable
     async def broadcast_transaction(self, tx: 'Transaction', *, timeout=None) -> None:
@@ -1012,54 +1014,32 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
     @best_effort_reliable
     @catch_server_exceptions
     async def request_chunk(self, height: int, tip=None, *, can_return_early=False):
-        if not is_non_negative_integer(height):
-            raise Exception(f"{repr(height)} is not a block height")
         return await self.interface.request_chunk(height, tip=tip, can_return_early=can_return_early)
 
     @best_effort_reliable
     @catch_server_exceptions
     async def get_transaction(self, tx_hash: str, *, timeout=None) -> str:
-        if not is_hash256_str(tx_hash):
-            raise Exception(f"{repr(tx_hash)} is not a txid")
-        iface = self.interface
-        raw = await iface.session.send_request('blockchain.transaction.get', [tx_hash], timeout=timeout)
-        # validate response
-        tx = Transaction(raw)
-        try:
-            tx.deserialize()  # see if raises
-        except Exception as e:
-            self.logger.warning(f"cannot deserialize received transaction (txid {tx_hash}). from {str(iface)}")
-            raise RequestCorrupted() from e  # TODO ban server?
-        if tx.txid() != tx_hash:
-            self.logger.warning(f"received tx does not match expected txid {tx_hash} (got {tx.txid()}). from {str(iface)}")
-            raise RequestCorrupted()  # TODO ban server?
-        return raw
+        return await self.interface.get_transaction(tx_hash=tx_hash, timeout=timeout)
 
     @best_effort_reliable
     @catch_server_exceptions
     async def get_history_for_scripthash(self, sh: str) -> List[dict]:
-        if not is_hash256_str(sh):
-            raise Exception(f"{repr(sh)} is not a scripthash")
-        return await self.interface.session.send_request('blockchain.scripthash.get_history', [sh])
+        return await self.interface.get_history_for_scripthash(sh)
 
     @best_effort_reliable
     @catch_server_exceptions
     async def listunspent_for_scripthash(self, sh: str) -> List[dict]:
-        if not is_hash256_str(sh):
-            raise Exception(f"{repr(sh)} is not a scripthash")
-        return await self.interface.session.send_request('blockchain.scripthash.listunspent', [sh])
+        return await self.interface.listunspent_for_scripthash(sh)
 
     @best_effort_reliable
     @catch_server_exceptions
     async def get_balance_for_scripthash(self, sh: str) -> dict:
-        if not is_hash256_str(sh):
-            raise Exception(f"{repr(sh)} is not a scripthash")
-        return await self.interface.session.send_request('blockchain.scripthash.get_balance', [sh])
+        return await self.interface.get_balance_for_scripthash(sh)
 
     @best_effort_reliable
+    @catch_server_exceptions
     async def get_txid_from_txpos(self, tx_height, tx_pos, merkle):
-        command = 'blockchain.transaction.id_from_pos'
-        return await self.interface.session.send_request(command, [tx_height, tx_pos, merkle])
+        return await self.interface.get_txid_from_txpos(tx_height, tx_pos, merkle)
 
     def blockchain(self) -> Blockchain:
         interface = self.interface

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -168,15 +168,12 @@ class Synchronizer(SynchronizerBase):
         self.requested_histories.add((addr, status))
         h = address_to_scripthash(addr)
         self._requests_sent += 1
-        result = await self.network.get_history_for_scripthash(h)
+        result = await self.interface.get_history_for_scripthash(h)
         self._requests_answered += 1
         self.logger.info(f"receiving history {addr} {len(result)}")
         hashes = set(map(lambda item: item['tx_hash'], result))
         hist = list(map(lambda item: (item['tx_hash'], item['height']), result))
         # tx_fees
-        for item in result:
-            if item['height'] in (-1, 0) and 'fee' not in item:
-                raise Exception("server response to get_history contains unconfirmed tx without fee")
         tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
         tx_fees = dict(filter(lambda x:x[1] is not None, tx_fees))
         # Check that txids are unique
@@ -214,7 +211,7 @@ class Synchronizer(SynchronizerBase):
     async def _get_transaction(self, tx_hash, *, allow_server_not_finding_tx=False):
         self._requests_sent += 1
         try:
-            raw_tx = await self.network.get_transaction(tx_hash)
+            raw_tx = await self.interface.get_transaction(tx_hash)
         except UntrustedServerReturnedError as e:
             # most likely, "No such mempool or blockchain transaction"
             if allow_server_not_finding_tx:

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -582,6 +582,30 @@ def is_non_negative_integer(val) -> bool:
     return False
 
 
+def is_integer(val) -> bool:
+    try:
+        int(val)
+    except:
+        return False
+    else:
+        return True
+
+
+def is_real_number(val, *, as_str: bool = False) -> bool:
+    if as_str:  # only accept str
+        if not isinstance(val, str):
+            return False
+    else:  # only accept int/float/etc.
+        if isinstance(val, str):
+            return False
+    try:
+        Decimal(val)
+    except:
+        return False
+    else:
+        return True
+
+
 def chunks(items, size: int):
     """Break up items, an iterable, into chunks of length size."""
     if size < 1:


### PR DESCRIPTION
some basic sanity checks

Previously if the server sent back a malformed response, it could partially corrupt a wallet file.
(as sometimes the response would get persisted, and issues would only arise later when the values were used)