### PR TITLE
Allow 'serialize' command to be run from cli

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -360,6 +360,7 @@ class Commands:
         Inputs must have a redeemPubkey.
         Outputs must be a list of {'address':address, 'value':satoshi_amount}.
         """
+        jsontx = json_decode(jsontx)
         keypairs = {}
         inputs = []  # type: List[PartialTxInput]
         locktime = jsontx.get('lockTime', 0)


### PR DESCRIPTION
CLI arguments are always strings and `serialize` expects a dict.  Added simple call to `json_decode` to allow either a string or a dict to be passed as the jsontx parameter.  The `json_decode` command is non-destructive so if it is passed a dict, it simply returns the passed in dict.

This PR allows the following type commands to work

```shell
python run_electrum serialize --testnet '{"inputs": ... }'
```