### PR TITLE
Allow sending to scripts from payto and paytomany RPCs

### DIFF
--- a/electrum/bitcoin.py
+++ b/electrum/bitcoin.py
@@ -752,6 +752,26 @@ def is_private_key(key: str, *, raise_on_error=False) -> bool:
             raise
         return False
 
+def parse_script(x):
+    script = ''
+    for word in x.split():
+        if word[0:3] == 'OP_':
+            opcode_int = opcodes[word]
+            script += construct_script([opcode_int])
+        else:
+            bfh(word)  # to test it is hex data
+            script += construct_script([word])
+    return script
+
+def parse_output(x) -> bytes:
+    if is_address(x):
+        return bfh(address_to_script(address))
+    try:
+        script = parse_script(x)
+        return bfh(script)
+    except Exception:
+        pass
+    raise Exception("Invalid address or script.")
 
 ########### end pywallet functions #######################
 

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -622,7 +622,7 @@ class Commands:
         change_addr = self._resolver(change_addr, wallet)
         domain_addr = None if domain_addr is None else map(self._resolver, domain_addr, repeat(wallet))
         amount_sat = satoshis_or_max(amount)
-        outputs = [PartialTxOutput.from_address_and_value(destination, amount_sat)]
+        outputs = [PartialTxOutput(scriptpubkey=bitcoin.parse_output(destination), value=amount_sat)]
         tx = wallet.create_transaction(
             outputs,
             fee=tx_fee,

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -653,7 +653,7 @@ class Commands:
         for address, amount in outputs:
             address = self._resolver(address, wallet)
             amount_sat = satoshis_or_max(amount)
-            final_outputs.append(PartialTxOutput.from_address_and_value(address, amount_sat))
+            final_outputs.append(PartialTxOutput(scriptpubkey=bitcoin.parse_output(address), value=amount_sat))
         tx = wallet.create_transaction(
             final_outputs,
             fee=tx_fee,

--- a/electrum/gui/qt/paytoedit.py
+++ b/electrum/gui/qt/paytoedit.py
@@ -109,23 +109,7 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit, Logger):
             return bfh(bitcoin.address_to_script(address))
         except Exception:
             pass
-        try:
-            script = self.parse_script(x)
-            return bfh(script)
-        except Exception:
-            pass
-        raise Exception("Invalid address or script.")
-
-    def parse_script(self, x):
-        script = ''
-        for word in x.split():
-            if word[0:3] == 'OP_':
-                opcode_int = opcodes[word]
-                script += construct_script([opcode_int])
-            else:
-                bfh(word)  # to test it is hex data
-                script += construct_script([word])
-        return script
+        return bitcoin.parse_output(x)
 
     def parse_amount(self, x):
         x = x.strip()


### PR DESCRIPTION
This PR:

- Refactors `parse_script` and `parse_output` from the `gui` module into `bitcoin`
- Allows `payto` to accept scripts just like the GUI
- Allows `paytomany` to accept scripts like the GUI

The use-case of this PR is for creating OP_RETURN outputs from the command line.

Before this change:
```
electrum --testnet payto -F tb1q2s7kk7qp0urvz46wpjg2jgp7vfxhj7gy63p2sh -c tb1q2s7kk7qp0urvz46wpjg2jgp7vfxhj7gy63p2sh "OP_RETURN 94cab8cbeb53d63dba67e015450eb83c0682b5aa2d232fbb06ddf260d64a65b1" 0
invalid bitcoin address: OP_RETURN 94cab8cbeb53d63dba67e015450eb83c0682b5aa2d232fbb06ddf260d64a65b1
``` 

After:
```
electrum --testnet payto -F tb1q2s7kk7qp0urvz46wpjg2jgp7vfxhj7gy63p2sh -c tb1q2s7kk7qp0urvz46wpjg2jgp7vfxhj7gy63p2sh "OP_RETURN 94cab8cbeb53d63dba67e015450eb83c0682b5aa2d232fbb06ddf260d64a65b1" 0
02000000000101d7e6deda8ad91c1fe7ab3d0cff3d2d95b0e9efc3b774a74d995ff69736f547f80100000000fdffffff020000000000000000226a2094cab8cbeb53d63dba67e015450eb83c0682b5aa2d232fbb06ddf260d64a65b18641100000000000160014543d6b78017f06c1574e0c90a9203e624d79790402473044022002d20f5298dfa29fd106903c62b93138dcada10745547d45edbcd6922f52cea602204f69dd8bba9908821fa8004fd1c758122aada6643b1753527e6eed89e0c695460121022dab9a6611baa4d42d2ec0cc8741c1f369f8265b1eeaedcbd971533885d9eebf28141e00
```

Here's the TX: https://blockstream.info/testnet/tx/c6c4ba712ceb1f948dc66067228529ae1d21733ffccba681927c8fb8fda61d55