### PR TITLE
logging: don't lose log messages during early startup

### DIFF
--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -10,7 +10,6 @@ from electrum.util import format_satoshis
 from electrum.bitcoin import is_address, COIN
 from electrum.transaction import PartialTxOutput
 from electrum.network import TxBroadcastError, BestEffortRequestFailed
-from electrum.logging import console_stderr_handler
 
 _ = lambda x:x  # i18n
 
@@ -35,8 +34,6 @@ class ElectrumGui:
 
         self.done = 0
         self.last_balance = ""
-
-        console_stderr_handler.setLevel(logging.CRITICAL)
 
         self.str_recipient = ""
         self.str_description = ""

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -18,7 +18,6 @@ from electrum.wallet_db import WalletDB
 from electrum.storage import WalletStorage
 from electrum.network import NetworkParameters, TxBroadcastError, BestEffortRequestFailed
 from electrum.interface import ServerAddr
-from electrum.logging import console_stderr_handler
 
 if TYPE_CHECKING:
     from electrum.daemon import Daemon
@@ -64,7 +63,6 @@ class ElectrumGui:
         self.set_cursor(0)
         self.w = curses.newwin(10, 50, 5, 5)
 
-        console_stderr_handler.setLevel(logging.CRITICAL)
         self.tab = 0
         self.pos = 0
         self.popup_pos = 0

--- a/electrum/tests/__init__.py
+++ b/electrum/tests/__init__.py
@@ -3,6 +3,8 @@ import threading
 import tempfile
 import shutil
 
+import electrum
+import electrum.logging
 from electrum import constants
 
 
@@ -11,6 +13,9 @@ from electrum import constants
 # will only be run once, using the fastest implementation.
 # e.g. libsecp256k1 vs python-ecdsa. pycryptodomex vs pyaes.
 FAST_TESTS = False
+
+
+electrum.logging._configure_stderr_logging()
 
 
 # some unit tests are modifying globals...

--- a/run_electrum
+++ b/run_electrum
@@ -78,7 +78,9 @@ if not is_android:
     check_imports()
 
 
-from electrum.logging import get_logger, configure_logging
+sys._ELECTRUM_RUNNING_VIA_RUNELECTRUM = True  # used by logging.py
+
+from electrum.logging import get_logger, configure_logging  # import logging submodule first
 from electrum import util
 from electrum import constants
 from electrum import SimpleConfig


### PR DESCRIPTION
Previously, during early-startup (until configure_logging(config) is
called in run_electrum),
- the stderr log handler lost all log messages below warning level (irrespective of `-v`), and
- the file log handler lost all log messages regardless of log level

We now instead start buffering log messages in memory as soon as
electrum.logging is imported. The buffer is dumped into the
stderr and file log handlers when they are fully set up, and then
the buffer is discarded (and the temporary log handler is removed).

Note that messages are not logged until configure_logging() is called.
Previously WARNING/ERROR messages would get logged immediately to stderr,
but not anymore. This was changed so that the order of the log messages
can be kept intact. (if we log WARNINGs immediately, but need to delay
INFOs until the config is available, messages would either be out of order
or alternatively there would be duplicates)

Relatedly, we now follow the [recommendation of the python docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) re
logging for libraries: we try to only configure logging if running via
run_electrum (the main script) and not when e.g. a 3rd party script
imports electrum.