### PR TITLE
build: don't allow setuptools to sneakily install build-time deps

### DIFF
--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -94,6 +94,8 @@ python='appdir_python'
 info "installing pip."
 "$python" -m ensurepip
 
+break_legacy_easy_install
+
 
 info "preparing electrum-locale."
 (

--- a/contrib/build-linux/sdist/build.sh
+++ b/contrib/build-linux/sdist/build.sh
@@ -12,6 +12,8 @@ DISTDIR="$PROJECT_ROOT/dist"
 # note that at least py3.7 is needed, to have https://bugs.python.org/issue30693
 python3 --version || fail "python interpreter not found"
 
+break_legacy_easy_install
+
 # upgrade to modern pip so that it knows the flags we need.
 # we will then install a pinned version of pip as part of requirements-build-sdist
 python3 -m pip install --upgrade pip

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -60,6 +60,8 @@ for msifile in core dev exe lib pip tools; do
     wine msiexec /i "$PYTHON_DOWNLOADS/${msifile}.msi" /qb TARGETDIR=$PYHOME
 done
 
+break_legacy_easy_install
+
 info "Installing build dependencies."
 $PYTHON -m pip install --no-dependencies --no-warn-script-location -r "$CONTRIB"/deterministic-build/requirements-build-wine.txt
 

--- a/contrib/build_tools_util.sh
+++ b/contrib/build_tools_util.sh
@@ -129,3 +129,25 @@ fi
 
 export GCC_STRIP_BINARIES="${GCC_STRIP_BINARIES:-0}"
 
+
+function break_legacy_easy_install() {
+    # We don't want setuptools sneakily installing dependencies, invisible to pip.
+    # This ensures that if setuptools calls distutils which then calls easy_install,
+    # easy_install will not download packages over the network.
+    # see https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires
+    # see https://github.com/pypa/setuptools/issues/1916#issuecomment-743350566
+    info "Intentionally breaking legacy easy_install."
+    DISTUTILS_CFG="${HOME}/.pydistutils.cfg"
+    DISTUTILS_CFG_BAK="${HOME}/.pydistutils.cfg.orig"
+    # If we are not inside docker, we might be overwriting a config file on the user's system...
+    if [ -e "$DISTUTILS_CFG" ] && [ ! -e "$DISTUTILS_CFG_BAK" ]; then
+        warn "Overwriting python distutils config file at '$DISTUTILS_CFG'. A copy will be saved at '$DISTUTILS_CFG_BAK'."
+        mv "$DISTUTILS_CFG" "$DISTUTILS_CFG_BAK"
+    fi
+    cat <<EOF > "$DISTUTILS_CFG"
+[easy_install]
+index_url = ''
+find_links = ''
+EOF
+}
+

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -72,6 +72,8 @@ PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s $PYTHON_VERSION && \
 pyenv global $PYTHON_VERSION || \
 fail "Unable to use Python $PYTHON_VERSION"
 
+break_legacy_easy_install
+
 # create a fresh virtualenv
 # This helps to avoid older versions of pip-installed dependencies interfering with the build.
 VENV_DIR="$CONTRIB_OSX/build-venv"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[easy_install]
+# We don't want setuptools sneakily installing dependencies, invisible to pip.
+# see https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires
+# see https://github.com/pypa/setuptools/issues/1916#issuecomment-743350566
+index_url = ''
+find_links = ''


### PR DESCRIPTION
see https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires
> Setuptools offers the `setup_requires` `setup()` keyword for specifying
> dependencies that need to be present in order for the `setup.py`
> script to run. Internally, Setuptools uses easy_install to
> fulfill these dependencies.
> pip has no way to control how these dependencies are located.
> None of the package index options have an effect.

With these changes, we will now instead hard fail if this were to happen.

related: https://github.com/spesmilo/electrum/issues/5859#issuecomment-743621898