### PR TITLE
mac build: don't create __pycache__ folders

### DIFF
--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -2,7 +2,7 @@
 
 NAME_ROOT=electrum
 
-export PYTHONDONTWRITEBYTECODE=1
+export PYTHONDONTWRITEBYTECODE=1  # don't create __pycache__/ folders with .pyc files
 
 
 # Let's begin!

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -7,6 +7,7 @@ PACKAGE=Electrum
 GIT_REPO=https://github.com/spesmilo/electrum
 
 export GCC_STRIP_BINARIES="1"
+export PYTHONDONTWRITEBYTECODE=1  # don't create __pycache__/ folders with .pyc files
 
 
 . "$(dirname "$0")/../build_tools_util.sh"


### PR DESCRIPTION
The .pyc files would get created when a .py module is imported,
which is done during the build for some source files by pyinstaller
(when it analyses imports).

I considered setting PYTHONDONTWRITEBYTECODE=1 in build_tools_util.sh,
to apply to all builds, but am not sure how it would affect the Android build,
where we actually want .pyc files included in the apk.

see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE

@ecdsa 