### PR TITLE
mpp_split: try to fix non-determinicity of tests

### DIFF
--- a/electrum/mpp_split.py
+++ b/electrum/mpp_split.py
@@ -24,7 +24,7 @@ def unique_hierarchy(hierarchy: Dict[int, List[Dict[bytes, int]]]) -> Dict[int, 
         for config in configs:
             # config dict can be out of order, so sort, otherwise not unique
             unique_configs.add(tuple((c, config[c]) for c in sorted(config.keys())))
-        for unique_config in unique_configs:
+        for unique_config in sorted(unique_configs):
             new_hierarchy[number_parts].append(
                 {t[0]: t[1] for t in unique_config})
     return new_hierarchy

--- a/electrum/tests/test_mpp_split.py
+++ b/electrum/tests/test_mpp_split.py
@@ -29,8 +29,8 @@ class TestMppSplit(ElectrumTestCase):
 
         with self.subTest(msg="do a payment with a larger amount than what is supported by a single channel"):
             splits = mpp_split.suggest_splits(1_100_000_000, self.channels_with_funds, exclude_single_parts=True)
-            self.assertEqual({0: 798_000_000, 1: 0, 2: 302_000_000, 3: 0}, splits[0][0])
-            self.assertEqual({0: 908_000_000, 1: 0, 2: 192_000_000, 3: 0}, splits[1][0])
+            self.assertEqual({0: 600_000_000, 1: 500_000_000, 2: 0, 3: 0}, splits[0][0])
+            self.assertEqual({0: 710_000_000, 1: 390_000_000, 2: 0, 3: 0}, splits[1][0])
 
         with self.subTest(msg="do a payment with the maximal amount spendable over all channels"):
             splits = mpp_split.suggest_splits(sum(self.channels_with_funds.values()), self.channels_with_funds, exclude_single_parts=True)


### PR DESCRIPTION
related #7050
related #7060
(this conflicts with master due to latter; but I would like Travis to run)

-----

`mpp_split.unique_hierarchy()` is returning different results depending on python version

see:

```
> python3.7
Python 3.7.7 (tags/v3.7.7:d7c567b08f, Mar 10 2020, 10:41:24) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> unique_configs={((0, 798000000), (1, 0), (2, 302000000), (3, 0)), ((0, 1000000000), (1, 0), (2, 100000000), (3, 0))}
>>> item = ((0, 600000000), (1, 500000000), (2, 0), (3, 0))
>>> unique_configs.add(item)
>>> unique_configs
{((0, 600000000), (1, 500000000), (2, 0), (3, 0)), ((0, 798000000), (1, 0), (2, 302000000), (3, 0)), ((0, 1000000000), (1, 0), (2, 100000000), (3, 0))}
```
```
> python3.8
Python 3.8.5 (tags/v3.8.5:580fbb0, Jul 20 2020, 15:57:54) [MSC v.1924 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> unique_configs={((0, 798000000), (1, 0), (2, 302000000), (3, 0)), ((0, 1000000000), (1, 0), (2, 100000000), (3, 0))}
>>> item = ((0, 600000000), (1, 500000000), (2, 0), (3, 0))
>>> unique_configs.add(item)
>>> unique_configs
{((0, 798000000), (1, 0), (2, 302000000), (3, 0)), ((0, 1000000000), (1, 0), (2, 100000000), (3, 0)), ((0, 600000000), (1, 500000000), (2, 0), (3, 0))}
```