### PR TITLE
Add Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -158,3 +158,14 @@ task:
     path: "contrib/build-wine/dist/*"
   env:
     CIRRUS_WORKING_DIR: /opt/wine64/drive_c/electrum
+
+task:
+  name: Android build
+  container:
+    dockerfile: contrib/android/Dockerfile
+    cpu: 2
+    memory: 2G
+  build_script:
+    - ./contrib/android/make_apk
+  binaries_artifacts:
+    path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,3 +76,31 @@ task:
   depends_on:
     - Tox Python 3.9
   only_if: $CIRRUS_BRANCH == 'master'
+
+task:
+  container:
+    image: $ELECTRUM_IMAGE
+    cpu: 1
+    memory: 1G
+  pip_cache:
+    folder: ~/.cache/pip
+    fingerprint_script: echo Flake8 && echo $ELECTRUM_IMAGE && cat $ELECTRUM_REQUIREMENTS
+    populate_script: mkdir -p ~/.cache/pip
+  electrum_cache:
+    folder: /tmp/electrum-build
+    populate_script: mkdir -p /tmp/electrum-build
+  install_script:
+    - pip install flake8
+  flake8_script:
+    - flake8 . --count --select=$ELECTRUM_LINTERS --show-source --statistics
+  env:
+    ELECTRUM_IMAGE: python:3.7
+    ELECTRUM_REQUIREMENTS: contrib/requirements/requirements-travis.txt
+  matrix:
+    - name: Flake8 Mandatory
+      env:
+        ELECTRUM_LINTERS: E9,F63,F7,F82
+    - name: Flake8 Non-Mandatory
+      env:
+        ELECTRUM_LINTERS: E,F,W,C90
+      allow_failures: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,51 @@
+task:
+  container:
+    image: $ELECTRUM_IMAGE
+    cpu: 1
+    memory: 1G
+  matrix:
+    - name: Tox Python $ELECTRUM_PYTHON_VERSION
+      env:
+        ELECTRUM_IMAGE: python:$ELECTRUM_PYTHON_VERSION
+        TOXENV: py3
+        ELECTRUM_PYTHON_NAME: python3
+      matrix:
+       - env:
+           ELECTRUM_PYTHON_VERSION: 3.6
+       - env:
+           ELECTRUM_PYTHON_VERSION: 3.7
+       - env:
+           ELECTRUM_PYTHON_VERSION: 3.8
+       - env:
+           ELECTRUM_PYTHON_VERSION: 3.9
+       - env:
+           ELECTRUM_PYTHON_VERSION: 3
+       - env:
+           ELECTRUM_PYTHON_VERSION: rc
+    - name: Tox PyPy
+      allow_failures: true
+      env:
+        ELECTRUM_IMAGE: pypy:3
+        TOXENV: pypy3
+        ELECTRUM_PYTHON_NAME: pypy3
+  pip_cache:
+    folder: ~/.cache/pip
+    fingerprint_script: echo $ELECTRUM_IMAGE && cat $ELECTRUM_REQUIREMENTS
+    populate_script: mkdir -p ~/.cache/pip
+  electrum_cache:
+    folder: /tmp/electrum-build
+    populate_script: mkdir -p /tmp/electrum-build
+  version_script:
+    - $ELECTRUM_PYTHON_NAME --version
+  tag_script:
+    - git tag
+  install_script:
+    - apt-get update
+    - apt-get -y install libsecp256k1-0
+    - pip install -r $ELECTRUM_REQUIREMENTS
+  tox_script:
+    - tox
+  coveralls_script:
+    - coveralls
+  env:
+    ELECTRUM_REQUIREMENTS: contrib/requirements/requirements-travis.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -207,3 +207,15 @@ task:
     - ./contrib/build-linux/sdist/make_sdist.sh
   binaries_artifacts:
     path: "dist/*"
+
+task:
+  name: Submodules
+  container:
+    image: python:3.7
+    cpu: 1
+    memory: 1G
+  fetch_script:
+    - git fetch --all --tags
+  check_script:
+    - ./contrib/deterministic-build/check_submodules.sh
+  only_if: $CIRRUS_TAG != ''

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,6 +78,46 @@ task:
   only_if: $CIRRUS_BRANCH == 'master'
 
 task:
