### PR TITLE
Add option to use deterministic entropy in make_seed

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -320,10 +320,10 @@ class Commands:
         return self.config.get_ssl_domain()
 
     @command('')
-    async def make_seed(self, nbits=132, language=None, seed_type=None):
+    async def make_seed(self, nbits=132, language=None, seed_type=None, entropy=None):
         """Create a seed"""
         from .mnemonic import Mnemonic
-        s = Mnemonic(language).make_seed(seed_type, num_bits=nbits)
+        s = Mnemonic(language).make_seed(seed_type, num_bits=nbits, user_entropy=entropy)
         return s
 
     @command('n')
@@ -1224,6 +1224,7 @@ command_options = {
     'to_height':   (None, "Only show transactions that confirmed before given block height"),
     'iknowwhatimdoing': (None, "Acknowledge that I understand the full implications of what I am about to do"),
     'gossip':      (None, "Apply command to gossip node instead of wallet"),
+    'entropy':     (None, "User provided entropy. Only use this option with > 128 bits of true randomness"),
 }
 
 

--- a/electrum/tests/test_mnemonic.py
+++ b/electrum/tests/test_mnemonic.py
@@ -94,6 +94,24 @@ SEED_TEST_CASES = {
         bip32_seed='c274665e5453c72f82b8444e293e048d700c59bf000cacfba597629d202dcf3aab1cf9c00ba8d3456b7943428541fed714d01d8a0a4028fc3a9bb33d981cb49f'),
 }
 
+class DeterministicSeedTestCase(NamedTuple):
+    entropy: str
+    words: str
+
+DETERMINISTIC_SEED_TEST_CASES = [
+    DeterministicSeedTestCase(
+        entropy='BcBeF4AcBf3ba5AbBbD1bFf0C7dEa38a18DD10CcfF2FA0CD06d21c37aafDDA3B',
+        words='law hope answer pistol leisure company erosion blame novel rule evoke tribe able candy comic loop bench mango duck winner resist hello umbrella above'),
+    DeterministicSeedTestCase(
+        entropy='AORakGJlxLBKXAEkXWKnkfVNnEUvegxtOwaEpFXkJeBkGWUSxG',
+        words='idle group shock express hybrid vehicle similar left midnight calm feature twist arrive hedgehog hello cup slim law soap merge future address large absorb'),
+    DeterministicSeedTestCase(
+        entropy='OOHAPJQWsDojtkC94M3QBQC7R5kwKjRk4SwM7vom5vKWZxZOC6meFcStIkdyK59imuOYmDxR3Qk',
+        words='bunker home goose lottery pass pledge blossom make boat turkey fine blade beauty raven save mercy gravity day tourist audit cabbage worry inquiry'),
+    DeterministicSeedTestCase(
+        entropy='4132561243561243651246512416234615243615241625341263416254615234165243615243612461253461523461243612341623412633162461253462146124361246215',
+        words='spare dizzy empower surge hawk throw interest jar scout mixed hip flash social number prefer million there wisdom twin finger long wild ball absorb')
+]
 
 class Test_NewMnemonic(ElectrumTestCase):
 
@@ -124,6 +142,11 @@ class Test_NewMnemonic(ElectrumTestCase):
             i = m.mnemonic_decode(seed)
             self.assertEqual(m.mnemonic_encode(i), seed)
 
+    def test_deterministic_seeds(self):
+        m = mnemonic.Mnemonic(lang='en')
+        for test in DETERMINISTIC_SEED_TEST_CASES:
+            seed = m.make_seed(seed_type = "segwit", user_entropy = test.entropy)
+            self.assertEqual(test.words, seed)
 
 class Test_OldMnemonic(ElectrumTestCase):
 


### PR DESCRIPTION
I noticed that electrum does not currently have the option to generate a seed with user-provided entropy. Also, the current source of entropy comes from `os.urandom()` via the python-ecdsa dependency. That project's [README](https://github.com/warner/python-ecdsa) explicitly states:

```
This library depends upon a strong source of random numbers. Do not use it on a system where os.urandom() does not provide cryptographically secure random numbers.
```

While practically speaking this will rarely be an issue, I think it's a useful to be able to supply entropy deterministically so users can _eliminate_ this risk categorically. 

My main concern with adding this feature is novices mistakenly using it and providing a very low entropy input without clearly understanding what it does. Is it correct to assume the CLI is generally only used by power-users? In any case, I made the option's description cautionary to guard against this risk. 