### PR TITLE
Fix kivy RefLabel on_touched; status.kv: update balances only when shown

### DIFF
--- a/electrum/gui/kivy/main.kv
+++ b/electrum/gui/kivy/main.kv
@@ -183,7 +183,10 @@
         touch = args[1]
         touched = bool(self.collide_point(*touch.pos))
         if touched: self.touch_callback()
-        if touched: self.touched = True
+        if touched and not self.touched: self.touched = True
+    on_touch_up:
+        touched = bool(self.collide_point(*(args[1].pos)))
+        if touched and self.touched: self.touched = False
     canvas.before:
         Color:
             rgba: root.background_color

--- a/electrum/gui/kivy/uix/dialogs/addresses.py
+++ b/electrum/gui/kivy/uix/dialogs/addresses.py
@@ -177,7 +177,7 @@ Builder.load_string('''
                 RefLabel:
                     data: root.pk
                     name: _('Private key')
-                    on_touched: if not self.data: root.do_export(self)
+                    on_touched: if self.touched and not self.data: root.do_export(self)
         Widget:
             size_hint: 1, 0.1
         BoxLayout:

--- a/electrum/gui/kivy/uix/ui_screens/status.kv
+++ b/electrum/gui/kivy/uix/ui_screens/status.kv
@@ -7,8 +7,8 @@ Popup:
     watching_only: app.wallet.is_watching_only()
     has_seed: app.wallet.has_seed()
     on_parent:
-        self.confirmed, self.unconfirmed, self.unmatured = app.wallet.get_balance()
-        self.lightning = int(app.wallet.lnworker.get_balance()) if app.wallet.lnworker else 0
+        if self.parent: self.confirmed, self.unconfirmed, self.unmatured = app.wallet.get_balance()
+        if self.parent: self.lightning = int(app.wallet.lnworker.get_balance()) if app.wallet.lnworker else 0
     BoxLayout:
         orientation: 'vertical'
         ScrollView:

--- a/electrum/gui/kivy/uix/ui_screens/status.kv
+++ b/electrum/gui/kivy/uix/ui_screens/status.kv
@@ -65,7 +65,7 @@ Popup:
                         visible: root.has_seed
                         data: ''
                         name: _('Seed')
-                        on_touched: if not self.data and root.has_seed: app.show_seed(seed_label)
+                        on_touched: if self.touched and not self.data and root.has_seed: app.show_seed(seed_label)
 
         BoxLayout:
             size_hint: 1, None


### PR DESCRIPTION
Two small fixes on Kivy GUI:

In `uix/ui_screens/status.kv`, when touched seed and then cancel Pin/Question
popup, second try to show seed is not working. Same for privk in `uix/dialogs/addresses.py`.
This commit fixes this problem:

- kivy: fix RefLabel on_touched processing

Second problem can be reproduced only in Kivy+Linux. If `status.kv` popup is shown
and window is closed by window manager means, exception is raised (parent is set to None,
but `app.wallet` is unloaded already). Possibly it should be fixed by:

- kivy status.kv: update balance only when shown