### PR TITLE
wallet: "up_to_date" to wait for SPV/Verifier

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -90,7 +90,7 @@ class AddressSynchronizer(Logger):
         # Txs the server claims are in the mempool:
         self.unconfirmed_tx = defaultdict(int)  # type: Dict[str, int]  # txid -> height. Access with self.lock.
         # true when synchronized
-        self._up_to_date = False
+        self._up_to_date = False  # considers both Synchronizer and Verifier
         # thread local storage for caching stuff
         self.threadlocal_cache = threading.local()
 
@@ -922,5 +922,6 @@ class AddressSynchronizer(Logger):
         c, u, x = self.get_addr_balance(address)
         return c+u+x == 0
 
-    def synchronize(self):
-        pass
+    def synchronize(self) -> int:
+        """Returns the number of new addresses we generated."""
+        return 0

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -2,10 +2,12 @@ from decimal import Decimal
 import getpass
 import datetime
 import logging
+from typing import Optional
 
 from electrum.gui import BaseElectrumGui
 from electrum import util
 from electrum import WalletStorage, Wallet
+from electrum.wallet import Abstract_Wallet
 from electrum.wallet_db import WalletDB
 from electrum.util import format_satoshis
 from electrum.bitcoin import is_address, COIN
@@ -41,7 +43,7 @@ class ElectrumGui(BaseElectrumGui):
         self.str_amount = ""
         self.str_fee = ""
 
-        self.wallet = Wallet(db, storage, config=config)
+        self.wallet = Wallet(db, storage, config=config)  # type: Optional[Abstract_Wallet]
         self.wallet.start_network(self.network)
         self.contacts = self.wallet.contacts
 

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -6,7 +6,7 @@ import locale
 from decimal import Decimal
 import getpass
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import electrum
 from electrum.gui import BaseElectrumGui
@@ -14,7 +14,7 @@ from electrum import util
 from electrum.util import format_satoshis
 from electrum.bitcoin import is_address, COIN
 from electrum.transaction import PartialTxOutput
-from electrum.wallet import Wallet
+from electrum.wallet import Wallet, Abstract_Wallet
 from electrum.wallet_db import WalletDB
 from electrum.storage import WalletStorage
 from electrum.network import NetworkParameters, TxBroadcastError, BestEffortRequestFailed
@@ -42,7 +42,7 @@ class ElectrumGui(BaseElectrumGui):
             password = getpass.getpass('Password:', stream=None)
             storage.decrypt(password)
         db = WalletDB(storage.read(), manual_upgrades=False)
-        self.wallet = Wallet(db, storage, config=config)
+        self.wallet = Wallet(db, storage, config=config)  # type: Optional[Abstract_Wallet]
         self.wallet.start_network(self.network)
         self.contacts = self.wallet.contacts
 

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -60,7 +60,6 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
     """
     def __init__(self, network: 'Network'):
         self.asyncio_loop = network.asyncio_loop
-        self._reset_request_counters()
 
         NetworkJobOnDefaultServer.__init__(self, network)
 
@@ -69,7 +68,6 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
         self.requested_addrs = set()
         self.scripthash_to_address = {}
         self._processed_some_notifications = False  # so that we don't miss them
-        self._reset_request_counters()
         # Queues
         self.add_queue = asyncio.Queue()
         self.status_queue = asyncio.Queue()
@@ -84,10 +82,6 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
         finally:
             # we are being cancelled now
             self.session.unsubscribe(self.status_queue)
-
-    def _reset_request_counters(self):
-        self._requests_sent = 0
-        self._requests_answered = 0
 
     def add(self, addr):
         asyncio.run_coroutine_threadsafe(self._add_address(addr), self.asyncio_loop)
@@ -128,9 +122,6 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
             addr = self.scripthash_to_address[h]
             await self.taskgroup.spawn(self._on_address_status, addr, status)
             self._processed_some_notifications = True
-
-    def num_requests_sent_and_answered(self) -> Tuple[int, int]:
-        return self._requests_sent, self._requests_answered
 
     async def main(self):
         raise NotImplementedError()  # implemented by subclasses
@@ -271,8 +262,6 @@ class Synchronizer(SynchronizerBase):
             if (up_to_date != self.wallet.is_up_to_date()
                     or up_to_date and self._processed_some_notifications):
                 self._processed_some_notifications = False
-                if up_to_date:
-                    self._reset_request_counters()
                 self.wallet.set_up_to_date(up_to_date)
                 util.trigger_callback('wallet_updated', self.wallet)
 

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1326,6 +1326,7 @@ class NetworkJobOnDefaultServer(Logger, ABC):
         server connection changes.
         """
         self.taskgroup = OldTaskGroup()
