### PR TITLE
Liquidity hints for pathfinding

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -32,7 +32,7 @@ from aiorpcx import TaskGroup
 
 from . import bitcoin, util
 from .bitcoin import COINBASE_MATURITY
-from .util import profiler, bfh, TxMinedInfo, UnrelatedTransactionException
+from .util import profiler, bfh, TxMinedInfo, UnrelatedTransactionException, with_lock
 from .transaction import Transaction, TxOutput, TxInput, PartialTxInput, TxOutpoint, PartialTransaction
 from .synchronizer import Synchronizer
 from .verifier import SPV
@@ -97,12 +97,6 @@ class AddressSynchronizer(Logger):
         self._get_addr_balance_cache = {}
 
         self.load_and_cleanup()
-
-    def with_lock(func):
-        def func_wrapper(self: 'AddressSynchronizer', *args, **kwargs):
-            with self.lock:
-                return func(self, *args, **kwargs)
-        return func_wrapper
 
     def with_transaction_lock(func):
         def func_wrapper(self: 'AddressSynchronizer', *args, **kwargs):

--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -29,7 +29,7 @@ from . import util
 from .bitcoin import hash_encode, int_to_hex, rev_hex
 from .crypto import sha256d
 from . import constants
-from .util import bfh, bh2u
+from .util import bfh, bh2u, with_lock
 from .simple_config import SimpleConfig
 from .logging import get_logger, Logger
 
@@ -194,12 +194,6 @@ class Blockchain(Logger):
         self._prev_hash = prev_hash  # blockhash immediately before forkpoint
         self.lock = threading.RLock()
         self.update_size()
-
-    def with_lock(func):
-        def func_wrapper(self, *args, **kwargs):
-            with self.lock:
-                return func(self, *args, **kwargs)
-        return func_wrapper
 
     @property
     def checkpoints(self):

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1091,6 +1091,10 @@ class Commands:
     async def clear_ln_blacklist(self):
         self.network.path_finder.liquidity_hints.clear_blacklist()
 
+    @command('n')
+    async def reset_liquidity_hints(self):
+        self.network.path_finder.liquidity_hints.reset_liquidity_hints()
+
     @command('w')
     async def list_invoices(self, wallet: Abstract_Wallet = None):
         l = wallet.get_invoices()

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1089,7 +1089,7 @@ class Commands:
 
     @command('n')
     async def clear_ln_blacklist(self):
-        self.network.path_finder.blacklist.clear()
+        self.network.path_finder.liquidity_hints.clear_blacklist()
 
     @command('w')
     async def list_invoices(self, wallet: Abstract_Wallet = None):

--- a/electrum/lnhtlc.py
+++ b/electrum/lnhtlc.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence, Tuple, List, Dict, TYPE_CHECKING, Set
 import threading
 
 from .lnutil import SENT, RECEIVED, LOCAL, REMOTE, HTLCOwner, UpdateAddHtlc, Direction, FeeUpdate
-from .util import bh2u, bfh
+from .util import bh2u, bfh, with_lock
 
 if TYPE_CHECKING:
     from .json_db import StoredDict
@@ -49,12 +49,6 @@ class HTLCManager:
         self.lock = log.lock
 
         self._init_maybe_active_htlc_ids()
-
-    def with_lock(func):
-        def func_wrapper(self, *args, **kwargs):
-            with self.lock:
-                return func(self, *args, **kwargs)
-        return func_wrapper
 
     @with_lock
     def ctn_latest(self, sub: HTLCOwner) -> int:

--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -334,29 +334,11 @@ class LiquidityHintMgr:
             can_send = hint.can_send(node_from < node_to)
             cannot_send = hint.cannot_send(node_from < node_to)
 
