### PR TITLE
network dialog: include protocol in server address field

### DIFF
--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -327,7 +327,7 @@ class NetworkChoiceLayout(object):
         server = net_params.server
         auto_connect = net_params.auto_connect
         if not self.server_e.hasFocus():
-            self.server_e.setText(str(server))
+            self.server_e.setText(server.to_friendly_name())
         self.autoconnect_cb.setChecked(auto_connect)
 
         height_str = "%d "%(self.network.get_local_height()) + _('blocks')

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -327,7 +327,7 @@ class NetworkChoiceLayout(object):
         server = net_params.server
         auto_connect = net_params.auto_connect
         if not self.server_e.hasFocus():
-            self.server_e.setText(server.net_addr_str())
+            self.server_e.setText(str(server))
         self.autoconnect_cb.setChecked(auto_connect)
 
         height_str = "%d "%(self.network.get_local_height()) + _('blocks')

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -292,6 +292,12 @@ class ServerAddr:
             protocol = PREFERRED_NETWORK_PROTOCOL
         return ServerAddr(host=host, port=port, protocol=protocol)
 
+    def to_friendly_name(self) -> str:
+        # note: this method is closely linked to from_str_with_inference
+        if self.protocol == 's':  # hide trailing ":s"
+            return self.net_addr_str()
+        return str(self)
+
     def __str__(self):
         return '{}:{}'.format(self.net_addr_str(), self.protocol)
 


### PR DESCRIPTION
Fixes #6576.

When a server address is entered without the protocol (`t`/`s`), we guess the preferred protocol to use (`s`) and configure it.
It is also possible to give the string `host:port:protocol` as a connection string as the server. On update of the server field,
only the server address and port are written back into the server field.

In #6576, a server is entered to use the plain protocol. Focus loss of the field triggers a config update (working correctly) and the field is updated, removing the protocol part. Because the protocol was missing due to autofill, the protocol guessing gets active and wrongly selects again the `s` protocol and configures it. Thanks to @SomberNight for the hints.

In this PR, the full connection string is written back to the server field, which fixes the described behavior above. This enables a user again to change from the `s` to `t` protocol manually (for experienced users), while having also the possibility of protocol guessing, when only the host and port are entered (for more unexperienced users).

Possible alternatives:
* introduce `s`/`t` checkbox