### PR TITLE
kivy: fix some resource path issues

### DIFF
--- a/electrum/gui/kivy/__init__.py
+++ b/electrum/gui/kivy/__init__.py
@@ -29,6 +29,9 @@ import sys
 import os
 from typing import TYPE_CHECKING
 
+KIVY_GUI_PATH = os.path.abspath(os.path.dirname(__file__))
+os.environ['KIVY_DATA_DIR'] = os.path.join(KIVY_GUI_PATH, 'data')
+
 try:
     sys.argv = ['']
     import kivy

--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -2,6 +2,7 @@
 #:import Window kivy.core.window.Window
 #:import Factory kivy.factory.Factory
 #:import _ electrum.gui.kivy.i18n._
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 
 
 ###########################
@@ -211,7 +212,7 @@
         Color:
             rgba: 0.192, .498, 0.745, 1
         BorderImage:
-            source: 'atlas://electrum/gui/kivy/theming/light/card_bottom'
+            source: f'atlas://{KIVY_GUI_PATH}/theming/light/card_bottom'
             size: self.size
             pos: self.pos
 
@@ -225,7 +226,7 @@
 		Color:
 			rgba: 0.192, .498, 0.745, 1
 		BorderImage:
-			source: 'atlas://electrum/gui/kivy/theming/light/card_bottom'
+			source: f'atlas://{KIVY_GUI_PATH}/theming/light/card_bottom'
 			size: self.size
 			pos: self.pos
 
@@ -238,7 +239,7 @@
 		Color:
 			rgba: 0.192, .498, 0.745, 1
         BorderImage:
-            source: 'atlas://electrum/gui/kivy/theming/light/card_bottom'
+            source: f'atlas://{KIVY_GUI_PATH}/theming/light/card_bottom'
             size: self.size
             pos: self.pos
 
@@ -326,8 +327,8 @@
     valign: 'middle'
     bold: True
     font_size: '12.5sp'
-    background_normal: 'atlas://electrum/gui/kivy/theming/light/tab_btn'
-    background_down: 'atlas://electrum/gui/kivy/theming/light/tab_btn_pressed'
+    background_normal: f'atlas://{KIVY_GUI_PATH}/theming/light/tab_btn'
+    background_down: f'atlas://{KIVY_GUI_PATH}/theming/light/tab_btn_pressed'
 
 
 <ColoredLabel@Label>:
@@ -417,7 +418,7 @@ BoxLayout:
             rgb: .6, .6, .6
         Rectangle:
             size: self.size
-            source: 'electrum/gui/kivy/data/background.png'
+            source: f'{KIVY_GUI_PATH}/data/background.png'
 
     ActionBar:
 

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -23,6 +23,7 @@ from electrum.network import Network, TxBroadcastError, BestEffortRequestFailed
 from electrum.interface import PREFERRED_NETWORK_PROTOCOL, ServerAddr
 from electrum.logging import Logger
 from .i18n import _
+from . import KIVY_GUI_PATH
 
 from kivy.app import App
 from kivy.core.window import Window
@@ -68,11 +69,13 @@ Factory.register('TabbedCarousel', module='electrum.gui.kivy.uix.screens')
 # Register fonts without this you won't be able to use bold/italic...
 # inside markup.
 from kivy.core.text import Label
