### PR TITLE
mpp_split: optimize split parameters

### DIFF
--- a/electrum/mpp_split.py
+++ b/electrum/mpp_split.py
@@ -12,9 +12,9 @@ REDISTRIBUTION_FRACTION = 10
 SPLIT_FRACTION = 10
 
 # these parameters affect the computational work in the probabilistic algorithm
-STARTING_CONFIGS = 30
-CANDIDATES_PER_LEVEL = 20
-REDISTRIBUTE = 5
+STARTING_CONFIGS = 50
+CANDIDATES_PER_LEVEL = 10
+REDISTRIBUTE = 10
 
 
 def unique_hierarchy(hierarchy: Dict[int, List[Dict[bytes, int]]]) -> Dict[int, List[Dict[bytes, int]]]:

--- a/electrum/tests/test_mpp_split.py
+++ b/electrum/tests/test_mpp_split.py
@@ -13,14 +13,17 @@ class TestMppSplit(ElectrumTestCase):
         super().setUp()
         # to make tests reproducible:
         random.seed(0)
-        # undo side effect
-        mpp_split.PART_PENALTY = PART_PENALTY
         self.channels_with_funds = {
             0: 1_000_000_000,
             1: 500_000_000,
             2: 302_000_000,
             3: 101_000_000,
         }
+
+    def tearDown(self):
+        super().tearDown()
+        # undo side effect
+        mpp_split.PART_PENALTY = PART_PENALTY
 
     def test_suggest_splits(self):
         with self.subTest(msg="do a payment with the maximal amount spendable over a single channel"):


### PR DESCRIPTION
Optimizes split parameters and leaves tests in a proper state by undoing side effects in tearDown.