### PR TITLE
mac build: download python from python.org instead of using pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ contrib/build-linux/sdist/fresh_clone/
 contrib/build-linux/appimage/build/
 contrib/build-linux/appimage/.cache/
 contrib/build-linux/appimage/fresh_clone/
+contrib/osx/.cache/
 contrib/android/fresh_clone
 contrib/android/android_debug.keystore
 contrib/secp256k1/

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Parameterize
-PYTHON_VERSION=3.7.10
+PYTHON_VERSION=3.7.9
 BUILDDIR=/tmp/electrum-build
 PACKAGE=Electrum
 GIT_REPO=https://github.com/spesmilo/electrum
@@ -16,6 +16,9 @@ export PYTHONDONTWRITEBYTECODE=1  # don't create __pycache__/ folders with .pyc 
 CONTRIB_OSX="$(dirname "$(realpath "$0")")"
 CONTRIB="$CONTRIB_OSX/.."
 PROJECT_ROOT="$CONTRIB/.."
+CACHEDIR="$CONTRIB_OSX/.cache"
+
+mkdir -p "$CACHEDIR"
 
 cd "$PROJECT_ROOT"
 
@@ -60,17 +63,19 @@ function DoCodeSignMaybe { # ARGS: infoName fileOrDirName
     codesign -f -v $deep -s "$CODESIGN_CERT" $hardened_arg "$file" || fail "Could not code sign ${infoName}"
 }
 
-
 info "Installing Python $PYTHON_VERSION"
-export PATH="~/.pyenv/bin:~/.pyenv/shims:~/Library/Python/3.7/bin:$PATH"
-if [ -d "${HOME}/.pyenv" ]; then
-  pyenv update
-else
-  curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash > /dev/null 2>&1
+curl -o "$CACHEDIR/python-${PYTHON_VERSION}-macosx10.9.pkg" \
+    "https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macosx10.9.pkg"
+echo "bf54a14eef23467991e8c7a88c7307762e484c024a94ec1ee292ac1db3d41fc9  $CACHEDIR/python-${PYTHON_VERSION}-macosx10.9.pkg" | shasum -a 256 -c \
+    || fail "python pkg checksum mismatched"
+sudo installer -pkg "$CACHEDIR/python-${PYTHON_VERSION}-macosx10.9.pkg" -target / \
+    || fail "failed to install python"
+
+# sanity check "python3" has the version we just installed.
+FOUND_PY_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
+if [[ "$FOUND_PY_VERSION" != "$PYTHON_VERSION" ]]; then
+    fail "python version mismatch: $FOUND_PY_VERSION != $PYTHON_VERSION"
 fi
-PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s $PYTHON_VERSION && \
-pyenv global $PYTHON_VERSION || \
-fail "Unable to use Python $PYTHON_VERSION"
 
 break_legacy_easy_install
 


### PR DESCRIPTION
related: https://github.com/spesmilo/electrum/issues/7266

We are trying to make the macOS builds reproducible...
Compiling python from source on OSX seems to be very difficult in a reproducible way.
As a workaround, we make the same tradeoff the Windows binaries already have: we trust the python binaries distributed by `python.org`.