### PR TITLE
Feature: more price sources for BRL and remove scam broker

### DIFF
--- a/electrum/currencies.json
+++ b/electrum/currencies.json
@@ -882,9 +882,6 @@
     "MercadoBitcoin": [
         "BRL"
     ],
-    "NegocieCoins": [
-        "BRL"
-    ],
     "TheRockTrading": [
         "EUR"
     ],

--- a/electrum/currencies.json
+++ b/electrum/currencies.json
@@ -891,5 +891,11 @@
     "Zaif": [
         "JPY"
     ],
-    "itBit": []
+    "itBit": [],
+    "Bitragem": [
+        "BRL"
+    ],
+    "Biscoint": [
+        "BRL"
+    ]
 }

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -352,12 +352,6 @@ class MercadoBitcoin(ExchangeBase):
         return {'BRL': Decimal(json['ticker_1h']['exchanges']['MBT']['last'])}
 
 
-class NegocieCoins(ExchangeBase):
-
-    async def get_rates(self,ccy):
-        json = await self.get_json('api.bitvalor.com', '/v1/ticker.json')
-        return {'BRL': Decimal(json['ticker_1h']['exchanges']['NEG']['last'])}
-
 class TheRockTrading(ExchangeBase):
 
     async def get_rates(self, ccy):

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -400,7 +400,7 @@ class Biscoint(ExchangeBase):
 
     async def get_rates(self,ccy):
         json = await self.get_json('api.biscoint.io', '/v1/ticker?base=BTC&quote=BRL')
-        return {'BRL': Decimal(json['data']['last']['last'])}
+        return {'BRL': Decimal(json['data']['last'])}
 
 
 def dictinvert(d):

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -389,6 +389,20 @@ class Zaif(ExchangeBase):
         return {'JPY': Decimal(json['last_price'])}
 
 
+class Bitragem(ExchangeBase):
+
+    async def get_rates(self,ccy):
+        json = await self.get_json('api.bitragem.com', '/v1/index?asset=BTC&market=BRL')
+        return {'BRL': Decimal(json['response']['index'])}
+
+
+class Biscoint(ExchangeBase):
+
+    async def get_rates(self,ccy):
+        json = await self.get_json('api.biscoint.io', '/v1/ticker?base=BTC&quote=BRL')
+        return {'BRL': Decimal(json['data']['last']['last'])}
+
+
 def dictinvert(d):
     inv = {}
     for k, vlist in d.items():


### PR DESCRIPTION
Added [Bitragem](https://bitragem.com/) and [Biscoint](https://biscoint.io/buy/btc/brl?amount=1000&isQuote=true) for BRL.

I chose to remove the NEGOCIECOINS exchange as it stole many users, evidence below.

https://cointelegraph.com.br/news/folha-de-sao-paulo-states-that-negociecoins-has-millionaire-debt
https://canaltech.com.br/criptomoedas/clientes-processam-empresa-paranaense-de-bitcoins-por-sumico-de-dinheiro-146475/
https://etopsaber.com/o-caso-da-negociecoins/