### PR TITLE
Fix bug with new password prompt

### DIFF
--- a/run_electrum
+++ b/run_electrum
@@ -166,7 +166,7 @@ def init_cmdline(config_options, wallet_path, server, *, config: 'SimpleConfig')
 
     config_options['password'] = config_options.get('password') or password
 
-    if cmd.name == 'password':
+    if cmd.name == 'password' and 'new_password' not in config_options:
         new_password = prompt_password('New password:')
         config_options['new_password'] = new_password
 


### PR DESCRIPTION
No longer prompts for new password if `--new_password` parameter is used

fixes https://github.com/spesmilo/electrum/issues/7475