### PR TITLE
Improve performance with large wallets and bad connections

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -80,7 +80,8 @@ class NetworkTimeout:
     class Generic:
         NORMAL = 30
         RELAXED = 45
-        MOST_RELAXED = 180
+        MOST_RELAXED = 600
+
     class Urgent(Generic):
         NORMAL = 10
         RELAXED = 20

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -731,7 +731,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         util.trigger_callback('network_updated')
 
     def get_network_timeout_seconds(self, request_type=NetworkTimeout.Generic) -> int:
-        if self.oneserver and not self.auto_connect:
+        if self.oneserver:
             return request_type.MOST_RELAXED
         if self.proxy:
             return request_type.RELAXED

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -232,7 +232,7 @@ class Synchronizer(SynchronizerBase):
     async def main(self):
         self.wallet.set_up_to_date(False)
         # request missing txns, if any
-        for addr in self.wallet.db.get_history():
+        for addr in random_shuffled_copy(self.wallet.db.get_history()):
             history = self.wallet.db.get_addr_history(addr)
             # Old electrum servers returned ['*'] when all history for the address
             # was pruned. This no longer happens but may remain in old wallets.


### PR DESCRIPTION
Implement a number of fixes as per issues #6697 #6625 and #5489 to handle situations where electrum is currently choking on large wallets and/or failing to complete the initial request-missing-tx run.