### PR TITLE
Use default sys.ps1 and ps2 as console prompts

### DIFF
--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -15,6 +15,10 @@ from electrum.i18n import _
 
 from .util import MONOSPACE_FONT
 
+# sys.ps1 and sys.ps2 are only declared if an interpreter is in interactive mode.
+sys.ps1 = '>>> '
+sys.ps2 = '... '
+
 
 class OverlayLabel(QtWidgets.QLabel):
     STYLESHEET = '''
@@ -44,10 +48,9 @@ class OverlayLabel(QtWidgets.QLabel):
 
 
 class Console(QtWidgets.QPlainTextEdit):
-    def __init__(self, prompt='>>> ', parent=None):
+    def __init__(self, parent=None):
         QtWidgets.QPlainTextEdit.__init__(self, parent)
 
-        self.prompt = prompt
         self.history = []
         self.namespace = {}
         self.construct = []
@@ -86,7 +89,7 @@ class Console(QtWidgets.QPlainTextEdit):
         self.namespace.update(namespace)
 
     def showMessage(self, message):
-        curr_line = self.getCommand()
+        curr_line = self.getCommand(strip=False)
         self.appendPlainText(message)
         self.newPrompt(curr_line)
 
@@ -102,9 +105,9 @@ class Console(QtWidgets.QPlainTextEdit):
 
     def newPrompt(self, curr_line):
         if self.construct:
-            prompt = '... ' + curr_line
+            prompt = sys.ps2 + curr_line
         else:
-            prompt = self.prompt + curr_line
+            prompt = sys.ps1 + curr_line
 
         self.completions_pos = self.textCursor().position()
         self.completions_visible = False
@@ -112,11 +115,12 @@ class Console(QtWidgets.QPlainTextEdit):
         self.appendPlainText(prompt)
         self.moveCursor(QtGui.QTextCursor.End)
 
-    def getCommand(self):
+    def getCommand(self, *, strip=True):
         doc = self.document()
         curr_line = doc.findBlockByLineNumber(doc.lineCount() - 1).text()
-        curr_line = curr_line.rstrip()
-        curr_line = curr_line[len(self.prompt):]
+        if strip:
+            curr_line = curr_line.rstrip()
+        curr_line = curr_line[len(sys.ps1):]
         return curr_line
 
     def setCommand(self, command):
@@ -126,7 +130,7 @@ class Console(QtWidgets.QPlainTextEdit):
         doc = self.document()
         curr_line = doc.findBlockByLineNumber(doc.lineCount() - 1).text()
         self.moveCursor(QtGui.QTextCursor.End)
-        for i in range(len(curr_line) - len(self.prompt)):
+        for i in range(len(curr_line) - len(sys.ps1)):
             self.moveCursor(QtGui.QTextCursor.Left, QtGui.QTextCursor.KeepAnchor)
 
         self.textCursor().removeSelectedText()
@@ -201,11 +205,11 @@ class Console(QtWidgets.QPlainTextEdit):
 
     def getCursorPosition(self):
         c = self.textCursor()
-        return c.position() - c.block().position() - len(self.prompt)
+        return c.position() - c.block().position() - len(sys.ps1)
 
     def setCursorPosition(self, position):
         self.moveCursor(QtGui.QTextCursor.StartOfLine)
-        for i in range(len(self.prompt) + position):
+        for i in range(len(sys.ps1) + position):
             self.moveCursor(QtGui.QTextCursor.Right)
 
     def run_command(self):


### PR DESCRIPTION
sys.ps1 and sys.ps2 define the strings used as primary and secondary prompts in the Python interpreter.

Also fix a rare bug introduced by myself in 7772af6 (#6607) where spaces at the end of the current line would not be remembered when switching server.