### PR TITLE
Add support to save uncompleted multisig wallets

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -495,6 +495,8 @@ class Daemon(Logger):
             return
         if db.get_action():
             return
+        if db.check_unfinished_multisig():
+            return
         wallet = Wallet(db, storage, config=self.config)
         wallet.start_network(self.network)
         self._wallets[path] = wallet

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -696,7 +696,12 @@ class ElectrumWindow(App, Logger):
             assert storage.is_past_initial_decryption()
             db = WalletDB(storage.read(), manual_upgrades=False)
             assert not db.requires_upgrade()
-            self.on_wizard_success(storage, db, password)
+            if db.check_unfinished_multisig():
+                wizard = InstallWizard(self.electrum_config, self.plugins)
+                wizard.path = storage.path
+                wizard.continue_multisig_setup(storage)
+            else:
+                self.on_wizard_success(storage, db, password)
 
     def on_stop(self):
         self.logger.info('on_stop')

--- a/electrum/gui/kivy/uix/dialogs/password_dialog.py
+++ b/electrum/gui/kivy/uix/dialogs/password_dialog.py
@@ -360,7 +360,11 @@ class OpenWalletDialog(PasswordDialog):
             # it is a bit wasteful load the wallet here and load it again in main_window,
             # but that is fine, because we are progressively enforcing storage encryption.
             db = WalletDB(self.storage.read(), manual_upgrades=False)
-            wallet = Wallet(db, self.storage, config=self.app.electrum_config)
-            self.require_password = wallet.has_password()
-            self.pw_check = wallet.check_password
-            self.message = self.enter_pw_message if self.require_password else _('Wallet not encrypted')
+            if db.check_unfinished_multisig():
+                self.require_password = False
+            else:
+                wallet = Wallet(db, self.storage, config=self.app.electrum_config)
+                self.require_password = wallet.has_password()
+                self.pw_check = wallet.check_password
+            self.message = (self.enter_pw_message if self.require_password
+                            else _('Wallet not encrypted'))

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -310,9 +310,18 @@ class ElectrumGui(Logger):
                 wizard.path = path  # needed by trustedcoin plugin
                 wizard.run('new')
                 storage, db = wizard.create_storage(path)
+                if db.check_unfinished_multisig():
+                    wizard.show_message(_('Saved unfinished multisig wallet'))
+                    return
             else:
                 db = WalletDB(storage.read(), manual_upgrades=False)
                 wizard.run_upgrades(storage, db)
+            if db.check_unfinished_multisig():
+                wizard.continue_multisig_setup(storage)
+                storage, db = wizard.create_storage(storage.path)
+                if db.check_unfinished_multisig():
+                    wizard.show_message(_('Saved unfinished multisig wallet'))
+                    return
         except (UserCancelled, GoBack):
             return
         except WalletAlreadyOpenInMemory as e:

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -32,6 +32,9 @@ class ElectrumGui:
             storage.decrypt(password)
 
         db = WalletDB(storage.read(), manual_upgrades=False)
+        if db.check_unfinished_multisig():
+            print('Can not open unfinished multisig wallet')
+            exit()
 
         self.done = 0
         self.last_balance = ""

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -43,6 +43,9 @@ class ElectrumGui:
             password = getpass.getpass('Password:', stream=None)
             storage.decrypt(password)
         db = WalletDB(storage.read(), manual_upgrades=False)
+        if db.check_unfinished_multisig():
+            print('Can not open unfinished multisig wallet')
+            exit()
         self.wallet = Wallet(db, storage, config=config)
         self.wallet.start_network(self.network)
         self.contacts = self.wallet.contacts

