### PR TITLE
build appimage: bump pkg2appimage version

### DIFF
--- a/contrib/build-linux/appimage/make_appimage.sh
+++ b/contrib/build-linux/appimage/make_appimage.sh
@@ -15,7 +15,7 @@ export GCC_STRIP_BINARIES="1"
 
 # pinned versions
 PYTHON_VERSION=3.9.11
-PKG2APPIMAGE_COMMIT="eb8f3acdd9f11ab19b78f5cb15daa772367daf15"
+PKG2APPIMAGE_COMMIT="a9c85b7e61a3a883f4a35c41c5decb5af88b6b5d"
 
 
 VERSION=`git describe --tags --dirty --always`
@@ -32,7 +32,7 @@ rm -rf "$PROJECT_ROOT/build"
 
 info "downloading some dependencies."
 download_if_not_exist "$CACHEDIR/functions.sh" "https://raw.githubusercontent.com/AppImage/pkg2appimage/$PKG2APPIMAGE_COMMIT/functions.sh"
-verify_hash "$CACHEDIR/functions.sh" "78b7ee5a04ffb84ee1c93f0cb2900123773bc6709e5d1e43c37519f590f86918"
+verify_hash "$CACHEDIR/functions.sh" "8f67711a28635b07ce539a9b083b8c12d5488c00003d6d726c7b134e553220ed"
 
 download_if_not_exist "$CACHEDIR/appimagetool" "https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage"
 verify_hash "$CACHEDIR/appimagetool" "df3baf5ca5facbecfc2f3fa6713c29ab9cefa8fd8c1eac5d283b79cab33e4acb"


### PR DESCRIPTION
should fix https://github.com/spesmilo/electrum/issues/7784
by including commit https://github.com/AppImage/pkg2appimage/commit/1e3ecde6b92ef198405463415b8090a4435d0cb0