### PR TITLE
watchtower: continuously check for added channels

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -306,7 +306,7 @@ class WatchTowerServer(AuthenticatedServer):
         await site.start()
 
     async def get_ctn(self, *args):
-        return await self.lnwatcher.sweepstore.get_ctn(*args)
+        return await self.lnwatcher.get_ctn(*args)
 
     async def add_sweep_tx(self, *args):
         return await self.lnwatcher.sweepstore.add_sweep_tx(*args)

--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -313,10 +313,11 @@ class WatchTower(LNWatcher):
                 await self.tx_progress[funding_outpoint].tx_queue.put(tx)
             return txid
 
-    def get_ctn(self, outpoint, addr):
-        async def f():
-            return await self.sweepstore.get_ctn(outpoint, addr)
-        return self.network.run_from_another_thread(f())
+    async def get_ctn(self, outpoint, addr):
+        if addr not in self.callbacks.keys():
+            self.logger.info(f'watching new channel: {outpoint} {addr}')
+            self.add_channel(outpoint, addr)
+        return await self.sweepstore.get_ctn(outpoint, addr)
 
     def get_num_tx(self, outpoint):
         async def f():

--- a/electrum/sql_db.py
+++ b/electrum/sql_db.py
@@ -1,5 +1,4 @@
 import os
-import concurrent
 import queue
 import threading
 import asyncio
@@ -10,7 +9,10 @@ from .util import test_read_write_permissions
 
 
 def sql(func):
-    """wrapper for sql methods"""
+    """wrapper for sql methods
+
+    returns an awaitable asyncio.Future
+    """
     def wrapper(self: 'SqlDB', *args, **kwargs):
         assert threading.currentThread() != self.sql_thread
         f = self.asyncio_loop.create_future()
@@ -20,7 +22,7 @@ def sql(func):
 
 
 class SqlDB(Logger):
-    
+
     def __init__(self, asyncio_loop: asyncio.BaseEventLoop, path, commit_interval=None):
         Logger.__init__(self)
         self.asyncio_loop = asyncio_loop

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -340,10 +340,17 @@ if [[ $1 == "watchtower" ]]; then
     invoice2=$($bob add_lightning_request 0.01 -m "invoice2" | jq -r ".invoice")
     $alice lnpay $invoice2
     msg="waiting until watchtower is synchronized"
-    while watchtower_ctn=$($carol get_watchtower_ctn $channel) && [ $watchtower_ctn != "3" ]; do
+    while watchtower_ctn=$($carol get_watchtower_ctn $channel) && [[ $watchtower_ctn != "3" ]]; do
         sleep 1
-	msg="$msg."
-	printf "$msg\r"
+        msg="$msg."
+        printf "$msg\r"
     done
     printf "\n"
+    echo "alice and bob do nothing"
+    $bob stop
+    $alice stop
+    ctx_id=$($bitcoin_cli sendrawtransaction $ctx)
+    echo "alice breaches with old ctx:" $ctx_id
+    echo "watchtower publishes justice transaction"
+    wait_until_spent $ctx_id 1  # alice's to_local gets punished immediately
 fi


### PR DESCRIPTION
From my testing I saw that the watchtower isn't actually tested for publication of the punishment transaction. That test fails, which is fixed by the watchtower polling the sweepstore. Maybe there's a more efficient way using events?