### PR TITLE
Keep current input when clearing Python console

### DIFF
--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -91,17 +91,18 @@ class Console(QtWidgets.QPlainTextEdit):
 
     def showMessage(self, message):
         self.appendPlainText(message)
-        self.newPrompt()
+        self.newPrompt('')
 
     def clear(self):
+        curr_line = self.getCommand()
         self.setPlainText('')
-        self.newPrompt()
+        self.newPrompt(curr_line)
 
-    def newPrompt(self):
+    def newPrompt(self, curr_line):
         if self.construct:
             prompt = '.' * len(self.prompt)
         else:
-            prompt = self.prompt
+            prompt = self.prompt + curr_line
 
         self.completions_pos = self.textCursor().position()
         self.completions_visible = False
@@ -244,7 +245,7 @@ class Console(QtWidgets.QPlainTextEdit):
             if type(self.namespace.get(command)) == type(lambda:None):
                 self.appendPlainText("'{}' is a function. Type '{}()' to use it in the Python console."
                                      .format(command, command))
-                self.newPrompt()
+                self.newPrompt('')
                 return
 
             sys.stdout = stdoutProxy(self.appendPlainText)
@@ -269,7 +270,7 @@ class Console(QtWidgets.QPlainTextEdit):
                     traceback_lines.pop(i)
                 self.appendPlainText('\n'.join(traceback_lines))
             sys.stdout = tmp_stdout
-        self.newPrompt()
+        self.newPrompt('')
         self.set_json(False)
 
 


### PR DESCRIPTION
Ctrl+L should clear the whole console except the current line like
a standard Python console.