### PR TITLE
Handle KeyboardInterrupt in Python Console

### DIFF
--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -95,6 +95,11 @@ class Console(QtWidgets.QPlainTextEdit):
         self.setPlainText('')
         self.newPrompt(curr_line)
 
+    def keyboard_interrupt(self):
+        self.construct = []
+        self.appendPlainText('KeyboardInterrupt')
+        self.newPrompt('')
+
     def newPrompt(self, curr_line):
         if self.construct:
             prompt = '... ' + curr_line
@@ -286,6 +291,8 @@ class Console(QtWidgets.QPlainTextEdit):
             return
         elif event.key() == QtCore.Qt.Key_L and event.modifiers() == QtCore.Qt.ControlModifier:
             self.clear()
+        elif event.key() == QtCore.Qt.Key_C and event.modifiers() == QtCore.Qt.ControlModifier:
+            self.keyboard_interrupt()
 
         super(Console, self).keyPressEvent(event)
 


### PR DESCRIPTION
Use Ctrl+C to raise a KeyboardInterrupt.
This is especially useful to escape constructs.

Example:
```
>>> for i in range(0, 3):
...
KeyboardInterrupt
>>>
```