### PR TITLE
signmessage: also accept Trezor-type sigs for p2wpkh and p2wpkh-p2sh addrs

### DIFF
--- a/electrum/plugins/digitalbitbox/digitalbitbox.py
+++ b/electrum/plugins/digitalbitbox/digitalbitbox.py
@@ -491,7 +491,7 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
                 sig_string = binascii.unhexlify(reply['sign'][0]['sig'])
                 recid = int(reply['sign'][0]['recid'], 16)
                 sig = ecc.construct_sig65(sig_string, recid, True)
-                pubkey, compressed = ecc.ECPubkey.from_signature65(sig, msg_hash)
+                pubkey, compressed, txin_type_guess = ecc.ECPubkey.from_signature65(sig, msg_hash)
                 addr = public_key_to_p2pkh(pubkey.get_public_key_bytes(compressed=compressed))
                 if ecc.verify_message_with_address(addr, sig, message) is False:
                     raise Exception(_("Could not sign message"))


### PR DESCRIPTION
see https://github.com/spesmilo/electrum/issues/3861:
> there is no clear consensus how to sign messages with segwit addresses (txin type of `p2wpkh-p2sh` and `p2wpkh`)
> We do one thing, and Trezor does something else. Bitcoin Core has this disabled.

This PR only changes the signature verification we do:
- the signatures we create are unchanged,
- but we now also accept signatures created by Trezor and others.

closes https://github.com/spesmilo/electrum/issues/3861
closes https://github.com/spesmilo/electrum/issues/7660