### PR TITLE
lnworker: fix path_finder access

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1092,11 +1092,13 @@ class Commands:
 
     @command('n')
     async def clear_ln_blacklist(self):
-        self.network.path_finder.liquidity_hints.clear_blacklist()
+        if self.network.path_finder:
+            self.network.path_finder.liquidity_hints.clear_blacklist()
 
     @command('n')
     async def reset_liquidity_hints(self):
-        self.network.path_finder.liquidity_hints.reset_liquidity_hints()
+        if self.network.path_finder:
+            self.network.path_finder.liquidity_hints.reset_liquidity_hints()
 
     @command('w')
     async def list_invoices(self, wallet: Abstract_Wallet = None):

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -65,6 +65,7 @@ from .logging import get_logger, Logger
 
 if TYPE_CHECKING:
     from .channel_db import ChannelDB
+    from .lnrouter import LNPathFinder
     from .lnworker import LNGossip
     from .lnwatcher import WatchTower
     from .daemon import Daemon
@@ -256,6 +257,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
     channel_db: Optional['ChannelDB'] = None
     lngossip: Optional['LNGossip'] = None
     local_watchtower: Optional['WatchTower'] = None
+    path_finder: Optional['LNPathFinder'] = None
 
     def __init__(self, config: SimpleConfig, *, daemon: 'Daemon' = None):
         global _INSTANCE


### PR DESCRIPTION
Fixes #7242. I went through all occurrences of `network.path_finder` and added checks for `path_finder` initialization, in scopes that do not apply the `if not self.channeldb` check previously. Right now I'm unsure whether we should check explicitly for `network.path_finder` or to use `lnworker.channel_db` as a check, i.e. check on the per wallet or per network basis.

I also think we could make the code more readable by converting `if not self.channeldb` to something more explicit, `network.uses_gossip`/`network.uses_trampoline`, perhaps.