### PR TITLE
bitbox02: implement get_soft_device_id so multisig runs more smoothly

### DIFF
--- a/electrum/plugins/bitbox02/bitbox02.py
+++ b/electrum/plugins/bitbox02/bitbox02.py
@@ -251,7 +251,12 @@ class BitBox02Client(HardwareClientBase):
             return super().label()
         if self.bitbox02_device is None:
             self.pairing_dialog()
-        return self.bitbox02_device.device_info()["name"]
+        # We add the fingerprint to the label, as if there are two devices with the same label, the
+        # device manager can mistake one for another and fail.
+        return "%s (%s)" % (
+            self.bitbox02_device.device_info()["name"],
+            self.bitbox02_device.root_fingerprint().hex(),
+        )
 
     def request_root_fingerprint_from_device(self) -> str:
         if self.bitbox02_device is None:

--- a/electrum/plugins/bitbox02/bitbox02.py
+++ b/electrum/plugins/bitbox02/bitbox02.py
@@ -91,10 +91,10 @@ class BitBox02Client(HardwareClientBase):
             # listing the devices.
             return None
         if self.bitbox02_device is None:
-            self.pairing_dialog(wizard=False)
+            self.pairing_dialog()
         return self.bitbox02_device.root_fingerprint().hex()
 
-    def pairing_dialog(self, wizard: bool = True):
+    def pairing_dialog(self):
         def pairing_step(code: str, device_response: Callable[[], bool]) -> bool:
             msg = "Please compare and confirm the pairing code on your BitBox02:\n" + code
             self.handler.show_message(msg)
@@ -206,7 +206,7 @@ class BitBox02Client(HardwareClientBase):
 
     def get_xpub(self, bip32_path: str, xtype: str, *, display: bool = False) -> str:
         if self.bitbox02_device is None:
-            self.pairing_dialog(wizard=False)
+            self.pairing_dialog()
 
         if self.bitbox02_device is None:
             raise Exception(

--- a/electrum/plugins/bitbox02/bitbox02.py
+++ b/electrum/plugins/bitbox02/bitbox02.py
@@ -85,6 +85,15 @@ class BitBox02Client(HardwareClientBase):
             return False
         return True
 
+    def get_soft_device_id(self) -> Optional[str]:
+        if self.handler is None:
+            # Can't do the pairing without the handler. This happens at wallet creation time, when
+            # listing the devices.
+            return None
+        if self.bitbox02_device is None:
+            self.pairing_dialog(wizard=False)
+        return self.bitbox02_device.root_fingerprint().hex()
+
     def pairing_dialog(self, wizard: bool = True):
         def pairing_step(code: str, device_response: Callable[[], bool]) -> bool:
             msg = "Please compare and confirm the pairing code on your BitBox02:\n" + code

--- a/electrum/plugins/bitbox02/bitbox02.py
+++ b/electrum/plugins/bitbox02/bitbox02.py
@@ -244,6 +244,15 @@ class BitBox02Client(HardwareClientBase):
             display=display,
         )
 
+    def label(self) -> str:
+        if self.handler is None:
+            # Can't do the pairing without the handler. This happens at wallet creation time, when
+            # listing the devices.
+            return super().label()
+        if self.bitbox02_device is None:
+            self.pairing_dialog()
+        return self.bitbox02_device.device_info()["name"]
+
     def request_root_fingerprint_from_device(self) -> str:
         if self.bitbox02_device is None:
             raise Exception(


### PR DESCRIPTION
Without it, if you have say a 1-of-2 multisig with two BitBox02s, you
would run into trouble if the first keystore would try to match to the
wrong inserted BitBox02 (wrong order, or the first one is not
inserted, etc. ).

With the soft device id, the device manager can figure it on its own
which keystore belongs to which connected bb02.