### PR TITLE
fix htlc switch fulfilling htlc too soon (in case of race)

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -858,6 +858,7 @@ class Channel(AbstractChannel):
             local_ctn = self.get_latest_ctn(LOCAL)
             remote_ctn = self.get_latest_ctn(REMOTE)
             if onion_packet:
+                # TODO neither local_ctn nor remote_ctn are used anymore... no point storing them.
                 self.hm.log['unfulfilled_htlcs'][htlc.htlc_id] = local_ctn, remote_ctn, onion_packet.hex(), False
 
         self.logger.info("receive_htlc")

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -997,6 +997,7 @@ class Channel(AbstractChannel):
             self.hm.recv_rev()
             self.config[REMOTE].current_per_commitment_point=self.config[REMOTE].next_per_commitment_point
             self.config[REMOTE].next_per_commitment_point=revocation.next_per_commitment_point
+        assert new_ctn == self.get_oldest_unrevoked_ctn(REMOTE)
         # lnworker callbacks
         if self.lnworker:
             sent = self.hm.sent_in_ctn(new_ctn)

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1666,10 +1666,7 @@ class Peer(Logger):
                 done = set()
                 unfulfilled = chan.hm.log.get('unfulfilled_htlcs', {})
                 for htlc_id, (local_ctn, remote_ctn, onion_packet_hex, forwarding_info) in unfulfilled.items():
-                    # FIXME this test is not sufficient:
-                    if chan.get_oldest_unrevoked_ctn(LOCAL) <= local_ctn:
-                        continue
-                    if chan.get_oldest_unrevoked_ctn(REMOTE) <= remote_ctn:
+                    if not chan.hm.is_add_htlc_irrevocably_committed_yet(htlc_proposer=REMOTE, htlc_id=htlc_id):
                         continue
                     chan.logger.info(f'found unfulfilled htlc: {htlc_id}')
                     htlc = chan.hm.get_htlc_by_id(REMOTE, htlc_id)

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1432,6 +1432,7 @@ class Peer(Logger):
     def fulfill_htlc(self, chan: Channel, htlc_id: int, preimage: bytes):
         self.logger.info(f"_fulfill_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}")
         assert chan.can_send_ctx_updates(), f"cannot send updates: {chan.short_channel_id}"
+        assert chan.hm.is_add_htlc_irrevocably_committed_yet(htlc_proposer=REMOTE, htlc_id=htlc_id)
         chan.settle_htlc(preimage, htlc_id)
         self.send_message("update_fulfill_htlc",
                           channel_id=chan.channel_id,
@@ -1665,6 +1666,7 @@ class Peer(Logger):
                 done = set()
                 unfulfilled = chan.hm.log.get('unfulfilled_htlcs', {})
                 for htlc_id, (local_ctn, remote_ctn, onion_packet_hex, forwarding_info) in unfulfilled.items():
+                    # FIXME this test is not sufficient:
                     if chan.get_oldest_unrevoked_ctn(LOCAL) <= local_ctn:
                         continue
                     if chan.get_oldest_unrevoked_ctn(REMOTE) <= remote_ctn:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1299,6 +1299,7 @@ class LNWallet(LNWorker):
             self.set_payment_status(bfh(key), status)
 
     async def await_payment(self, payment_hash: bytes) -> BarePaymentAttemptLog:
+        # note side-effect: Future is created and added here (defaultdict):
         payment_attempt = await self.pending_payments[payment_hash]
         self.pending_payments.pop(payment_hash)
         return payment_attempt


### PR DESCRIPTION
This PR adds a unit test which showcases that on current master we might fulfill an HTLC before it is irrecovably committed;
and fixes that behaviour.

Note that this makes two of the four fields stored in `hm.log['unfulfilled_htlcs']` useless, so we could rm those. This would need a wallet upgrade. Shall we do that?