### PR TITLE
swaps: fix swap sanity check

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -519,10 +519,11 @@ class SwapManager(Logger):
         recv_amount = self._get_recv_amount(send_amount, is_reverse=is_reverse)
         # sanity check calculation can be inverted
         if recv_amount is not None:
-            inverted_recv_amount = self._get_send_amount(recv_amount, is_reverse=is_reverse)
-            if send_amount != inverted_recv_amount:
+            inverted_send_amount = self._get_send_amount(recv_amount, is_reverse=is_reverse)
+            # accept off-by ones as amt_rcv = recv_amt(send_amt(amt_rcv)) only up to +-1
+            if abs(send_amount - inverted_send_amount) > 1:
                 raise Exception(f"calc-invert-sanity-check failed. is_reverse={is_reverse}. "
-                                f"send_amount={send_amount} -> recv_amount={recv_amount} -> inverted_recv_amount={inverted_recv_amount}")
+                                f"send_amount={send_amount} -> recv_amount={recv_amount} -> inverted_send_amount={inverted_send_amount}")
         # account for on-chain claim tx fee
         if is_reverse and recv_amount is not None:
             recv_amount -= self.get_claim_fee()
@@ -532,10 +533,10 @@ class SwapManager(Logger):
         send_amount = self._get_send_amount(recv_amount, is_reverse=is_reverse)
         # sanity check calculation can be inverted
         if send_amount is not None:
-            inverted_send_amount = self._get_recv_amount(send_amount, is_reverse=is_reverse)
-            if recv_amount != inverted_send_amount:
+            inverted_recv_amount = self._get_recv_amount(send_amount, is_reverse=is_reverse)
+            if recv_amount != inverted_recv_amount:
                 raise Exception(f"calc-invert-sanity-check failed. is_reverse={is_reverse}. "
-                                f"recv_amount={recv_amount} -> send_amount={send_amount} -> inverted_send_amount={inverted_send_amount}")
+                                f"recv_amount={recv_amount} -> send_amount={send_amount} -> inverted_recv_amount={inverted_recv_amount}")
         # account for on-chain claim tx fee
         if is_reverse and send_amount is not None:
             send_amount += self.get_claim_fee()


### PR DESCRIPTION
In #7186  it is reported that the inverse `send_amount` is not the `send_amount` that we gave.
I tried to run through some explicit sample values and I see that
`recv_amount == SwapManager._get_recv_amount(SwapManager._get_send_amount(recv_amount))`
but
`send_amount != SwapManager._get_send_amount_get(SwapManager._recv_amount(send_amount))`
for some `send_amount` values, see the test cases. The probability of the occurrence of these errors is the same as the swap fee percentage, but it shows up when the swap slider in kivy is moved many times or continuously.

Both methods internally use `math.floor` and `math.ceil` which are non-invertible, which probably leads to these off-by-one errors. I suggest to relax the cross check regarding off-by-ones. I don't think those methods can be made exactly the inverse of each other if we follow the specification of the bolt backend. I also renamed the variable names of `inverted_XXX`, which is now more intuitive to me. I would remove the tests once you agree with the change.