### PR TITLE
Avoid hiding QR codes with help_text

### DIFF
--- a/electrum/gui/qt/qrcodewidget.py
+++ b/electrum/gui/qt/qrcodewidget.py
@@ -118,6 +118,7 @@ class QRDialog(WindowModalDialog):
 
         help_text = data if show_text else help_text
         if help_text:
+            qr_hbox.setContentsMargins(0, 0, 0, 44)
             text_label = WWLabel()
             text_label.setText(help_text)
             vbox.addWidget(text_label)


### PR DESCRIPTION
In some situations, if a QR code's data and help_text were too long, the QR code was unscannable.

Before:
https://ipfs.io/ipfs/Qmc6Sa39BWnPbwuzpj8fXJ82U51Tf9cQGCYpoCFpMxXabi?filename=qr_before.png

After:
https://ipfs.io/ipfs/QmRAUufgXZB8we1WXBGB1Dbb2UYkHZhbMTQBti4CFd3XuT?filename=qr_after.png

Quick way to test it in the console:
```
>>> from electrum.i18n import _
>>> from electrum.gui import messages
>>> window.show_qrcode('channel_backup:AShYky6ADIEoGkWQy12/sJKj7cLg+wlo+IZzi4w8FjYz6RpjrEHi9752qL5XNZFHWJiqMaqZ1jzOCrCZuA57jj4CHaWA8jG+nzi567No9IUdkfXzDMgqrPsOnGbflPHSD+9UV3t+krbT1Hb+75aQAS9KLMWvMmY53vCGP9qVACYVH1gstqaDyLQ6y0tcNZBwbTnMS3GsYplL1SEMEhGBtAceMgUFYg4UybmWWhqx2kXlWLuvtpJuZGJsvuJBIBfFMaso2vybFOxT68BVBvMFPd2RPC8hD3Zz7ToDXoTCqSxABP4+yWCgQ3nF5Y6ukOMeIMAUwFvF3Q3oFvRDr+kKl5fcFQRfqMBm3a3SyKIOU506zRUyaS9DUU2KtoztcRB+oTZMqBmib05/JyPKvfrx9k6Uj34Z', _('Save channel backup'), help_text=_(messages.MSG_CREATED_NON_RECOVERABLE_CHANNEL), show_copy_text_btn=True)
```