### PR TITLE
Fixed Installation Error

### DIFF
--- a/contrib/build-wine/README.md
+++ b/contrib/build-wine/README.md
@@ -20,7 +20,7 @@ folder.
 2. Build image
 
     ```
-    $ sudo docker build -t electrum-wine-builder-img contrib/build-wine
+    $ sudo docker build -t dalijolijo/electrum-wine-builder-img contrib/build-wine
     ```
 
     Note: see [this](https://stackoverflow.com/a/40516974/7499128) if having dns problems
@@ -47,7 +47,7 @@ folder.
         -v $PWD:/opt/wine64/drive_c/electrum \
         --rm \
         --workdir /opt/wine64/drive_c/electrum/contrib/build-wine \
-        electrum-wine-builder-img \
+        dalijolijo/electrum-wine-builder-img \
         ./build.sh
     ```
 4. The generated binaries are in `./contrib/build-wine/dist`.


### PR DESCRIPTION
The current installation image for docker give the following error.
```
Unable to find image 'electrum-wine-builder-img:latest' locally
docker: Error response from daemon: pull access denied for electrum-wine-builder-img, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```
I changed it so it works now