-Label.register('Roboto',
-               'electrum/gui/kivy/data/fonts/Roboto.ttf',
-               'electrum/gui/kivy/data/fonts/Roboto.ttf',
-               'electrum/gui/kivy/data/fonts/Roboto-Bold.ttf',
-               'electrum/gui/kivy/data/fonts/Roboto-Bold.ttf')
+Label.register(
+    'Roboto',
+    KIVY_GUI_PATH + '/data/fonts/Roboto.ttf',
+    KIVY_GUI_PATH + '/data/fonts/Roboto.ttf',
+    KIVY_GUI_PATH + '/data/fonts/Roboto-Bold.ttf',
+    KIVY_GUI_PATH + '/data/fonts/Roboto-Bold.ttf',
+)
 
 
 from electrum.util import (NoDynamicFeeEstimates, NotEnoughFunds,
@@ -530,7 +533,7 @@ class ElectrumWindow(App, Logger):
         currentActivity.startActivity(it)
 
     def build(self):
-        return Builder.load_file('electrum/gui/kivy/main.kv')
+        return Builder.load_file(KIVY_GUI_PATH + '/main.kv')
 
     def _pause(self):
         if platform == 'android':
@@ -724,7 +727,7 @@ class ElectrumWindow(App, Logger):
         elif name == 'wallets':
             self.wallets_dialog()
         elif name == 'status':
-            popup = Builder.load_file('electrum/gui/kivy/uix/ui_screens/'+name+'.kv')
+            popup = Builder.load_file(KIVY_GUI_PATH + f'/uix/ui_screens/{name}.kv')
             master_public_keys_layout = popup.ids.master_public_keys
             for xpub in self.wallet.get_master_public_keys()[1:]:
                 master_public_keys_layout.add_widget(TopLabel(text=_('Master Public Key')))
@@ -736,7 +739,7 @@ class ElectrumWindow(App, Logger):
         elif name.endswith("_dialog"):
             getattr(self, name)()
         else:
-            popup = Builder.load_file('electrum/gui/kivy/uix/ui_screens/'+name+'.kv')
+            popup = Builder.load_file(KIVY_GUI_PATH + f'/uix/ui_screens/{name}.kv')
             popup.open()
 
     @profiler
@@ -766,7 +769,7 @@ class ElectrumWindow(App, Logger):
         self.history_screen = None
         self.send_screen = None
         self.receive_screen = None
-        self.icon = "electrum/gui/icons/electrum.png"
+        self.icon = os.path.dirname(KIVY_GUI_PATH) + "/icons/electrum.png"
         self.tabs = self.root.ids['tabs']
 
     def update_interfaces(self, dt):
@@ -968,7 +971,7 @@ class ElectrumWindow(App, Logger):
         self.qr_dialog(label.name, label.data, True)
 
     def show_error(self, error, width='200dp', pos=None, arrow_pos=None,
-                   exit=False, icon='atlas://electrum/gui/kivy/theming/light/error', duration=0,
+                   exit=False, icon=f'atlas://{KIVY_GUI_PATH}/theming/light/error', duration=0,
                    modal=False):
         ''' Show an error Message Bubble.
         '''
@@ -980,7 +983,7 @@ class ElectrumWindow(App, Logger):
                   exit=False, duration=0, modal=False):
         ''' Show an Info Message Bubble.
         '''
