### PR TITLE
Save wallet DB after adding or removing payment requests

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -846,12 +846,14 @@ class Commands:
         expiration = int(expiration) if expiration else None
         req = wallet.make_payment_request(addr, amount, memo, expiration)
         wallet.add_payment_request(req)
+        wallet.save_db()
         return wallet.export_request(req)
 
     @command('wn')
     async def add_lightning_request(self, amount, memo='', expiration=3600, wallet: Abstract_Wallet = None):
         amount_sat = int(satoshis(amount))
         key = await wallet.lnworker._add_request_coro(amount_sat, memo, expiration)
+        wallet.save_db()
         return wallet.get_formatted_request(key)
 
     @command('w')
@@ -875,7 +877,9 @@ class Commands:
     @command('w')
     async def rmrequest(self, address, wallet: Abstract_Wallet = None):
         """Remove a payment request"""
-        return wallet.remove_payment_request(address)
+        result = wallet.remove_payment_request(address)
+        wallet.save_db()
+        return result
 
     @command('w')
     async def clear_requests(self, wallet: Abstract_Wallet = None):


### PR DESCRIPTION
## Description

When using the `add_request` command I realized that the returned address will be reused in the next payment request after I restart my electrum daemon (if no other operation which saves the walletDB has been performed in the meantime).

It seems that the `add_request`, `add_lightning_request` and `rmrequest` commands change the wallet DB (_by adding or removing payment requests_), but do not flush the changes down to the disk.

If any other operation later on changes the wallet DB, then the changes of the 3 commands will also be flushed. If not, then the changes (payment requests) might get lost.

(`clear_requests` is not affected as `self.save_db()` is called in `wallet.py` in `clear_requests(self)`.)

### This PR:
- adds `wallet.save_db()` to RPC commands which change the Wallet DB but didn't save them