### PR TITLE
lnchannel: reflect frozen amounts and disconnected peers

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -530,6 +530,9 @@ class Channel(AbstractChannel):
     def is_initiator(self):
         return self.constraints.is_initiator
 
+    def is_active(self):
+        return self.get_state() == ChannelState.OPEN and self.peer_state == PeerState.GOOD
+
     def funding_txn_minimum_depth(self):
         return self.constraints.funding_txn_minimum_depth
 

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1376,15 +1376,23 @@ class LNWallet(LNWorker):
             return Decimal(sum(chan.balance(LOCAL) if not chan.is_closed() else 0
                                for chan in self.channels.values())) / 1000
 
-    def num_sats_can_send(self) -> Union[Decimal, int]:
+    def num_sats_can_send(self) -> Decimal:
+        send_values = [Decimal(0)]
         with self.lock:
-            return Decimal(max(chan.available_to_spend(LOCAL) if chan.is_open() else 0
-                               for chan in self.channels.values()))/1000 if self.channels else 0
+            if self.channels:
+                for c in self.channels.values():
+                    if c.is_active() and not c.is_frozen_for_sending():
+                        send_values.append(Decimal(c.available_to_spend(LOCAL)) / 1000)
+        return max(send_values)
 
-    def num_sats_can_receive(self) -> Union[Decimal, int]:
+    def num_sats_can_receive(self) -> Decimal:
+        receive_values = [Decimal(0)]
         with self.lock:
-            return Decimal(max(chan.available_to_spend(REMOTE) if chan.is_open() else 0
-                               for chan in self.channels.values()))/1000 if self.channels else 0
+            if self.channels:
+                for c in self.channels.values():
+                    if c.is_active() and not c.is_frozen_for_receiving():
+                        receive_values.append(Decimal(c.available_to_spend(REMOTE)) / 1000)
+        return max(receive_values)
 
     def can_pay_invoice(self, invoice: LNInvoice) -> bool:
         return invoice.get_amount_sat() <= self.num_sats_can_send()


### PR DESCRIPTION
in the num_sats_can_send/receive methods of the lnwallet. Fixes #6855.