### PR TITLE
Fix daemon being treated as a function

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2143,7 +2143,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                                              self.password_dialog,
                                              **{**kwargs, 'wallet': self.wallet})
         for m in dir(c):
-            if m[0]=='_' or m in ['network','wallet','config']: continue
+            if m[0]=='_' or m in ['network','wallet','config','daemon']: continue
             methods[m] = mkfunc(c._run, m)
 
         console.updateNamespace(methods)


### PR DESCRIPTION
`daemon` was improperly turned into a function in the Python console.
Point `daemon` to `window.gui_object.daemon` instead.

```
Before:
>>> window.gui_object.daemon
<electrum.daemon.Daemon object at 0xffff8d116970>
>>> daemon
'daemon' is a function. Type 'daemon()' to use it in the Python console.
>>> daemon()
Traceback (most recent call last):
  File "***/electrum/electrum/gui/qt/main_window.py", line 2141, in <lambda>
    return lambda *args, **kwargs: f(method,
  File "***/electrum/electrum/commands.py", line 161, in _run
    cmd = known_commands[method]
KeyError: 'daemon'

After:
>>> window.gui_object.daemon
<electrum.daemon.Daemon object at 0xffffb1eff730>
>>> daemon
<electrum.daemon.Daemon object at 0xffffb1eff730>
```