### PR TITLE
Correct errors in command 'serialize(deserialize(pbst))'

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -362,7 +362,7 @@ class Commands:
         """
         keypairs = {}
         inputs = []  # type: List[PartialTxInput]
-        locktime = jsontx.get('lockTime', 0)
+        locktime = jsontx.get('locktime', 0)
         for txin_dict in jsontx.get('inputs'):
             if txin_dict.get('prevout_hash') is not None and txin_dict.get('prevout_n') is not None:
                 prevout = TxOutpoint(txid=bfh(txin_dict['prevout_hash']), out_idx=int(txin_dict['prevout_n']))
@@ -371,7 +371,7 @@ class Commands:
             else:
                 raise Exception("missing prevout for txin")
             txin = PartialTxInput(prevout=prevout)
-            txin._trusted_value_sats = int(txin_dict['value'])
+            txin._trusted_value_sats = int(txin_dict.get('value', txin_dict['value_sats']))
             nsequence = txin_dict.get('nsequence', None)
             if nsequence is not None:
                 txin.nsequence = nsequence
@@ -385,7 +385,7 @@ class Commands:
                 txin.num_sig = 1
             inputs.append(txin)
 
-        outputs = [PartialTxOutput.from_address_and_value(txout['address'], int(txout['value']))
+        outputs = [PartialTxOutput.from_address_and_value(txout['address'], int(txout.get('value', txout['value_sats'])))
                    for txout in jsontx.get('outputs')]
         tx = PartialTransaction.from_io(inputs, outputs, locktime=locktime)
         tx.sign(keypairs)


### PR DESCRIPTION
Ideally the commands `deserialize` and `serialize` should reverse each other.  This will provide the minimum amount of correction to allow `serialize(deserialize(pbst))` to complete without error

* Fixed 'locktime' typo that had it incorrectly camel-cased
* Made 'value' and 'value_sats' synonyms so either can be used

It is assumed that the field "value" is a already in SATs.  If "value" is assumed to be in BTC or mBTC, a correction will be needed.