### PR TITLE
fix the coldcard multi-sig show address issue

### DIFF
--- a/electrum/plugins/coldcard/coldcard.py
+++ b/electrum/plugins/coldcard/coldcard.py
@@ -608,7 +608,8 @@ class ColdcardPlugin(HW_PluginBase):
             pubkey_deriv_info = wallet.get_public_keys_with_deriv_info(address)
             pubkey_hexes = sorted([pk.hex() for pk in list(pubkey_deriv_info)])
             xfp_paths = []
-            for pubkey in pubkey_deriv_info:
+            for pubkey_hex in pubkey_hexes:
+                pubkey = bytes.fromhex(pubkey_hex)
                 ks, der_suffix = pubkey_deriv_info[pubkey]
                 fp_bytes, der_full = ks.get_fp_and_derivation_to_be_used_in_partial_tx(der_suffix, only_der_suffix=False)
                 xfp_int = xfp_int_from_xfp_bytes(fp_bytes)


### PR DESCRIPTION
For the multi-sig wallet On Coldcard, there is a function called "show address on ColdCard" 
which will show the address into on ColdCard device to verify. but there is a bug on this function which will raise Error like
![image](https://user-images.githubusercontent.com/7855886/90485589-4b0abf80-e16a-11ea-9d59-e1156396caef.jpg)

this is because on `show_p2sh_address`  function,  items in `xfp_paths` should have the same order as `pubkeys` on the script. this fix is to make they have the same order
