### PR TITLE
CLI: allow specifying --wallet at any arg position, as before

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1351,6 +1351,7 @@ def get_parser():
     parser = argparse.ArgumentParser(
         epilog="Run 'electrum help <command>' to see the help for a command")
     add_global_options(parser)
+    add_wallet_option(parser)
     subparsers = parser.add_subparsers(dest='cmd', metavar='<command>')
     # gui
     parser_gui = subparsers.add_parser('gui', description="Run Electrum's Graphical User Interface.", help="Run GUI (default)")

--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -413,6 +413,9 @@ class Daemon(Logger):
             fd = get_file_descriptor(config)
             if fd is None:
                 raise Exception('failed to lock daemon; already running?')
+        if 'wallet_path' in config.cmdline_options:
+            self.logger.warning("Ignoring parameter 'wallet_path' for daemon. "
+                                "Use the load_wallet command instead.")
         self.asyncio_loop = asyncio.get_event_loop()
         self.network = None
         if not config.get('offline'):


### PR DESCRIPTION
Before commit 46ffab0b5547050881eab5622dac07bb41769793 all of these used to work:
```
./run_electrum -o signmessage tb1qeh090ruc3cs5hry90tev4fsvrnegulw8xssdzx "asdasd" -w ~/.electrum/testnet/wallets/test_segwit_2 --testnet
./run_electrum -o signmessage -w ~/.electrum/testnet/wallets/test_segwit_2 tb1qeh090ruc3cs5hry90tev4fsvrnegulw8xssdzx "asdasd" --testnet
./run_electrum -w ~/.electrum/testnet/wallets/test_segwit_2 -o signmessage tb1qeh090ruc3cs5hry90tev4fsvrnegulw8xssdzx "asdasd" --testnet
```
Since then, the last one no longer works.

Related: 9d2ede8796f4b9c460d50cd7dfc0a85a0de50b6d