### PR TITLE
QR codes: Only adjust layout as much as necessary

### DIFF
--- a/electrum/gui/qt/qrcodewidget.py
+++ b/electrum/gui/qt/qrcodewidget.py
@@ -118,7 +118,6 @@ class QRDialog(WindowModalDialog):
 
         help_text = data if show_text else help_text
         if help_text:
-            qr_hbox.setContentsMargins(0, 0, 0, 44)
             text_label = WWLabel()
             text_label.setText(help_text)
             vbox.addWidget(text_label)
@@ -167,3 +166,8 @@ class QRDialog(WindowModalDialog):
 
         vbox.addLayout(hbox)
         self.setLayout(vbox)
+
+        if help_text:
+            # Geometry will be wrong if not shown.
+            self.show()
+            qr_hbox.setContentsMargins(0, 0, 0, max(0, qrw.geometry().height() + qrw.geometry().y() - text_label.y()))


### PR DESCRIPTION
Small change related to #7218 

Margin only changes if necessary and in the right proportions.

Before:
https://ipfs.io/ipfs/QmZT1ovGLFbRRKiG51RYieeLRyMaRkwHAq7hgXJTT3o3g1?filename=Before%20002.png

After:
https://ipfs.io/ipfs/QmaNptBRpoJ9eZxmS6kxYXR5sW2FpX8GWUR4y6enoWJxvv?filename=After%20002.png

Notice the differences:
```
>>> from electrum.i18n import _
>>> from electrum.gui import messages
>>> window.show_qrcode('channel_backup:AShYky6ADIEoGkWQy12/sJKj7cLg+wlo+IZzi4w8FjYz6RpjrEHi9752qL5XNZFHWJiqMaqZ1jzOCrCZuA57jj4CHaWA8jG+nzi567No9IUdkfXzDMgqrPsOnGbflPHSD+9UV3t+krbT1Hb+75aQAS9KLMWvMmY53vCGP9qVACYVH1gstqaDyLQ6y0tcNZBwbTnMS3GsYplL1SEMEhGBtAceMgUFYg4UybmWWhqx2kXlWLuvtpJuZGJsvuJBIBfFMaso2vybFOxT68BVBvMFPd2RPC8hD3Zz7ToDXoTCqSxABP4+yWCgQ3nF5Y6ukOMeIMAUwFvF3Q3oFvRDr+kKl5fcFQRfqMBm3a3SyKIOU506zRUyaS9DUU2KtoztcRB+oTZMqBmib05/JyPKvfrx9k6Uj34Z', _('Save channel backup'), help_text=_(messages.MSG_CREATED_NON_RECOVERABLE_CHANNEL), show_copy_text_btn=True)
>>> window.show_qrcode('1234', _('Save channel backup'), help_text=_(messages.MSG_CREATED_NON_RECOVERABLE_CHANNEL), show_copy_text_btn=True)
```

Note: I suspect there's a bigger problem behind that but it works.