### PR TITLE
keystore to store seed_type; wallet.init_lightning() to sometimes create deterministic LN keys

### DIFF
--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -545,7 +545,7 @@ class BaseWizard(Logger):
 
     def create_keystore(self, seed, passphrase):
         k = keystore.from_seed(seed, passphrase, self.wallet_type == 'multisig')
-        if self.wallet_type == 'standard' and self.seed_type == 'segwit':
+        if k.can_have_deterministic_lightning_xprv():
             self.data['lightning_xprv'] = k.get_lightning_xprv(None)
         self.on_keystore(k)
 

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -1421,23 +1421,26 @@ class ElectrumWindow(App, Logger):
                             "This means that you must save a backup of your wallet everytime you create a new channel.\n\n"
                             "If you want to have recoverable channels, you must create a new wallet with an Electrum seed")
                 self.show_info(msg)
-        else:
-            if self.wallet.can_have_lightning():
-                root.dismiss()
+        elif self.wallet.can_have_lightning():
+            root.dismiss()
+            if self.wallet.can_have_deterministic_lightning():
+                msg = messages.MSG_LIGHTNING_SCB_WARNING + "\n" + _("Create lightning keys?")
+            else:
                 msg = _(
                     "Warning: this wallet type does not support channel recovery from seed. "
                     "You will need to backup your wallet everytime you create a new wallet. "
                     "Create lightning keys?")
-                d = Question(msg, self._enable_lightning, title=_('Enable Lightning?'))
-                d.open()
-            else:
-                pass
+            d = Question(msg, self._enable_lightning, title=_('Enable Lightning?'))
+            d.open()
 
     def _enable_lightning(self, b):
         if not b:
             return
+        self.protected(_("Create lightning keys?"), self.__enable_lightning, ())
+
+    def __enable_lightning(self, password):
         wallet_path = self.get_wallet_path()
-        self.wallet.init_lightning()
+        self.wallet.init_lightning(password=password)
         self.show_info(_('Lightning keys have been initialized.'))
         self.stop_wallet()
         self.load_wallet_by_name(wallet_path)

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2400,7 +2400,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         wallet_type = self.wallet.db.get('wallet_type', '')
         if self.wallet.is_watching_only():
             wallet_type += ' [{}]'.format(_('watching-only'))
-        seed_available = _('True') if self.wallet.has_seed() else _('False')
+        seed_available = _('False')
+        if self.wallet.has_seed():
+            seed_available = _('True')
+            ks = self.wallet.keystore
+            assert isinstance(ks, keystore.Deterministic_KeyStore)
+            seed_available += f" ({ks.get_seed_type()})"
         keystore_types = [k.get_type_text() for k in self.wallet.get_keystores()]
         grid = QGridLayout()
         basename = os.path.basename(self.wallet.storage.path)

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2386,12 +2386,21 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.set_contact(line2.text(), line1.text())
 
     def init_lightning_dialog(self):
-        if self.question(_(
+        assert not self.wallet.has_lightning()
+        if self.wallet.can_have_deterministic_lightning():
+            msg = messages.MSG_LIGHTNING_SCB_WARNING + "\n" + _("Create lightning keys?")
+        else:
+            msg = _(
                 "Warning: this wallet type does not support channel recovery from seed. "
                 "You will need to backup your wallet everytime you create a new wallet. "
-                "Create lightning keys?")):
-            self.wallet.init_lightning()
-            self.show_message("Lightning keys created. Please restart Electrum")
+                "Create lightning keys?")
+        if self.question(msg):
+            self._init_lightning_dialog()
+
+    @protected
+    def _init_lightning_dialog(self, *, password):
+        self.wallet.init_lightning(password=password)
+        self.show_message("Lightning keys created. Please restart Electrum")
 
     def show_wallet_info(self):
         dialog = WindowModalDialog(self, _("Wallet Information"))

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -282,8 +282,9 @@ class Deterministic_KeyStore(Software_KeyStore):
 
     def __init__(self, d):
         Software_KeyStore.__init__(self, d)
-        self.seed = d.get('seed', '')
+        self.seed = d.get('seed', '')  # only electrum seeds
         self.passphrase = d.get('passphrase', '')
+        self._seed_type = d.get('seed_type', None)  # only electrum seeds
 
     def is_deterministic(self):
         return True
@@ -297,10 +298,15 @@ class Deterministic_KeyStore(Software_KeyStore):
             d['seed'] = self.seed
         if self.passphrase:
             d['passphrase'] = self.passphrase
+        if self._seed_type:
+            d['seed_type'] = self._seed_type
         return d
 
     def has_seed(self):
         return bool(self.seed)
+
+    def get_seed_type(self) -> Optional[str]:
+        return self._seed_type
 
     def is_watching_only(self):
         return not self.has_seed()
@@ -313,6 +319,7 @@ class Deterministic_KeyStore(Software_KeyStore):
         if self.seed:
             raise Exception("a seed exists")
         self.seed = self.format_seed(seed)
+        self._seed_type = seed_type(seed) or None
 
     def get_seed(self, password):
         if not self.has_seed():

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3185,7 +3185,7 @@ def create_new_wallet(*, path, config: SimpleConfig, passphrase=None, password=N
     k = keystore.from_seed(seed, passphrase)
     db.put('keystore', k.dump())
     db.put('wallet_type', 'standard')
-    if keystore.seed_type(seed) == 'segwit':
+    if k.can_have_deterministic_lightning_xprv():
         db.put('lightning_xprv', k.get_lightning_xprv(None))
     if gap_limit is not None:
         db.put('gap_limit', gap_limit)
@@ -3229,7 +3229,7 @@ def restore_wallet_from_text(text, *, path, config: SimpleConfig,
             k = keystore.from_master_key(text)
         elif keystore.is_seed(text):
             k = keystore.from_seed(text, passphrase)
-            if keystore.seed_type(text) == 'segwit':
+            if k.can_have_deterministic_lightning_xprv():
                 db.put('lightning_xprv', k.get_lightning_xprv(None))
         else:
             raise Exception("Seed or key not recognized")


### PR DESCRIPTION
- implement `Deterministic_KeyStore.get_seed_type()`, to be able to tell the seed type without prompting the user for password
    - wallet_db upgrade: put 'seed_type' into existing keystores
- keystore: encapsulate "can_have_deterministic_lightning_xprv" logic
- change `wallet.init_lightning()` to be able to either deterministic or random LN keys, preferring deterministic ones if available
    - expose some of this to GUI logic to adapt messages