-        # if we know nothing about the channel, return a default penalty
-        if (can_send, cannot_send) == (None, None):
-            return fee_for_edge_msat(amount, DEFAULT_PENALTY_BASE_MSAT, DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH)
-        # next cases are with half information
-        elif can_send and not cannot_send:
-            if amount <= can_send:
-                return 0
-            else:
-                return fee_for_edge_msat(amount, DEFAULT_PENALTY_BASE_MSAT, DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH)
-        elif not can_send and cannot_send:
-            if amount >= cannot_send:
-                return inf
-            else:
-                return fee_for_edge_msat(amount, DEFAULT_PENALTY_BASE_MSAT, DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH)
-        # we know how much we can/cannot send
-        elif can_send and cannot_send:
-            if amount <= can_send:
-                return 0
-            elif amount < cannot_send:
-                return fee_for_edge_msat(amount, DEFAULT_PENALTY_BASE_MSAT, DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH)
-            else:
-                return inf
-        return 0
+        if cannot_send is not None and amount >= cannot_send:
+            return inf
+        if can_send is not None and amount <= can_send:
+            return 0
+        return fee_for_edge_msat(amount, DEFAULT_PENALTY_BASE_MSAT, DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH)
 
     @with_lock
     def add_to_blacklist(self, node_from: bytes, node_to: bytes, channel_id: ShortChannelID):

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1354,16 +1354,3 @@ class OnionFailureCodeMetaFlag(IntFlag):
     UPDATE   = 0x1000
 
 
-class ChannelBlackList:
-
-    def __init__(self):
-        self.blacklist = dict() # short_chan_id -> timestamp
-
-    def add(self, short_channel_id: ShortChannelID):
-        now = int(time.time())
-        self.blacklist[short_channel_id] = now
-
-    def get_current_list(self) -> Set[ShortChannelID]:
-        BLACKLIST_DURATION = 3600
-        now = int(time.time())
-        return set(k for k, t in self.blacklist.items() if now - t < BLACKLIST_DURATION)

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1208,6 +1208,11 @@ class LNWallet(LNWorker):
                 raise Exception(f"amount_inflight={amount_inflight} < 0")
             log.append(htlc_log)
             if htlc_log.success:
+                # TODO: report every route to liquidity hints for mpp
+                # even in the case of success, we report channels of the
+                # route as being able to send the same amount in the future,
+                # as we assume to not know the capacity
+                self.network.path_finder.update_liquidity_hints(htlc_log.route, htlc_log.amount_msat)
                 return
             # htlc failed
             if len(log) >= attempts:
@@ -1235,7 +1240,7 @@ class LNWallet(LNWorker):
                     raise PaymentFailure(failure_msg.code_name())
             else:
                 self.handle_error_code_from_failed_htlc(
-                    route=route, sender_idx=sender_idx, failure_msg=failure_msg)
+                    route=route, sender_idx=sender_idx, failure_msg=failure_msg, amount=htlc_log.amount_msat)
 
     async def pay_to_route(
             self, *,
@@ -1281,7 +1286,8 @@ class LNWallet(LNWorker):
             *,
             route: LNPaymentRoute,
             sender_idx: int,
-            failure_msg: OnionRoutingFailure) -> None:
+            failure_msg: OnionRoutingFailure,
+            amount: int) -> None:
         code, data = failure_msg.code, failure_msg.data
         # TODO can we use lnmsg.OnionWireSerializer here?
         # TODO update onion_wire.csv
@@ -1294,40 +1300,53 @@ class LNWallet(LNWorker):
             OnionFailureCode.EXPIRY_TOO_SOON: 0,
             OnionFailureCode.CHANNEL_DISABLED: 2,
         }
