### PR TITLE
allow 15 cosigners on android (typofix in GUI)

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum/gui/kivy/uix/dialogs/installwizard.py
@@ -139,7 +139,7 @@ Builder.load_string('''
             text: _('From {} cosigners').format(n.value)
         Slider:
             id: n
-            range: 2, 5
+            range: 2, 15
             step: 1
             value: 2
         Label:


### PR DESCRIPTION
looks like a "1" got missing. electrum desktop allows 15, android just 5 cosigners with multisig wallet.

for reference maximum number of cosigners in qt version is here: https://github.com/spesmilo/electrum/blob/1c52203346f9049f6c3fe201f672960339d8273b/electrum/gui/qt/installwizard.py#L757

i tested it its just kivy ui everything else works. thank you very much