### PR TITLE
Change default invoice to never expires

### DIFF
--- a/electrum/invoices.py
+++ b/electrum/invoices.py
@@ -50,7 +50,7 @@ pr_tooltips = {
     PR_ROUTING: _('Computing route...'),
 }
 
-PR_DEFAULT_EXPIRATION_WHEN_CREATING = 24*60*60  # 1 day
+PR_DEFAULT_EXPIRATION_WHEN_CREATING = 0 # Never
 pr_expiration_values = {
     0: _('Never'),
     10*60: _('10 minutes'),


### PR DESCRIPTION
Resolves #6364 

I think this a valid point - an invoice with a time limit will definitely be set by the user but most payment times are flexible. I'd rather have it not expire by default and manually change the expiry during the few situations where it is time-sensitive.