### PR TITLE
Trampoline

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -450,7 +450,8 @@ class Daemon(Logger):
         if self.network:
             self.network.start(jobs=[self.fx.run])
             # prepare lightning functionality, also load channel db early
-            self.network.init_channel_db()
+            if self.config.get('use_gossip', False):
+                self.network.start_gossip()
 
         self.taskgroup = TaskGroup()
         asyncio.run_coroutine_threadsafe(self._run(jobs=daemon_jobs), self.asyncio_loop)

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -183,6 +183,14 @@ class ElectrumWindow(App, Logger):
     def on_use_rbf(self, instance, x):
         self.electrum_config.set_key('use_rbf', self.use_rbf, True)
 
+    use_gossip = BooleanProperty(False)
+    def on_use_gossip(self, instance, x):
+        self.electrum_config.set_key('use_gossip', self.use_gossip, True)
+        if self.use_gossip:
+            self.network.start_gossip()
+        else:
+            self.network.stop_gossip()
+
     android_backups = BooleanProperty(False)
     def on_android_backups(self, instance, x):
         self.electrum_config.set_key('android_backups', self.android_backups, True)
@@ -394,6 +402,7 @@ class ElectrumWindow(App, Logger):
         self.fx = self.daemon.fx
         self.use_rbf = config.get('use_rbf', True)
         self.android_backups = config.get('android_backups', False)
+        self.use_gossip = config.get('use_gossip', False)
         self.use_unconfirmed = not config.get('confirmed_only', False)
 
         # create triggers so as to minimize updating a max of 2 times a sec

