### PR TITLE
Keep console input when switching server

### DIFF
--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -86,8 +86,9 @@ class Console(QtWidgets.QPlainTextEdit):
         self.namespace.update(namespace)
 
     def showMessage(self, message):
+        curr_line = self.getCommand()
         self.appendPlainText(message)
-        self.newPrompt('')
+        self.newPrompt(curr_line)
 
     def clear(self):
         curr_line = self.getCommand()
@@ -96,7 +97,7 @@ class Console(QtWidgets.QPlainTextEdit):
 
     def newPrompt(self, curr_line):
         if self.construct:
-            prompt = '... '
+            prompt = '... ' + curr_line
         else:
             prompt = self.prompt + curr_line
 


### PR DESCRIPTION
Console input was being replaced by an empty line every time the server used changed.

Before:
```
>>> for i in range(0, 3):
...     print(i)
Welcome to electrum.blockstream.info - no logs and Tor support - Please learn about running your own server!
... 
```

After:
```
>>> for i in range(0, 3):
...     print(i)
Welcome to electrum.blockstream.info - no logs and Tor support - Please learn about running your own server!
...     print(i)
... 
0
1
2
>>> 
```