-        blacklist = False
-        update = False
+
+        # determine a fallback channel to blacklist if we don't get the erring
+        # channel via the payload
+        if sender_idx is None:
+            raise PaymentFailure(failure_msg.code_name())
+        try:
+            fallback_channel = route[sender_idx + 1].short_channel_id
+            node_from = route[sender_idx].start_node
+            node_to = route[sender_idx].end_node
+        except IndexError:
+            raise PaymentFailure(f'payment destination reported error: {failure_msg.code_name()}') from None
+
+        # TODO: handle unknown next peer?
+        # handle failure codes that include a channel update
         if code in failure_codes:
             offset = failure_codes[code]
             channel_update_len = int.from_bytes(data[offset:offset+2], byteorder="big")
             channel_update_as_received = data[offset+2: offset+2+channel_update_len]
             payload = self._decode_channel_update_msg(channel_update_as_received)
+
             if payload is None:
-                self.logger.info(f'could not decode channel_update for failed htlc: {channel_update_as_received.hex()}')
-                blacklist = True
+                self.logger.info(f'could not decode channel_update for failed htlc: '
+                                 f'{channel_update_as_received.hex()}')
+                self.network.path_finder.channel_blacklist.add(fallback_channel)
             else:
+                # apply the channel update or get blacklisted
                 blacklist, update = self._handle_chanupd_from_failed_htlc(
                     payload, route=route, sender_idx=sender_idx)
+
+                # we interpret a temporary channel failure as a liquidity issue
+                # in the channel and update our liquidity hints accordingly
+                if code == OnionFailureCode.TEMPORARY_CHANNEL_FAILURE:
+                    self.network.path_finder.update_liquidity_hints(
+                        route,
+                        amount,
+                        failing_channel=ShortChannelID(payload['short_channel_id']))
+                elif blacklist:
+                    self.network.path_finder.liquidity_hints.add_to_blacklist(
+                        node_from, node_to, payload['short_channel_id'])
+
+                # if we can't decide on some action, we are stuck
+                if not (blacklist or update):
+                    raise PaymentFailure(failure_msg.code_name())
+
+        # for errors that do not include a channel update
         else:
-            blacklist = True
-
-        if blacklist:
-            # blacklist channel after reporter node
-            # TODO this should depend on the error (even more granularity)
-            # also, we need finer blacklisting (directed edges; nodes)
-            if sender_idx is None:
-                raise PaymentFailure(failure_msg.code_name())
-            try:
-                short_chan_id = route[sender_idx + 1].short_channel_id
-            except IndexError:
-                raise PaymentFailure(f'payment destination reported error: {failure_msg.code_name()}') from None
-            # TODO: for MPP we need to save the amount for which
-            # we saw temporary channel failure
-            self.logger.info(f'blacklisting channel {short_chan_id}')
-            self.network.channel_blacklist.add(short_chan_id)
-
-        # we should not continue if we did not blacklist or update anything
-        if not (blacklist or update):
-            raise PaymentFailure(failure_msg.code_name())
+            self.network.path_finder.liquidity_hints.add_to_blacklist(node_from, node_to, fallback_channel)
 
     def _handle_chanupd_from_failed_htlc(self, payload, *, route, sender_idx) -> Tuple[bool, bool]:
         blacklist = False
@@ -1597,7 +1616,6 @@ class LNWallet(LNWorker):
             chan.short_channel_id: chan for chan in channels
             if chan.short_channel_id is not None
         }
-        blacklist = self.network.channel_blacklist.get_current_list()
         # Collect all private edges from route hints.
         # Note: if some route hints are multiple edges long, and these paths cross each other,
         #       we allow our path finding to cross the paths; i.e. the route hints are not isolated.
@@ -1629,8 +1647,7 @@ class LNWallet(LNWorker):
                         fee_proportional_millionths=fee_proportional_millionths,
                         cltv_expiry_delta=cltv_expiry_delta,
                         node_features=node_info.features if node_info else 0)
-                if route_edge.short_channel_id not in blacklist:
-                    private_route_edges[route_edge.short_channel_id] = route_edge
+                private_route_edges[route_edge.short_channel_id] = route_edge
                 start_node = end_node
         # now find a route, end to end: between us and the recipient
         try:
