### PR TITLE
BUGFIX: invalid client loaded for identical wallet with different HW type

### DIFF
--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -531,11 +531,15 @@ class DeviceMgr(ThreadJob):
                 pass
             else:
                 client = self.force_pair_xpub(plugin, handler, info, xpub, derivation)
-        if client:
+        if client and type(client.plugin) == type(plugin):
+            # make sure we do not use wrong client (typecheck)
             handler.update_status(True)
-        if client:
             # note: if select_device was called, we might also update label etc here:
             keystore.opportunistically_fill_in_missing_info_from_device(client)
+        else:
+            # if type of client.plugin is different then chosen plugin
+            # wrong client was initialized - return None
+            client = None
         self.logger.info("end client for keystore")
         return client
 

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -499,16 +499,6 @@ class DeviceMgr(ThreadJob):
                     return client
         return None
 
-    def _type_check_client_plugin(self, client: 'HardwareClientBase', plugin: "HW_PluginBase"):
-        # client must have correct plugin attribute - hasattr unnecessary
-        client_plugin_type = type(client.plugin)
-        plugin_type = type(plugin)
-        if client_plugin_type == plugin_type:
-            return True
-        else:
-            self.logger.info("client.plugin {} does not match plugin {}".format(client_plugin_type, plugin_type))
-            return False
-
     def client_by_id(self, id_, *, scan_now: bool = True) -> Optional['HardwareClientBase']:
         '''Returns a client for the device ID if one is registered.  If
         a device is wiped or in bootloader mode pairing is impossible;
@@ -552,9 +542,9 @@ class DeviceMgr(ThreadJob):
                        devices: Sequence['Device']) -> Optional['HardwareClientBase']:
         _id = self.xpub_id(xpub)
         client = self._client_by_id(_id)
-        if client and not self._type_check_client_plugin(client, plugin):
-            return
         if client:
+            if type(client.plugin) != type(plugin):
+                return
             # An unpaired client might have another wallet's handler
             # from a prior scan.  Replace to fix dialog parenting.
             client.handler = handler
@@ -570,7 +560,7 @@ class DeviceMgr(ThreadJob):
         # choose an unpaired device and compare its first address.
         xtype = bip32.xpub_type(xpub)
         client = self._client_by_id(info.device.id_)
-        if client and client.is_pairable() and self._type_check_client_plugin(client, plugin):
+        if client and client.is_pairable() and type(client.plugin) == type(plugin):
             # See comment above for same code
             client.handler = handler
             # This will trigger a PIN/passphrase entry request

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -531,15 +531,19 @@ class DeviceMgr(ThreadJob):
                 pass
             else:
                 client = self.force_pair_xpub(plugin, handler, info, xpub, derivation)
-        if client and type(client.plugin) == type(plugin):
-            # make sure we do not use wrong client (typecheck)
-            handler.update_status(True)
-            # note: if select_device was called, we might also update label etc here:
-            keystore.opportunistically_fill_in_missing_info_from_device(client)
-        else:
-            # if type of client.plugin is different then chosen plugin
-            # wrong client was initialized - return None
-            client = None
+        if client:
+            client_plugin_type = type(client.plugin)
+            plugin_type = type(plugin)
+            if client_plugin_type == plugin_type:
+                # make sure we do not use wrong client (typecheck)
+                handler.update_status(True)
+                # note: if select_device was called, we might also update label etc here:
+                keystore.opportunistically_fill_in_missing_info_from_device(client)
+            else:
+                self.logger.info("client.plugin {} does not match plugin {}".format(client_plugin_type, plugin_type))
+                # if type of client.plugin is different from chosen plugin
+                # wrong client was initialized - return None
+                client = None
         self.logger.info("end client for keystore")
         return client
 


### PR DESCRIPTION
This is a BUG which causes electrum to load incorrect client for keystores with identical xpub.

Steps to reproduce:
    1. create multisig/singlesig wallet with some of your hardware devices
    2. create same multisig/singlesig wallet with at least one device different (but with same wallet loaded, in my case I used same seed and derivation path loaded on ledger and coldcard)
    3. open 1. in electrum
    4. open 2. in electrum but with device from one connected
    5. get Attribute error back from specific plugin (depends on which you used, in my case opened wallet with ledger with coldcard connected)

`  AttributeError: 'CKCCClient' object has no attribute 'checkDevice'` --> tried to use LedgerClient methods on CKCCClient

After above error is thrown, your Ledger device, that is not connected will appear as connected (green icon) and its label will be overwritten with label from connected coldcard which is definitely wrong.

I found an easy and imo elegant fix where we type check current plugin with plugin attribute from loaded client. I have only tested with ledger, trezor and coldcard, yet as all client classes have plugin attribute, this should work even for other hw_types
(stating based on this `HardwareClientBase.__init__(self, plugin=plugin)`)
       
