### PR TITLE
lnpeer: fix possibly nonexistant to_remote check

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1807,8 +1807,9 @@ class Peer(Logger):
                     raise Exception('failed to verify their signature')
             # at this point we know how the closing tx looks like
             # check that their output is above their scriptpubkey's network dust limit
-            if not drop_to_remote:
-                to_remote_idx = closing_tx.get_output_idxs_from_scriptpubkey(their_scriptpubkey.hex()).pop()
+            to_remote_set = closing_tx.get_output_idxs_from_scriptpubkey(their_scriptpubkey.hex())
+            if not drop_to_remote and to_remote_set:
+                to_remote_idx = to_remote_set.pop()
                 to_remote_amount = closing_tx.outputs()[to_remote_idx].value
                 transaction.check_scriptpubkey_template_and_dust(their_scriptpubkey, to_remote_amount)
 


### PR DESCRIPTION
`drop_to_remote` can be False and at the same time the to_remote output
is not present, because it is below dust. Therefore, we have to explicitly
check if to_remote is present when checking for the allowed script types and
dust limits. This affects channels which have sent only dust values, they
can't be closed unilaterally without this fix.

Fixes a regression introduced by 947693c90d6579ca52281ea7228a91fd59a81c81.