-        self.show_error(error, icon='atlas://electrum/gui/kivy/theming/light/important',
+        self.show_error(error, icon=f'atlas://{KIVY_GUI_PATH}/theming/light/important',
             duration=duration, modal=modal, exit=exit, pos=pos,
             arrow_pos=arrow_pos)
 
@@ -1021,7 +1024,7 @@ class ElectrumWindow(App, Logger):
             info_bubble.show_arrow = False
             img.allow_stretch = True
             info_bubble.dim_background = True
-            info_bubble.background_image = 'atlas://electrum/gui/kivy/theming/light/card'
+            info_bubble.background_image = f'atlas://{KIVY_GUI_PATH}/theming/light/card'
         else:
             info_bubble.fs = False
             info_bubble.icon = icon

--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 Builder.load_string('''
 #:import Window kivy.core.window.Window
 #:import _ electrum.gui.kivy.i18n._
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 
 
 <WizardTextInput@TextInput>
@@ -43,8 +44,8 @@ Builder.load_string('''
     background_color: (1, 1, 1, 1) if self.focus else (0.454, 0.698, 0.909, 1)
     foreground_color: (0.31, 0.31, 0.31, 1) if self.focus else (0.835, 0.909, 0.972, 1)
     hint_text_color: self.foreground_color
-    background_active: 'atlas://electrum/gui/kivy/theming/light/create_act_text_active'
-    background_normal: 'atlas://electrum/gui/kivy/theming/light/create_act_text_active'
+    background_active: f'atlas://{KIVY_GUI_PATH}/theming/light/create_act_text_active'
+    background_normal: f'atlas://{KIVY_GUI_PATH}/theming/light/create_act_text_active'
     size_hint_y: None
     height: '48sp'
 
@@ -93,7 +94,7 @@ Builder.load_string('''
                 size_hint: 1, None
                 height: self.texture_size[1] if self.opacity else 0
                 font_size: '33sp'
-                font_name: 'electrum/gui/kivy/data/fonts/tron/Tr2n.ttf'
+                font_name: f'{KIVY_GUI_PATH}/data/fonts/tron/Tr2n.ttf'
         GridLayout:
             cols: 1
             id: crcontent
@@ -314,7 +315,7 @@ Builder.load_string('''
     font_size: '18dp'
     text_size: self.width - dp(24), self.height - dp(12)
     color: .1, .1, .1, 1
-    background_normal: 'atlas://electrum/gui/kivy/theming/light/white_bg_round_top'
+    background_normal: f'atlas://{KIVY_GUI_PATH}/theming/light/white_bg_round_top'
     background_down: self.background_normal
     size_hint_y: None
 
@@ -343,7 +344,7 @@ Builder.load_string('''
         height: '30dp'
         width: '30dp'
         size_hint: 1, None
-        icon: 'atlas://electrum/gui/kivy/theming/light/gear'
+        icon: f'atlas://{KIVY_GUI_PATH}/theming/light/gear'
         on_release:
             root.options_dialog() if root.options_dialog else None
 
@@ -479,7 +480,7 @@ Builder.load_string('''
             id: scan
             height: '48sp'
             on_release: root.scan_xpub()
-            icon: 'atlas://electrum/gui/kivy/theming/light/camera'
+            icon: f'atlas://{KIVY_GUI_PATH}/theming/light/camera'
             size_hint: 1, None
         WizardButton:
             text: _('Paste')

--- a/electrum/gui/kivy/uix/dialogs/invoice_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/invoice_dialog.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
+
 <InvoiceDialog@Popup>
     id: popup
     amount_str: ''
@@ -66,12 +68,12 @@ Builder.load_string('''
                     text: _('Delete')
                     on_release: root.delete_dialog()
                 IconButton:
-                    icon: 'atlas://electrum/gui/kivy/theming/light/copy'
+                    icon: f'atlas://{KIVY_GUI_PATH}/theming/light/copy'
                     size_hint: 0.5, None
                     height: '48dp'
                     on_release: root.copy_to_clipboard()
                 IconButton:
-                    icon: 'atlas://electrum/gui/kivy/theming/light/share'
+                    icon: f'atlas://{KIVY_GUI_PATH}/theming/light/share'
                     size_hint: 0.5, None
                     height: '48dp'
                     on_release: root.do_share()

--- a/electrum/gui/kivy/uix/dialogs/label_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/label_dialog.py
@@ -4,6 +4,8 @@ from kivy.properties import ObjectProperty
 from kivy.lang import Builder
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
+
 <LabelDialog@Popup>
     id: popup
     title: ''
@@ -21,8 +23,8 @@ Builder.load_string('''
             pos_hint: {'center_y':.5}
             text:''
             multiline: False
-            background_normal: 'atlas://electrum/gui/kivy/theming/light/tab_btn'
-            background_active: 'atlas://electrum/gui/kivy/theming/light/textinput_active'
+            background_normal: f'atlas://{KIVY_GUI_PATH}/theming/light/tab_btn'
+            background_active: f'atlas://{KIVY_GUI_PATH}/theming/light/textinput_active'
             hint_text_color: self.foreground_color
             foreground_color: 1, 1, 1, 1
             font_size: '16dp'

--- a/electrum/gui/kivy/uix/dialogs/lightning_open_channel.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_open_channel.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
+
 <LightningOpenChannelDialog@Popup>
     id: s
     name: 'lightning_open_channel'
@@ -38,7 +40,7 @@ Builder.load_string('''
                 size_hint: 1, None
                 height: blue_bottom.item_height
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/globe'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/globe'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -51,7 +53,7 @@ Builder.load_string('''
                 size_hint: 1, None
                 height: blue_bottom.item_height
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/calculator'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/calculator'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -64,12 +66,12 @@ Builder.load_string('''
             size_hint: 1, None
             height: '48dp'
             IconButton:
-                icon: 'atlas://electrum/gui/kivy/theming/light/copy'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/copy'
                 size_hint: 0.5, None
                 height: '48dp'
                 on_release: s.do_paste()
             IconButton:
-                icon: 'atlas://electrum/gui/kivy/theming/light/camera'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/camera'
                 size_hint: 0.5, None
                 height: '48dp'
                 on_release: app.scan_qr(on_complete=s.on_qr)

--- a/electrum/gui/kivy/uix/dialogs/password_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/password_dialog.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from electrum.storage import WalletStorage
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 
 <PasswordDialog@Popup>
     id: popup
@@ -47,7 +48,7 @@ Builder.load_string('''
             IconButton:
                 size_hint: 0.15, None
                 height: '40dp'
-                icon: 'atlas://electrum/gui/kivy/theming/light/btn_create_account'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/btn_create_account'
                 on_release: root.select_file()
                 disabled: root.is_change
                 opacity: 0 if root.is_change else 1
@@ -81,7 +82,7 @@ Builder.load_string('''
             IconButton:
                 height: '40dp'
                 size_hint: 0.15, None
-                icon: 'atlas://electrum/gui/kivy/theming/light/eye1'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/eye1'
                 icon_size: '40dp'
                 on_release:
                     textinput_generic_password.password = False if textinput_generic_password.password else True

--- a/electrum/gui/kivy/uix/dialogs/qr_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/qr_dialog.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
+
 <QRDialog@Popup>
     id: popup
     title: ''
@@ -47,7 +49,7 @@ Builder.load_string('''
                     on_release:
                         root.copy_to_clipboard()
                 IconButton:
-                    icon: 'atlas://electrum/gui/kivy/theming/light/share'
+                    icon: f'atlas://{KIVY_GUI_PATH}/theming/light/share'
                     size_hint: 0.6, None
                     height: '48dp'
                     on_release: root.do_share()

--- a/electrum/gui/kivy/uix/dialogs/qr_scanner.py
+++ b/electrum/gui/kivy/uix/dialogs/qr_scanner.py
@@ -21,6 +21,8 @@ class QrScannerDialog(Factory.AnimatedPopup):
 
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
+
 <QrScannerDialog>
     title:
         _(\
@@ -33,7 +35,7 @@ Builder.load_string('''
     #separator_color: .89, .89, .89, 1
     #separator_height: '1.2dp'
     #title_color: .437, .437, .437, 1
-    #background: 'atlas://electrum/gui/kivy/theming/light/dialog'
+    #background: f'atlas://{KIVY_GUI_PATH}/theming/light/dialog'
     on_activate:
         qrscr.start()
         qrscr.size = self.size

--- a/electrum/gui/kivy/uix/dialogs/request_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/request_dialog.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
+
 <RequestDialog@Popup>
     id: popup
     amount_str: ''
@@ -66,12 +68,12 @@ Builder.load_string('''
                     text: _('Delete')
                     on_release: root.delete_dialog()
                 IconButton:
-                    icon: 'atlas://electrum/gui/kivy/theming/light/copy'
+                    icon: f'atlas://{KIVY_GUI_PATH}/theming/light/copy'
                     size_hint: 0.5, None
                     height: '48dp'
                     on_release: root.copy_to_clipboard()
                 IconButton:
-                    icon: 'atlas://electrum/gui/kivy/theming/light/share'
+                    icon: f'atlas://{KIVY_GUI_PATH}/theming/light/share'
                     size_hint: 0.5, None
                     height: '48dp'
                     on_release: root.do_share()

--- a/electrum/gui/kivy/uix/dialogs/settings.py
+++ b/electrum/gui/kivy/uix/dialogs/settings.py
@@ -9,6 +9,8 @@ from electrum.gui.kivy.i18n import _
 from electrum.plugin import run_hook
 from electrum import coinchooser
 
+from electrum.gui.kivy import KIVY_GUI_PATH
+
 from .choice_dialog import ChoiceDialog
 
 Builder.load_string('''
@@ -193,7 +195,7 @@ class SettingsDialog(Factory.Popup):
                 net_params = net_params._replace(proxy=proxy)
                 network.run_from_another_thread(network.set_parameters(net_params))
                 item.status = self.proxy_status()
-            popup = Builder.load_file('electrum/gui/kivy/uix/ui_screens/proxy.kv')
+            popup = Builder.load_file(KIVY_GUI_PATH + '/uix/ui_screens/proxy.kv')
             popup.ids.mode.text = proxy.get('mode') if proxy else 'None'
             popup.ids.host.text = proxy.get('host') if proxy else ''
             popup.ids.port.text = proxy.get('port') if proxy else ''

--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 
 Builder.load_string('''
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 
 <TxDialog>
     id: popup
@@ -102,7 +103,7 @@ Builder.load_string('''
             IconButton:
                 size_hint: 0.5, None
                 height: '48dp'
-                icon: 'atlas://electrum/gui/kivy/theming/light/qrcode'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/qrcode'
                 on_release: root.show_qr()
             Button:
                 size_hint: 0.5, None

--- a/electrum/gui/kivy/uix/screens.py
+++ b/electrum/gui/kivy/uix/screens.py
@@ -40,6 +40,7 @@ from electrum.logging import Logger
 from .dialogs.question import Question
 from .dialogs.lightning_open_channel import LightningOpenChannelDialog
 
+from electrum.gui.kivy import KIVY_GUI_PATH
 from electrum.gui.kivy.i18n import _
 
 if TYPE_CHECKING:
@@ -96,9 +97,9 @@ TX_ICONS = [
 ]
 
 
-Builder.load_file('electrum/gui/kivy/uix/ui_screens/history.kv')
-Builder.load_file('electrum/gui/kivy/uix/ui_screens/send.kv')
-Builder.load_file('electrum/gui/kivy/uix/ui_screens/receive.kv')
+Builder.load_file(KIVY_GUI_PATH + '/uix/ui_screens/history.kv')
+Builder.load_file(KIVY_GUI_PATH + '/uix/ui_screens/send.kv')
+Builder.load_file(KIVY_GUI_PATH + '/uix/ui_screens/receive.kv')
 
 
 class HistoryScreen(CScreen):
@@ -132,7 +133,7 @@ class HistoryScreen(CScreen):
         if is_lightning:
             status = 0
             status_str = 'unconfirmed' if timestamp is None else format_time(int(timestamp))
-            icon = "atlas://electrum/gui/kivy/theming/light/lightning"
+            icon = f'atlas://{KIVY_GUI_PATH}/theming/light/lightning'
             message = tx_item['label']
             fee_msat = tx_item['fee_msat']
             fee = int(fee_msat/1000) if fee_msat else None
@@ -144,7 +145,7 @@ class HistoryScreen(CScreen):
                                         conf=tx_item['confirmations'],
                                         timestamp=tx_item['timestamp'])
             status, status_str = self.app.wallet.get_tx_status(tx_hash, tx_mined_info)
-            icon = "atlas://electrum/gui/kivy/theming/light/" + TX_ICONS[status]
+            icon = f'atlas://{KIVY_GUI_PATH}/theming/light/' + TX_ICONS[status]
             message = tx_item['label'] or tx_hash
             fee = tx_item['fee_sat']
             fee_text = '' if fee is None else 'fee: %d sat'%fee

--- a/electrum/gui/kivy/uix/ui_screens/history.kv
+++ b/electrum/gui/kivy/uix/ui_screens/history.kv
@@ -1,6 +1,7 @@
 #:import _ electrum.gui.kivy.i18n._
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 #:import Factory kivy.factory.Factory
-#:set font_light 'electrum/gui/kivy/data/fonts/Roboto-Condensed.ttf'
+#:set font_light f'{KIVY_GUI_PATH}/data/fonts/Roboto-Condensed.ttf'
 #:set btc_symbol chr(171)
 #:set mbtc_symbol chr(187)
 
@@ -15,7 +16,7 @@
 
 
 <HistoryItem@CardItem>
-    icon: 'atlas://electrum/gui/kivy/theming/light/important'
+    icon: f'atlas://{KIVY_GUI_PATH}/theming/light/important'
     message: ''
     fee_text: ''
     is_mine: True

--- a/electrum/gui/kivy/uix/ui_screens/receive.kv
+++ b/electrum/gui/kivy/uix/ui_screens/receive.kv
@@ -1,11 +1,12 @@
 #:import _ electrum.gui.kivy.i18n._
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 #:import pr_color electrum.invoices.pr_color
 #:import PR_UNKNOWN electrum.invoices.PR_UNKNOWN
 #:import Factory kivy.factory.Factory
 #:import Decimal decimal.Decimal
 #:set btc_symbol chr(171)
 #:set mbtc_symbol chr(187)
-#:set font_light 'electrum/gui/kivy/data/fonts/Roboto-Condensed.ttf'
+#:set font_light f'{KIVY_GUI_PATH}/data/fonts/Roboto-Condensed.ttf'
 
 
 <RequestLabel@Label>
@@ -85,7 +86,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/lightning' if root.is_lightning else 'atlas://electrum/gui/kivy/theming/light/globe'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/lightning' if root.is_lightning else f'atlas://{KIVY_GUI_PATH}/theming/light/globe'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -102,7 +103,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/calculator'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/calculator'
                     opacity: 0.7
                     size_hint: None, None
                     size: '22dp', '22dp'
@@ -122,7 +123,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/pen'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/pen'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -134,12 +135,12 @@
             size_hint: 1, None
             height: '48dp'
             IconButton:
-                icon: 'atlas://electrum/gui/kivy/theming/light/delete'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/delete'
                 size_hint: 0.5, None
                 height: '48dp'
                 on_release: Clock.schedule_once(lambda dt: s.clear_requests_dialog())
             IconButton:
-                icon: 'atlas://electrum/gui/kivy/theming/light/clock1'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/clock1'
                 size_hint: 0.5, None
                 height: '48dp'
                 on_release: Clock.schedule_once(lambda dt: s.expiration_dialog(s))

--- a/electrum/gui/kivy/uix/ui_screens/send.kv
+++ b/electrum/gui/kivy/uix/ui_screens/send.kv
@@ -1,11 +1,12 @@
 #:import _ electrum.gui.kivy.i18n._
+#:import KIVY_GUI_PATH electrum.gui.kivy.KIVY_GUI_PATH
 #:import pr_color electrum.invoices.pr_color
 #:import PR_UNKNOWN electrum.invoices.PR_UNKNOWN
 #:import Factory kivy.factory.Factory
 #:import Decimal decimal.Decimal
 #:set btc_symbol chr(171)
 #:set mbtc_symbol chr(187)
-#:set font_light 'electrum/gui/kivy/data/fonts/Roboto-Condensed.ttf'
+#:set font_light f'{KIVY_GUI_PATH}/data/fonts/Roboto-Condensed.ttf'
 
 <PaymentLabel@Label>
     #color: .305, .309, .309, 1
@@ -85,7 +86,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/lightning' if root.is_lightning else 'atlas://electrum/gui/kivy/theming/light/globe'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/lightning' if root.is_lightning else f'atlas://{KIVY_GUI_PATH}/theming/light/globe'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -102,7 +103,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/calculator'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/calculator'
                     opacity: 0.7
                     size_hint: None, None
                     size: '22dp', '22dp'
@@ -121,7 +122,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/pen'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/pen'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -137,7 +138,7 @@
                 height: blue_bottom.item_height
                 spacing: '5dp'
                 Image:
-                    source: 'atlas://electrum/gui/kivy/theming/light/star_big_inactive'
+                    source: f'atlas://{KIVY_GUI_PATH}/theming/light/star_big_inactive'
                     size_hint: None, None
                     size: '22dp', '22dp'
                     pos_hint: {'center_y': .5}
@@ -150,20 +151,20 @@
             size_hint: 1, None
             height: '48dp'
             IconButton:
-                icon: 'atlas://electrum/gui/kivy/theming/light/delete'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/delete'
                 size_hint: 0.5, 1
                 on_release: Clock.schedule_once(lambda dt: s.clear_invoices_dialog())
             IconButton:
                 size_hint: 0.5, 1
                 on_release: s.do_save()
-                icon: 'atlas://electrum/gui/kivy/theming/light/save'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/save'
             IconButton:
                 size_hint: 0.5, 1
                 on_release: s.do_clear()
-                icon: 'atlas://electrum/gui/kivy/theming/light/closebutton'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/closebutton'
             IconButton:
                 size_hint: 0.5, 1
-                icon: 'atlas://electrum/gui/kivy/theming/light/copy'
+                icon: f'atlas://{KIVY_GUI_PATH}/theming/light/copy'
                 on_release: s.do_paste()
             Button:
                 id: qr

--- a/run_electrum
+++ b/run_electrum
@@ -49,9 +49,6 @@ if is_local:  # running from source
     # developers should probably see all deprecation warnings.
     warnings.simplefilter('default', DeprecationWarning)
 
-# move this back to gui/kivy/__init.py once plugins are moved
-os.environ['KIVY_DATA_DIR'] = os.path.abspath(os.path.dirname(__file__)) + '/electrum/gui/kivy/data/'
-
 if is_local or is_android:
     sys.path.insert(0, os.path.join(script_dir, 'packages'))
 


### PR DESCRIPTION
When running kivy on Linux desktop,
running from git clone, `./run_electrum -g kivy` worked,
but `pip install -e . ; electrum -g kivy` did not.
This was due to the relative paths using cwd as base.

see #6835

note: I have also tried using [kivy.resources.resource_add_path](https://kivy.org/doc/stable/api-kivy.resources.html#kivy.resources.resource_add_path) as an alternative, but could not get that to work.