### PR TITLE
lnpeer: fix timed out mpp

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1434,7 +1434,7 @@ class Peer(Logger):
         if accepted:
             return preimage, None
         elif expired:
-            reason = OnionRoutingFailureMessage(code=OnionFailureCode.MPP_TIMEOUT)
+            reason = OnionRoutingFailureMessage(code=OnionFailureCode.MPP_TIMEOUT, data=b'')
             return None, reason
         else:
             # waiting for more htlcs


### PR DESCRIPTION
Fix to correcly instantiate OnionRoutingFailureMessage, otherwise this can lead to an endless reconnection when a multipart payment times out.