### PR TITLE
Android: Fix wallet backup 

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -1335,7 +1335,6 @@ class ElectrumWindow(App, Logger):
                 self.show_error(_("Backup NOT saved. Backup directory not configured."))
             return
 
-        backup_dir = util.android_backup_dir()
         from android.permissions import request_permissions, Permission
         def cb(permissions, grant_results: Sequence[bool]):
             if not grant_results or not grant_results[0]:
@@ -1343,6 +1342,7 @@ class ElectrumWindow(App, Logger):
                 return
             # note: Clock.schedule_once is a hack so that we get called on a non-daemon thread
             #       (needed for WalletDB.write)
+            backup_dir = util.android_backup_dir()
             Clock.schedule_once(lambda dt: self._save_backup(backup_dir))
         request_permissions([Permission.WRITE_EXTERNAL_STORAGE], cb)
 


### PR DESCRIPTION
This change fixes the storage access behavior for the wallet backup for android. Ref: https://github.com/spesmilo/electrum/issues/6774

The permission for accessing storage has to be granted in runtime. This is already implemented, but in the wrong order when it comes to creating the back up dir.




