### PR TITLE
Use os._exit() for FORKed child browser opener process. Fixes #6404.

### DIFF
--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -1001,7 +1001,7 @@ def webopen(url: str):
         if os.fork() == 0:
             del os.environ['LD_LIBRARY_PATH']
             webbrowser.open(url)
-            sys.exit(0)
+            os._exit(0)
     else:
         webbrowser.open(url)
 


### PR DESCRIPTION
On Linux, when Electrum is executed from Appimage file, to prevent system library
inconsistence for Electrum and web browser and all issues involving that,
Electrum starts web browser and opens web page upon clicking on
'View on block explorer' by fork()'ing the process, unsetting
its custom LD_LIBRARY_PATH environment variable in the child process,
and calling webbrowser.open().

Due to incorrect usage of sys.exit() instead of os._exit() for child process,
Electrum (parent) can't be terminated and endlessly waits for child process upon
exit, while child process does nothing but still exists.

Fix this issue by using os._exit function, which should be used for
child processes (not only in Python).