### PR TITLE
Cirrus: Use VM instead of Docker for functional tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -108,7 +108,8 @@ task:
     - apt-get update
     - apt-get -y install libsecp256k1-0 curl jq bc
     - pip3 install .[tests]
-    - pip3 install electrumx
+    #- pip3 install e-x # Broken because of https://github.com/spesmilo/electrumx/issues/117 , use older version for now.
+    - pip3 install electrumx==1.15.0
     - "BITCOIND_VERSION=$(curl https://bitcoincore.org/en/download/ | grep -E -i --only-matching 'Latest version: [0-9\\.]+' | grep -E --only-matching '[0-9\\.]+')"
     - BITCOIND_FILENAME=bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz
     - BITCOIND_PATH=/tmp/bitcoind/$BITCOIND_FILENAME

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,13 +88,15 @@ task:
 
 task:
   name: Regtest functional tests
-  container:
-    image: $ELECTRUM_IMAGE
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder
+    platform: linux
     cpu: 1
     memory: 1G
   pip_cache:
     folder: ~/.cache/pip
-    fingerprint_script: echo Regtest && echo $ELECTRUM_IMAGE && cat $ELECTRUM_REQUIREMENTS
+    fingerprint_script: echo Regtest && echo docker_builder && cat $ELECTRUM_REQUIREMENTS
     populate_script: mkdir -p ~/.cache/pip
   electrum_cache:
     folder: /tmp/electrum-build
@@ -121,7 +123,6 @@ task:
     - sleep 10s
     - python3 -m unittest electrum/tests/regtest.py
   env:
-    ELECTRUM_IMAGE: python:3.7
     ELECTRUM_REQUIREMENTS: contrib/requirements/requirements-travis.txt
     # ElectrumX exits with an error without this:
     ALLOW_ROOT: 1


### PR DESCRIPTION
Electrum seems to encounter bizarre network connectivity errors (in the form of failed syscalls) when run in a Docker container on Cirrus.  This was causing the functional tests on Cirrus to fail, presumably because some of Electrum's Lightning-related socket syscalls were failing.  Switching that task to run in a VM instead of a Docker container fixes the failure.

I am not sure whether this is a Cirrus-specific issue or if Electrum has these issues in Docker in general.  There is also some nondeterministic behavior in the functional tests that can cause them to sometimes hang; that is out of scope for this PR, but the easy workaround is to restart the affected Cirrus task.

I also fixed the ElectrumX version at v1.15.0, since Electrum master is using the BSV ElectrumX repo (which obviously won't work), and the latest spesmilo/electrumx release has broken wheels.

Fixes https://github.com/spesmilo/electrum/issues/7593