### PR TITLE
lnrater: follow-up for save channel db attribute accesses

### DIFF
--- a/electrum/channel_db.py
+++ b/electrum/channel_db.py
@@ -762,11 +762,11 @@ class ChannelDB(SqlDB):
 
     def get_node_infos(self) -> Dict[bytes, NodeInfo]:
         with self.lock:
-            return self._nodes
+            return self._nodes.copy()
 
     def get_node_policies(self) -> Dict[Tuple[bytes, ShortChannelID], Policy]:
         with self.lock:
-            return self._policies
+            return self._policies.copy()
 
     def to_dict(self) -> dict:
         """ Generates a graph representation in terms of a dictionary.

--- a/electrum/lnrater.py
+++ b/electrum/lnrater.py
@@ -214,9 +214,11 @@ class LNRater(Logger):
             heuristics = []
             heuristics_weights = []
 
-            # example of how we could construct a scalar score for nodes
-            # this is probably not what we want to to, this is roughly
-            # preferential attachment
+            # Construct an average score which leads to recommendation of nodes
+            # with low fees, large capacity and reasonable number of channels.
+            # This is somewhat akin to preferential attachment, but low fee
+            # nodes are more favored. Here we make a compromise between user
+            # comfort and decentralization, tending towards user comfort.
 
             # number of channels
             heuristics.append(stats.number_channels / max_num_chan)


### PR DESCRIPTION
Add comment on node score and return copies of channel db dicts as per comment in #6705 @SomberNight.