### PR TITLE
Remove rogue phishing server enode.duckdns.org

### DIFF
--- a/electrum/servers.json
+++ b/electrum/servers.json
@@ -190,12 +190,6 @@
         "t": "50001",
         "version": "1.4"
     },
-    "enode.duckdns.org": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4"
-    },
     "fedaykin.goip.de": {
         "pruning": "-",
         "s": "50002",


### PR DESCRIPTION
Server turned rogue after dyn DNS expired as was re-registered by scammers.