### PR TITLE
Modified two files to include a brazilian source.

### DIFF
--- a/electrum/currencies.json
+++ b/electrum/currencies.json
@@ -793,6 +793,9 @@
         "ZRX",
         "ZWL"
     ],
+    "CointraderMonitor": [
+        "BRL"
+    ],
     "Kraken": [
         "CAD",
         "EUR",

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -315,6 +315,13 @@ class CoinGecko(ExchangeBase):
                      for h in history['prices']])
 
 
+class CointraderMonitor(ExchangeBase):
+
+    async def get_rates(self, ccy):
+        json = await self.get_json('cointradermonitor.com', '/api/pbb/beta/ticker')
+        return {'BRL': Decimal(json['last'])}
+
+
 class itBit(ExchangeBase):
 
     async def get_rates(self, ccy):


### PR DESCRIPTION
Added Brazilian Bitcoin Index from Cointrader Monitor (https://cointradermonitor.com/api/pbb/v1/ticker) as a "BRL" Fiat source.
The index is calculated from the last price and volume from 30 brazilian exchanges. It is a well-known price index used by bitcoin brazilian users.
More information at https://cointradermonitor.com/

![image](https://user-images.githubusercontent.com/68483439/87864837-d0793500-c95c-11ea-9124-ecbe74d07b7d.png)
