### PR TITLE
Attempt to use empty imported addresses as change

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2639,6 +2639,8 @@ class Imported_Wallet(Simple_Wallet):
 
     def __init__(self, db, storage, *, config):
         Abstract_Wallet.__init__(self, db, storage, config=config)
+        #Keep the old default behaviour of not using change address in imported wallets
+        self.use_change = db.get('use_change', False)
 
     def is_watching_only(self):
         return self.keystore is None
@@ -2681,7 +2683,7 @@ class Imported_Wallet(Simple_Wallet):
         return self.get_addresses()
 
     def get_change_addresses(self, **kwargs):
-        return []
+        return [addr for addr in self.get_addresses() if len(self.db.get_addr_history(addr)) == 0]
 
     def import_addresses(self, addresses: List[str], *,
                          write_to_disk=True) -> Tuple[List[str], List[Tuple[str, str]]]:


### PR DESCRIPTION
Previously when spending coins on imported-key wallets, the change address
would always be an address from one of the inputs. This address reuse is
pretty bad for privacy because it leaks which output is change.

This commit attempts to find unused imported addresses, and if there are any
then use them as change addresses.

The practical use-case I considered was the situation when using the Electrum
android app to do a cash-in-person trade. Some people might want to bring only
one of their UTXOs to the meetup for safety. This commit allows them to import
that one UTXO plus an unused change address, allowing them to create a
transaction without address reuse.

The diff is a single line which shouldn't cause any serious maintenance burden.

I haven't actually tested it on the Android app but by my reading it uses the classes in `electrum/wallet.py` all the same.

Here are screenshots showing before and after the edit.

Before:

![imported-wallet-no-reuse-change-addr-before](https://user-images.githubusercontent.com/8398185/120334590-a9172680-c2e8-11eb-8383-39b991da91b4.png)

After:

![imported-wallet-no-reuse-change-addr-after](https://user-images.githubusercontent.com/8398185/120334609-addbda80-c2e8-11eb-9458-0497021ced87.png)

As you can see, the transaction created now uses the unused imported address as change.