### PR TITLE
Added placeholder text in the cosigner dialog. 

### DIFF
--- a/electrum/gui/qt/installwizard.py
+++ b/electrum/gui/qt/installwizard.py
@@ -442,9 +442,10 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
     def remove_from_recently_open(self, filename):
         self.config.remove_from_recently_open(filename)
 
-    def text_input(self, title, message, is_valid, allow_multi=False):
+    def text_input(self, title, message, is_valid, allow_multi=False, placeholder_text=None):
         slayout = KeysLayout(parent=self, header_layout=message, is_valid=is_valid,
-                             allow_multi=allow_multi)
+                             allow_multi=allow_multi, placeholder_text=placeholder_text)
+
         self.exec_layout(slayout, title, next_enabled=False)
         return slayout.get_text()
 
@@ -470,7 +471,12 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
             _('Please enter the master public key (xpub) of your cosigner.'),
             _('Enter their master private key (xprv) if you want to be able to sign for them.')
         ])
-        return self.text_input(title, message, is_valid)
+        placeholder_text =  ' '.join([
+            _('If you do not have this master public key (xpub) yet, leave this '
+              'dialog open and create the required cosigner wallet.'),
+            _('Multi-Signature seeds should not be created on the same device for security reasons.')
+        ])
+        return self.text_input(title, message, is_valid, placeholder_text=placeholder_text)
 
     @wizard_dialog
     def restore_seed_dialog(self, run_next, test):

--- a/electrum/gui/qt/qrtextedit.py
+++ b/electrum/gui/qt/qrtextedit.py
@@ -32,7 +32,7 @@ class ShowQRTextEdit(ButtonsTextEdit):
 
 class ScanQRTextEdit(ButtonsTextEdit, MessageBoxMixin):
 
-    def __init__(self, text="", allow_multi=False):
+    def __init__(self, text="", allow_multi=False, placeholder_text=None):
         ButtonsTextEdit.__init__(self, text)
         self.allow_multi = allow_multi
         self.setReadOnly(0)
@@ -40,6 +40,8 @@ class ScanQRTextEdit(ButtonsTextEdit, MessageBoxMixin):
         icon = "camera_white.png" if ColorScheme.dark_scheme else "camera_dark.png"
         self.addButton(icon, self.qr_input, _("Read QR code"))
         run_hook('scan_text_edit', self)
+        if placeholder_text:
+            self.setPlaceholderText(placeholder_text)
 
     def file_input(self):
         fileName, __ = QFileDialog.getOpenFileName(self, 'select file')

--- a/electrum/gui/qt/seed_dialog.py
+++ b/electrum/gui/qt/seed_dialog.py
@@ -197,11 +197,12 @@ class SeedLayout(QVBoxLayout):
         self.seed_e.enable_suggestions()
 
 class KeysLayout(QVBoxLayout):
-    def __init__(self, parent=None, header_layout=None, is_valid=None, allow_multi=False):
+    def __init__(self, parent=None, header_layout=None, is_valid=None, allow_multi=False, placeholder_text=None):
         QVBoxLayout.__init__(self)
         self.parent = parent
         self.is_valid = is_valid
-        self.text_e = ScanQRTextEdit(allow_multi=allow_multi)
+        self.text_e = ScanQRTextEdit(allow_multi=allow_multi, placeholder_text=placeholder_text)
+
         self.text_e.textChanged.connect(self.on_edit)
         if isinstance(header_layout, str):
             self.addWidget(WWLabel(header_layout))


### PR DESCRIPTION
Added placeholder text in the cosigner dialog. The placeholder text explains what to do if one does not have the remaining xpubs yet.

Linked Issue: https://github.com/spesmilo/electrum/issues/6456

Problems with the pull request:
- The placeholder message might not be ideal for all occurrences of the cosigner dialog.