### PR TITLE
sdist build: let pip install put ~everything from tar.gz to site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,17 +79,10 @@ setup(
     package_dir={
         'electrum': 'electrum'
     },
-    package_data={
-        '': ['*.txt', '*.json', '*.ttf', '*.otf', '*.csv'],
-        'electrum': [
-            'wordlist/*.txt',
-            'locale/*/LC_MESSAGES/electrum.mo',
-            'lnwire/*.csv',
-        ],
-        'electrum.gui': [
-            'icons/*',
-        ],
-    },
+    # Note: MANIFEST.in lists what gets included in the tar.gz, and the
+    # package_data kwarg lists what gets put in site-packages when pip installing the tar.gz.
+    # By specifying include_package_data=True, MANIFEST.in becomes responsible for both.
+    include_package_data=True,
     scripts=['electrum/electrum'],
     data_files=data_files,
     description="Lightweight Bitcoin Wallet",


### PR DESCRIPTION
This makes pip install copy ~all files from the tar.gz to site-packages.

(well, not everything, only files in `electrum/` (so e.g. not `contrib`))
See comment in `setup.py`.

E.g. we have been including the www/ folder in the tar.gz but have not been installing it to site-packages. Now we do.
Or we have been including the kivy GUI files in the tar.gz but not installing them. Now we do.

I like this because it simplifies setup.py and should be easier to reason about too.

should fix #7089 (at least when using the tar.gz)

-----
related:
https://github.com/pypa/sampleproject/issues/30#issuecomment-143947944
https://github.com/pypa/sampleproject/issues/30#issuecomment-597944718
(most of that thread really)