### PR TITLE
Qt GUI: add dotted underline to HelpLabels

### DIFF
--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -101,11 +101,22 @@ class WWLabel(QLabel):
 
 class HelpLabel(QLabel):
 
+    STYLESHEET = """
+    HelpLabel {
+        border-bottom-width: 1px;
+        border-bottom-style: dotted;
+        border-radius: 0px;
+    }
+    HelpLabel::hover {
+        border-bottom-style: solid;
+    }
+    """
+
     def __init__(self, text, help_text):
         QLabel.__init__(self, text)
         self.help_text = help_text
         self.app = QCoreApplication.instance()
-        self.font = QFont()
+        self.setStyleSheet(self.STYLESHEET)
 
     def mouseReleaseEvent(self, x):
         custom_message_box(icon=QMessageBox.Information,
@@ -114,14 +125,10 @@ class HelpLabel(QLabel):
                            text=self.help_text)
 
     def enterEvent(self, event):
-        self.font.setUnderline(True)
-        self.setFont(self.font)
         self.app.setOverrideCursor(QCursor(Qt.PointingHandCursor))
         return QLabel.enterEvent(self, event)
 
     def leaveEvent(self, event):
-        self.font.setUnderline(False)
-        self.setFont(self.font)
         self.app.setOverrideCursor(QCursor(Qt.ArrowCursor))
         return QLabel.leaveEvent(self, event)
 


### PR DESCRIPTION
I am fairly certain the majority of users never noticed many of the
labels in the UI are clickable.

Case in point, lots of information hidden behind clicking is out-of-date.
We should update them; ideally this could reduce support load.


![pic](https://user-images.githubusercontent.com/29142493/102678769-6cc09580-41a2-11eb-9e9f-018f7d327054.png)

-----

In particular the expiration time of "bitcoin addresses" is a recurring question on the forums.
I am hoping that after making there being a help text more visible (and perhaps updating the text itself) fewer people would ask.