### PR TITLE
Fix ledger sign message

### DIFF
--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -334,7 +334,12 @@ class Ledger_KeyStore(Hardware_KeyStore):
         if sLength == 33:
             s = s[1:]
         # And convert it
-        return bytes([27 + 4 + (signature[0] & 0x01)]) + r + s
+
+        # Pad r and s points with 0x00 bytes when the point is small to get valid signature.
+        r_padded = bytes([0x00]) * (32 - len(r)) + r
+        s_padded = bytes([0x00]) * (32 - len(s)) + s
+        
+        return bytes([27 + 4 + (signature[0] & 0x01)]) + r_padded + s_padded
 
     @runs_in_hwd_thread
     @test_pin_unlocked


### PR DESCRIPTION
This PR is fixing the issue with invalid signatures for "small" r & s values when signing the message with Ledger wallet.

The issue lies in the signed message format, the format expects 32 bytes for r and 32 bytes for s values if the value starts with 2 or more zeros for either r or s it will create invalid base64 signature.

The one example I stumbled upon is this:

hash to sign: `cfd24a369db6159bdf9c96e8e00bae3f9042eb029e88fae9196f56f9daee8014`
address: `bc1quprwg497w2p6up7upqscfedz6crepz9fvcr3qs` aka `1MSsHdMg7oFUDx7FhNj2vh9SRRjqZcWAD4`

> {
>   "v": 0,
>   "r": "0ec5cacf09793857d6daf65783b0c3b1d08bf6fd6af404e8896ef73a680678",
>   "s": "5ec8f943682c0bd5b0147f8f320ea141bd98c863f3b157323a9dff4a2dc26a6f"
> }

current Electrum implementation spits: `Hw7Fys8JeThX1tr2V4Oww7HQi/b9avQE6Ilu9zpoBnheyPlDaCwL1bAUf48yDqFBvZjIY/OxVzI6nf9KLcJqbw==`

Which is invalid signature even if tested by Electrum immediately after signing, Bitcoin Core, or any other online tool for verifying Bitcoin signatures.

The valid one should be:
`HwAOxcrPCXk4V9ba9leDsMOx0Iv2/Wr0BOiJbvc6aAZ4Xsj5Q2gsC9WwFH+PMg6hQb2YyGPzsVcyOp3/Si3Cam8=`

I'm attaching some examples:

When trying to sign the message in Electrum and verifying the signature immediately after:
![example_electrum_ledger_issue_01](https://user-images.githubusercontent.com/48327736/107102855-0825cc80-681c-11eb-860a-1be2ff80a339.gif)

When manually replacing signature in Electrum with correctly formatted one.
![example_electrum_ledger_issue_02](https://user-images.githubusercontent.com/48327736/107102861-09ef9000-681c-11eb-91e1-7d35f9ee3dea.gif)

When trying to verify the message in Bitcoin Core:
![example_bitcoin_core_ledger_issue_01](https://user-images.githubusercontent.com/48327736/107102852-06f49f80-681c-11eb-9d74-85ce333272fe.gif)



