### PR TITLE
Deterministic node

### DIFF
--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -545,6 +545,8 @@ class BaseWizard(Logger):
 
     def create_keystore(self, seed, passphrase):
         k = keystore.from_seed(seed, passphrase, self.wallet_type == 'multisig')
+        if self.wallet_type == 'standard' and self.seed_type == 'segwit':
+            self.data['lightning_xprv'] = k.get_lightning_xprv(None)
         self.on_keystore(k)
 
     def on_bip43(self, seed, passphrase, derivation, script_type):

--- a/electrum/bitcoin.py
+++ b/electrum/bitcoin.py
@@ -295,6 +295,10 @@ def push_script(data: str) -> str:
     return _op_push(data_len) + bh2u(data)
 
 
+def make_op_return(x:bytes) -> bytes:
+    return bytes([opcodes.OP_RETURN]) + bytes.fromhex(push_script(x.hex()))
+
+
 def add_number_to_script(i: int) -> bytes:
     return bfh(push_script(script_num_to_hex(i)))
 

--- a/electrum/channel_db.py
+++ b/electrum/channel_db.py
@@ -867,6 +867,13 @@ class ChannelDB(SqlDB):
         with self.lock:
             return self._policies.copy()
 
+    def get_node_by_prefix(self, prefix):
+        with self.lock:
+            for k in self._addresses.keys():
+                if k.startswith(prefix):
+                    return k
+        raise Exception('node not found')
+
     def to_dict(self) -> dict:
         """ Generates a graph representation in terms of a dictionary.
 

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -54,6 +54,7 @@ from .address_synchronizer import TX_HEIGHT_LOCAL
 from .mnemonic import Mnemonic
 from .lnutil import SENT, RECEIVED
 from .lnutil import LnFeatures
+from .lnutil import extract_nodeid
 from .lnpeer import channel_id_from_funding_tx
 from .plugin import run_hook
 from .version import ELECTRUM_VERSION
@@ -997,9 +998,11 @@ class Commands:
         funding_sat = satoshis(amount)
         push_sat = satoshis(push_amount)
         coins = wallet.get_spendable_coins(None)
+        node_id, rest = extract_nodeid(connection_string)
         funding_tx = wallet.lnworker.mktx_for_open_channel(
             coins=coins,
             funding_sat=funding_sat,
+            node_id=node_id,
             fee_est=None)
         chan, funding_tx = await wallet.lnworker._open_channel_coroutine(
             connect_str=connection_string,

--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -98,6 +98,26 @@
         id: lbl2
         text: root.value
 
+<BoxButton@BoxLayout>
+    text: ''
+    value: ''
+    size_hint_y: None
+    height: max(lbl1.height, lbl2.height)
+    TopLabel
+        id: lbl1
+        text: root.text
+        pos_hint: {'top':1}
+    Button
+        id: lbl2
+        text: root.value
+        background_color: (0,0,0,0)
+        bold: True
+        size_hint_y: None
+        text_size: self.width, None
+        height: self.texture_size[1]
+        on_release:
+            root.callback()
+
 <OutputItem>
     address: ''
     value: ''

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -208,6 +208,10 @@ class ElectrumWindow(App, Logger):
     def on_use_unconfirmed(self, instance, x):
         self.electrum_config.set_key('confirmed_only', not self.use_unconfirmed, True)
 
+    use_recoverable_channels = BooleanProperty(True)
+    def on_use_recoverable_channels(self, instance, x):
+        self.electrum_config.set_key('use_recoverable_channels', self.use_recoverable_channels, True)
+
     def switch_to_send_screen(func):
         # try until send_screen is available
         def wrapper(self, *args):
@@ -1352,3 +1356,59 @@ class ElectrumWindow(App, Logger):
             self.show_error("failed to import backup" + '\n' + str(e))
             return
         self.lightning_channels_dialog()
+
+    def lightning_status(self):
+        if self.wallet.has_lightning():
+            if self.wallet.lnworker.has_deterministic_node_id():
+                status = _('Enabled')
+            else:
+                status = _('Enabled, non-recoverable channels')
+                if self.wallet.db.get('seed_type') == 'segwit':
+                    msg = _("Your channels cannot be recovered from seed, because they were created with an old version of Electrum. "
+                            "This means that you must save a backup of your wallet everytime you create a new channel.\n\n"
+                            "If you want this wallet to have recoverable channels, you must close your existing channels and restore this wallet from seed")
+                else:
+                    msg = _("Your channels cannot be recovered from seed. "
+                            "This means that you must save a backup of your wallet everytime you create a new channel.\n\n"
+                            "If you want to have recoverable channels, you must create a new wallet with an Electrum seed")
+        else:
+            if self.wallet.can_have_lightning():
+                status = _('Not enabled')
+            else:
+                status = _("Not available for this wallet.")
+        return status
+
+    def on_lightning_status(self, root):
+        if self.wallet.has_lightning():
+            if self.wallet.lnworker.has_deterministic_node_id():
+                pass
+            else:
+                if self.wallet.db.get('seed_type') == 'segwit':
+                    msg = _("Your channels cannot be recovered from seed, because they were created with an old version of Electrum. "
+                            "This means that you must save a backup of your wallet everytime you create a new channel.\n\n"
+                            "If you want this wallet to have recoverable channels, you must close your existing channels and restore this wallet from seed")
+                else:
+                    msg = _("Your channels cannot be recovered from seed. "
+                            "This means that you must save a backup of your wallet everytime you create a new channel.\n\n"
+                            "If you want to have recoverable channels, you must create a new wallet with an Electrum seed")
+                self.show_info(msg)
+        else:
+            if self.wallet.can_have_lightning():
+                root.dismiss()
+                msg = _(
+                    "Warning: this wallet type does not support channel recovery from seed. "
+                    "You will need to backup your wallet everytime you create a new wallet. "
+                    "Create lightning keys?")
+                d = Question(msg, self._enable_lightning, title=_('Enable Lightning?'))
+                d.open()
+            else:
+                pass
+
+    def _enable_lightning(self, b):
+        if not b:
+            return
+        wallet_path = self.get_wallet_path()
+        self.wallet.init_lightning()
+        self.show_info(_('Lightning keys have been initialized.'))
+        self.stop_wallet()
+        self.load_wallet_by_name(wallet_path)

--- a/electrum/gui/kivy/uix/dialogs/lightning_channels.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_channels.py
@@ -528,7 +528,7 @@ class ChannelDetailsPopup(Popup, Logger):
         to_self_delay = self.chan.config[REMOTE].to_self_delay
         help_text = ' '.join([
             _('If you force-close this channel, the funds you have in it will not be available for {} blocks.').format(to_self_delay),
-            _('During that time, funds will not be recoverabe from your seed, and may be lost if you lose your device.'),
+            _('During that time, funds will not be recoverable from your seed, and may be lost if you lose your device.'),
             _('To prevent that, please save this channel backup.'),
             _('It may be imported in another wallet with the same seed.')
         ])

--- a/electrum/gui/kivy/uix/dialogs/lightning_open_channel.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_open_channel.py
@@ -9,7 +9,7 @@ from electrum.util import bh2u
 from electrum.bitcoin import COIN
 import electrum.simple_config as config
 from electrum.logging import Logger
-from electrum.lnutil import ln_dummy_address
+from electrum.lnutil import ln_dummy_address, extract_nodeid
 
 from .label_dialog import LabelDialog
 from .confirm_tx_dialog import ConfirmTxDialog
@@ -178,9 +178,11 @@ class LightningOpenChannelDialog(Factory.Popup, Logger):
         self.dismiss()
         lnworker = self.app.wallet.lnworker
         coins = self.app.wallet.get_spendable_coins(None, nonlocal_only=True)
+        node_id, rest = extract_nodeid(conn_str)
         make_tx = lambda rbf: lnworker.mktx_for_open_channel(
             coins=coins,
             funding_sat=amount,
+            node_id=node_id,
             fee_est=None)
         on_pay = lambda tx: self.app.protected('Create a new channel?', self.do_open_channel, (tx, conn_str))
         d = ConfirmTxDialog(

--- a/electrum/gui/kivy/uix/dialogs/settings.py
+++ b/electrum/gui/kivy/uix/dialogs/settings.py
@@ -16,6 +16,7 @@ from .choice_dialog import ChoiceDialog
 Builder.load_string('''
 #:import partial functools.partial
 #:import _ electrum.gui.kivy.i18n._
+#:import messages electrum.gui.messages
 
 <SettingsDialog@Popup>
     id: settings
@@ -79,6 +80,13 @@ Builder.load_string('''
                     title: _('Password')
                     description: _('Change your password') if app._use_single_password else _("Change your password for this wallet.")
                     action: root.change_password
+                CardSeparator
+                SettingsItem:
+                    status: _('Yes') if app.use_recoverable_channels else _('No')
+                    title: _('Use recoverable channels') + ': ' + self.status
+                    description: _("Add channel recovery data to funding transaction.")
+                    message: _(messages.MSG_RECOVERABLE_CHANNELS)
+                    action: partial(root.boolean_dialog, 'use_recoverable_channels', _('Use recoverable_channels'), self.message)
                 CardSeparator
                 SettingsItem:
                     status: _('Trampoline') if not app.use_gossip else _('Gossip')

--- a/electrum/gui/kivy/uix/ui_screens/status.kv
+++ b/electrum/gui/kivy/uix/ui_screens/status.kv
@@ -31,22 +31,21 @@ Popup:
                     BoxLabel:
                         text: _("Wallet type:")
                         value: app.wallet.wallet_type
-                    BoxLabel:
+                    BoxButton:
                         text: _("Lightning:")
-                        value: (_('Enabled') if app.wallet.has_lightning() else _('Disabled')) if app.wallet.can_have_lightning() else _('Not available')
+                        value: app.lightning_status()
+                        callback: lambda: app.on_lightning_status(root)
                     BoxLabel:
                         text: _("Balance") + ':'
                         value: app.format_amount_and_units(root.confirmed + root.unconfirmed + root.unmatured + root.lightning)
                     BoxLabel:
-                        text: _("Onchain") + ':'
+                        text: ' - ' + _("Onchain") + ':'
                         value: app.format_amount_and_units(root.confirmed + root.unconfirmed + root.unmatured)
                         opacity: 1 if root.lightning else 0
                     BoxLabel:
-                        text: _("Lightning") + ':'
+                        text: ' - ' + _("Lightning") + ':'
                         opacity: 1 if root.lightning else 0
                         value: app.format_amount_and_units(root.lightning)
-
-
                 GridLayout:
                     cols: 1
                     height: self.minimum_height

--- a/electrum/gui/messages.py
+++ b/electrum/gui/messages.py
@@ -1,0 +1,14 @@
+# note: qt and kivy use different i18n methods
+
+MSG_RECOVERABLE_CHANNELS = """
+Add extra data to your channel funding transactions, so that a static backup can be
+recovered from your seed.
+
+Note that static backups only allow you to request a force-close with the remote node.
+This assumes that the remote node is still online, did not lose its data, and accepts
+to force close the channel.
+
+If this is enabled, other nodes cannot open a channel to you. Channel recovery data
+is encrypted, so that only your wallet can decrypt it. However, blockchain analysis
+will be able to tell that the transaction was probably created by Electrum.
+"""

--- a/electrum/gui/qt/channels_list.py
+++ b/electrum/gui/qt/channels_list.py
@@ -345,13 +345,14 @@ class ChannelsList(MyTreeView):
 
     def new_channel_with_warning(self):
         if not self.parent.wallet.lnworker.channels:
-            warning1 = _("Lightning support in Electrum is experimental. "
+            warning = _("Lightning support in Electrum is experimental. "
                          "Do not put large amounts in lightning channels.")
-            warning2 = _("Funds stored in lightning channels are not recoverable from your seed. "
-                         "You must backup your wallet file everytime you create a new channel.")
+            if not self.parent.wallet.lnworker.has_recoverable_channels():
+                warning += _("Funds stored in lightning channels are not recoverable from your seed. "
+                             "You must backup your wallet file everytime you create a new channel.")
             answer = self.parent.question(
                 _('Do you want to create your first channel?') + '\n\n' +
-                _('WARNINGS') + ': ' + '\n\n' + warning1 + '\n\n' + warning2)
+                _('WARNING') + ': ' + '\n\n' + warning)
             if answer:
                 self.new_channel_dialog()
         else:

--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -41,6 +41,7 @@ from .util import (ColorScheme, WindowModalDialog, HelpLabel, Buttons,
 
 from electrum.i18n import languages
 from electrum import qrscanner
+from electrum.gui import messages
 
 if TYPE_CHECKING:
     from electrum.simple_config import SimpleConfig
@@ -129,6 +130,17 @@ class SettingsDialog(WindowModalDialog):
 
         # lightning
         lightning_widgets = []
+
+        if self.wallet.lnworker and self.wallet.lnworker.has_deterministic_node_id():
+            help_recov = _(messages.MSG_RECOVERABLE_CHANNELS)
+            recov_cb = QCheckBox(_("Create recoverable channels"))
+            recov_cb.setToolTip(help_recov)
+            recov_cb.setChecked(bool(self.config.get('use_recoverable_channels', True)))
+            def on_recov_checked(x):
+                self.config.set_key('use_recoverable_channels', bool(x))
+            recov_cb.stateChanged.connect(on_recov_checked)
+            recov_cb.setEnabled(not bool(self.config.get('lightning_listen')))
+            lightning_widgets.append((recov_cb, None))
 
         help_gossip = _("""If this option is enabled, Electrum will download the network
 channels graph and compute payment path locally, instead of using trampoline payments. """)

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -613,6 +613,11 @@ class BIP32_KeyStore(Xpub, Deterministic_KeyStore):
         cK = ecc.ECPrivkey(k).get_public_key_bytes()
         return cK, k
 
+    def get_lightning_xprv(self, password):
+        xprv = self.get_master_private_key(password)
+        rootnode = BIP32Node.from_xkey(xprv)
+        node = rootnode.subkey_at_private_derivation("m/67'/")
+        return node.to_xprv()
 
 class Old_KeyStore(MasterPublicKeyMixin, Deterministic_KeyStore):
 

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -141,7 +141,6 @@ if [[ $1 == "backup" ]]; then
     echo "channel point: $channel"
     new_blocks 3
     wait_until_channel_open alice
-    backup=$($alice export_channel_backup $channel)
     request=$($bob add_lightning_request 0.01 -m "blah" | jq -r ".invoice")
     echo "alice pays"
     $alice lnpay $request
@@ -151,7 +150,6 @@ if [[ $1 == "backup" ]]; then
     $alice -o restore "$seed"
     $alice daemon -d
     $alice load_wallet
-    $alice import_channel_backup $backup
     $alice request_force_close $channel
     wait_for_balance alice 0.989
 fi

--- a/electrum/tests/test_wallet.py
+++ b/electrum/tests/test_wallet.py
@@ -167,7 +167,7 @@ class TestCreateRestoreWallet(WalletTestCase):
         wallet = d['wallet']  # type: Standard_Wallet
 
         # lightning initialization
-        self.assertTrue(wallet.db.get('lightning_privkey2').startswith('xprv'))
+        self.assertTrue(wallet.db.get('lightning_xprv').startswith('zprv'))
 
         wallet.check_password(password)
         self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -37,7 +37,8 @@ from .invoices import PR_TYPE_ONCHAIN, Invoice
 from .keystore import bip44_derivation
 from .transaction import Transaction, TxOutpoint, tx_from_any, PartialTransaction, PartialTxOutput
 from .logging import Logger
-from .lnutil import LOCAL, REMOTE, FeeUpdate, UpdateAddHtlc, LocalConfig, RemoteConfig, Keypair, OnlyPubkeyKeypair, RevocationStore, ChannelBackupStorage
+from .lnutil import LOCAL, REMOTE, FeeUpdate, UpdateAddHtlc, LocalConfig, RemoteConfig, Keypair, OnlyPubkeyKeypair, RevocationStore
+from .lnutil import ImportedChannelBackupStorage, OnchainChannelBackupStorage
 from .lnutil import ChannelConstraints, Outpoint, ShachainElement
 from .json_db import StoredDict, JsonDB, locked, modifier
 from .plugin import run_hook, plugin_loaders
@@ -52,7 +53,7 @@ if TYPE_CHECKING:
 
 OLD_SEED_VERSION = 4        # electrum versions < 2.0
 NEW_SEED_VERSION = 11       # electrum versions >= 2.0
-FINAL_SEED_VERSION = 38     # electrum >= 2.7 will set this to prevent
+FINAL_SEED_VERSION = 39     # electrum >= 2.7 will set this to prevent
                             # old versions from overwriting new format
 
 
@@ -186,6 +187,7 @@ class WalletDB(JsonDB):
         self._convert_version_36()
         self._convert_version_37()
         self._convert_version_38()
+        self._convert_version_39()
         self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
 
         self._after_upgrade_tasks()
@@ -778,6 +780,13 @@ class WalletDB(JsonDB):
                         del d[key]
         self.data['seed_version'] = 38
 
+    def _convert_version_39(self):
+        # this upgrade prevents initialization of lightning_privkey2 after lightning_xprv has been set
+        if not self._is_upgrade_method_needed(38, 38):
+            return
+        self.data['imported_channel_backups'] = self.data.pop('channel_backups', {})
+        self.data['seed_version'] = 39
+
     def _convert_imported(self):
         if not self._is_upgrade_method_needed(0, 13):
             return
@@ -1273,8 +1282,10 @@ class WalletDB(JsonDB):
             v = dict((k, FeeUpdate(**x)) for k, x in v.items())
         elif key == 'submarine_swaps':
             v = dict((k, SwapData(**x)) for k, x in v.items())
-        elif key == 'channel_backups':
-            v = dict((k, ChannelBackupStorage(**x)) for k, x in v.items())
+        elif key == 'imported_channel_backups':
+            v = dict((k, ImportedChannelBackupStorage(**x)) for k, x in v.items())
+        elif key == 'onchain_channel_backups':
+            v = dict((k, OnchainChannelBackupStorage(**x)) for k, x in v.items())
         elif key == 'tx_fees':
             v = dict((k, TxFeesValue(*x)) for k, x in v.items())
         elif key == 'prevouts_by_scripthash':


### PR DESCRIPTION
    Deterministic NodeID:
     - lightning_xprv is derived from seed at wallet creation
     - only for standard wallets with a 'segwit' seed_type
     - other wallets still use 'lightning_privkey2'
    
    Recoverable channels:
     - channel recovery data is added funding tx using an OP_RETURN
     - recovery data = 4 magic bytes + node id[0:16]
     - recovery data is chacha20 encrypted using funding_address as nonce.
       (this will allow to fund multiple channels in the same tx)
    
    GUI:
      - whether channels are recoverable is shown in wallet info dialog.
      - if the wallet can have recoverable channels but has an old node_id,
        users are told to close their channels and restore from seed
        to have that feature.
