### PR TITLE
Remove phishing server

### DIFF
--- a/electrum/servers.json
+++ b/electrum/servers.json
@@ -58,12 +58,6 @@
         "t": "50001",
         "version": "1.4"
     },
-    "currentlane.lovebitco.in": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4"
-    },
     "electrum.jochen-hoenicke.de": {
         "pruning": "-",
         "s": "50005",


### PR DESCRIPTION
Currentlane.lovebitco.in is being actively used in the phishing attack against Electrum users.
This can be confirmed by looking at https://ra.pe or https://hodlister.co/server-verification.txt,
the server points directly to an ip in the /24 range being used by phishing ElectrumX servers (46.148.231.31) (https://check-host.net/ip-info?host=currentlane.lovebitco.in)

You can also confirm this by connecting directly to the node using versions 3.3.2 and below and attempt to broadcast a transaction.