+        self.reset_request_counters()
 
     async def _start(self, interface: 'Interface'):
         self.interface = interface
@@ -1356,6 +1357,13 @@ class NetworkJobOnDefaultServer(Logger, ABC):
             await self.stop(full_shutdown=False)
             self._reset()
             await self._start(interface)
+
+    def reset_request_counters(self):
+        self._requests_sent = 0
+        self._requests_answered = 0
+
+    def num_requests_sent_and_answered(self) -> Tuple[int, int]:
+        return self._requests_sent, self._requests_answered
 
     @property
     def session(self):

--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -187,7 +187,8 @@ class SPV(NetworkJobOnDefaultServer):
         self.requested_merkle.discard(tx_hash)
 
     def is_up_to_date(self):
-        return not self.requested_merkle
+        return (not self.requested_merkle
+                and not self.wallet.unverified_tx)
 
 
 def verify_tx_is_in_block(tx_hash: str, merkle_branch: Sequence[str],

--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -87,6 +87,7 @@ class SPV(NetworkJobOnDefaultServer):
             header = self.blockchain.read_header(tx_height)
             if header is None:
                 if tx_height < constants.net.max_checkpoint():
+                    # FIXME these requests are not counted (self._requests_sent += 1)
                     await self.taskgroup.spawn(self.interface.request_chunk(tx_height, None, can_return_early=True))
                 continue
             # request now
@@ -96,6 +97,7 @@ class SPV(NetworkJobOnDefaultServer):
 
     async def _request_and_verify_single_proof(self, tx_hash, tx_height):
         try:
+            self._requests_sent += 1
             async with self._network_request_semaphore:
                 merkle = await self.interface.get_merkle_for_transaction(tx_hash, tx_height)
         except aiorpcx.jsonrpc.RPCError:
@@ -103,6 +105,8 @@ class SPV(NetworkJobOnDefaultServer):
             self.wallet.remove_unverified_tx(tx_hash, tx_height)
             self.requested_merkle.discard(tx_hash)
             return
+        finally:
+            self._requests_answered += 1
         # Verify the hash of the server-provided merkle branch to a
         # transaction matches the merkle root of its block
         if tx_height != merkle.get('block_height'):


### PR DESCRIPTION
This PR changes `wallet.is_up_to_date()` to consider both the Synchronizer and the Verifier (SPV).
Without this, currently, `wallet.is_up_to_date()` only considers the Synchronizer.

IIRC historically this choice was made to show the wallet balance as early as possible when restoring from seed. At the time, the Synchronizer did not depend on the Verifier at all, so this was reasonable. (obviously the Verifier does depend on the Synchronizer: that's how it gets txs to verify)
However, this is no longer the case, since https://github.com/spesmilo/electrum/commit/9c31c1f970d9bc371ed2dcba26354c71c6ec8756, the wallet only generates new addresses and rolls the gap limit forward after existing addresses have spv-verified confirmed history. That is, the Synchronizer too depends on the Verifier.

So, this PR makes it a bit slower to get to the state where we display the balance when restoring, however, not by much...
The above commit already made the Synchronizer wait for the Verifier before new addresses are generated, so the only (new) slowdown is re the "last batch of addresses", after which the gap limit won't be rolled forward -- previously the Synchronizer would not wait in that case only. Hmm... how does the Synchronizer even know that there wouldn't be new addresses generated? Well... it is racing the Verifier, and there is a timing issue.

Without this, while syncing a wallet, `wallet.is_up_to_date()` can flip-flop between true and false multiple times, depending on timing. An easy way to reproduce is to sync a wallet of non-trivial size but slow down the polling interval of the Verifier to e.g. 5 seconds:
https://github.com/spesmilo/electrum/blob/250795f137281b8d2c8d29081949ee781a1c0b2a/electrum/verifier.py#L73
If `wallet.is_up_to_date()` flips, the sync state progress indicator is reset, probably confusing the user:
https://github.com/spesmilo/electrum/blob/250795f137281b8d2c8d29081949ee781a1c0b2a/electrum/synchronizer.py#L268-L269

Originally I just wanted to provide some new API to wait until a wallet is fully synced including SPV, but now I think we should just change the behaviour of `wallet.is_up_to_date()` (as in this PR).