### PR TITLE
wallet: fire "request_status" event also when conf number changes

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -36,7 +36,7 @@ from .util import profiler, bfh, TxMinedInfo, UnrelatedTransactionException, wit
 from .transaction import Transaction, TxOutput, TxInput, PartialTxInput, TxOutpoint, PartialTransaction
 from .synchronizer import Synchronizer
 from .verifier import SPV
-from .blockchain import hash_header
+from .blockchain import hash_header, Blockchain
 from .i18n import _
 from .logging import Logger
 
@@ -591,7 +591,7 @@ class AddressSynchronizer(Logger):
         with self.lock:
             return dict(self.unverified_tx)  # copy
 
-    def undo_verifications(self, blockchain, above_height):
+    def undo_verifications(self, blockchain: Blockchain, above_height: int) -> Set[str]:
         '''Used by the verifier when a reorg has happened'''
         txs = set()
         with self.lock:


### PR DESCRIPTION
Previously the `request_status` event was only called when a tx touching the receive request was added to the wallet (typically while unconfirmed). Notably, it will now also fire when the tx gets its first confirmation. Subsequent confirmation number changes for the receive request can be tracked by listening to the `blockchain_updated` event.
After either event, the status of the request can be checked via `wallet.get_onchain_request_status(req)`.