### PR TITLE
fix typo in warning message shown when enabling lightning

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -1461,7 +1461,7 @@ class ElectrumWindow(App, Logger):
             else:
                 msg = _(
                     "Warning: this wallet type does not support channel recovery from seed. "
-                    "You will need to backup your wallet everytime you create a new wallet. "
+                    "You will need to backup your wallet everytime you create a new channel. "
                     "Create lightning keys?")
             d = Question(msg, self._enable_lightning, title=_('Enable Lightning?'))
             d.open()

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2608,7 +2608,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         else:
             msg = _(
                 "Warning: this wallet type does not support channel recovery from seed. "
-                "You will need to backup your wallet everytime you create a new wallet. "
+                "You will need to backup your wallet everytime you create a new channel. "
                 "Create lightning keys?")
         if self.question(msg):
             self._init_lightning_dialog(dialog=dialog)


### PR DESCRIPTION
Seems like a small typo.