### PR TITLE
bitbox02: more robust account keypath

### DIFF
--- a/electrum/plugins/bitbox02/bitbox02.py
+++ b/electrum/plugins/bitbox02/bitbox02.py
@@ -293,8 +293,7 @@ class BitBox02Client(HardwareClientBase):
             raise Exception(
                 "Need to setup communication first before attempting any BitBox02 calls"
             )
-
-        account_keypath = bip32_path[:4]
+        account_keypath = bip32_path[:-2]
         xpubs = wallet.get_master_public_keys()
         our_xpub = self.get_xpub(
             bip32.convert_bip32_intpath_to_strpath(account_keypath), xtype
@@ -504,15 +503,7 @@ class BitBox02Client(HardwareClientBase):
                     )
                 )
 
-        if type(wallet) is Standard_Wallet:
-            keypath_account = full_path[:3]
-        elif type(wallet) is Multisig_Wallet:
-            keypath_account = full_path[:4]
-        else:
-            raise Exception(
-                "BitBox02 does not support this wallet type: {}".format(type(wallet))
-            )
-
+        keypath_account = full_path[:-2]
         sigs = self.bitbox02_device.btc_sign(
             coin,
             [bitbox02.btc.BTCScriptConfigWithKeypath(


### PR DESCRIPTION
In multisig, we plan to allow other kinds of keypaths that are not
exactly 4 elements long. This change allows parsing the account
keypath for any kind of keypath, assuming the last two element are /change/address.