### PR TITLE
Swap improvements

### DIFF
--- a/electrum/gui/qt/channels_list.py
+++ b/electrum/gui/qt/channels_list.py
@@ -225,6 +225,7 @@ class ChannelsList(MyTreeView):
             self._update_chan_frozen_bg(chan=chan, items=items)
         if wallet.lnworker:
             self.update_can_send(wallet.lnworker)
+            self.update_swap_button(wallet.lnworker)
 
     @QtCore.pyqtSlot()
     def on_gossip_db(self):
@@ -280,13 +281,20 @@ class ChannelsList(MyTreeView):
               + ' ' + self.parent.base_unit()
         self.can_send_label.setText(msg)
 
+    def update_swap_button(self, lnworker: LNWallet):
+        if lnworker.num_sats_can_send() or lnworker.num_sats_can_receive():
+            self.swap_button.setEnabled(True)
+        else:
+            self.swap_button.setEnabled(False)
+
     def get_toolbar(self):
         h = QHBoxLayout()
         self.can_send_label = QLabel('')
         h.addWidget(self.can_send_label)
         h.addStretch()
         self.swap_button = EnterButton(_('Swap'), self.swap_dialog)
-        self.swap_button.setEnabled(self.parent.wallet.has_lightning())
+        self.swap_button.setToolTip("Have at least one channel to do swaps.")
+        self.swap_button.setDisabled(True)
         self.new_channel_button = EnterButton(_('Open Channel'), self.new_channel_with_warning)
         self.new_channel_button.setEnabled(self.parent.wallet.has_lightning())
         h.addWidget(self.new_channel_button)

--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -126,14 +126,15 @@ class SwapDialog(WindowModalDialog):
         self._update_tx('!')
         if self.tx:
             amount = self.tx.output_value_for_address(ln_dummy_address())
-            max_amt = self.swap_manager.get_max_amount()
+            max_swap_amt = self.swap_manager.get_max_amount()
+            max_recv_amt = int(self.lnworker.num_sats_can_receive())
+            max_amt = min(max_swap_amt, max_recv_amt)
             if amount > max_amt:
                 amount = max_amt
                 self._update_tx(amount)
             if self.tx:
                 amount = self.tx.output_value_for_address(ln_dummy_address())
                 assert amount <= max_amt
-                # TODO: limit onchain amount if lightning cannot receive this much
                 self.send_amount_e.setAmount(amount)
 
     def _spend_max_reverse_swap(self):


### PR DESCRIPTION
This PR fixes some issues with the swaps:
* We disable the swap button if no channels are present. It is enabled when channels are open.
* In the case when we have more onchain funds than we can receive on the Lightning wallet, the max button didn't take into account the amount receivable by the Lightning wallet, which led to an empty "you receive" field. The max amount in the normal swap is now limited to the receivable amount on Lightning.
* In case of a forward swap, the swap amount calculation was previously not using a formula that led to the exact expected amount requested by the server, which led to a slight overpayment, depending on the overall swap amount. Using the formula given in the commit message, our estimated amount is now the expected amount from the server.