### PR TITLE
Removes inaccurate "brasilian" language

### DIFF
--- a/electrum/i18n.py
+++ b/electrum/i18n.py
@@ -69,7 +69,7 @@ languages = {
     'nb_NO': _('Norwegian Bokmal'),
     'nl_NL': _('Dutch'),
     'pl_PL': _('Polish'),
-    'pt_BR': _('Brasilian'),
+    'pt_BR': _('Portuguese (Brazil)'),
     'pt_PT': _('Portuguese'),
     'ro_RO': _('Romanian'),
     'ru_RU': _('Russian'),


### PR DESCRIPTION
The option "brasilian" is inaccurate since we brazilians do speak Portuguese.
We don't consider "brasilian" as a language, so I believe this change I've made is a more accurate option for this public.