@@ -1640,7 +1657,6 @@ class LNWallet(LNWorker):
                 invoice_amount_msat=amount_msat,
                 path=full_path,
                 my_channels=scid_to_my_channels,
-                blacklist=blacklist,
                 private_route_edges=private_route_edges)
         except NoChannelPolicy as e:
             raise NoPathFound() from e

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1338,7 +1338,7 @@ class LNWallet(LNWorker):
                         failing_channel=ShortChannelID(payload['short_channel_id']))
                 elif blacklist:
                     self.network.path_finder.liquidity_hints.add_to_blacklist(
-                        node_from, node_to, payload['short_channel_id'])
+                        payload['short_channel_id'])
 
                 # if we can't decide on some action, we are stuck
                 if not (blacklist or update):
@@ -1346,7 +1346,7 @@ class LNWallet(LNWorker):
 
         # for errors that do not include a channel update
         else:
-            self.network.path_finder.liquidity_hints.add_to_blacklist(node_from, node_to, fallback_channel)
+            self.network.path_finder.liquidity_hints.add_to_blacklist(fallback_channel)
 
     def _handle_chanupd_from_failed_htlc(self, payload, *, route, sender_idx) -> Tuple[bool, bool]:
         blacklist = False

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -62,7 +62,6 @@ from .version import PROTOCOL_VERSION
 from .simple_config import SimpleConfig
 from .i18n import _
 from .logging import get_logger, Logger
-from .lnutil import ChannelBlackList
 
 if TYPE_CHECKING:
     from .channel_db import ChannelDB
@@ -350,7 +349,6 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         self._has_ever_managed_to_connect_to_server = False
 
         # lightning network
-        self.channel_blacklist = ChannelBlackList()
         if self.config.get('run_watchtower', False):
             from . import lnwatcher
             self.local_watchtower = lnwatcher.WatchTower(self)

--- a/electrum/tests/test_lnrouter.py
+++ b/electrum/tests/test_lnrouter.py
@@ -4,6 +4,7 @@ import shutil
 import asyncio
 
 from electrum.util import bh2u, bfh, create_and_start_event_loop
+from electrum.lnutil import ShortChannelID
 from electrum.lnonion import (OnionHopsDataSingle, new_onion_packet,
                               process_onion_packet, _decode_onion_error, decode_onion_error,
                               OnionFailureCode, OnionPacket)
@@ -14,6 +15,14 @@ from electrum.lnrouter import PathEdge
 
 from . import TestCaseForTestnet
 from .test_bitcoin import needs_test_with_all_chacha20_implementations
+
+
+def channel(number: int) -> ShortChannelID:
+    return ShortChannelID(bfh(format(number, '016x')))
+
+
+def node(character: str) -> bytes:
+    return b'\x02' + f'{character}'.encode() * 32
 
 
 class Test_LNRouter(TestCaseForTestnet):
@@ -28,7 +37,24 @@ class Test_LNRouter(TestCaseForTestnet):
         self._loop_thread.join(timeout=1)
         super().tearDown()
 
-    def test_find_path_for_payment(self):
+    def prepare_graph(self):
+        """
+        Network topology with channel ids:
+                3
+            A  ---  B
+            |    2/ |
+          6 |   E   | 1
+            | /5 \7 |
+            D  ---  C
+                4
+        valid routes from A -> E:
+        A -3-> B -2-> E
+        A -6-> D -5-> E
+        A -6-> D -4-> C -7-> E
+        A -3-> B -1-> C -7-> E
+        A -6-> D -4-> C -1-> B -2-> E
+        A -3-> B -1-> C -4-> D -5-> E
+        """
         class fake_network:
             config = self.config
             asyncio_loop = asyncio.get_event_loop()
@@ -37,67 +63,95 @@ class Test_LNRouter(TestCaseForTestnet):
             interface = None
         fake_network.channel_db = lnrouter.ChannelDB(fake_network())
         fake_network.channel_db.data_loaded.set()
