### PR TITLE
blockchain.py: bugfixes re `bits_to_target` and `target_to_bits`

### DIFF
--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -542,21 +542,37 @@ class Blockchain(Logger):
 
     @classmethod
     def bits_to_target(cls, bits: int) -> int:
+        # arith_uint256::SetCompact in Bitcoin Core
+        if not (0 <= bits < (1 << 32)):
+            raise Exception(f"bits should be uint32. got {bits!r}")
         bitsN = (bits >> 24) & 0xff
-        if not (0x03 <= bitsN <= 0x1d):
-            raise Exception("First part of bits should be in [0x03, 0x1d]")
-        bitsBase = bits & 0xffffff
-        if not (0x8000 <= bitsBase <= 0x7fffff):
-            raise Exception("Second part of bits should be in [0x8000, 0x7fffff]")
-        return bitsBase << (8 * (bitsN-3))
+        bitsBase = bits & 0x7fffff
+        if bitsN <= 3:
+            target = bitsBase >> (8 * (3-bitsN))
+        else:
+            target = bitsBase << (8 * (bitsN-3))
+        if target != 0 and bits & 0x800000 != 0:
+            # Bit number 24 (0x800000) represents the sign of N
+            raise Exception("target cannot be negative")
+        if (target != 0 and
+                (bitsN > 34 or
+                 (bitsN > 33 and bitsBase > 0xff) or
+                 (bitsN > 32 and bitsBase > 0xffff))):
+            raise Exception("target has overflown")
+        return target
 
     @classmethod
     def target_to_bits(cls, target: int) -> int:
+        # arith_uint256::GetCompact in Bitcoin Core
+        # see https://github.com/bitcoin/bitcoin/blob/7fcf53f7b4524572d1d0c9a5fdc388e87eb02416/src/arith_uint256.cpp#L223
         c = target.to_bytes(length=32, byteorder='big')
-        c = c[1:]  # FIXME why is this done unconditionally?
-        while c[0] == 0 and len(c) > 3:
+        bitsN = len(c)
+        while bitsN > 0 and c[0] == 0:
             c = c[1:]
-        bitsN, bitsBase = len(c), int.from_bytes(c[:3], byteorder='big')
+            bitsN -= 1
+            if len(c) < 3:
+                c += b'\x00'
+        bitsBase = int.from_bytes(c[:3], byteorder='big')
         if bitsBase >= 0x800000:
             bitsN += 1
             bitsBase >>= 8

--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -37,7 +37,9 @@ from .logging import get_logger, Logger
 _logger = get_logger(__name__)
 
 HEADER_SIZE = 80  # bytes
-MAX_TARGET = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+
+# see https://github.com/bitcoin/bitcoin/blob/feedb9c84e72e4fff489810a2bbeec09bcda5763/src/chainparams.cpp#L76
+MAX_TARGET = 0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff  # compact: 0x1d00ffff
 
 
 class MissingHeader(Exception):

--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -552,10 +552,11 @@ class Blockchain(Logger):
 
     @classmethod
     def target_to_bits(cls, target: int) -> int:
-        c = ("%064x" % target)[2:]
-        while c[:2] == '00' and len(c) > 6:
-            c = c[2:]
-        bitsN, bitsBase = len(c) // 2, int.from_bytes(bfh(c[:6]), byteorder='big')
+        c = target.to_bytes(length=32, byteorder='big')
+        c = c[1:]  # FIXME why is this done unconditionally?
+        while c[0] == 0 and len(c) > 3:
+            c = c[1:]
+        bitsN, bitsBase = len(c), int.from_bytes(c[:3], byteorder='big')
         if bitsBase >= 0x800000:
             bitsN += 1
             bitsBase >>= 8


### PR DESCRIPTION
Besides minor clean-up, this intends to fix three bugs:
- too large targets: `target_to_bits` was unconditionally discarding the highest
  byte of the target, which meant that we would not handle such targets properly.
  This however cannot happen due to these being over MAX_TARGET. (difficulty 1)
- too small targets: in `bits_to_target`, very small targets were not handled well:
  ```
  >>> Blockchain.bits_to_target(0x03008000)
  32768
  ```
  We could not process headers with targets smaller than the above value.
  (note that these small targets would only occur at astronomically high mining difficulty)
- non-canonically encoded targets:
  we would not accept headers that had targets encoded in compact form (nBits) in a non-canonical way.
  I think this bug could actually be triggered by mining such a header.
  E.g. consider the target `1167130406913723784571467005534932607254396928`
  ```
  Blockchain.target_to_bits(1167130406913723784571467005534932607254396928).to_bytes(4, "big").hex()
  '13345600'
  ```
  Bitcoin Core when used to e.g. mine a block would encode this target as `0x13345600` in compact form.
  However, AFAICT, when validating Bitcoin Core would equally accept `0x14003456` which decodes to the
  same target. We were however rejecting such non-canonical compact nBits.
  ```
  >>> from electrum.blockchain import Blockchain
  >>> Blockchain.bits_to_target(0x14003456)
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "/home/user/wspace/electrum/electrum/blockchain.py", line 548, in bits_to_target
      raise Exception("Second part of bits should be in [0x8000, 0x7fffff]")
  Exception: Second part of bits should be in [0x8000, 0x7fffff]
  >>> Blockchain.bits_to_target(0x13345600)
  1167130406913723784571467005534932607254396928
  ```