### PR TITLE
dependencies: document again choice between pycryptodomex/cryptography

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,9 @@ libsecp256k1 yourself::
     sudo apt-get install automake libtool
     ./contrib/make_libsecp256k1.sh
 
-Due to the need for fast symmetric ciphers, `cryptography`_ is required.
-Install from your package manager (or from pip)::
+Due to the need for fast symmetric ciphers, either one of `pycryptodomex`_
+or `cryptography`_ is required. Install from your package manager
+(or from pip)::
 
     sudo apt-get install python3-cryptography
 


### PR DESCRIPTION
Before upgrading `dnspython` to 2.0 in #6828, we have supported both
`pycryptodomex` and `cryptography` as crypto backends. We use `dnspython`
for DNSSEC, and also some other things. The DNSSEC part of `dnspython` is
an optional extra which requires `cryptography`. This is why we removed
the choice of `pycryptodomex` as a backend: we would need `cryptography`
for DNSSEC anyway.

Note that DNSSEC is only used for OpenAlias, which itself is probably
only used by a handful of people. We have considered removing OpenAlias
support as then we could also remove DNSSEC, see #6232.

Recently `cryptography` (since version 3.4) [started using Rust code](https://github.com/pyca/cryptography/blob/58f0ad5b6b928677931c7ad44deee839a29ee9d3/CHANGELOG.rst#34---2021-02-07), which
necessitates having a Rust compiler if building from source.
Some people complained this is problematic for them.

With this PR, we restore the choice between `pycryptodomex` and `cryptography`.
(Though the code that can utilise either backend has not even been removed,
it is in `crypto.py`)
We support having either dependency; with the caveat that DNSSEC is only
available if `cryptography` is available.