### PR TITLE
create chmod aware of XDG_RUNTIME_DIR

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -64,7 +64,7 @@ from electrum.util import (format_time,
                            InvalidBitcoinURI, maybe_extract_bolt11_invoice, NotEnoughFunds,
                            NoDynamicFeeEstimates,
                            AddTransactionException, BITCOIN_BIP21_URI_SCHEME,
-                           InvoiceError, parse_max_spend)
+                           InvoiceError, parse_max_spend, os_chmod)
 from electrum.invoices import PR_TYPE_ONCHAIN, PR_TYPE_LN, PR_DEFAULT_EXPIRATION_WHEN_CREATING, Invoice
 from electrum.invoices import PR_PAID, PR_FAILED, pr_expiration_values, LNInvoice, OnchainInvoice
 from electrum.transaction import (Transaction, PartialTxInput,
@@ -3035,7 +3035,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
     def do_export_privkeys(self, fileName, pklist, is_csv):
         with open(fileName, "w+") as f:
-            os.chmod(fileName, 0o600)
+            os_chmod(fileName, 0o600)
             if is_csv:
                 transaction = csv.writer(f)
                 transaction.writerow(["address", "private_key"])

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -14,7 +14,7 @@ from aiorpcx import NetAddress
 from . import util
 from . import constants
 from .util import base_units, base_unit_name_to_decimal_point, decimal_point_to_base_unit_name, UnknownBaseUnit, DECIMAL_POINT_DEFAULT
-from .util import format_satoshis, format_fee_satoshis
+from .util import format_satoshis, format_fee_satoshis, os_chmod
 from .util import user_dir, make_dir, NoDynamicFeeEstimates, quantize_feerate
 from .i18n import _
 from .logging import get_logger, Logger
@@ -270,7 +270,7 @@ class SimpleConfig(Logger):
         try:
             with open(path, "w", encoding='utf-8') as f:
                 f.write(s)
-            os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
+            os_chmod(path, stat.S_IREAD | stat.S_IWRITE)
         except FileNotFoundError:
             # datadir probably deleted while running...
             if os.path.exists(self.path):  # or maybe not?

--- a/electrum/storage.py
+++ b/electrum/storage.py
@@ -32,7 +32,7 @@ from enum import IntEnum
 
 from . import ecc
 from .util import (profiler, InvalidPassword, WalletFileException, bfh, standardize_path,
-                   test_read_write_permissions)
+                   test_read_write_permissions, os_chmod)
 
 from .wallet_db import WalletDB
 from .logging import Logger
@@ -95,7 +95,7 @@ class WalletStorage(Logger):
         if not self.file_exists():
             assert not os.path.exists(self.path)
         os.replace(temp_path, self.path)
-        os.chmod(self.path, mode)
+        os_chmod(self.path, mode)
         self._file_exists = True
         self.logger.info(f"saved {self.path}")
 

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1132,6 +1132,7 @@ def read_json_file(path):
         raise FileImportFailed(e)
     return data
 
+
 def write_json_file(path, data):
     try:
         with open(path, 'w+', encoding='utf-8') as f:
@@ -1141,13 +1142,25 @@ def write_json_file(path, data):
         raise FileExportFailed(e)
 
 
+def os_chmod(path, mode):
+    """chmod aware of tmpfs"""
+    try:
+        os.chmod(path, mode)
+    except OSError as e:
+        xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR", None)
+        if xdg_runtime_dir and xdg_runtime_dir in path:
+            print("Tried to chmod in tmpfs. Skipping...", e)
+        else:
+            raise
+
+
 def make_dir(path, allow_symlink=True):
     """Make directory if it does not yet exist."""
     if not os.path.exists(path):
         if not allow_symlink and os.path.islink(path):
             raise Exception('Dangling link: ' + path)
         os.mkdir(path)
-        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        os_chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
 
 def log_exceptions(func):


### PR DESCRIPTION
`chmod` is not implemented in `XDG_RUNTIME_DIR` created by pam_systemd (tmpfs)

I use this directory for testing. I do not think people should use this as after logout directory is wiped.

I tried to find a better and more general way to decide whether file is stored in tmpfs only from its path using standard POSIX tools, yet was not able - maybe some of you can help here.


Resources:
http://liupeng0518.github.io/2018/06/28/linux/linux-tmpfs/
https://unix.stackexchange.com/questions/162900/what-is-this-folder-run-user-1000