### PR TITLE
Fix windows build(travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,13 @@ jobs:
         - TARGET_OS=Windows
       services:
         - docker
+      before_install:
+        - sudo rm -rf /var/lib/apt/lists/*
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        - sudo apt-get update
+        - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+        - docker version
       install:
         - sudo docker build --no-cache -t electrum-wine-builder-img ./contrib/build-wine/
       script:


### PR DESCRIPTION
Using Docker-ce(18.x) will cause windows build to fail.
I change to use the latest stable.

build log https://gist.github.com/wakiyamap/dcb638a6df1aeeffd3a61d94cb1a9488

ref. https://www.docker.com/blog/multi-arch-build-what-about-travis/