### PR TITLE
Change lightning node(signet)

### DIFF
--- a/electrum/trampoline.py
+++ b/electrum/trampoline.py
@@ -66,7 +66,8 @@ TRAMPOLINE_NODES_TESTNET = {
 }
 
 TRAMPOLINE_NODES_SIGNET = {
-    'wakiyamap.dev': LNPeerAddr(host='signet-electrumx.wakiyamap.dev', port=9735, pubkey=bytes.fromhex('02dadf6c28f3284d591cd2a4189d1530c1ff82c07059ebea150a33ab76e7364b4a')),
+    'lnd wakiyamap.dev': LNPeerAddr(host='signet-electrumx.wakiyamap.dev', port=9735, pubkey=bytes.fromhex('02dadf6c28f3284d591cd2a4189d1530c1ff82c07059ebea150a33ab76e7364b4a')),
+    'eclair wakiyamap.dev': LNPeerAddr(host='signet-eclair.wakiyamap.dev', port=9735, pubkey=bytes.fromhex('0271cf3881e6eadad960f47125434342e57e65b98a78afa99f9b4191c02dd7ab3b')),
 }
 
 _TRAMPOLINE_NODES_UNITTESTS = {}  # used in unit tests


### PR DESCRIPTION
I forked eclair and handled supporting signet for electrum.
https://github.com/wakiyamap/eclair/commits/bitcoin-signet
https://github.com/wakiyamap/bitcoin-lib/commits/bitcoin-signet

Please teach me know if you have any problems.

eclair.conf
```
eclair.chain=signet
eclair.bitcoind.rpcport=38332
eclair.bitcoind.rpcuser=********
eclair.bitcoind.rpcpassword=********
eclair.bitcoind.zmqblock="tcp://127.0.0.1:29000"
eclair.bitcoind.zmqtx="tcp://127.0.0.1:29001"
eclair.api.password=********
eclair.api.enabled=true
eclair.trampoline-payments-enable=true
eclair.node-alias="eclair@wakiyamap"
eclair.server.public-ips=[signet-eclair.wakiyamap.dev]
eclair.server.port=9735
eclair.max-funding-satoshis=500000000
```