### PR TITLE
GUI: fix send Payment msg (BIP70)

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/tx_dialog.py
@@ -128,11 +128,12 @@ class ActionButtonOption(NamedTuple):
 
 class TxDialog(Factory.Popup):
 
-    def __init__(self, app, tx):
+    def __init__(self, app, tx, pr=None):
         Factory.Popup.__init__(self)
         self.app = app  # type: ElectrumWindow
         self.wallet = self.app.wallet
         self.tx = tx  # type: Transaction
+        self.pr = pr
         self._action_button_fn = lambda btn: None
 
         # If the wallet can populate the inputs with more info, do it now.
@@ -339,7 +340,7 @@ class TxDialog(Factory.Popup):
         self.update()
 
     def do_broadcast(self):
-        self.app.broadcast(self.tx)
+        self.app.broadcast(self.tx, self.pr)
 
     def show_qr(self):
         original_raw_tx = str(self.tx)

--- a/electrum/gui/kivy/uix/screens.py
+++ b/electrum/gui/kivy/uix/screens.py
@@ -383,19 +383,20 @@ class SendScreen(CScreen, Logger):
     def send_tx(self, tx, invoice, password):
         if self.app.wallet.has_password() and password is None:
             return
+        pr = self.payment_request
         self.save_invoice(invoice)
         def on_success(tx):
             if tx.is_complete():
-                self.app.broadcast(tx)
+                self.app.broadcast(tx, pr)
             else:
-                self.app.tx_dialog(tx)
+                self.app.tx_dialog(tx, pr)
         def on_failure(error):
             self.app.show_error(error)
         if self.app.wallet.can_sign(tx):
             self.app.show_info("Signing...")
             self.app.sign_tx(tx, password, on_success, on_failure)
         else:
-            self.app.tx_dialog(tx)
+            self.app.tx_dialog(tx, pr)
 
 
 class ReceiveScreen(CScreen):

--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -222,10 +222,11 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
         )
 
     def do_broadcast(self):
+        pr = self.main_window.payment_request
         self.main_window.push_top_level_window(self)
         self.main_window.save_pending_invoice()
         try:
-            self.main_window.broadcast_transaction(self.tx)
+            self.main_window.broadcast_transaction(self.tx, pr)
         finally:
             self.main_window.pop_top_level_window(self)
         self.saved = True


### PR DESCRIPTION
In qt/kivy there is no Payment msg (bip70) sent. Try to fix it (possibly not very clean way).

- qt: fix sending Payment msg on tx broadcast
- kivy: fix sending Payment msg on tx broadcast