### PR TITLE
Fix dumpgraph command: give out json encoded nodes and channels

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1043,7 +1043,7 @@ class Commands:
 
     @command('wn')
     async def dumpgraph(self, wallet: Abstract_Wallet = None):
-        return list(map(bh2u, wallet.lnworker.channel_db.nodes.keys()))
+        return wallet.lnworker.channel_db.to_dict()
 
     @command('n')
     async def inject_fees(self, fees):

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -39,8 +39,8 @@ from decimal import Decimal
 from typing import Optional, TYPE_CHECKING, Dict, List
 
 from .import util, ecc
-from .util import bfh, bh2u, format_satoshis, json_decode, json_encode, is_hash256_str, is_hex_str, to_bytes, timestamp_to_datetime
-from .util import standardize_path
+from .util import (bfh, bh2u, format_satoshis, json_decode, json_normalize,
+                   is_hash256_str, is_hex_str, to_bytes)
 from . import bitcoin
 from .bitcoin import is_address,  hash_160, COIN
 from .bip32 import BIP32Node
@@ -81,13 +81,6 @@ def satoshis(amount):
 
 def format_satoshis(x):
     return str(Decimal(x)/COIN) if x is not None else None
-
-def json_normalize(x):
-    # note: The return value of commands, when going through the JSON-RPC interface,
-    #       is json-encoded. The encoder used there cannot handle some types, e.g. electrum.util.Satoshis.
-    # note: We should not simply do "json_encode(x)" here, as then later x would get doubly json-encoded.
-    # see #5868
-    return json_decode(json_encode(x))
 
 
 class Command:

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -379,6 +379,13 @@ def json_decode(x):
     except:
         return x
 
+def json_normalize(x):
+    # note: The return value of commands, when going through the JSON-RPC interface,
+    #       is json-encoded. The encoder used there cannot handle some types, e.g. electrum.util.Satoshis.
+    # note: We should not simply do "json_encode(x)" here, as then later x would get doubly json-encoded.
+    # see #5868
+    return json_decode(json_encode(x))
+
 
 # taken from Django Source Code
 def constant_time_compare(val1, val2):


### PR DESCRIPTION
The `dumpgraph` command is broken at the moment, which is fixed by this PR.
This PR adds channels to the output to have a complete view of the whole graph
(excluding one own's node) in terms of a dict, which is json encodeable.

Tested with the Qr-console and with the command line interface.

The `ShortChannelID` is currently encoded to a hex string, as it came from [bytes](https://github.com/spesmilo/electrum/blob/52bd0eb1a656bdd0eb32340350fb4bf82af5c690/electrum/util.py#L258). Should we
print out a more human readable form, we could use the x notation or the int version that lnd uses?

As a side note, I observe that channels seem have no capacity assigned (tested on LN testnet).