### PR TITLE
swaps: revise send/recv amount calculation

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1189,7 +1189,8 @@ class Commands:
             success = None
         else:
             lightning_amount_sat = satoshis(lightning_amount)
-            onchain_amount_sat = satoshis(onchain_amount)
+            claim_fee = sm.get_claim_fee()
+            onchain_amount_sat = satoshis(onchain_amount + claim_fee)
             success = await wallet.lnworker.swap_manager.reverse_swap(
                 lightning_amount_sat=lightning_amount_sat,
                 expected_onchain_amount_sat=onchain_amount_sat,

--- a/electrum/gui/kivy/uix/dialogs/lightning_channels.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_channels.py
@@ -726,7 +726,9 @@ class SwapDialog(Factory.Popup):
             max_onchain_spend = 0
         reverse = int(min(self.lnworker.num_sats_can_send(),
                           self.swap_manager.get_max_amount()))
-        forward = int(min(self.swap_manager.num_sats_can_receive(),
+        max_recv_amt_ln = int(self.swap_manager.num_sats_can_receive())
+        max_recv_amt_oc = self.swap_manager.get_send_amount(max_recv_amt_ln, is_reverse=False) or float('inf')
+        forward = int(min(max_recv_amt_oc,
                           # maximally supported swap amount by provider
                           self.swap_manager.get_max_amount(),
                           max_onchain_spend))

--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -145,7 +145,7 @@ class SwapDialog(WindowModalDialog):
             return
         self.send_amount_e.setStyleSheet(ColorScheme.DEFAULT.as_stylesheet())
         send_amount = self.send_amount_e.get_amount()
-        recv_amount = self.swap_manager.get_recv_amount(send_amount, self.is_reverse)
+        recv_amount = self.swap_manager.get_recv_amount(send_amount, is_reverse=self.is_reverse)
         if self.is_reverse and send_amount and send_amount > self.lnworker.num_sats_can_send():
             # cannot send this much on lightning
             recv_amount = None
@@ -166,7 +166,7 @@ class SwapDialog(WindowModalDialog):
             return
         self.recv_amount_e.setStyleSheet(ColorScheme.DEFAULT.as_stylesheet())
         recv_amount = self.recv_amount_e.get_amount()
-        send_amount = self.swap_manager.get_send_amount(recv_amount, self.is_reverse)
+        send_amount = self.swap_manager.get_send_amount(recv_amount, is_reverse=self.is_reverse)
         if self.is_reverse and send_amount and send_amount > self.lnworker.num_sats_can_send():
             send_amount = None
         self.send_amount_e.follows = True

--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -126,8 +126,9 @@ class SwapDialog(WindowModalDialog):
         if self.tx:
             amount = self.tx.output_value_for_address(ln_dummy_address())
             max_swap_amt = self.swap_manager.get_max_amount()
-            max_recv_amt = int(self.swap_manager.num_sats_can_receive())
-            max_amt = min(max_swap_amt, max_recv_amt)
+            max_recv_amt_ln = int(self.swap_manager.num_sats_can_receive())
+            max_recv_amt_oc = self.swap_manager.get_send_amount(max_recv_amt_ln, is_reverse=False) or float('inf')
+            max_amt = int(min(max_swap_amt, max_recv_amt_oc))
             if amount > max_amt:
                 amount = max_amt
                 self._update_tx(amount)


### PR DESCRIPTION
First commit:
- document `SwapManager._get_recv_amount` and `SwapManager._get_send_amount`
- change calculations so that they match the boltz-backend
  - note that in the reverse swap case, the server does not care about the on-chain claim tx the client
    needs to pay for. This introduced some implicit hacks and inconsistencies in the code in the past,
    it is still a bit ugly but at least this is now explicit.
- `SwapManager._get_recv_amount` and `SwapManager._get_send_amount` are now proper inverses of each other

Second commit:
- swaps: (fix) for forward swaps, correctly consider `num_sats_can_receive`
  - Previously the `min()` was passed lightning amounts and on-chain amounts mixed;
    which is conceptually a type error. It is now only passed on-chain amounts.
    Due to the bug, we did not allow a swap to fully exhaust our "LN receive" capacity.
    Now the max amt can be slighly larger.


@bitromortac you touched this code ~recently, so it would be nice if you could take a look :)

-----

For the first commit, here are some code snippets to play around with in Qt console.
For the forward swap case:
```
from electrum import ecc; lnworker = wallet.lnworker; sm = lnworker.swap_manager

invoice = network.run_from_another_thread(lnworker.create_invoice(amount_msat=3000000*1000, message="swap", expiry=86400))[1]; request_data = {"type": "submarine", "pairId": "BTC/BTC", "orderSide": "sell", "invoice": invoice, "refundPublicKey": ecc.GENERATOR.get_public_key_bytes().hex()}

network.send_http_on_proxy('post', sm.api_url + '/createswap', json=request_data, timeout=30)

sm.get_send_amount(3000000, is_reverse=False)
sm.get_recv_amount(3026730, is_reverse=False)
```

For the reverse swap case:
```
from electrum import ecc; import os; lnworker = wallet.lnworker; sm = lnworker.swap_manager

request_data = {"type": "reversesubmarine", "pairId": "BTC/BTC", "orderSide": "buy", "invoiceAmount": 3000000, "preimageHash": os.urandom(32).hex(), "claimPublicKey": ecc.GENERATOR.get_public_key_bytes().hex()}

network.send_http_on_proxy('post', sm.api_url + '/createswap', json=request_data, timeout=30)

sm.get_recv_amount(3000000, is_reverse=True)
sm.get_send_amount(2974443, is_reverse=True)
```