### PR TITLE
Export full derivation paths for Coldcard v3.2.1

### DIFF
--- a/electrum/plugins/coldcard/README.md
+++ b/electrum/plugins/coldcard/README.md
@@ -1,4 +1,3 @@
-
 # Coldcard Hardware Wallet Plugin
 
 ## Just the glue please
@@ -14,22 +13,18 @@ this reason, all PIN code entry is done directly on the device.
 Coldcard does not appear on the USB bus until unlocked with appropriate
 PIN. Initial setup, and seed generation must be done offline.
 
-Coldcard uses an emerging standard for unsigned tranasctions:
+Coldcard uses the standard for unsigned tranasctions:
 
 PSBT = Partially Signed Bitcoin Transaction = BIP174
-
-However, this spec is still under heavy discussion and in flux. At
-this point, the PSBT files generated will only be compatible with
-Coldcard.
 
 The Coldcard can be used 100% offline: it can generate a skeleton
 Electrum wallet and save it to MicroSD card. Transport that file
 to Electrum and it will fetch history, blockchain details and then
 operate in "unpaired" mode.
 
-Spending transactions can be saved to MicroSD using the "Export PSBT"
-button on the transaction preview dialog (when this plugin is
-owner of the wallet). That PSBT can be signed on the Coldcard
+Spending transactions can be saved to MicroSD using by exporting them
+from transaction preview dialog (when this plugin is
+owner of the wallet). That PSBT is then signed on the Coldcard
 (again using MicroSD both ways). The result is a ready-to-transmit
 bitcoin transaction, which can be transmitted using Tools > Load
 Transaction > From File in Electrum or really any tool.
@@ -39,12 +34,8 @@ Transaction > From File in Electrum or really any tool.
 ## TODO Items
 
 - No effort yet to support translations or languages other than English, sorry.
-- Coldcard PSBT format is not likely to be compatible with other devices, because the BIP174 is still in flux.
-- Segwit support not 100% complete: can pay to them, but cannot setup wallet to receive them.
-- Limited support for segwit wrapped in P2SH.
-- Someday we could support multisig hardware wallets based on PSBT where each participant
-  is using different devices/systems for signing, however, that belongs in an independant
-  plugin that is PSBT focused and might not require a Coldcard to be present.
+- We support multisig hardware wallets based on PSBT where each participant
+  is using different devices/systems for signing.
 
 ### Ctags
 
@@ -52,14 +43,3 @@ Transaction > From File in Electrum or really any tool.
 
     ctags -f .tags electrum `find . -name ENV -prune -o -name \*.py`
 
-
-### Working with latest ckcc-protocol
-
-- at top level, do this:
-
-    pip install -e git+ssh://git@github.com/Coldcard/ckcc-protocol.git#egg=ckcc-protocol
-
-- but you'll need the https version of that, not ssh like I can.
-- also a branch name would be good in there
-- do `pip uninstall ckcc` first
-- see <https://stackoverflow.com/questions/4830856>

--- a/electrum/plugins/coldcard/coldcard.py
+++ b/electrum/plugins/coldcard/coldcard.py
@@ -570,28 +570,21 @@ class ColdcardPlugin(HW_PluginBase):
         print(f'Format: {wallet.txin_type.upper()}' , file=fp)
 
         xpubs = []
-        derivs = set()
         for xpub, ks in zip(wallet.get_master_public_keys(), wallet.get_keystores()):  # type: str, KeyStoreWithMPK
             fp_bytes, der_full = ks.get_fp_and_derivation_to_be_used_in_partial_tx(der_suffix=[], only_der_suffix=False)
             fp_hex = fp_bytes.hex().upper()
             der_prefix_str = bip32.convert_bip32_intpath_to_strpath(der_full)
             xpubs.append( (fp_hex, xpub, der_prefix_str) )
-            derivs.add(der_prefix_str)
 
-        # Derivation doesn't matter too much to the Coldcard, since it
-        # uses key path data from PSBT or USB request as needed. However,
-        # if there is a clear value, provide it.
-        if len(derivs) == 1:
-            print("Derivation: " + derivs.pop(), file=fp)
+        # Before v3.2.1 derivation didn't matter too much to the Coldcard, since it
+        # could use key path data from PSBT or USB request as needed. However,
+        # derivation data is now required.
 
         print('', file=fp)
 
         assert len(xpubs) == wallet.n
         for xfp, xpub, der_prefix in xpubs:
-            if derivs:
-                # show as a comment if unclear
-                print(f'# derivation: {der_prefix}', file=fp)
-
+            print(f'Derivation: {der_prefix}', file=fp)
             print(f'{xfp}: {xpub}\n', file=fp)
 
     def show_address(self, wallet, address, keystore: 'Coldcard_KeyStore' = None):


### PR DESCRIPTION
Latest version of Coldcard firmware (3.2.1) requires derivation paths to be known for all co-signers during multisig signing. This change adds that information, which was previously shown as comment in the same spot. With a multisig wallet open, go to _Wallet > Information > Export for Coldcard_ to exercise this change.

Also updates plugin README, removing historical junk.

[v3.2.1 firmware release notes](https://blog.coinkite.com/version-3.2.1-released/)