### PR TITLE
Fix multiline script error

### DIFF
--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -80,10 +80,7 @@ class Console(QtWidgets.QPlainTextEdit):
         with open(filename) as f:
             script = f.read()
 
-        # eval is generally considered bad practice. use it wisely!
-        result = eval(script, self.namespace, self.namespace)
-
-
+        self.exec_command(script)
 
     def updateNamespace(self, namespace):
         self.namespace.update(namespace)
@@ -205,61 +202,62 @@ class Console(QtWidgets.QPlainTextEdit):
         for i in range(len(self.prompt) + position):
             self.moveCursor(QtGui.QTextCursor.Right)
 
-    def runCommand(self):
+    def run_command(self):
         command = self.getCommand()
         self.addToHistory(command)
 
         command = self.getConstruct(command)
 
         if command:
-            tmp_stdout = sys.stdout
-
-            class stdoutProxy():
-                def __init__(self, write_func):
-                    self.write_func = write_func
-                    self.skip = False
-
-                def flush(self):
-                    pass
-
-                def write(self, text):
-                    if not self.skip:
-                        stripped_text = text.rstrip('\n')
-                        self.write_func(stripped_text)
-                        QtCore.QCoreApplication.processEvents()
-                    self.skip = not self.skip
-
-            if type(self.namespace.get(command)) == type(lambda:None):
-                self.appendPlainText("'{}' is a function. Type '{}()' to use it in the Python console."
-                                     .format(command, command))
-                self.newPrompt('')
-                return
-
-            sys.stdout = stdoutProxy(self.appendPlainText)
-            try:
-                try:
-                    # eval is generally considered bad practice. use it wisely!
-                    result = eval(command, self.namespace, self.namespace)
-                    if result is not None:
-                        if self.is_json:
-                            util.print_msg(util.json_encode(result))
-                        else:
-                            self.appendPlainText(repr(result))
-                except SyntaxError:
-                    # exec is generally considered bad practice. use it wisely!
-                    exec(command, self.namespace, self.namespace)
-            except SystemExit:
-                self.close()
-            except BaseException:
-                traceback_lines = traceback.format_exc().split('\n')
-                # Remove traceback mentioning this file, and a linebreak
-                for i in (3,2,1,-1):
-                    traceback_lines.pop(i)
-                self.appendPlainText('\n'.join(traceback_lines))
-            sys.stdout = tmp_stdout
+            self.exec_command(command)
         self.newPrompt('')
         self.set_json(False)
 
+    def exec_command(self, command):
+        tmp_stdout = sys.stdout
+
+        class stdoutProxy():
+            def __init__(self, write_func):
+                self.write_func = write_func
+                self.skip = False
+
+            def flush(self):
+                pass
+
+            def write(self, text):
+                if not self.skip:
+                    stripped_text = text.rstrip('\n')
+                    self.write_func(stripped_text)
+                    QtCore.QCoreApplication.processEvents()
+                self.skip = not self.skip
+
+        if type(self.namespace.get(command)) == type(lambda:None):
+            self.appendPlainText("'{}' is a function. Type '{}()' to use it in the Python console."
+                                 .format(command, command))
+            return
+
+        sys.stdout = stdoutProxy(self.appendPlainText)
+        try:
+            try:
+                # eval is generally considered bad practice. use it wisely!
+                result = eval(command, self.namespace, self.namespace)
+                if result is not None:
+                    if self.is_json:
+                        util.print_msg(util.json_encode(result))
+                    else:
+                        self.appendPlainText(repr(result))
+            except SyntaxError:
+                # exec is generally considered bad practice. use it wisely!
+                exec(command, self.namespace, self.namespace)
+        except SystemExit:
+            self.close()
+        except BaseException:
+            traceback_lines = traceback.format_exc().split('\n')
+            # Remove traceback mentioning this file, and a linebreak
+            for i in (3,2,1,-1):
+                traceback_lines.pop(i)
+            self.appendPlainText('\n'.join(traceback_lines))
+        sys.stdout = tmp_stdout
 
     def keyPressEvent(self, event):
         if event.key() == QtCore.Qt.Key_Tab:
@@ -269,7 +267,7 @@ class Console(QtWidgets.QPlainTextEdit):
         self.hide_completions()
 
         if event.key() in (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return):
-            self.runCommand()
+            self.run_command()
             return
         if event.key() == QtCore.Qt.Key_Home:
             self.setCursorPosition(0)


### PR DESCRIPTION
Syntax errors emerged when running multiline scripts in the console
when using the run() command.

Example `file.py`:
```
print(1)
print(2)
```

Before:
```
>>> run('file.py')
Traceback (most recent call last):
  File "/***/electrum/gui/qt/console.py", line 84, in run_script
    result = eval(script, self.namespace, self.namespace)
  File "<string>", line 2
    print(2)
    ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/***/electrum/gui/qt/console.py", line 250, in runCommand
    exec(command, self.namespace, self.namespace)
  File "<string>", line 1, in <module>
  File "/***/electrum/gui/qt/console.py", line 84, in run_script
    result = eval(script, self.namespace, self.namespace)
  File "<string>", line 2
    print(2)
    ^
SyntaxError: invalid syntax
```

After:
```
>>> run('file.py')
1
2
```