--- a/electrum/tests/test_base_wizard.py
+++ b/electrum/tests/test_base_wizard.py
@@ -1,0 +1,127 @@
+import os
+import inspect
+import json
+import shutil
+import tempfile
+
+from electrum.base_wizard import BaseWizard
+from electrum.keystore import BIP32_KeyStore
+from electrum.simple_config import SimpleConfig
+from electrum.storage import WalletStorage, StorageEncryptionVersion
+from electrum.wallet_db import WalletDB, FINAL_SEED_VERSION
+
+from . import TestCaseForTestnet
+
+
+X1 = {
+    'derivation': "m/45'/0",
+    'pw_hash_version': 1,
+    'root_fingerprint': '3f635a63',
+    'type': 'bip32',
+    'xprv': 'tprv8e9ce2psffApayzry2mGdWP2zkFGomo4xgNVj3dyohcaxwiR7vZ'
+            'GtE5dzqCUTah7QoZb716n21QdHptT1d9DYNALyaio5gVyQTHQmy6Fyk9',
+    'xpub': 'tpubDAqenSs7p2rVUT2ergRs2v39ZmmCy6yyXyyH1ZgHDyQyoRyBkKN'
+            's4ihWAyr9b5uuJpuZvUYC9xDabdsoP9As2ZZZmSLEkLEkMDsaoEUaPNo'
+}
+
+X2 = {
+    'derivation': "m/45'/0",
+    'pw_hash_version': 1,
+    'root_fingerprint': 'e54b06c8',
+    'type': 'bip32',
+    'xprv': 'tprv8eFGXNuTxVENvqBHHHGjQ61WaWqmjx9rp4vtZVNhskcBZUbdmD1'
+            'Nws8sGqBttSJUxPLT9VEYNHcHUbXx6UkPCtiQjN5DqCWPmo3bvUW7W5Z',
+    'xpub': 'tpubDAwJfnwi6rv3pJD5AvwKoVfd9YMhuHLmPNXfr1R1J2QaPxrQPbp'
+            'y8MkjSweG9YkwiSi5YAjvuyoezMWH8k18oUyfiHSTUHdqZLQLTY5AtuD'
+}
+
+
+X1_VIEW_ONLY = {
+    'derivation': None,
+    'pw_hash_version': 1,
+    'root_fingerprint': None,
+    'type': 'bip32',
+    'xprv': None,
+    'xpub': 'tpubDAwJfnwi6rv3pJD5AvwKoVfd9YMhuHLmPNXfr1R1J2QaPxrQPbp'
+            'y8MkjSweG9YkwiSi5YAjvuyoezMWH8k18oUyfiHSTUHdqZLQLTY5AtuD'
+}
+
+
+class SimpleWizard(BaseWizard):
+
+    def continue_multisig_setup_dialog(self, m, n, keystores, run_next):
+        self.last_method = inspect.currentframe().f_code.co_name
+        self.last_args = (m, n, keystores, run_next)
+
+
+class BaseWizardTestCase(TestCaseForTestnet):
+
+    def setUp(self):
+        super(BaseWizardTestCase, self).setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+        self.wallet_path = os.path.join(self.electrum_path, "somewallet")
+        self.wizard = SimpleWizard(self.config, None)
+
+    def test_continue_multisig_setup(self):
+        wiz = self.wizard
+        storage = WalletStorage(self.wallet_path)
+        d = {'wallet_type': 'standard', "seed_version": FINAL_SEED_VERSION}
+        d['wallet_type'] = '2of3'
+        d['x1/'] = X1
+        db = WalletDB(json.dumps(d), manual_upgrades=True)
+        assert db.check_unfinished_multisig()
+        db.write(storage)
+        storage = WalletStorage(self.wallet_path)
+        wiz.continue_multisig_setup(storage)
+        assert wiz.unfinished_multisig
+        assert wiz.unfinished_enc_version == StorageEncryptionVersion.PLAINTEXT
+        assert not wiz.unfinished_check_password
+        assert wiz.last_method == 'continue_multisig_setup_dialog'
+        last_args = wiz.last_args
+        assert last_args[0:2] == (2, 3)  # m, n
+        assert last_args[2] == wiz.keystores  # keystores
+        assert len(last_args[2]) == 1
+        k1 = last_args[2][0]
+        assert type(k1) == BIP32_KeyStore
+        assert k1.get_root_fingerprint() == '3f635a63'
+        assert last_args[3] == wiz.choose_keystore  # run_next
+
+        d['x2/'] = X2
+        db = WalletDB(json.dumps(d), manual_upgrades=True)
+        assert db.check_unfinished_multisig()
+        db.write(storage)
+        storage = WalletStorage(self.wallet_path)
+        wiz.continue_multisig_setup(storage)
+        assert wiz.unfinished_multisig
+        assert wiz.unfinished_enc_version == StorageEncryptionVersion.PLAINTEXT
+        assert not wiz.unfinished_check_password
+        assert wiz.last_method == 'continue_multisig_setup_dialog'
+        last_args = wiz.last_args
+        assert last_args[0:2] == (2, 3)  # m, n
+        assert last_args[2] == wiz.keystores  # keystores
+        assert len(last_args[2]) == 2
+        k1, k2 = last_args[2]
+        assert type(k1) == BIP32_KeyStore
+        assert k1.get_root_fingerprint() == '3f635a63'
+        assert type(k2) == BIP32_KeyStore
+        assert k2.get_root_fingerprint() == 'e54b06c8'
+        assert last_args[3] == wiz.choose_keystore  # run_next
+
+    def test_check_need_confirm_password(self):
+        wiz = self.wizard
+        storage = WalletStorage(self.wallet_path)
+        d = {'wallet_type': 'standard', "seed_version": FINAL_SEED_VERSION}
+        d['wallet_type'] = '2of3'
+        d['x1/'] = X1_VIEW_ONLY
+        d['x2/'] = X2
+        db = WalletDB(json.dumps(d), manual_upgrades=True)
+        db.write(storage)
+        storage = WalletStorage(self.wallet_path)
+        wiz.continue_multisig_setup(storage)
+
+        wiz.unfinished_check_password = storage.check_password
+        assert wiz.check_need_confirm_password()
+        wiz.unfinished_check_password = None
+        assert not wiz.check_need_confirm_password()
+        wiz.keystores[1].update_password(None, 'test')
+        assert wiz.check_need_confirm_password()

