### PR TITLE
installwizard: show hw xpub after adding cosigner

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -492,9 +492,10 @@ Builder.load_string('''
 
 <ShowXpubDialog>
     xpub: ''
-    message: _('Here is your master public key. Share it with your cosigners.')
+    message: ''
+    title: ''
     BigLabel:
-        text: "MASTER PUBLIC KEY"
+        text: root.title
     GridLayout
         cols: 1
         padding: 0, '12dp'
@@ -1018,6 +1019,14 @@ class ShowXpubDialog(WizardDialog):
     def __init__(self, wizard, **kwargs):
         WizardDialog.__init__(self, wizard, **kwargs)
         self.xpub = kwargs['xpub']
+        hw_info = kwargs.get('hw_info')
+        self.title = (_('Hardware Wallet Public Key') if hw_info else
+                      _('Master Public Key')).upper()
+        self.message = ' '.join([
+            _("Here is your {} public key.").format(hw_info) if hw_info else
+            _("Here is your master public key."),
+            _("Please share it with your cosigners.")
+        ])
         self.ids.next.disabled = False
 
     def do_copy(self):

--- a/electrum/gui/qt/installwizard.py
+++ b/electrum/gui/qt/installwizard.py
@@ -709,8 +709,11 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         return line.text()
 
     @wizard_dialog
-    def show_xpub_dialog(self, xpub, run_next):
+    def show_xpub_dialog(self, xpub, run_next, hw_info=None):
+        title = (_('Hardware Wallet Public Key') if hw_info else
+                 _('Master Public Key'))
         msg = ' '.join([
+            _("Here is your {} public key.").format(hw_info) if hw_info else
             _("Here is your master public key."),
             _("Please share it with your cosigners.")
         ])
@@ -723,7 +726,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
             config=self.config,
         )
         vbox.addLayout(layout.layout())
-        self.exec_layout(vbox, _('Master Public Key'))
+        self.exec_layout(vbox, title)
         return None
 
     def init_network(self, network: 'Network'):


### PR DESCRIPTION
Show hardware wallet xpub when hw wallet is used as cosigner.

It could be useful, for example, when setting up 2of2 on desktop and mobile.