-        cdb = fake_network.channel_db
-        path_finder = lnrouter.LNPathFinder(cdb)
-        self.assertEqual(cdb.num_channels, 0)
-        cdb.add_channel_announcements({'node_id_1': b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'node_id_2': b'\x02cccccccccccccccccccccccccccccccc',
-                                     'bitcoin_key_1': b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'bitcoin_key_2': b'\x02cccccccccccccccccccccccccccccccc',
-                                     'short_channel_id': bfh('0000000000000001'),
-                                     'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
-                                     'len': 0, 'features': b''}, trusted=True)
-        self.assertEqual(cdb.num_channels, 1)
-        cdb.add_channel_announcements({'node_id_1': b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'node_id_2': b'\x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-                                     'bitcoin_key_1': b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'bitcoin_key_2': b'\x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-                                     'short_channel_id': bfh('0000000000000002'),
-                                     'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
-                                     'len': 0, 'features': b''}, trusted=True)
-        cdb.add_channel_announcements({'node_id_1': b'\x02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'node_id_2': b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-                                     'bitcoin_key_1': b'\x02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bitcoin_key_2': b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-                                     'short_channel_id': bfh('0000000000000003'),
-                                     'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
-                                     'len': 0, 'features': b''}, trusted=True)
-        cdb.add_channel_announcements({'node_id_1': b'\x02cccccccccccccccccccccccccccccccc', 'node_id_2': b'\x02dddddddddddddddddddddddddddddddd',
-                                     'bitcoin_key_1': b'\x02cccccccccccccccccccccccccccccccc', 'bitcoin_key_2': b'\x02dddddddddddddddddddddddddddddddd',
-                                     'short_channel_id': bfh('0000000000000004'),
-                                     'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
-                                     'len': 0, 'features': b''}, trusted=True)
-        cdb.add_channel_announcements({'node_id_1': b'\x02dddddddddddddddddddddddddddddddd', 'node_id_2': b'\x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-                                     'bitcoin_key_1': b'\x02dddddddddddddddddddddddddddddddd', 'bitcoin_key_2': b'\x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-                                     'short_channel_id': bfh('0000000000000005'),
-                                     'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
-                                     'len': 0, 'features': b''}, trusted=True)
-        cdb.add_channel_announcements({'node_id_1': b'\x02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'node_id_2': b'\x02dddddddddddddddddddddddddddddddd',
-                                     'bitcoin_key_1': b'\x02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bitcoin_key_2': b'\x02dddddddddddddddddddddddddddddddd',
-                                     'short_channel_id': bfh('0000000000000006'),
-                                     'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
-                                     'len': 0, 'features': b''}, trusted=True)
+        self.cdb = fake_network.channel_db
+        self.path_finder = lnrouter.LNPathFinder(self.cdb)
+        self.assertEqual(self.cdb.num_channels, 0)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('b'), 'node_id_2': node('c'),
+            'bitcoin_key_1': node('b'), 'bitcoin_key_2': node('c'),
+            'short_channel_id': channel(1),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
+        self.assertEqual(self.cdb.num_channels, 1)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('b'), 'node_id_2': node('e'),
+            'bitcoin_key_1': node('b'), 'bitcoin_key_2': node('e'),
+            'short_channel_id': channel(2),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('a'), 'node_id_2': node('b'),
+            'bitcoin_key_1': node('a'), 'bitcoin_key_2': node('b'),
+            'short_channel_id': channel(3),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('c'), 'node_id_2': node('d'),
+            'bitcoin_key_1': node('c'), 'bitcoin_key_2': node('d'),
+            'short_channel_id': channel(4),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('d'), 'node_id_2': node('e'),
+            'bitcoin_key_1': node('d'), 'bitcoin_key_2': node('e'),
+            'short_channel_id': channel(5),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('a'), 'node_id_2': node('d'),
+            'bitcoin_key_1': node('a'), 'bitcoin_key_2': node('d'),
+            'short_channel_id': channel(6),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
+        self.cdb.add_channel_announcements({
+            'node_id_1': node('c'), 'node_id_2': node('e'),
+            'bitcoin_key_1': node('c'), 'bitcoin_key_2': node('e'),
+            'short_channel_id': channel(7),
+            'chain_hash': BitcoinTestnet.rev_genesis_bytes(),
+            'len': 0, 'features': b''
+        }, trusted=True)
         def add_chan_upd(payload):
