### PR TITLE
close unused client connections

### DIFF
--- a/electrum/base_wizard.py
+++ b/electrum/base_wizard.py
@@ -389,6 +389,11 @@ class BaseWizard(Logger):
             self.show_error(str(e))
             raise ChooseHwDeviceAgain()
 
+        # close clients that are not used
+        for cl, (path, id_) in list(devmgr.clients.items()):  # list func will copy it, therefore we can work with devmgr.clients dict
+            if cl != client:
+                devmgr._close_client(id_)
+
         if purpose == HWD_SETUP_NEW_WALLET:
             def f(derivation, script_type):
                 derivation = normalize_bip32_derivation(derivation)


### PR DESCRIPTION
This is more of a discussion PR, why do we keep clients for unused hww open? 

Scenario:
1. create sigle sig wallet with one of your hww devices and encrypt it
2. connect other hww to PC
3. cloose and re-open wallet from 1.
4. choices dialog from base wizard is opened with hww choices
5. choose one of your hww to decrypt wallet
6. after this wallet 1. is opened and connected to target device, yet all other hww are connected too, even if unused. This will cause that no other application can use them as they are already opened in electrum (but for no reason)