### PR TITLE
add function to determine script-type for all inputs in a psbt

### DIFF
--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1361,7 +1361,8 @@ class PartialTxInput(TxInput, PSBTSection):
                 inner_type = get_script_type_from_output_script(self.witness_script)
             if inner_type is not None:
                 type = inner_type + '-' + type
-            self.script_type = type
+            if type in ('p2pkh', 'p2wpkh-p2sh', 'p2wpkh'):
+                self.script_type = type
         return
 
     def is_complete(self) -> bool:

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1353,12 +1353,14 @@ class PartialTxInput(TxInput, PSBTSection):
         if self.scriptpubkey is None:
             return
         type = get_script_type_from_output_script(self.scriptpubkey)
+        inner_type = None
         if type is not None:
-            if type in ('p2sh', 'p2wsh'):
-                if self.redeem_script is not None:
-                    inner_type = get_script_type_from_output_script(self.redeem_script)
-                    if inner_type is not None:
-                        type = inner_type + '-' + type
+            if type == 'p2sh':
+                inner_type = get_script_type_from_output_script(self.redeem_script)
+            elif type == 'p2wsh':
+                inner_type = get_script_type_from_output_script(self.witness_script)
+            if inner_type is not None:
+                type = inner_type + '-' + type
             self.script_type = type
         return
 


### PR DESCRIPTION
Currently it's only possible to set the script-type for the inputs in a psbt for wallet owned inputs. For other imported inputs(payjoin) they stay 'unknown'. 
This PR adds a function to determine the inputs-types by checking if a script(in scriptpubkey or redeem-script) matches a scripts pattern.

I wanna use this function in this PR: https://github.com/spesmilo/electrum/pull/6804 to validate equality of input-types in the payjoin.

---
general question:
Why is the naming of the script-types different than in most other application/BIPs? If I'm right, in Electrum composed names are in the form: [inner/encapsulated-type]-outer (p2wpkh-p2sh), but in the BIP's the naming is p2sh-p2wpkh. Do I understand it correctly?
