### PR TITLE
git update to 2.17.1-1ubuntu0.11 for appimage

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -q && \
     apt-get install -qy \
-        git=1:2.17.1-1ubuntu0.10 \
+        git=1:2.17.1-1ubuntu0.11 \
         wget=1.19.4-1ubuntu2.2 \
         make=4.1-9.1ubuntu1 \
         autotools-dev=20180224.1 \


### PR DESCRIPTION
https://launchpad.net/ubuntu/+source/git/1:2.17.1-1ubuntu0.11

* SECURITY REGRESSION: Previous update was incomplete causing regressions
    and not correctly fixing the issue.
    - debian/patches/CVE-2022-24765-5.patch: fix safe.directory
      key not being checked in setup.c.
    - debian/patches/CVE-2022-24765-6.patch:
      opt-out of check with safe.directory=* in setup.c. (LP: [#1970260](https://launchpad.net/bugs/1970260))