### PR TITLE
qt gui: send tab: change "Pay" button text to "Pay..."

### DIFF
--- a/electrum/gui/qt/invoice_list.py
+++ b/electrum/gui/qt/invoice_list.py
@@ -142,7 +142,7 @@ class InvoiceList(MyTreeView):
             can_batch_pay = all([i.type == PR_TYPE_ONCHAIN and wallet.get_invoice_status(i) == PR_UNPAID for i in invoices])
             menu = QMenu(self)
             if can_batch_pay:
-                menu.addAction(_("Batch pay invoices"), lambda: self.parent.pay_multiple_invoices(invoices))
+                menu.addAction(_("Batch pay invoices") + "...", lambda: self.parent.pay_multiple_invoices(invoices))
             menu.addAction(_("Delete invoices"), lambda: self.parent.delete_invoices(keys))
             menu.exec_(self.viewport().mapToGlobal(position))
             return
@@ -163,7 +163,7 @@ class InvoiceList(MyTreeView):
             menu.addAction(_("Details"), lambda: self.parent.show_onchain_invoice(invoice))
         status = wallet.get_invoice_status(invoice)
         if status == PR_UNPAID:
-            menu.addAction(_("Pay"), lambda: self.parent.do_pay_invoice(invoice))
+            menu.addAction(_("Pay") + "...", lambda: self.parent.do_pay_invoice(invoice))
         if status == PR_FAILED:
             menu.addAction(_("Retry"), lambda: self.parent.do_pay_invoice(invoice))
         if self.parent.wallet.lnworker:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1370,7 +1370,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         grid.addWidget(self.max_button, 3, 3)
 
         self.save_button = EnterButton(_("Save"), self.do_save_invoice)
-        self.send_button = EnterButton(_("Pay"), self.do_pay)
+        self.send_button = EnterButton(_("Pay") + "...", self.do_pay)
         self.clear_button = EnterButton(_("Clear"), self.do_clear)
 
         buttons = QHBoxLayout()


### PR DESCRIPTION
Based on repeated anecdotal evidence ISTM some users are afraid to click "Pay".
Notably, these are typically users looking for fee settings (and who are not familiar with the architecture: the client cannot sign without prompting for the password ofc).
These users then go on and open thread on reddit/bitcointalk or ask on IRC -- support load that we could do without.

I was pondering how we could change the button text from "Pay" to something else that suggests that there is still a dialog before sign/broadcast, and "Pay..." is my best idea atm.

Ellipsis ("...") is sometimes used in UIs to suggest there will be an additional modal dialog before executing the action. see https://stackoverflow.com/q/637683
Note that I am cheating as the referenced UI guides are talking about menu items, not first-class buttons :)