### PR TITLE
windows build: update gnupg(2.2.19-3ubuntu2.1)

### DIFF
--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -7,8 +7,8 @@ RUN dpkg --add-architecture i386 && \
     apt-get update -q && \
     apt-get install -qy \
         wget=1.20.3-1ubuntu1 \
-        gnupg2=2.2.19-3ubuntu2 \
-        dirmngr=2.2.19-3ubuntu2 \
+        gnupg2=2.2.19-3ubuntu2.1 \
+        dirmngr=2.2.19-3ubuntu2.1 \
         python3-software-properties=0.98.9.2 \
         software-properties-common=0.98.9.2 \
         && \


### PR DESCRIPTION
```
The following packages have unmet dependencies:
 dirmngr : Depends: gpgconf (= 2.2.19-3ubuntu2)
           Recommends: gnupg (= 2.2.19-3ubuntu2) but it is not going to be installed
 gnupg2 : Depends: gnupg (>= 2.2.19-3ubuntu2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

Current version is `2.2.19-3ubuntu2.1`.
https://packages.ubuntu.com/en/focal-updates/gnupg2
https://packages.ubuntu.com/en/focal-updates/utils/dirmngr