### PR TITLE
wallet_db upgrade: recalc keys of outgoing on-chain invoices

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -19,7 +19,7 @@ from electrum import util
 from electrum.util import (profiler, InvalidPassword, send_exception_to_crash_reporter,
                            format_satoshis, format_satoshis_plain, format_fee_satoshis,
                            maybe_extract_bolt11_invoice, parse_max_spend)
-from electrum.invoices import PR_PAID, PR_FAILED
+from electrum.invoices import PR_PAID, PR_FAILED, Invoice
 from electrum import blockchain
 from electrum.network import Network, TxBroadcastError, BestEffortRequestFailed
 from electrum.interface import PREFERRED_NETWORK_PROTOCOL, ServerAddr
@@ -447,8 +447,7 @@ class ElectrumWindow(App, Logger):
             self.show_error(_('No wallet loaded.'))
             return
         if pr.verify(self.wallet.contacts):
-            key = pr.get_id()
-            invoice = self.wallet.get_invoice(key)  # FIXME wrong key...
+            invoice = Invoice.from_bip70_payreq(pr, height=0)
             if invoice and self.wallet.get_invoice_status(invoice) == PR_PAID:
                 self.show_error("invoice already paid")
                 self.send_screen.do_clear()

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2092,9 +2092,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         pr = self.payment_request
         if not pr:
             return
-        key = pr.get_id()
-        invoice = self.wallet.get_invoice(key)
-        if invoice and self.wallet.get_invoice_status(invoice) == PR_PAID:
+        invoice = Invoice.from_bip70_payreq(pr, height=0)
+        if self.wallet.get_invoice_status(invoice) == PR_PAID:
             self.show_message("invoice already paid")
             self.do_clear()
             self.payment_request = None
@@ -2333,8 +2332,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             grid.addWidget(QLabel(_("Signature") + ':'), 6, 0)
             grid.addWidget(QLabel(pr.get_verify_status()), 6, 1)
             def do_export():
-                key = pr.get_id()
-                name = str(key) + '.bip70'
+                name = pr.get_name_for_export() or "payment_request"
+                name = f"{name}.bip70"
                 fn = getSaveFileName(
                     parent=self,
                     title=_("Save invoice to file"),

--- a/electrum/paymentrequest.py
+++ b/electrum/paymentrequest.py
@@ -41,7 +41,7 @@ except ImportError:
 
 from . import bitcoin, constants, ecc, util, transaction, x509, rsakey
 from .util import bh2u, bfh, make_aiohttp_session
-from .invoices import Invoice
+from .invoices import Invoice, get_id_from_onchain_outputs
 from .crypto import sha256
 from .bitcoin import address_to_script
 from .transaction import PartialTxOutput
@@ -135,7 +135,6 @@ class PaymentRequest:
         self.outputs = []  # type: List[PartialTxOutput]
         if self.error:
             return
-        self.id = bh2u(sha256(r)[0:16])
         try:
             self.data = pb2.PaymentRequest()
             self.data.ParseFromString(r)
@@ -275,8 +274,10 @@ class PaymentRequest:
     def get_memo(self):
         return self.memo
 
-    def get_id(self):
-        return self.id if self.requestor else self.get_address()
+    def get_name_for_export(self) -> Optional[str]:
+        if not hasattr(self, 'details'):
+            return None
+        return get_id_from_onchain_outputs(self.outputs, timestamp=self.get_time())
 
     def get_outputs(self):
         return self.outputs[:]

--- a/electrum/paymentrequest.py
+++ b/electrum/paymentrequest.py
@@ -121,7 +121,7 @@ async def get_payment_request(url: str) -> 'PaymentRequest':
 
 class PaymentRequest:
 
-    def __init__(self, data, *, error=None):
+    def __init__(self, data: bytes, *, error=None):
         self.raw = data
         self.error = error  # FIXME overloaded and also used when 'verify' succeeds
         self.parse(data)
@@ -131,7 +131,7 @@ class PaymentRequest:
     def __str__(self):
         return str(self.raw)
 
-    def parse(self, r):
+    def parse(self, r: bytes):
         self.outputs = []  # type: List[PartialTxOutput]
         if self.error:
             return

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -773,9 +773,9 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
             }
 
     def create_invoice(self, *, outputs: List[PartialTxOutput], message, pr, URI) -> Invoice:
-        height=self.get_local_height()
+        height = self.get_local_height()
         if pr:
-            return Invoice.from_bip70_payreq(pr, height)
+            return Invoice.from_bip70_payreq(pr, height=height)
         amount_msat = 0
         for x in outputs:
             if parse_max_spend(x.value):
@@ -2380,11 +2380,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
     @classmethod
     def get_key_for_outgoing_invoice(cls, invoice: Invoice) -> str:
         """Return the key to use for this invoice in self.invoices."""
-        if invoice.is_lightning():
-            key = invoice.rhash
-        else:
-            key = bh2u(sha256d(repr(invoice.get_outputs()) + "%d"%invoice.time))[0:10]
-        return key
+        return invoice.get_id()
 
     def get_key_for_receive_request(self, req: Invoice, *, sanity_checks: bool = False) -> str:
         """Return the key to use for this invoice in self.receive_requests."""


### PR DESCRIPTION
I think this should fix https://github.com/spesmilo/electrum/issues/7777

- the key of outgoing on-chain invoices is redefined to avoid using `TxOutput.__repr__()`
- a wallet_db upgrade is included that rekeys the (outgoing) `invoices` dict accordingly
- `PaymentRequest.get_id()` is removed