### PR TITLE
Fix error of showing bitcoin paper(testnet)

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -766,7 +766,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         help_menu.addAction(_("&Official website"), lambda: webopen("https://electrum.org"))
         help_menu.addSeparator()
         help_menu.addAction(_("&Documentation"), lambda: webopen("http://docs.electrum.org/")).setShortcut(QKeySequence.HelpContents)
-        help_menu.addAction(_("&Bitcoin Paper"), self.show_bitcoin_paper)
+        if not constants.net.TESTNET:
+            help_menu.addAction(_("&Bitcoin Paper"), self.show_bitcoin_paper)
         help_menu.addAction(_("&Report Bug"), self.show_report_bug)
         help_menu.addSeparator()
         help_menu.addAction(_("&Donate to server"), self.donate_to_server)


### PR DESCRIPTION
on git master d7515b936e32efc02f6b4b0dd97b8520b5c447a7
```
E | gui.qt.exception_window.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
  File "/home/wakiyamap/electrum/electrum/network.py", line 857, in wrapper
    return await func(self, *args, **kwargs)
  File "/home/wakiyamap/electrum/electrum/network.py", line 1042, in get_transaction
    return await self.interface.get_transaction(tx_hash=tx_hash, timeout=timeout)
  File "/home/wakiyamap/electrum/electrum/interface.py", line 918, in get_transaction
    raw = await self.session.send_request('blockchain.transaction.get', [tx_hash], timeout=timeout)
  File "/home/wakiyamap/electrum/electrum/interface.py", line 173, in send_request
    timeout)
  File "/usr/lib/python3.6/asyncio/tasks.py", line 339, in wait_for
    return (yield from fut)
  File "/usr/local/lib/python3.6/dist-packages/aiorpcx/session.py", line 525, in send_request
    return await self._send_concurrent(message, future, 1)
  File "/usr/local/lib/python3.6/dist-packages/aiorpcx/session.py", line 495, in _send_concurrent
    return await future
  File "/usr/local/lib/python3.6/dist-packages/aiorpcx/jsonrpc.py", line 722, in receive_message
    item, request_id = self._protocol.message_to_item(message)
  File "/usr/local/lib/python3.6/dist-packages/aiorpcx/jsonrpc.py", line 274, in message_to_item
    return cls._process_response(payload)
  File "/usr/local/lib/python3.6/dist-packages/aiorpcx/jsonrpc.py", line 221, in _process_response
    raise cls._error(code, message, False, request_id)
aiorpcx.jsonrpc.ProtocolError: (-32600, 'ill-formed response error object: missing transaction')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/wakiyamap/electrum/electrum/gui/qt/main_window.py", line 798, in show_bitcoin_paper
    self.network.get_transaction("54e48e5f5c656b26c3bca14a8c95aa583d07ebe84dde3b7dd4a78f4e4186e713"))
  File "/home/wakiyamap/electrum/electrum/network.py", line 382, in run_from_another_thread
    return fut.result(timeout)
  File "/usr/lib/python3.6/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/usr/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/wakiyamap/electrum/electrum/network.py", line 838, in make_reliable_wrapper
    raise success_fut.exception()
  File "/home/wakiyamap/electrum/electrum/network.py", line 859, in wrapper
    raise UntrustedServerReturnedError(original_exception=e) from e
electrum.network.UntrustedServerReturnedError: The server returned an error.
```