### PR TITLE
docs-compliant get_balance method

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -1019,7 +1019,7 @@ class Interface(Logger):
         # check response
         assert_dict_contains_field(res, field_name='confirmed')
         assert_dict_contains_field(res, field_name='unconfirmed')
-        assert_integer(res['confirmed'])
+        assert_non_negative_integer(res['confirmed'])
         assert_integer(res['unconfirmed'])
         return res
 

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -1019,8 +1019,8 @@ class Interface(Logger):
         # check response
         assert_dict_contains_field(res, field_name='confirmed')
         assert_dict_contains_field(res, field_name='unconfirmed')
-        assert_non_negative_integer(res['confirmed'])
-        assert_non_negative_integer(res['unconfirmed'])
+        assert_integer(res['confirmed'])
+        assert_integer(res['unconfirmed'])
         return res
 
     async def get_txid_from_txpos(self, tx_height: int, tx_pos: int, merkle: bool):


### PR DESCRIPTION
This value can be also negative because of an unconfirmed spending transaction.

References:
- https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance
- https://github.com/spesmilo/electrumx/blob/c8d2cc0d5cf9e549a90ca876d85fed9a90b8c4ed/electrumx/server/session.py#L1133
- https://github.com/spesmilo/electrumx/blob/c8d2cc0d5cf9e549a90ca876d85fed9a90b8c4ed/electrumx/server/mempool.py#L371
- https://github.com/spesmilo/electrum/blob/master/electrum/interface.py#L1023