### PR TITLE
Kivy: use the same password for all wallets

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -1149,9 +1149,8 @@ class InstallWizard(BaseWizard, Widget):
         Clock.schedule_once(lambda dt: self.app.show_error(msg))
 
     def request_password(self, run_next, force_disable_encrypt_cb=False):
-        if force_disable_encrypt_cb:
-            # do not request PIN for watching-only wallets
-            run_next(None, False)
+        if self.app.password is not None:
+            run_next(self.app.password, True)
             return
         def on_success(old_pw, pw):
             assert old_pw is None

--- a/electrum/gui/kivy/uix/dialogs/settings.py
+++ b/electrum/gui/kivy/uix/dialogs/settings.py
@@ -87,7 +87,7 @@ Builder.load_string('''
                 CardSeparator
                 SettingsItem:
                     title: _('Password')
-                    description: _("Change wallet password.")
+                    description: _('Change your password') if app._use_single_password else _("Change your password for this wallet.")
                     action: root.change_password
                 CardSeparator
                 SettingsItem:

--- a/electrum/gui/kivy/uix/dialogs/wallets.py
+++ b/electrum/gui/kivy/uix/dialogs/wallets.py
@@ -16,6 +16,7 @@ Builder.load_string('''
     title: _('Wallets')
     id: popup
     path: ''
+    disable_new: True
     BoxLayout:
         orientation: 'vertical'
         padding: '10dp'
@@ -33,7 +34,8 @@ Builder.load_string('''
             cols: 3
             size_hint_y: 0.1
             Button:
-                id: open_button
+                id: new_button
+                disabled: root.disable_new
                 size_hint: 0.1, None
                 height: '48dp'
                 text: _('New')
@@ -53,12 +55,14 @@ Builder.load_string('''
 
 class WalletDialog(Factory.Popup):
 
-    def __init__(self, path, callback):
+    def __init__(self, path, callback, disable_new):
         Factory.Popup.__init__(self)
         self.path = path
         self.callback = callback
+        self.disable_new = disable_new
 
     def new_wallet(self, dirname):
+        assert self.disable_new is False
         def cb(filename):
             if not filename:
                 return

--- a/run_electrum
+++ b/run_electrum
@@ -317,6 +317,7 @@ def main():
             'verbosity': '*' if build_config.DEBUG else '',
             'cmd': 'gui',
             'gui': 'kivy',
+            'single_password':True,
         }
     else:
         config_options = args.__dict__


### PR DESCRIPTION
When a wallet password is updated, check the password for all
wallets in directory. If that check passes, update password for
all wallets. If it fails, update only the current wallet.