### PR TITLE
Pass wallet to invoice_status/request_status

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -318,7 +318,7 @@ class PayServer(Logger):
         # FIXME specify wallet somehow?
         return list(self.daemon.get_wallets().values())[0]
 
-    async def on_payment(self, evt, key, status):
+    async def on_payment(self, evt, wallet, key, status):
         if status == PR_PAID:
             self.pending[key].set()
 

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -249,7 +249,7 @@ class ElectrumWindow(App):
     def on_fee_histogram(self, *args):
         self._trigger_update_history()
 
-    def on_request_status(self, event, key, status):
+    def on_request_status(self, event, wallet, key, status):
         if key not in self.wallet.receive_requests:
             return
         self.update_tab('receive')
@@ -259,7 +259,7 @@ class ElectrumWindow(App):
             self.show_info(_('Payment Received') + '\n' + key)
             self._trigger_update_history()
 
-    def on_invoice_status(self, event, key):
+    def on_invoice_status(self, event, wallet, key):
         req = self.wallet.get_invoice(key)
         if req is None:
             return

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1514,6 +1514,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.invoice_list.update()
 
     def on_request_status(self, wallet, key, status):
+        if wallet != self.wallet:
+            return
         if key not in self.wallet.receive_requests:
             return
         if status == PR_PAID:
@@ -1521,6 +1523,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.need_update.set()
 
     def on_invoice_status(self, wallet, key):
+        if wallet != self.wallet:
+            return
         req = self.wallet.get_invoice(key)
         if req is None:
             return

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1513,14 +1513,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.wallet.thread.add(task)
         self.invoice_list.update()
 
-    def on_request_status(self, key, status):
+    def on_request_status(self, wallet, key, status):
         if key not in self.wallet.receive_requests:
             return
         if status == PR_PAID:
             self.notify(_('Payment received') + '\n' + key)
             self.need_update.set()
 
-    def on_invoice_status(self, key):
+    def on_invoice_status(self, wallet, key):
         req = self.wallet.get_invoice(key)
         if req is None:
             return

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -883,10 +883,10 @@ class LNWallet(LNWorker):
                 # note: path-finding runs in a separate thread so that we don't block the asyncio loop
                 # graph updates might occur during the computation
                 self.set_invoice_status(key, PR_ROUTING)
-                util.trigger_callback('invoice_status', key)
+                util.trigger_callback('invoice_status', self.wallet, key)
                 route = await run_in_thread(partial(self._create_route_from_invoice, lnaddr, full_path=full_path))
                 self.set_invoice_status(key, PR_INFLIGHT)
-                util.trigger_callback('invoice_status', key)
+                util.trigger_callback('invoice_status', self.wallet, key)
                 payment_attempt_log = await self._pay_to_route(route, lnaddr)
             except Exception as e:
                 log.append(PaymentAttemptLog(success=False, exception=e))
@@ -899,7 +899,7 @@ class LNWallet(LNWorker):
                 break
         else:
             reason = _('Failed after {} attempts').format(attempts)
-        util.trigger_callback('invoice_status', key)
+        util.trigger_callback('invoice_status', self.wallet, key)
         if success:
             util.trigger_callback('payment_succeeded', self.wallet, key)
         else:
@@ -1239,7 +1239,7 @@ class LNWallet(LNWorker):
         else:
             chan.logger.info('received unexpected payment_failed, probably from previous session')
             key = payment_hash.hex()
-            util.trigger_callback('invoice_status', key)
+            util.trigger_callback('invoice_status', self.wallet, key)
             util.trigger_callback('payment_failed', self.wallet, key, '')
         util.trigger_callback('ln_payment_failed', payment_hash, chan.channel_id)
 
@@ -1255,13 +1255,13 @@ class LNWallet(LNWorker):
         else:
             chan.logger.info('received unexpected payment_sent, probably from previous session')
             key = payment_hash.hex()
-            util.trigger_callback('invoice_status', key)
+            util.trigger_callback('invoice_status', self.wallet, key)
             util.trigger_callback('payment_succeeded', self.wallet, key)
         util.trigger_callback('ln_payment_completed', payment_hash, chan.channel_id)
 
     def payment_received(self, chan, payment_hash: bytes):
         self.set_payment_status(payment_hash, PR_PAID)
-        util.trigger_callback('request_status', payment_hash.hex(), PR_PAID)
+        util.trigger_callback('request_status', self.wallet, payment_hash.hex(), PR_PAID)
         util.trigger_callback('ln_payment_completed', payment_hash, chan.channel_id)
 
     async def _calc_routing_hints_for_invoice(self, amount_sat: Optional[int]):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1788,7 +1788,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
             addr = self.get_txout_address(txo)
             if addr in self.receive_requests:
                 status = self.get_request_status(addr)
-                util.trigger_callback('request_status', addr, status)
+                util.trigger_callback('request_status', self, addr, status)
 
     def make_payment_request(self, address, amount_sat, message, expiration):
         # TODO maybe merge with wallet.create_invoice()...


### PR DESCRIPTION
This PR returns passing wallet to `request_status` (and `invoice_status` for symmetry) events.
It is useful to track which wallet changed request/invoice refers to in event handler (useful for payment processing, complex event forwarding, etc.)
One question: should I change `self.wallet` to `wallet` in some event handlers?