--- a/electrum/tests/test_wallet_db.py
+++ b/electrum/tests/test_wallet_db.py
@@ -1,0 +1,42 @@
+import json
+
+from electrum.wallet_db import WalletDB, FINAL_SEED_VERSION
+
+from . import SequentialTestCase
+
+
+class WalletDBTestCase(SequentialTestCase):
+
+    def test_check_unfinished_multisig(self):
+        d = {'wallet_type': 'standard', "seed_version": FINAL_SEED_VERSION}
+
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()
+
+        d['wallet_type'] = '2of3'
+        d['x1/'] = d['x2/'] = d['x3/'] = 'some data'
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()
+
+        del d['x3/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert db.check_unfinished_multisig()  # x1/, x2/ pass
+        assert db.check_unfinished_multisig()
+
+        del d['x2/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert db.check_unfinished_multisig()  # x1/ pass
+        assert db.check_unfinished_multisig()
+
+        del d['x1/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()  # no x1/ fails
+
+        d['x1/'] = d['x3/'] = 'some data'
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()  # x1/, x3/ fails
+
+        d['x2/'] = 'some data'
+        del d['x1/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()  # x2/, x3/ fails

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -104,6 +104,29 @@ class WalletDB(JsonDB):
         elif not self._manual_upgrades:
             self.upgrade()
 
+    def check_unfinished_multisig(self):
+        wallet_type = self.data.get('wallet_type')
+        if not wallet_type:
+            return False
+        m_n = multisig_type(wallet_type)
+        if not m_n:
+            return False
+        x1 = self.data.get('x1/')
+        if not x1:
+            return False
+        m, n = m_n
+        next_cosigner = None
+        for i in range(2, n+1):
+            cosigner_name = f'x{i}/'
+            if self.data.get(cosigner_name):
+                if next_cosigner:
+                    return False
+            elif not next_cosigner:
+                next_cosigner = i
+        if not next_cosigner:
+            return False
+        return True
+
     def requires_split(self):
         d = self.get('accounts', {})
         return len(d) > 1

--- a/run_electrum
+++ b/run_electrum
@@ -222,6 +222,9 @@ async def run_offline_command(config, config_options, plugins: 'Plugins'):
                 config_options['password'] = password
             storage.decrypt(password)
         db = WalletDB(storage.read(), manual_upgrades=False)
+        if db.check_unfinished_multisig():
+            print_msg("Error: Can not open unfinished multisig wallet.")
+            sys.exit(1)
         wallet = Wallet(db, storage, config=config)
         config_options['wallet'] = wallet
     else:


### PR DESCRIPTION
- Add support to save uncompleted multisig wallets and then
continue setup when cosigners xpub is available.

Maybe related to #6456.

Some screens:

1. "Save and exit" button is added when saving is possible:

<img src="https://user-images.githubusercontent.com/992125/110709783-72f46a00-8205-11eb-89fd-a0a4e8c6e9a8.png" width="300">

<img src="https://user-images.githubusercontent.com/992125/110709804-7be53b80-8205-11eb-9a29-0a57eb3f5018.png" width="300">

2. Continue multisig setup, when already stored xpub can be viewed:

<img src="https://user-images.githubusercontent.com/992125/110710165-1180cb00-8206-11eb-809f-4c7a9f81dd53.png" width="300">

<img src="https://user-images.githubusercontent.com/992125/110710154-0b8aea00-8206-11eb-86a1-53fb50e29fb5.png" width="300">