-            cdb.add_channel_update(payload, verify=False)
-        add_chan_upd({'short_channel_id': bfh('0000000000000001'), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000001'), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000002'), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 99, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000002'), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000003'), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000003'), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000004'), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000004'), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000005'), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000005'), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 999, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000006'), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 99999999, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        add_chan_upd({'short_channel_id': bfh('0000000000000006'), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
-        path = path_finder.find_path_for_payment(
-            nodeA=b'\x02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nodeB=b'\x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-            invoice_amount_msat=100000)
-        self.assertEqual([PathEdge(start_node=b'\x02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', end_node=b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', short_channel_id=bfh('0000000000000003')),
-                          PathEdge(start_node=b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', end_node=b'\x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', short_channel_id=bfh('0000000000000002')),
-                         ], path)
-        route = path_finder.create_route_from_path(path)
-        self.assertEqual(b'\x02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', route[0].node_id)
-        self.assertEqual(bfh('0000000000000003'),                 route[0].short_channel_id)
+            self.cdb.add_channel_update(payload, verify=False)
+        add_chan_upd({'short_channel_id': channel(1), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(1), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(2), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 99, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(2), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(3), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(3), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(4), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(4), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(5), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(5), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 999, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(6), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 200, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(6), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(7), 'message_flags': b'\x00', 'channel_flags': b'\x00', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
+        add_chan_upd({'short_channel_id': channel(7), 'message_flags': b'\x00', 'channel_flags': b'\x01', 'cltv_expiry_delta': 10, 'htlc_minimum_msat': 250, 'fee_base_msat': 100, 'fee_proportional_millionths': 150, 'chain_hash': BitcoinTestnet.rev_genesis_bytes(), 'timestamp': 0})
 
-        cdb.stop()
-        asyncio.run_coroutine_threadsafe(cdb.stopped_event.wait(), self.asyncio_loop).result()
+    def test_find_path_for_payment(self):
+        self.prepare_graph()
+        amount_to_send = 100000
+
+        path = self.path_finder.find_path_for_payment(
+            nodeA=node('a'),
+            nodeB=node('e'),
+            invoice_amount_msat=amount_to_send)
+        self.assertEqual([
+            PathEdge(start_node=node('a'), end_node=node('b'), short_channel_id=channel(3)),
+            PathEdge(start_node=node('b'), end_node=node('e'), short_channel_id=channel(2)),
+        ], path)
+
+        route = self.path_finder.create_route_from_path(path)
+        self.assertEqual(node('b'), route[0].node_id)
+        self.assertEqual(channel(3), route[0].short_channel_id)
+
+        self.cdb.stop()
+        asyncio.run_coroutine_threadsafe(self.cdb.stopped_event.wait(), self.asyncio_loop).result()
 
     @needs_test_with_all_chacha20_implementations
     def test_new_onion_packet_legacy(self):

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -776,7 +776,7 @@ mainnet_block_explorers = {
     'mempool.space': ('https://mempool.space/',
                         {'tx': 'tx/', 'addr': 'address/'}),
     'mempool.emzy.de': ('https://mempool.emzy.de/',
-                        {'tx': 'tx/', 'addr': 'address/'}),  
+                        {'tx': 'tx/', 'addr': 'address/'}),
     'OXT.me': ('https://oxt.me/',
                         {'tx': 'transaction/', 'addr': 'address/'}),
     'smartbit.com.au': ('https://www.smartbit.com.au/',
@@ -797,7 +797,7 @@ testnet_block_explorers = {
     'Blockstream.info': ('https://blockstream.info/testnet/',
                         {'tx': 'tx/', 'addr': 'address/'}),
     'mempool.space': ('https://mempool.space/testnet/',
-                        {'tx': 'tx/', 'addr': 'address/'}),    
+                        {'tx': 'tx/', 'addr': 'address/'}),
     'smartbit.com.au': ('https://testnet.smartbit.com.au/',
                        {'tx': 'tx/', 'addr': 'address/'}),
     'system default': ('blockchain://000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943/',
@@ -1114,6 +1114,14 @@ def ignore_exceptions(func):
         except Exception as e:
             pass
     return wrapper
+
+
+def with_lock(func):
+    """Decorator to enforce a lock on a function call."""
+    def func_wrapper(self, *args, **kwargs):
+        with self.lock:
+            return func(self, *args, **kwargs)
+    return func_wrapper
 
 
 class TxMinedInfo(NamedTuple):


### PR DESCRIPTION
Implements liquidity hints for pathfinding, i.e., take information of successful and failed routing attempts to improve pathfinding, similar to the strategy LND employs.

We interpret temporary channel failures such that a node couldn't forward a payment as the channel (or node pair) didn't have enough balance on its side of the channel. Based on this assumption, we can keep a record of the previous part of the route (which was successful) and the failing channel. For each channel we record the `can_send` and cannot_send values upon which we build a new penalty for edge weights in pathfinding. Likewise, when a payment succeeds, we record `can_send` amounts for the channels involved (the assumption is that we can send the same amount again, even if we changed the balances by sending).

Model:
The liquidity hint for a channel keeps four pieces of information, the amounts it can and cannot send for each direction. The direction dependence is kept, as we don't know the capacity of the channel. Furthermore, there can be [non strict forwarding](https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#non-strict-forwarding) and shadow (private) channels present. Therefore we cannot relate `local_balance = capacity - remote_balance`.

Penalty:
The penalty depends on the `can_send` and `cannot_send` values that were possibly recorded in previous payment attempts. A channel that can send an amount is assigned a penalty of zero, a channel that cannot send an amount is assigned an infinite penalty. If the sending amount lies between `can_send` and `cannot_send`, there's uncertainty and we give a default penalty. The default penalty serves the function of giving a positive offset, from which we can discount from. There is a competition between low-fee channels and channels where we know with some certainty that they can support a payment. The penalty ultimately boils down to: how much more fees do we want to pay for certainty of payment success? This can be tuned via `DEFAULT_PENALTY_BASE_MSAT` and `DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH`. A base _and_ relative penalty was chosen such that the penalty will be able to compete with the regular base and relative fees. `DEFAULT_PENALTY_BASE_MSAT` is set to 500 msat (same as before) and `DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH` is 100 (i.e. 0.000100 relative factor), which seems fair but is open for discussion.

Solutions / Benefits:
* Bundles all the transient routing information we get about the graph (blacklist, hints) in one data structure
* Should make payments more reliable in general
* Once a payment has found its path to the destination, a repetition of the payment is much quicker
* Doesn't blacklist channels any more, but avoids sending over channels based on the amount, which is beneficial for multipart payments
* Introduces the LiquidityHints data structure which in the future can be used to keep track of in-flight HTLCs for mpp (to avoid sending multiple HTLCs over the same channel)

Downsides:
* Can lead to increased latency in pathfinding (although liquidity hints are only checked in the end of `_edge_cost`)
* Increases path re-usage (could randomize penalty)

Open questions:
* Right now an amount-independent default penalty is applied. We could make it dependent on the amount, based on how far we are away from known facts (e.g. the `can_send` amount)
* It may be useful to persist the information we gain for the next usage of the wallet
* If the wallet runs long enough, or liquidity information is loaded, we may disregard information after some time