--- a/electrum/gui/kivy/uix/dialogs/lightning_channels.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_channels.py
@@ -234,6 +234,7 @@ Builder.load_string(r'''
     can_send:''
     can_receive:''
     is_open:False
+    warning: ''
     BoxLayout:
         padding: '12dp', '12dp', '12dp', '12dp'
         spacing: '12dp'
@@ -246,6 +247,9 @@ Builder.load_string(r'''
                 height: self.minimum_height
                 size_hint_y: None
                 spacing: '5dp'
+                TopLabel:
+                    text: root.warning
+                    color: .905, .709, .509, 1
                 BoxLabel:
                     text: _('Channel ID')
                     value: root.short_id
@@ -470,6 +474,12 @@ class ChannelDetailsPopup(Popup, Logger):
         closed = chan.get_closing_height()
         if closed:
             self.closing_txid, closing_height, closing_timestamp = closed
+        msg = ' '.join([
+            _("Trampoline routing is enabled, but this channel is with a non-trampoline node."),
+            _("This channel may still be used for receiving, but it is frozen for sending."),
+            _("If you want to keep using this channel, you need to disable trampoline routing in your preferences."),
+        ])
+        self.warning = '' if self.app.wallet.lnworker.channel_db or chan.is_trampoline() else _('Warning') + ': ' + msg
 
     def close(self):
         Question(_('Close channel?'), self._close).open()

--- a/electrum/gui/kivy/uix/dialogs/lightning_open_channel.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_open_channel.py
@@ -107,13 +107,11 @@ class LightningOpenChannelDialog(Factory.Popup, Logger):
         d.open()
 
     def suggest_node(self):
-        self.app.wallet.network.start_gossip()
-        suggested = self.app.wallet.lnworker.lnrater.suggest_peer()
-        _, _, percent = self.app.wallet.network.lngossip.get_sync_progress_estimate()
-
+        suggested = self.app.wallet.lnworker.suggest_peer()
         if suggested:
             self.pubkey = suggested.hex()
         else:
+            _, _, percent = self.app.wallet.network.lngossip.get_sync_progress_estimate()
             if percent is None:
                 percent = "??"
             self.pubkey = f"Please wait, graph is updating ({percent}% / 30% done)."

--- a/electrum/gui/kivy/uix/dialogs/settings.py
+++ b/electrum/gui/kivy/uix/dialogs/settings.py
@@ -96,6 +96,17 @@ Builder.load_string('''
                     action: root.change_password
                 CardSeparator
                 SettingsItem:
+                    status: _('Trampoline') if not app.use_gossip else _('Gossip')
+                    title: _('Lightning Routing') + ': ' + self.status
+                    description: _("Use trampoline routing or gossip.")
+                    message:
+                        _('Lightning payments require finding a path through the Lightning Network.')\
+                        + ' ' + ('You may use trampoline routing, or local routing (gossip).')\
+                        + ' ' + ('Downloading the network gossip uses quite some bandwidth and storage, and is not recommended on mobile devices.')\
+                        + ' ' + ('If you use trampoline, you can only open channels with trampoline nodes.')
+                    action: partial(root.boolean_dialog, 'use_gossip', _('Download Gossip'), self.message)
+                CardSeparator
+                SettingsItem:
                     status: _('Yes') if app.android_backups else _('No')
                     title: _('Backups') + ': ' + self.status
                     description: _("Backup wallet to external storage.")

--- a/electrum/gui/qt/channels_list.py
+++ b/electrum/gui/qt/channels_list.py
@@ -145,6 +145,17 @@ class ChannelsList(MyTreeView):
             self.main_window.show_message('success')
         WaitingDialog(self, 'please wait..', task, on_success, self.on_failure)
 
+    def freeze_channel_for_sending(self, chan, b):
+        if self.lnworker.channel_db or self.lnworker.is_trampoline_peer(chan.node_id):
+            chan.set_frozen_for_sending(b)
+        else:
+            msg = ' '.join([
+                _("Trampoline routing is enabled, but this channel is with a non-trampoline node."),
+                _("This channel may still be used for receiving, but it is frozen for sending."),
+                _("If you want to keep using this channel, you need to disable trampoline routing in your preferences."),
+            ])
+            self.main_window.show_warning(msg, title=_('Channel is frozen for sending'))
+
     def create_menu(self, position):
         menu = QMenu()
         menu.setSeparatorsCollapsible(True)  # consecutive separators are merged together
@@ -177,9 +188,9 @@ class ChannelsList(MyTreeView):
             channel_id.hex(), title=_("Long Channel ID")))
         if not chan.is_closed():
             if not chan.is_frozen_for_sending():
-                menu.addAction(_("Freeze (for sending)"), lambda: chan.set_frozen_for_sending(True))
+                menu.addAction(_("Freeze (for sending)"), lambda: self.freeze_channel_for_sending(chan, True))
             else:
-                menu.addAction(_("Unfreeze (for sending)"), lambda: chan.set_frozen_for_sending(False))
+                menu.addAction(_("Unfreeze (for sending)"), lambda: self.freeze_channel_for_sending(chan, False))
             if not chan.is_frozen_for_receiving():
                 menu.addAction(_("Freeze (for receiving)"), lambda: chan.set_frozen_for_receiving(True))
             else:
@@ -359,7 +370,7 @@ class ChannelsList(MyTreeView):
         suggest_button = QPushButton(d, text=_('Suggest Peer'))
         def on_suggest():
             self.parent.wallet.network.start_gossip()
-            nodeid = bh2u(lnworker.lnrater.suggest_peer() or b'')
+            nodeid = bh2u(lnworker.suggest_peer() or b'')
             if not nodeid:
                 remote_nodeid.setText("")
                 remote_nodeid.setPlaceholderText(

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -742,7 +742,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             tools_menu.addAction(_("Electrum preferences"), self.settings_dialog)
 
         tools_menu.addAction(_("&Network"), self.gui_object.show_network_dialog).setEnabled(bool(self.network))
-        tools_menu.addAction(_("&Lightning Network"), self.gui_object.show_lightning_dialog).setEnabled(bool(self.wallet.has_lightning() and self.network))
+        tools_menu.addAction(_("&Lightning Gossip"), self.gui_object.show_lightning_dialog).setEnabled(bool(self.wallet.has_lightning() and self.network))
         tools_menu.addAction(_("Local &Watchtower"), self.gui_object.show_watchtower_dialog).setEnabled(bool(self.network and self.network.local_watchtower))
         tools_menu.addAction(_("&Plugins"), self.plugins_dialog)
         tools_menu.addSeparator()
@@ -2205,8 +2205,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.seed_button = StatusBarButton(read_QIcon("seed.png"), _("Seed"), self.show_seed_dialog )
         sb.addPermanentWidget(self.seed_button)
         self.lightning_button = None
-        if self.wallet.has_lightning() and self.network:
-            self.lightning_button = StatusBarButton(read_QIcon("lightning_disconnected.png"), _("Lightning Network"), self.gui_object.show_lightning_dialog)
+        if self.wallet.has_lightning():
+            self.lightning_button = StatusBarButton(read_QIcon("lightning.png"), _("Lightning Network"), self.gui_object.show_lightning_dialog)
             self.update_lightning_icon()
             sb.addPermanentWidget(self.lightning_button)
         self.status_button = None
@@ -2247,10 +2247,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         if self.lightning_button is None:
             return
         if self.network.lngossip is None:
+            self.lightning_button.setVisible(False)
             return
 
-        # display colorful lightning icon to signal connection
-        self.lightning_button.setIcon(read_QIcon("lightning.png"))
+        self.lightning_button.setVisible(True)
 
         cur, total, progress_percent = self.network.lngossip.get_sync_progress_estimate()
         # self.logger.debug(f"updating lngossip sync progress estimate: cur={cur}, total={total}")

--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -130,6 +130,24 @@ class SettingsDialog(WindowModalDialog):
         # lightning
         lightning_widgets = []
 
+        help_gossip = _("""If this option is enabled, Electrum will download the network
+channels graph and compute payment path locally, instead of using trampoline payments. """)
+        gossip_cb = QCheckBox(_("Download network graph"))
+        gossip_cb.setToolTip(help_gossip)
+        gossip_cb.setChecked(bool(self.config.get('use_gossip', False)))
+        def on_gossip_checked(x):
+            use_gossip = bool(x)
+            self.config.set_key('use_gossip', use_gossip)
+            if use_gossip:
+                self.window.network.start_gossip()
+            else:
+                self.window.network.stop_gossip()
+            util.trigger_callback('ln_gossip_sync_progress')
+            # FIXME: update all wallet windows
+            util.trigger_callback('channels_updated', self.wallet)
+        gossip_cb.stateChanged.connect(on_gossip_checked)
+        lightning_widgets.append((gossip_cb, None))
+
         help_local_wt = _("""If this option is checked, Electrum will
 run a local watchtower and protect your channels even if your wallet is not
 open. For this to work, your computer needs to be online regularly.""")

--- a/electrum/lnaddr.py
+++ b/electrum/lnaddr.py
@@ -215,6 +215,10 @@ def lnencode(addr: 'LnAddr', privkey) -> str:
                 pubkey, channel, feebase, feerate, cltv = step
                 route.append(bitstring.BitArray(pubkey) + bitstring.BitArray(channel) + bitstring.pack('intbe:32', feebase) + bitstring.pack('intbe:32', feerate) + bitstring.pack('intbe:16', cltv))
             data += tagged('r', route)
+        elif k == 't':
+            pubkey, feebase, feerate, cltv = v
+            route = bitstring.BitArray(pubkey) + bitstring.pack('intbe:32', feebase) + bitstring.pack('intbe:32', feerate) + bitstring.pack('intbe:16', cltv)
+            data += tagged('t', route)
         elif k == 'f':
             data += encode_fallback(v, addr.currency)
         elif k == 'd':
@@ -409,6 +413,13 @@ def lndecode(invoice: str, *, verbose=False, expected_hrp=None) -> LnAddr:
                               s.read(32).uintbe,
                               s.read(16).uintbe))
             addr.tags.append(('r',route))
+        elif tag == 't':
+            s = bitstring.ConstBitStream(tagdata)
+            e = (s.read(264).tobytes(),
+                 s.read(32).uintbe,
+                 s.read(32).uintbe,
+                 s.read(16).uintbe)
+            addr.tags.append(('t', e))
         elif tag == 'f':
             fallback = parse_fallback(tagdata, addr.currency)
             if fallback:

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -720,6 +720,8 @@ class Channel(AbstractChannel):
         return self.can_send_ctx_updates() and not self.is_closing()
 
     def is_frozen_for_sending(self) -> bool:
+        if self.lnworker and self.lnworker.channel_db is None and not self.lnworker.is_trampoline_peer(self.node_id):
+            return True
         return self.storage.get('frozen_for_sending', False)
 
     def set_frozen_for_sending(self, b: bool) -> None:

--- a/electrum/lnonion.py
+++ b/electrum/lnonion.py
@@ -40,8 +40,8 @@ if TYPE_CHECKING:
 
 
 HOPS_DATA_SIZE = 1300      # also sometimes called routingInfoSize in bolt-04
+TRAMPOLINE_HOPS_DATA_SIZE = 400
 LEGACY_PER_HOP_FULL_SIZE = 65
-NUM_STREAM_BYTES = 2 * HOPS_DATA_SIZE
 PER_HOP_HMAC_SIZE = 32
 
 
@@ -169,7 +169,7 @@ class OnionPacket:
 
     def __init__(self, public_key: bytes, hops_data: bytes, hmac: bytes):
         assert len(public_key) == 33
-        assert len(hops_data) == HOPS_DATA_SIZE
+        assert len(hops_data) in [ HOPS_DATA_SIZE, TRAMPOLINE_HOPS_DATA_SIZE ]
         assert len(hmac) == PER_HOP_HMAC_SIZE
         self.version = 0
         self.public_key = public_key
@@ -183,21 +183,21 @@ class OnionPacket:
         ret += self.public_key
         ret += self.hops_data
         ret += self.hmac
-        if len(ret) != 1366:
+        if len(ret) - 66 not in [ HOPS_DATA_SIZE, TRAMPOLINE_HOPS_DATA_SIZE ]:
             raise Exception('unexpected length {}'.format(len(ret)))
         return ret
 
     @classmethod
     def from_bytes(cls, b: bytes):
-        if len(b) != 1366:
+        if len(b) - 66 not in [ HOPS_DATA_SIZE, TRAMPOLINE_HOPS_DATA_SIZE ]:
             raise Exception('unexpected length {}'.format(len(b)))
         version = b[0]
         if version != 0:
             raise UnsupportedOnionPacketVersion('version {} is not supported'.format(version))
         return OnionPacket(
             public_key=b[1:34],
-            hops_data=b[34:1334],
-            hmac=b[1334:]
+            hops_data=b[34:-32],
+            hmac=b[-32:]
         )
 
 
@@ -226,25 +226,26 @@ def get_shared_secrets_along_route(payment_path_pubkeys: Sequence[bytes],
 
 
 def new_onion_packet(payment_path_pubkeys: Sequence[bytes], session_key: bytes,
-                     hops_data: Sequence[OnionHopsDataSingle], associated_data: bytes) -> OnionPacket:
+                     hops_data: Sequence[OnionHopsDataSingle], associated_data: bytes, trampoline=False) -> OnionPacket:
     num_hops = len(payment_path_pubkeys)
     assert num_hops == len(hops_data)
     hop_shared_secrets = get_shared_secrets_along_route(payment_path_pubkeys, session_key)
 
-    filler = _generate_filler(b'rho', hops_data, hop_shared_secrets)
+    data_size = TRAMPOLINE_HOPS_DATA_SIZE if trampoline else HOPS_DATA_SIZE
+    filler = _generate_filler(b'rho', hops_data, hop_shared_secrets, data_size)
     next_hmac = bytes(PER_HOP_HMAC_SIZE)
 
     # Our starting packet needs to be filled out with random bytes, we
     # generate some deterministically using the session private key.
     pad_key = get_bolt04_onion_key(b'pad', session_key)
-    mix_header = generate_cipher_stream(pad_key, HOPS_DATA_SIZE)
+    mix_header = generate_cipher_stream(pad_key, data_size)
 
     # compute routing info and MAC for each hop
     for i in range(num_hops-1, -1, -1):
         rho_key = get_bolt04_onion_key(b'rho', hop_shared_secrets[i])
         mu_key = get_bolt04_onion_key(b'mu', hop_shared_secrets[i])
         hops_data[i].hmac = next_hmac
-        stream_bytes = generate_cipher_stream(rho_key, HOPS_DATA_SIZE)
+        stream_bytes = generate_cipher_stream(rho_key, data_size)
         hop_data_bytes = hops_data[i].to_bytes()
         mix_header = mix_header[:-len(hop_data_bytes)]
         mix_header = hop_data_bytes + mix_header
@@ -283,21 +284,28 @@ def calc_hops_data_for_payment(route: 'LNPaymentRoute', amount_msat: int,
     # payloads, backwards from last hop (but excluding the first edge):
     for edge_index in range(len(route) - 1, 0, -1):
         route_edge = route[edge_index]
+        is_trampoline = route_edge.is_trampoline()
+        if is_trampoline:
+            amt += route_edge.fee_for_edge(amt)
+            cltv += route_edge.cltv_expiry_delta
         hop_payload = {
             "amt_to_forward": {"amt_to_forward": amt},
             "outgoing_cltv_value": {"outgoing_cltv_value": cltv},
             "short_channel_id": {"short_channel_id": route_edge.short_channel_id},
         }
-        hops_data += [OnionHopsDataSingle(is_tlv_payload=route[edge_index-1].has_feature_varonion(),
-                                          payload=hop_payload)]
-        amt += route_edge.fee_for_edge(amt)
-        cltv += route_edge.cltv_expiry_delta
+        hops_data.append(
+            OnionHopsDataSingle(
+                is_tlv_payload=route[edge_index-1].has_feature_varonion(),
+                payload=hop_payload))
+        if not is_trampoline:
+            amt += route_edge.fee_for_edge(amt)
+            cltv += route_edge.cltv_expiry_delta
     hops_data.reverse()
     return hops_data, amt, cltv
 
 
 def _generate_filler(key_type: bytes, hops_data: Sequence[OnionHopsDataSingle],
-                     shared_secrets: Sequence[bytes]) -> bytes:
+                     shared_secrets: Sequence[bytes], data_size:int) -> bytes:
     num_hops = len(hops_data)
 
     # generate filler that matches all but the last hop (no HMAC for last hop)
@@ -308,16 +316,16 @@ def _generate_filler(key_type: bytes, hops_data: Sequence[OnionHopsDataSingle],
 
     for i in range(0, num_hops-1):  # -1, as last hop does not obfuscate
         # Sum up how many frames were used by prior hops.
-        filler_start = HOPS_DATA_SIZE
+        filler_start = data_size
         for hop_data in hops_data[:i]:
             filler_start -= len(hop_data.to_bytes())
         # The filler is the part dangling off of the end of the
         # routingInfo, so offset it from there, and use the current
         # hop's frame count as its size.
-        filler_end = HOPS_DATA_SIZE + len(hops_data[i].to_bytes())
+        filler_end = data_size + len(hops_data[i].to_bytes())
 
         stream_key = get_bolt04_onion_key(key_type, shared_secrets[i])
-        stream_bytes = generate_cipher_stream(stream_key, NUM_STREAM_BYTES)
+        stream_bytes = generate_cipher_stream(stream_key, 2 * data_size)
         filler = xor_bytes(filler, stream_bytes[filler_start:filler_end])
         filler += bytes(filler_size - len(filler))  # right pad with zeroes
 
@@ -334,48 +342,59 @@ class ProcessedOnionPacket(NamedTuple):
     are_we_final: bool
     hop_data: OnionHopsDataSingle
     next_packet: OnionPacket
+    trampoline_onion_packet: OnionPacket
 
 
 # TODO replay protection
-def process_onion_packet(onion_packet: OnionPacket, associated_data: bytes,
-                         our_onion_private_key: bytes) -> ProcessedOnionPacket:
+def process_onion_packet(
+        onion_packet: OnionPacket,
+        associated_data: bytes,
+        our_onion_private_key: bytes) -> ProcessedOnionPacket:
     if not ecc.ECPubkey.is_pubkey_bytes(onion_packet.public_key):
         raise InvalidOnionPubkey()
     shared_secret = get_ecdh(our_onion_private_key, onion_packet.public_key)
-
     # check message integrity
     mu_key = get_bolt04_onion_key(b'mu', shared_secret)
-    calculated_mac = hmac_oneshot(mu_key, msg=onion_packet.hops_data+associated_data,
-                                  digest=hashlib.sha256)
+    calculated_mac = hmac_oneshot(
+        mu_key, msg=onion_packet.hops_data+associated_data,
+        digest=hashlib.sha256)
     if onion_packet.hmac != calculated_mac:
         raise InvalidOnionMac()
-
     # peel an onion layer off
     rho_key = get_bolt04_onion_key(b'rho', shared_secret)
-    stream_bytes = generate_cipher_stream(rho_key, NUM_STREAM_BYTES)
+    stream_bytes = generate_cipher_stream(rho_key, 2 * HOPS_DATA_SIZE)
     padded_header = onion_packet.hops_data + bytes(HOPS_DATA_SIZE)
     next_hops_data = xor_bytes(padded_header, stream_bytes)
     next_hops_data_fd = io.BytesIO(next_hops_data)
-
+    hop_data = OnionHopsDataSingle.from_fd(next_hops_data_fd)
+    # trampoline
+    trampoline_onion_packet = hop_data.payload.get('trampoline_onion_packet')
+    if trampoline_onion_packet:
+        top_version = trampoline_onion_packet.get('version')
+        top_public_key = trampoline_onion_packet.get('public_key')
+        top_hops_data = trampoline_onion_packet.get('hops_data')
+        top_hops_data_fd = io.BytesIO(top_hops_data)
+        top_hmac = trampoline_onion_packet.get('hmac')
+        trampoline_onion_packet = OnionPacket(
+            public_key=top_public_key,
+            hops_data=top_hops_data_fd.read(TRAMPOLINE_HOPS_DATA_SIZE),
+            hmac=top_hmac)
     # calc next ephemeral key
     blinding_factor = sha256(onion_packet.public_key + shared_secret)
     blinding_factor_int = int.from_bytes(blinding_factor, byteorder="big")
     next_public_key_int = ecc.ECPubkey(onion_packet.public_key) * blinding_factor_int
     next_public_key = next_public_key_int.get_public_key_bytes()
-
-    hop_data = OnionHopsDataSingle.from_fd(next_hops_data_fd)
     next_onion_packet = OnionPacket(
         public_key=next_public_key,
         hops_data=next_hops_data_fd.read(HOPS_DATA_SIZE),
-        hmac=hop_data.hmac
-    )
+        hmac=hop_data.hmac)
     if hop_data.hmac == bytes(PER_HOP_HMAC_SIZE):
         # we are the destination / exit node
         are_we_final = True
     else:
         # we are an intermediate node; forwarding
         are_we_final = False
-    return ProcessedOnionPacket(are_we_final, hop_data, next_onion_packet)
+    return ProcessedOnionPacket(are_we_final, hop_data, next_onion_packet, trampoline_onion_packet)
 
 
 class FailedToDecodeOnionError(Exception): pass
@@ -498,6 +517,8 @@ class OnionFailureCode(IntEnum):
     EXPIRY_TOO_FAR =                          21
     INVALID_ONION_PAYLOAD =                   PERM | 22
     MPP_TIMEOUT =                             23
+    TRAMPOLINE_FEE_INSUFFICIENT =             NODE | 51
+    TRAMPOLINE_EXPIRY_TOO_SOON =              NODE | 52
 
 
 # don't use these elsewhere, the names are ambiguous without context

--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -99,6 +99,16 @@ class RouteEdge(PathEdge):
         features = self.node_features
         return bool(features & LnFeatures.VAR_ONION_REQ or features & LnFeatures.VAR_ONION_OPT)
 
+    def is_trampoline(self):
+        return False
+
+@attr.s
+class TrampolineEdge(RouteEdge):
+    invoice_routing_info = attr.ib(type=bytes, default=None)
+    invoice_features = attr.ib(type=int, default=None)
+    short_channel_id = attr.ib(0)
+    def is_trampoline(self):
+        return True
 
 LNPaymentPath = Sequence[PathEdge]
 LNPaymentRoute = Sequence[RouteEdge]

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -949,6 +949,15 @@ class LnFeatures(IntFlag):
     _ln_feature_contexts[OPTION_SUPPORT_LARGE_CHANNEL_OPT] = (LNFC.INIT | LNFC.NODE_ANN | LNFC.CHAN_ANN_ALWAYS_EVEN)
     _ln_feature_contexts[OPTION_SUPPORT_LARGE_CHANNEL_REQ] = (LNFC.INIT | LNFC.NODE_ANN | LNFC.CHAN_ANN_ALWAYS_EVEN)
 
+    OPTION_TRAMPOLINE_ROUTING_REQ = 1 << 50
+    OPTION_TRAMPOLINE_ROUTING_OPT = 1 << 51
+
+    # We do not set trampoline_routing_opt in invoices, because the spec is not ready.
+    # This ensures that current version of Phoenix can pay us
+    # It also prevents Electrum from using t_tags from future implementations
+    _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_REQ] = (LNFC.INIT | LNFC.NODE_ANN) # | LNFC.INVOICE)
+    _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_OPT] = (LNFC.INIT | LNFC.NODE_ANN) # | LNFC.INVOICE)
+
     def validate_transitive_dependencies(self) -> bool:
         # for all even bit set, set corresponding odd bit:
         features = self  # copy
@@ -1014,6 +1023,7 @@ LN_FEATURES_IMPLEMENTED = (
         | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT | LnFeatures.OPTION_STATIC_REMOTEKEY_REQ
         | LnFeatures.VAR_ONION_OPT | LnFeatures.VAR_ONION_REQ
         | LnFeatures.PAYMENT_SECRET_OPT | LnFeatures.PAYMENT_SECRET_REQ
+        | LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT | LnFeatures.OPTION_TRAMPOLINE_ROUTING_REQ
 )
 
 

--- a/electrum/lnwire/onion_wire.csv
+++ b/electrum/lnwire/onion_wire.csv
@@ -7,6 +7,17 @@ tlvdata,tlv_payload,short_channel_id,short_channel_id,short_channel_id,
 tlvtype,tlv_payload,payment_data,8
 tlvdata,tlv_payload,payment_data,payment_secret,byte,32
 tlvdata,tlv_payload,payment_data,total_msat,tu64,
+tlvtype,tlv_payload,invoice_features,66097
+tlvdata,tlv_payload,invoice_features,invoice_features,u64,
+tlvtype,tlv_payload,outgoing_node_id,66098
+tlvdata,tlv_payload,outgoing_node_id,outgoing_node_id,byte,33
+tlvtype,tlv_payload,invoice_routing_info,66099
+tlvdata,tlv_payload,invoice_routing_info,invoice_routing_info,byte,...
+tlvtype,tlv_payload,trampoline_onion_packet,66100
+tlvdata,tlv_payload,trampoline_onion_packet,version,byte,1
+tlvdata,tlv_payload,trampoline_onion_packet,public_key,byte,33
+tlvdata,tlv_payload,trampoline_onion_packet,hops_data,byte,400
+tlvdata,tlv_payload,trampoline_onion_packet,hmac,byte,32
 msgtype,invalid_realm,PERM|1
 msgtype,temporary_node_failure,NODE|2
 msgtype,permanent_node_failure,PERM|NODE|2

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -359,22 +359,25 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
     def has_channel_db(self):
         return self.channel_db is not None
 
-    def init_channel_db(self):
-        if self.channel_db is None:
-            from . import lnrouter
-            from . import channel_db
+    def start_gossip(self):
+        from . import lnrouter
+        from . import channel_db
+        from . import lnworker
+        if not self.config.get('use_gossip'):
+            return
+        if self.lngossip is None:
             self.channel_db = channel_db.ChannelDB(self)
             self.path_finder = lnrouter.LNPathFinder(self.channel_db)
             self.channel_db.load_data()
-
-    def start_gossip(self):
-        if self.lngossip is None:
-            from . import lnworker
             self.lngossip = lnworker.LNGossip()
             self.lngossip.start_network(self)
 
     def stop_gossip(self):
-        self.lngossip.stop()
+        if self.lngossip:
+            self.lngossip.stop()
+            self.lngossip = None
+            self.channel_db.stop()
+            self.channel_db = None
 
     def run_from_another_thread(self, coro, *, timeout=None):
         assert self._loop_thread != threading.current_thread(), 'must not be called from network thread'

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -77,6 +77,7 @@ if [[ $1 == "init" ]]; then
     agent="./run_electrum --regtest -D /tmp/$2"
     $agent create --offline > /dev/null
     $agent setconfig --offline log_to_file True
+    $agent setconfig --offline use_gossip True
     $agent setconfig --offline server 127.0.0.1:51001:t
     $agent setconfig --offline lightning_to_self_delay 144
     # alice is funded, bob is listening


### PR DESCRIPTION
 - trampoline is enabled by default in config, to prevent download of `gossip_db`.
   (if disabled, `gossip_db` will be downloaded, regardless of the existence of channels)
 - if trampoline is enabled:
    - the wallet can only open channels with trampoline nodes
    - already-existing channels with non-trampoline nodes are frozen for sending.
 - there are two types of trampoline payments: legacy and end-to-end (e2e).
 - we decide to perform legacy or e2e based on the invoice:
    - we use `trampoline_routing_opt` in features to detect Eclair and Phoenix invoices
    - we use `trampoline_routing_hints` to detect Electrum invoices
 - when trying a legacy payment, we add a second trampoline to the path to preserve privacy.
   (we fall back to a single trampoline if the payment fails for all trampolines)
 - the trampoline list is hardcoded, it will remain so until `trampoline_routing_opt` feature flag is in INIT.
 - there are currently only two nodes in the hardcoded list, it would be nice to have more.
 - similar to Phoenix, we find the fee/cltv by trial-and-error.
   if there is a second trampoline in the path, we use the same fee for both.
   the final spec should add fee info in error messages, so we will be able to fine-tune fees
 
