### PR TITLE
invoice: fail gracefully with large amount

### DIFF
--- a/electrum/invoices.py
+++ b/electrum/invoices.py
@@ -6,7 +6,7 @@ import attr
 
 from .json_db import StoredObject
 from .i18n import _
-from .util import age
+from .util import age, InvoiceError
 from .lnaddr import lndecode, LnAddr
 from . import constants
 from .bitcoin import COIN, TOTAL_COIN_SUPPLY_LIMIT_IN_BTC
@@ -134,12 +134,12 @@ class OnchainInvoice(Invoice):
     def _validate_amount(self, attribute, value):
         if isinstance(value, int):
             if not (0 <= value <= TOTAL_COIN_SUPPLY_LIMIT_IN_BTC * COIN):
-                raise ValueError(f"amount is out-of-bounds: {value!r} sat")
+                raise InvoiceError(f"amount is out-of-bounds: {value!r} sat")
         elif isinstance(value, str):
             if value != "!":
-                raise ValueError(f"unexpected amount: {value!r}")
+                raise InvoiceError(f"unexpected amount: {value!r}")
         else:
-            raise ValueError(f"unexpected amount: {value!r}")
+            raise InvoiceError(f"unexpected amount: {value!r}")
 
     @classmethod
     def from_bip70_payreq(cls, pr: 'PaymentRequest', height:int) -> 'OnchainInvoice':
@@ -173,9 +173,9 @@ class LNInvoice(Invoice):
             return
         if isinstance(value, int):
             if not (0 <= value <= TOTAL_COIN_SUPPLY_LIMIT_IN_BTC * COIN * 1000):
-                raise ValueError(f"amount is out-of-bounds: {value!r} msat")
+                raise InvoiceError(f"amount is out-of-bounds: {value!r} msat")
         else:
-            raise ValueError(f"unexpected amount: {value!r}")
+            raise InvoiceError(f"unexpected amount: {value!r}")
 
     @property
     def _lnaddr(self) -> LnAddr:
@@ -231,4 +231,3 @@ class LNInvoice(Invoice):
             # 'tags': str(lnaddr.tags),
         })
         return d
-

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -872,7 +872,7 @@ class InvalidBitcoinURI(Exception): pass
 def parse_URI(uri: str, on_pr: Callable = None, *, loop=None) -> dict:
     """Raises InvalidBitcoinURI on malformed URI."""
     from . import bitcoin
-    from .bitcoin import COIN
+    from .bitcoin import COIN, TOTAL_COIN_SUPPLY_LIMIT_IN_BTC
 
     if not isinstance(uri, str):
         raise InvalidBitcoinURI(f"expected string, not {repr(uri)}")
@@ -912,6 +912,8 @@ def parse_URI(uri: str, on_pr: Callable = None, *, loop=None) -> dict:
                 amount = Decimal(m.group(1)) * pow(Decimal(10), k)
             else:
                 amount = Decimal(am) * COIN
+            if amount > TOTAL_COIN_SUPPLY_LIMIT_IN_BTC * COIN:
+                raise InvalidBitcoinURI(f"amount is out-of-bounds: {amount!r} BTC")
             out['amount'] = int(amount)
         except Exception as e:
             raise InvalidBitcoinURI(f"failed to parse 'amount' field: {repr(e)}") from e


### PR DESCRIPTION
Fixes #7184, where upon user input Electrum crashes after amount validation for very high amounts (for receiving and sending input). I suggest to handle the error more gracefully, however I have no idea why this happens all of a sudden. It could be that some service pushes out wrong bitcoin URIs as the user feedback in the issue indicates.
