### PR TITLE
Re-size the wizard before next frame is displayed.

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -590,7 +590,7 @@ class WizardDialog(EventsDialog):
         self.app = App.get_running_app()
         self.run_next = kwargs['run_next']
 
-        self._trigger_size_dialog = Clock.create_trigger(self._size_dialog)
+        self._trigger_size_dialog = Clock.create_trigger(self._size_dialog, -1)
         # note: everything bound here needs to be unbound as otherwise the
         # objects will be kept around and keep receiving the callbacks
         Window.bind(size=self._trigger_size_dialog,


### PR DESCRIPTION
Fixes a UI issue in kivy Install Wizzard.
The Choices UI was displayed in a small vertical line for a split second, before being resized to correct size.
This fixes that by ensuring resizing is done before next frame is displayed https://kivy.org/doc/stable/api-kivy.clock.html#schedule-before-frame .