### PR TITLE
Add support for Unix domain sockets

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1475,6 +1475,8 @@ def get_parser():
     # daemon
     parser_daemon = subparsers.add_parser('daemon', help="Run Daemon")
     parser_daemon.add_argument("-d", "--detached", action="store_true", dest="detach", default=False, help="run daemon in detached mode")
+    parser_daemon.add_argument("--rpcsock", dest="rpcsock", default=None, help="what socket type to which to bind RPC daemon", choices=['unix', 'tcp', 'auto'])
+    parser_daemon.add_argument("--rpcsockpath", dest="rpcsockpath", help="where to place RPC file socket")
     add_network_options(parser_daemon)
     add_global_options(parser_daemon)
     # commands

--- a/electrum/tests/regtest.py
+++ b/electrum/tests/regtest.py
@@ -34,6 +34,13 @@ class TestLightning(unittest.TestCase):
             self.run_shell(['stop', agent])
 
 
+class TestUnixSockets(TestLightning):
+    agents = []
+
+    def test_unixsockets(self):
+        self.run_shell(['unixsockets'])
+
+
 class TestLightningAB(TestLightning):
     agents = ['alice', 'bob']
 

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -356,3 +356,19 @@ if [[ $1 == "watchtower" ]]; then
     echo "watchtower publishes justice transaction"
     wait_until_spent $ctx_id 1  # alice's to_local gets punished immediately
 fi
+
+if [[ $1 == "unixsockets" ]]; then
+    # This looks different because it has to run the entire daemon
+    # Test domain socket behavior
+    ./run_electrum --regtest daemon -d --rpcsock=unix # Start daemon with unix domain socket
+    ./run_electrum --regtest stop # Errors if it can't connect
+    # Test custom socket path
+    f=$(mktemp --dry-run)
+    ./run_electrum --regtest daemon -d --rpcsock=unix --rpcsockpath=$f
+    [ -S $f ] # filename exists and is socket
+    ./run_electrum --regtest stop
+    rm $f # clean up
+    # Test for regressions in the ordinary TCP functionality.
+    ./run_electrum --regtest daemon -d --rpcsock=tcp
+    ./run_electrum --regtest stop
+fi


### PR DESCRIPTION
This patch adds support for Unix domain sockets to Electrum. To use, spawn the daemon with `-u` or `--unixdomain`, e.g.:
`electrum daemon -du`

You can also specify a path for the domain socket manually with the `--sockpath` argument, e.g.:
`electrum daemon -du --sockpath=$(mktemp --dry-run)`

An integration test is included under `electrum/tests/test_unixsocket.sh`. I am not at all sure if this would meet your standards for tests, because it's a shell script. I would thus be happy to receive feedback on this point.

Closes #4955.