### PR TITLE
auto import, add coolwallet S weird derivation path refer to #7259

### DIFF
--- a/electrum/bip39_wallet_formats.json
+++ b/electrum/bip39_wallet_formats.json
@@ -41,6 +41,12 @@
         "script_type": "p2wpkh",
         "iterate_accounts": true
     },
+      {
+        "description": "coolwallet S derivation path using bip44 but with segwit script format",
+        "derivation_path": "m/44'/0'/0'",
+        "script_type": "p2wpkh-p2sh",
+        "iterate_accounts": true
+    },
     {
         "description": "Samourai Bad Bank (toxic change)",
         "derivation_path": "m/84'/0'/2147483644'",


### PR DESCRIPTION
Would be nice to auto detect also coolwallet S derivation path.
In file bip39_wallet_formats.json :
{ "description": "coolwallet S derivation path using bip44 but with segwit script format",
"derivation_path": "m/44'/0'/0'",
"script_type": "p2wpkh-p2sh",
"iterate_accounts": true
}
see https://help.coolwallet.io/article/160-recover-btc-using-coolwallet-s-seed-without-the-wallet for their recovery instruction