### PR TITLE
lnpeer: MPP recv: only fulfill htlc if amt sum exact-matches total_msat

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1051,7 +1051,9 @@ class Channel(AbstractChannel):
             if is_sent:
                 self.lnworker.htlc_fulfilled(self, payment_hash, htlc.htlc_id, htlc.amount_msat)
             else:
-                self.lnworker.htlc_received(self, payment_hash)
+                # FIXME
+                #self.lnworker.htlc_received(self, payment_hash)
+                pass
 
     def balance(self, whose: HTLCOwner, *, ctx_owner=HTLCOwner.LOCAL, ctn: int = None) -> int:
         assert type(whose) is HTLCOwner

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1566,13 +1566,10 @@ class Peer(Logger):
         else:
             if payment_secret_from_onion != derive_payment_secret_from_payment_preimage(preimage):
                 raise OnionRoutingFailure(code=OnionFailureCode.INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS, data=b'')
-        expected_received_msat = info.amount_msat
-        if expected_received_msat is None:
-            return preimage
-
-        if not (expected_received_msat <= total_msat <= 2 * expected_received_msat):
+        invoice_msat = info.amount_msat
+        if not (invoice_msat is None or invoice_msat <= total_msat <= 2 * invoice_msat):
             raise OnionRoutingFailure(code=OnionFailureCode.INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS, data=b'')
-        accepted, expired = self.lnworker.htlc_received(chan.short_channel_id, htlc, expected_received_msat)
+        accepted, expired = self.lnworker.htlc_received(chan.short_channel_id, htlc, total_msat)
         if accepted:
             return preimage
         elif expired:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1692,7 +1692,7 @@ class LNWallet(LNWorker):
         total = sum([htlc.amount_msat for scid, htlc in s])
         first_timestamp = min([htlc.timestamp for scid, htlc in s])
         expired = time.time() - first_timestamp > MPP_EXPIRY
-        if total >= expected_msat and not expired:
+        if total == expected_msat and not expired:
             # status must be persisted
             self.set_payment_status(htlc.payment_hash, PR_PAID)
             util.trigger_callback('request_status', self.wallet, htlc.payment_hash.hex(), PR_PAID)


### PR DESCRIPTION
when receiving htlcs as part of MPP
- it is not the invoice_amount the htlc set sum should be tested against but `total_msat`,
  i.e. htlc set sum and `total_msat` should be compared
- specifically, BOLT-04 seems to suggest testing equality of htlc set sum and `total_msat` (instead of `>=`)
  > if the total `amount_msat` of this HTLC set equals `total_msat`
- re zero amount invoices, they too might be MPP, so the same tests still need to be done
- (the FIXME in `lnchannel.py` is pre-existing brokenness)

https://github.com/lightningnetwork/lightning-rfc/blob/90468030d5c374ced568c91df5d37699fe020010/04-onion-routing.md#basic-multi-part-payments