### PR TITLE
windows build: for the "setup" exe, put another "-debug" exe inside

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -139,7 +139,7 @@ exe_portable = EXE(
 #####
 # exe and separate files that NSIS uses to build installer "setup" exe
 
-exe_dependent = EXE(
+exe_inside_setup_noconsole = EXE(
     pyz,
     a.scripts,
     exclude_binaries=True,
@@ -150,8 +150,20 @@ exe_dependent = EXE(
     icon=home+'electrum/gui/icons/electrum.ico',
     console=False)
 
+exe_inside_setup_console = EXE(
+    pyz,
+    a.scripts,
+    exclude_binaries=True,
+    name=os.path.join('build\\pyi.win32\\electrum', cmdline_name+"-debug"),
+    debug=False,
+    strip=None,
+    upx=False,
+    icon=home+'electrum/gui/icons/electrum.ico',
+    console=True)
+
 coll = COLLECT(
-    exe_dependent,
+    exe_inside_setup_noconsole,
+    exe_inside_setup_console,
     a.binaries,
     a.zipfiles,
     a.datas,


### PR DESCRIPTION
The "setup" Windows binary we distribute allows users to "install" Electrum
on their system. The distributable is created by NSIS. During
installation a bunch of files will get unpacked in %programfiles(x86)%/Electrum,
including an "inner" exe that will be the entrypoint for the user to start
the application. A shortcut is also created for the inner exe.

With this change, there will now be two inner EXEs. One the same as before,
the other with a "-debug" suffix in its name. The debug exe is built as a
"console" application (as opposed to a "windowed" application), so when
launched via double-click a black console window would appear; and also
importantly stdin/stdout are handled properly for it (unlike for "windowed"
programs). (see #2592)

There will not be a shortcut or similar for the debug exe; it would just
be there as a debugging option we can instruct users to use when needed.
In particular early crashes during startup are hard to debug without
stdout/stderr. (see e.g. #6601)