### PR TITLE
qt taskthread cleaner shutdown

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1106,7 +1106,9 @@ class LNWallet(LNWorker):
         self.save_payment_info(info)
         self.wallet.set_label(key, lnaddr.get_description())
 
+        self.logger.info(f"pay_invoice starting session for RHASH={payment_hash.hex()}")
         self.set_invoice_status(key, PR_INFLIGHT)
+        success = False
         try:
             await self.pay_to_node(
                 node_pubkey=invoice_pubkey,
@@ -1121,8 +1123,9 @@ class LNWallet(LNWorker):
             success = True
         except PaymentFailure as e:
             self.logger.info(f'payment failure: {e!r}')
-            success = False
             reason = str(e)
+        finally:
+            self.logger.info(f"pay_invoice ending session for RHASH={payment_hash.hex()}. {success=}")
         if success:
             self.set_invoice_status(key, PR_PAID)
             util.trigger_callback('payment_succeeded', self.wallet, key)


### PR DESCRIPTION
fixes https://github.com/spesmilo/electrum/issues/7750

`window.run_coroutine_from_thread` no longer uses `wallet.thread`, hence the underlying coroutines are not serialised anymore (they can now run concurrently). Note that this means e.g. the GUI now allows trying to pay multiple LN invoices concurrently.

Also, each task we schedule on `TaskThread` (`wallet.thread`) can provide an optional `cancel` method.
When stopping `TaskThread`, we call this `cancel` method on all tasks in the queue. If the currently running task does not implement `cancel`, `TaskThread.stop` will block until that task finishes.