### PR TITLE
timeout improvement

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -759,6 +759,8 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         util.trigger_callback('network_updated')
 
     def get_network_timeout_seconds(self, request_type=NetworkTimeout.Generic) -> int:
+        if self.config.get('timeout'):
+            return self.config.get('timeout')
         if self.oneserver and not self.auto_connect:
             return request_type.MOST_RELAXED
         if self.proxy:


### PR DESCRIPTION
If custom timeout is defined as config, electrum doesn't honor it.