### PR TITLE
gui: update stdio and text after db and storage separation

### DIFF
--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -5,6 +5,7 @@ import logging
 
 from electrum import util
 from electrum import WalletStorage, Wallet
+from electrum.wallet_db import WalletDB
 from electrum.util import format_satoshis
 from electrum.bitcoin import is_address, COIN
 from electrum.transaction import PartialTxOutput
@@ -30,6 +31,8 @@ class ElectrumGui:
             password = getpass.getpass('Password:', stream=None)
             storage.decrypt(password)
 
+        db = WalletDB(storage.read(), manual_upgrades=False)
+
         self.done = 0
         self.last_balance = ""
 
@@ -40,7 +43,7 @@ class ElectrumGui:
         self.str_amount = ""
         self.str_fee = ""
 
-        self.wallet = Wallet(storage, config=config)
+        self.wallet = Wallet(db, storage, config=config)
         self.wallet.start_network(self.network)
         self.contacts = self.wallet.contacts
 

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -14,6 +14,7 @@ from electrum.util import format_satoshis
 from electrum.bitcoin import is_address, COIN
 from electrum.transaction import PartialTxOutput
 from electrum.wallet import Wallet
+from electrum.wallet_db import WalletDB
 from electrum.storage import WalletStorage
 from electrum.network import NetworkParameters, TxBroadcastError, BestEffortRequestFailed
 from electrum.interface import ServerAddr
@@ -41,7 +42,8 @@ class ElectrumGui:
         if storage.is_encrypted():
             password = getpass.getpass('Password:', stream=None)
             storage.decrypt(password)
-        self.wallet = Wallet(storage, config=config)
+        db = WalletDB(storage.read(), manual_upgrades=False)
+        self.wallet = Wallet(db, storage, config=config)
         self.wallet.start_network(self.network)
         self.contacts = self.wallet.contacts
 


### PR DESCRIPTION
Hi,

e1ce3aace7e3143da24115890d9bae78a9f5bca updated the qt and kivy guis, but not stdio or text one, so trying to use the text gui gives an error `missing 1 required positional argument: 'storage'`, coming from the line
```
self.wallet = Wallet(storage, config=config)
```
and `electrum --gui stdio` just closes without any output.

With this patch electrum starts as it should for both guis again.