+  name: Regtest functional tests
+  container:
+    image: $ELECTRUM_IMAGE
+    cpu: 1
+    memory: 1G
+  pip_cache:
+    folder: ~/.cache/pip
+    fingerprint_script: echo Regtest && echo $ELECTRUM_IMAGE && cat $ELECTRUM_REQUIREMENTS
+    populate_script: mkdir -p ~/.cache/pip
+  electrum_cache:
+    folder: /tmp/electrum-build
+    populate_script: mkdir -p /tmp/electrum-build
+  bitcoind_cache:
+    folder: /tmp/bitcoind
+    populate_script: mkdir -p /tmp/bitcoind
+  install_script:
+    - apt-get update
+    - apt-get -y install libsecp256k1-0 curl jq bc
+    - pip3 install .[tests]
+    - pip3 install electrumx
+    - "BITCOIND_VERSION=$(curl https://bitcoincore.org/en/download/ | grep -E -i --only-matching 'Latest version: [0-9\\.]+' | grep -E --only-matching '[0-9\\.]+')"
+    - BITCOIND_FILENAME=bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz
+    - BITCOIND_PATH=/tmp/bitcoind/$BITCOIND_FILENAME
+    - BITCOIND_URL=https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/$BITCOIND_FILENAME
+    - tar -xaf $BITCOIND_PATH || (rm -f /tmp/bitcoind/* && curl --output $BITCOIND_PATH $BITCOIND_URL && tar -xaf $BITCOIND_PATH)
+    - cp -a bitcoin-$BITCOIND_VERSION/* /usr/
+  bitcoind_service_background_script:
+    - electrum/tests/regtest/run_bitcoind.sh
+  electrumx_service_background_script:
+    - electrum/tests/regtest/run_electrumx.sh
+  regtest_script:
+    - sleep 10s
+    - python3 -m unittest electrum/tests/regtest.py
+  env:
+    ELECTRUM_IMAGE: python:3.7
+    ELECTRUM_REQUIREMENTS: contrib/requirements/requirements-travis.txt
+    # ElectrumX exits with an error without this:
+    ALLOW_ROOT: 1
+
+task:
   container:
     image: $ELECTRUM_IMAGE
     cpu: 1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -169,3 +169,19 @@ task:
     - ./contrib/android/make_apk
   binaries_artifacts:
     path: "dist/*"
+
+task:
+  name: MacOS build
+  macos_instance:
+    image: catalina-xcode-11.3.1
+  env:
+    TARGET_OS: macOS
+  install_script:
+    - git fetch --all --tags
+  build_script:
+    - ./contrib/osx/make_osx
+  sum_script:
+    - ls -lah dist
+    - shasum -a 256 dist/*.dmg
+  binaries_artifacts:
+    path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -196,3 +196,14 @@ task:
     - ./contrib/build-linux/appimage/make_appimage.sh
   binaries_artifacts:
     path: "dist/*"
+
+task:
+  name: tarball build
+  container:
+    dockerfile: contrib/build-linux/sdist/Dockerfile
+    cpu: 1
+    memory: 1G
+  build_script:
+    - ./contrib/build-linux/sdist/make_sdist.sh
+  binaries_artifacts:
+    path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,3 +49,30 @@ task:
     - coveralls
   env:
     ELECTRUM_REQUIREMENTS: contrib/requirements/requirements-travis.txt
+
+task:
+  name: Locale
+  container:
+    image: $ELECTRUM_IMAGE
+    cpu: 1
+    memory: 1G
+  pip_cache:
+    folder: ~/.cache/pip
+    fingerprint_script: echo Locale && echo $ELECTRUM_IMAGE && cat $ELECTRUM_REQUIREMENTS
+    populate_script: mkdir -p ~/.cache/pip
+  electrum_cache:
+    folder: /tmp/electrum-build
+    populate_script: mkdir -p /tmp/electrum-build
+  install_script:
+    - apt-get update
+    - apt-get -y install libsecp256k1-0
+    - pip install -r $ELECTRUM_REQUIREMENTS
+    - pip install requests
+  locale_script:
+    - contrib/push_locale
+  env:
+    ELECTRUM_IMAGE: python:3.7
+    ELECTRUM_REQUIREMENTS: contrib/requirements/requirements-travis.txt
+  depends_on:
+    - Tox Python 3.9
+  only_if: $CIRRUS_BRANCH == 'master'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -185,3 +185,14 @@ task:
     - shasum -a 256 dist/*.dmg
   binaries_artifacts:
     path: "dist/*"
+
+task:
+  name: AppImage build
+  container:
+    dockerfile: contrib/build-linux/appimage/Dockerfile
+    cpu: 2
+    memory: 1G
+  build_script:
+    - ./contrib/build-linux/appimage/make_appimage.sh
+  binaries_artifacts:
+    path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -144,3 +144,17 @@ task:
       env:
         ELECTRUM_LINTERS: E,F,W,C90
       allow_failures: true
+
+task:
+  name: Windows build
+  container:
+    dockerfile: contrib/build-wine/Dockerfile
+    cpu: 1
+    memory: 2G
+  build_script:
+    - cd contrib/build-wine
+    - ./make_win.sh
+  binaries_artifacts:
+    path: "contrib/build-wine/dist/*"
+  env:
+    CIRRUS_WORKING_DIR: /opt/wine64/drive_c/electrum

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -151,7 +151,7 @@ RUN chown ${USER} /opt
 USER ${USER}
 
 
-COPY requirements-build-android.txt /opt/deterministic-build/
+COPY contrib/deterministic-build/requirements-build-android.txt /opt/deterministic-build/
 RUN python3 -m pip install --no-dependencies --user \
     -r /opt/deterministic-build/requirements-build-android.txt
 

--- a/contrib/android/build.sh
+++ b/contrib/android/build.sh
@@ -22,13 +22,11 @@ if [ ! -z "$ELECBUILD_NOCACHE" ] ; then
 fi
 
 info "building docker image."
-cp "$CONTRIB/deterministic-build/requirements-build-android.txt" "$CONTRIB_ANDROID/requirements-build-android.txt"
 sudo docker build \
     $DOCKER_BUILD_FLAGS \
     -t electrum-android-builder-img \
     --file "$CONTRIB_ANDROID/Dockerfile" \
     "$PROJECT_ROOT"
-rm "$CONTRIB_ANDROID/requirements-build-android.txt"
 
 
 # maybe do fresh clone

--- a/contrib/android/build.sh
+++ b/contrib/android/build.sh
@@ -26,7 +26,8 @@ cp "$CONTRIB/deterministic-build/requirements-build-android.txt" "$CONTRIB_ANDRO
 sudo docker build \
     $DOCKER_BUILD_FLAGS \
     -t electrum-android-builder-img \
-    "$CONTRIB_ANDROID"
+    --file "$CONTRIB_ANDROID/Dockerfile" \
+    "$PROJECT_ROOT"
 rm "$CONTRIB_ANDROID/requirements-build-android.txt"
 
 

--- a/electrum/tests/regtest.py
+++ b/electrum/tests/regtest.py
@@ -10,6 +10,7 @@ class TestLightning(unittest.TestCase):
         process = subprocess.Popen(['electrum/tests/regtest/regtest.sh'] + args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         for line in iter(process.stdout.readline, b''):
             sys.stdout.write(line.decode(sys.stdout.encoding))
+            sys.stdout.flush()
         process.wait(timeout=timeout)
         process.stdout.close()
         assert process.returncode == 0

--- a/electrum/tests/regtest.py
+++ b/electrum/tests/regtest.py
@@ -7,9 +7,9 @@ class TestLightning(unittest.TestCase):
 
     @staticmethod
     def run_shell(args, timeout=30):
-        process = subprocess.Popen(['electrum/tests/regtest/regtest.sh'] + args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-        for line in iter(process.stdout.readline, b''):
-            sys.stdout.write(line.decode(sys.stdout.encoding))
+        process = subprocess.Popen(['electrum/tests/regtest/regtest.sh'] + args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, universal_newlines=True)
+        for line in iter(process.stdout.readline, ''):
+            sys.stdout.write(line)
             sys.stdout.flush()
         process.wait(timeout=timeout)
         process.stdout.close()

--- a/electrum/tests/regtest/run_bitcoind.sh
+++ b/electrum/tests/regtest/run_bitcoind.sh
@@ -17,9 +17,9 @@ rpcbind=0.0.0.0
 rpcport=18554
 EOF
 rm -rf ~/.bitcoin/regtest
-screen -S bitcoind -X quit || true
-screen -S bitcoind -m -d bitcoind -regtest
+bitcoind -regtest &
 sleep 6
 bitcoin-cli createwallet test_wallet
 addr=$(bitcoin-cli getnewaddress)
-bitcoin-cli generatetoaddress 150 $addr > /dev/null
+bitcoin-cli generatetoaddress 150 $addr
+tail -f ~/.bitcoin/regtest/debug.log

--- a/electrum/tests/regtest/run_electrumx.sh
+++ b/electrum/tests/regtest/run_electrumx.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+export HOME=~
+set -eux pipefail
+cd
+rm -rf $HOME/electrumx_db
+mkdir $HOME/electrumx_db
+COST_SOFT_LIMIT=0 COST_HARD_LIMIT=0 COIN=BitcoinSegwit SERVICES=tcp://:51001,rpc:// NET=regtest DAEMON_URL=http://doggman:donkey@127.0.0.1:18554 DB_DIRECTORY=$HOME/electrumx_db electrumx_server

--- a/electrum/tests/regtest/start_electrumx.sh
+++ b/electrum/tests/regtest/start_electrumx.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-export HOME=~
-set -eux pipefail
-cd
-rm -rf $HOME/electrumx_db
-mkdir $HOME/electrumx_db
-COST_SOFT_LIMIT=0 COST_HARD_LIMIT=0 COIN=BitcoinSegwit SERVICES=tcp://:51001,rpc:// NET=regtest DAEMON_URL=http://doggman:donkey@127.0.0.1:18554 DB_DIRECTORY=$HOME/electrumx_db electrumx_server > $HOME/electrumx.log &


### PR DESCRIPTION
As discussed on IRC, this PR adds Cirrus CI.

To see what the Cirrus results look like, see https://github.com/JeremyRand/electrum-nmc/runs/3155036786

Some random notes:

1. A few of the Lightning unit tests fail nondeterministically.  I haven't looked at this too closely, but I don't think this is caused by the Cirrus environment.
2. The functional regtests fail to break out of the "wait until Alice sees channel open" loop.  Again, I didn't look at this very closely.
3. I had to refactor the scripts that launch Bitcoin Core and ElectrumX for the functional tests.  One benefit of the refactor is that Cirrus shows the logs for each in a separate log section, which is helpful for debugging when the functional tests fail.
4. I had to slightly tweak the `docker build` command for the Android build script, so that it can access a file in a parent directory of the Dockerfile.   Note that the Cirrus docs indicate that the contents of `COPY` files are not taken into account when keying the Docker image cache.  I *think* that just means that you shouldn't configure Cirrus to allow the public to write to the cache (i.e. leave at default settings).  If a malicious actor did write to the cache, e.g. by submitting a malicious PR, they could change the contents of the "requirements" file that's cached in that Docker image.
5. Cirrus is configured to use the Dockerfiles directly, rather than running the `build.sh` scripts in a hardware VM.  This makes things much simpler and much faster, but does mean that if there's a Bash error in those scripts, Cirrus won't catch it.
6. Cirrus uploads artifacts of all the binary builds.  In many cases, these may be bit-for-bit identical to what manual builds produce, in which case you could hypothetically use Cirrus as a co-signer for reproducible builds.  The artifacts may also be useful for QA testers who want to try a nightly binary without building from source (obviously this should not be done with mainnet wallets with significant amounts of money, unless the QA testers trust Cirrus).  The Cirrus API can give you a URL that will always point to the latest build artifact that passed all tests.
7. I didn't test the submodule tests, since they only run for tags.
8. Cirrus runs the unit tests with PyPy too, but doesn't fail the build if they fail.  This is mainly to make it easier for people who want to improve PyPy compatibility to see what the status is.
9. Similarly, Cirrus runs additional flake8 tests, but doesn't fail the build if they fail.  The reason is the same: it makes it easier for people who want to improve that situation to see the status.
10. This PR also includes two trivial regtest fixes relating to output buffering.  Without these fixes, the regtests appear to hang until the regtests finish.

Let me know if anything looks obviously wrong.