### PR TITLE
make_unsigned_request: set network for testnet

### DIFF
--- a/electrum/paymentrequest.py
+++ b/electrum/paymentrequest.py
@@ -339,6 +339,8 @@ def make_unsigned_request(req: 'OnchainInvoice'):
     script = bfh(address_to_script(addr))
     outputs = [(script, amount)]
     pd = pb2.PaymentDetails()
+    if constants.net.TESTNET:
+        pd.network = 'test'
     for script, amount in outputs:
         pd.outputs.add(amount=amount, script=script)
     pd.time = time


### PR DESCRIPTION
Set PaymentDetails.network for testnet. Related to #6993.

- make_unsigned_request: set network for testnet