### PR TITLE
trezor: use `init_device` instead of `ping` to check connection

### DIFF
--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -112,8 +112,7 @@ class TrezorClientBase(HardwareClientBase, Logger):
             return True
 
         try:
-            res = self.client.ping("electrum pinging device")
-            assert res == "electrum pinging device"
+            self.client.init_device()
         except BaseException:
             return False
         return True


### PR DESCRIPTION
fixes #6457

Trezor T does not allow `Ping` message without unlocking the device. There's a matching bug in `trezorctl` which makes this worse: `client.ping()` should cleanly handle the situation but it doesn't.

The easiest and most user-friendly solution in Electrum is to use `init_device()` call instead; it's guaranteed to not require user interaction, which is what we want in `has_usable_connection`.