### PR TITLE
asyncio: stop using get_event_loop(). introduce ~singleton loop.

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -187,7 +187,7 @@ class Commands:
                 kwargs.pop('wallet')
 
         coro = f(*args, **kwargs)
-        fut = asyncio.run_coroutine_threadsafe(coro, asyncio.get_event_loop())
+        fut = asyncio.run_coroutine_threadsafe(coro, util.get_asyncio_loop())
         result = fut.result()
 
         if self._callback:

--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -124,7 +124,7 @@ def request(config: SimpleConfig, endpoint, args=(), timeout=60):
         rpc_user, rpc_password = get_rpc_credentials(config)
         server_url = 'http://%s:%d' % (host, port)
         auth = aiohttp.BasicAuth(login=rpc_user, password=rpc_password)
-        loop = asyncio.get_event_loop()
+        loop = util.get_asyncio_loop()
         async def request_coroutine():
             if socktype == 'unix':
                 connector = aiohttp.UnixConnector(path=path)
@@ -467,7 +467,7 @@ class Daemon(Logger):
         if 'wallet_path' in config.cmdline_options:
             self.logger.warning("Ignoring parameter 'wallet_path' for daemon. "
                                 "Use the load_wallet command instead.")
-        self.asyncio_loop = asyncio.get_event_loop()
+        self.asyncio_loop = util.get_asyncio_loop()
         self.network = None
         if not config.get('offline'):
             self.network = Network(config, daemon=self)

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -148,7 +148,7 @@ class ExchangeBase(Logger):
         if h is None:
             h = self.read_historical_rates(ccy, cache_dir)
         if h is None or h['timestamp'] < time.time() - 24*3600:
-            asyncio.get_event_loop().create_task(self.get_historical_rates_safe(ccy, cache_dir))
+            util.get_asyncio_loop().create_task(self.get_historical_rates_safe(ccy, cache_dir))
 
     def history_ccys(self) -> Sequence[str]:
         return []
@@ -471,7 +471,7 @@ def get_exchanges_and_currencies():
                 for name, klass in exchanges.items():
                     exchange = klass(None, None)
                     await group.spawn(get_currencies_safe(name, exchange))
-    loop = asyncio.get_event_loop()
+    loop = util.get_asyncio_loop()
     try:
         loop.run_until_complete(query_all_exchanges_for_their_ccys_over_network())
     except Exception as e:

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -394,7 +394,7 @@ class ElectrumWindow(App, Logger):
         self.is_exit = False
         self.wallet = None  # type: Optional[Abstract_Wallet]
         self.pause_time = 0
-        self.asyncio_loop = asyncio.get_event_loop()
+        self.asyncio_loop = util.get_asyncio_loop()
         self.password = None
         self._use_single_password = False
         self.resume_dialog = None

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -496,7 +496,7 @@ class LNWorker(Logger, NetworkRetryManager[LNPeerAddr]):
             # Try DNS-resolving the host (if needed). This is simply so that
             # the caller gets a nice exception if it cannot be resolved.
             try:
-                await asyncio.get_event_loop().getaddrinfo(host, port)
+                await asyncio.get_running_loop().getaddrinfo(host, port)
             except socket.gaierror:
                 raise ConnStringFormatError(_('Hostname does not resolve (getaddrinfo failed)'))
             # add peer

--- a/electrum/sql_db.py
+++ b/electrum/sql_db.py
@@ -26,7 +26,6 @@ class SqlDB(Logger):
     def __init__(self, asyncio_loop: asyncio.BaseEventLoop, path, commit_interval=None):
         Logger.__init__(self)
         self.asyncio_loop = asyncio_loop
-        asyncio.set_event_loop(asyncio_loop)
         self.stopping = False
         self.stopped_event = asyncio.Event()
         self.path = path

--- a/electrum/tests/__init__.py
+++ b/electrum/tests/__init__.py
@@ -6,6 +6,7 @@ import shutil
 import electrum
 import electrum.logging
 from electrum import constants
+from electrum import util
 
 
 # Set this locally to make the test suite run faster.
@@ -37,9 +38,12 @@ class ElectrumTestCase(SequentialTestCase):
 
     def setUp(self):
         super().setUp()
+        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.electrum_path = tempfile.mkdtemp()
 
     def tearDown(self):
+        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
+        self._loop_thread.join(timeout=1)
         super().tearDown()
         shutil.rmtree(self.electrum_path)
 

--- a/electrum/tests/test_commands.py
+++ b/electrum/tests/test_commands.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 from decimal import Decimal
 
-from electrum.util import create_and_start_event_loop
 from electrum.commands import Commands, eval_bool
 from electrum import storage, wallet
 from electrum.wallet import restore_wallet_from_text
@@ -18,13 +17,7 @@ class TestCommands(ElectrumTestCase):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-
-    def tearDown(self):
-        super().tearDown()
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
 
     def test_setconfig_non_auth_number(self):
         self.assertEqual(7777, Commands._setconfig_normalize_value('rpcport', "7777"))
@@ -135,13 +128,7 @@ class TestCommandsTestnet(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-
-    def tearDown(self):
-        super().tearDown()
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
 
     def test_convert_xkey(self):
         cmds = Commands(config=self.config)

--- a/electrum/tests/test_lnpeer.py
+++ b/electrum/tests/test_lnpeer.py
@@ -15,6 +15,7 @@ from aiorpcx import timeout_after, TaskTimeout
 import electrum
 import electrum.trampoline
 from electrum import bitcoin
+from electrum import util
 from electrum import constants
 from electrum.network import Network
 from electrum.ecc import ECPrivkey
@@ -62,7 +63,7 @@ class MockNetwork:
         user_config = {}
         user_dir = tempfile.mkdtemp(prefix="electrum-lnpeer-test-")
         self.config = simple_config.SimpleConfig(user_config, read_user_dir_function=lambda: user_dir)
-        self.asyncio_loop = asyncio.get_event_loop()
+        self.asyncio_loop = util.get_asyncio_loop()
         self.channel_db = ChannelDB(self)
         self.channel_db.data_loaded.set()
         self.path_finder = LNPathFinder(self.channel_db)
@@ -1361,4 +1362,4 @@ class TestPeer(TestCaseForTestnet):
 
 
 def run(coro):
-    return asyncio.run_coroutine_threadsafe(coro, loop=asyncio.get_event_loop()).result()
+    return asyncio.run_coroutine_threadsafe(coro, loop=util.get_asyncio_loop()).result()

--- a/electrum/tests/test_lnpeer.py
+++ b/electrum/tests/test_lnpeer.py
@@ -22,7 +22,7 @@ from electrum.ecc import ECPrivkey
 from electrum import simple_config, lnutil
 from electrum.lnaddr import lnencode, LnAddr, lndecode
 from electrum.bitcoin import COIN, sha256
-from electrum.util import bh2u, create_and_start_event_loop, NetworkRetryManager, bfh, OldTaskGroup
+from electrum.util import bh2u, NetworkRetryManager, bfh, OldTaskGroup
 from electrum.lnpeer import Peer
 from electrum.lnutil import LNPeerAddr, Keypair, privkey_to_pubkey
 from electrum.lnutil import PaymentFailure, LnFeatures, HTLCOwner
@@ -369,7 +369,6 @@ class TestPeer(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()
         self._lnworkers_created = []  # type: List[MockLNWallet]
 
     def tearDown(self):
@@ -380,8 +379,6 @@ class TestPeer(TestCaseForTestnet):
             self._lnworkers_created.clear()
         run(cleanup_lnworkers())
 
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
         super().tearDown()
 
     def prepare_peers(self, alice_channel: Channel, bob_channel: Channel):

--- a/electrum/tests/test_lnrouter.py
+++ b/electrum/tests/test_lnrouter.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 import asyncio
 
+from electrum import util
 from electrum.util import bh2u, bfh, create_and_start_event_loop
 from electrum.lnutil import ShortChannelID
 from electrum.lnonion import (OnionHopsDataSingle, new_onion_packet,
@@ -64,7 +65,7 @@ class Test_LNRouter(TestCaseForTestnet):
         """
         class fake_network:
             config = self.config
-            asyncio_loop = asyncio.get_event_loop()
+            asyncio_loop = util.get_asyncio_loop()
             trigger_callback = lambda *args: None
             register_callback = lambda *args: None
             interface = None

--- a/electrum/tests/test_lnrouter.py
+++ b/electrum/tests/test_lnrouter.py
@@ -5,7 +5,7 @@ import shutil
 import asyncio
 
 from electrum import util
-from electrum.util import bh2u, bfh, create_and_start_event_loop
+from electrum.util import bh2u, bfh
 from electrum.lnutil import ShortChannelID
 from electrum.lnonion import (OnionHopsDataSingle, new_onion_packet,
                               process_onion_packet, _decode_onion_error, decode_onion_error,
@@ -33,7 +33,6 @@ class Test_LNRouter(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
     def tearDown(self):
@@ -41,8 +40,6 @@ class Test_LNRouter(TestCaseForTestnet):
         if self.cdb:
             self.cdb.stop()
             asyncio.run_coroutine_threadsafe(self.cdb.stopped_event.wait(), self.asyncio_loop).result()
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
         super().tearDown()
 
     def prepare_graph(self):

--- a/electrum/tests/test_lntransport.py
+++ b/electrum/tests/test_lntransport.py
@@ -12,15 +12,6 @@ from .test_bitcoin import needs_test_with_all_chacha20_implementations
 
 class TestLNTransport(ElectrumTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
-
-    def tearDown(self):
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
-        super().tearDown()
-
     @needs_test_with_all_chacha20_implementations
     def test_responder(self):
         # local static

--- a/electrum/tests/test_lntransport.py
+++ b/electrum/tests/test_lntransport.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from electrum import util
 from electrum.ecc import ECPrivkey
 from electrum.lnutil import LNPeerAddr
 from electrum.lntransport import LNResponderTransport, LNTransport
@@ -10,6 +11,15 @@ from .test_bitcoin import needs_test_with_all_chacha20_implementations
 
 
 class TestLNTransport(ElectrumTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
+
+    def tearDown(self):
+        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
+        self._loop_thread.join(timeout=1)
+        super().tearDown()
 
     @needs_test_with_all_chacha20_implementations
     def test_responder(self):
@@ -38,11 +48,11 @@ class TestLNTransport(ElectrumTestCase):
                     assert num_bytes == 66
                     return bytes.fromhex('00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba')
         transport = LNResponderTransport(ls_priv, Reader(), Writer())
-        asyncio.get_event_loop().run_until_complete(transport.handshake(epriv=e_priv))
+        asyncio.run_coroutine_threadsafe(
+            transport.handshake(epriv=e_priv), self.asyncio_loop).result()
 
     @needs_test_with_all_chacha20_implementations
     def test_loop(self):
-        loop = asyncio.get_event_loop()
         responder_shaked = asyncio.Event()
         server_shaked = asyncio.Event()
         responder_key = ECPrivkey.generate_random_key()
@@ -96,4 +106,4 @@ class TestLNTransport(ElectrumTestCase):
                 server.close()
                 await server.wait_closed()
 
-        loop.run_until_complete(f())
+        asyncio.run_coroutine_threadsafe(f(), self.asyncio_loop).result()

--- a/electrum/tests/test_network.py
+++ b/electrum/tests/test_network.py
@@ -55,14 +55,8 @@ class TestNetwork(ElectrumTestCase):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
         self.interface = MockInterface(self.config)
-
-    def tearDown(self):
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
-        super().tearDown()
 
     def test_fork_noconflict(self):
         blockchain.blockchains = {}

--- a/electrum/tests/test_storage_upgrade.py
+++ b/electrum/tests/test_storage_upgrade.py
@@ -20,12 +20,9 @@ class TestStorageUpgrade(WalletTestCase):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
 
     def tearDown(self):
         super().tearDown()
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
 
     def testnet_wallet(func):
         # note: it's ok to modify global network constants in subclasses of SequentialTestCase

--- a/electrum/tests/test_storage_upgrade.py
+++ b/electrum/tests/test_storage_upgrade.py
@@ -18,12 +18,6 @@ from .test_wallet import WalletTestCase
 # TODO hw wallet with client version 2.6.x (single-, and multiacc)
 class TestStorageUpgrade(WalletTestCase):
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def testnet_wallet(func):
         # note: it's ok to modify global network constants in subclasses of SequentialTestCase
         def wrapper(self, *args, **kwargs):

--- a/electrum/tests/test_wallet.py
+++ b/electrum/tests/test_wallet.py
@@ -35,7 +35,6 @@ class WalletTestCase(ElectrumTestCase):
 
     def setUp(self):
         super(WalletTestCase, self).setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.user_dir = tempfile.mkdtemp()
         self.config = SimpleConfig({'electrum_path': self.user_dir})
 
@@ -46,8 +45,6 @@ class WalletTestCase(ElectrumTestCase):
         sys.stdout = self._stdout_buffer
 
     def tearDown(self):
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
         super(WalletTestCase, self).tearDown()
         shutil.rmtree(self.user_dir)
         # Restore the "real" stdout

--- a/electrum/tests/test_wallet_vertical.py
+++ b/electrum/tests/test_wallet_vertical.py
@@ -14,7 +14,7 @@ from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCON
 from electrum.wallet import (sweep, Multisig_Wallet, Standard_Wallet, Imported_Wallet,
                              restore_wallet_from_text, Abstract_Wallet, BumpFeeStrategy)
 from electrum.util import (
-    bfh, bh2u, create_and_start_event_loop, NotEnoughFunds, UnrelatedTransactionException,
+    bfh, bh2u, NotEnoughFunds, UnrelatedTransactionException,
     UserFacingException)
 from electrum.transaction import (TxOutput, Transaction, PartialTransaction, PartialTxOutput,
                                   PartialTxInput, tx_from_any, TxOutpoint)
@@ -701,13 +701,7 @@ class TestWalletSending(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-
-    def tearDown(self):
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
-        super().tearDown()
 
     def create_standard_wallet_from_seed(self, seed_words, *, config=None, gap_limit=2):
         if config is None:
@@ -3271,13 +3265,7 @@ class TestWalletHistory_DoubleSpend(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
-        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-
-    def tearDown(self):
-        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
-        self._loop_thread.join(timeout=1)
-        super().tearDown()
 
     @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
     def test_restoring_wallet_without_manual_delete(self, mock_save_db):

--- a/electrum/tests/test_wallet_vertical.py
+++ b/electrum/tests/test_wallet_vertical.py
@@ -9,6 +9,7 @@ import copy
 from electrum import storage, bitcoin, keystore, bip32, slip39, wallet
 from electrum import Transaction
 from electrum import SimpleConfig
+from electrum import util
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCONF_PARENT
 from electrum.wallet import (sweep, Multisig_Wallet, Standard_Wallet, Imported_Wallet,
                              restore_wallet_from_text, Abstract_Wallet, BumpFeeStrategy)
@@ -18,6 +19,7 @@ from electrum.util import (
 from electrum.transaction import (TxOutput, Transaction, PartialTransaction, PartialTxOutput,
                                   PartialTxInput, tx_from_any, TxOutpoint)
 from electrum.mnemonic import seed_type
+from electrum.network import Network
 
 from electrum.plugins.trustedcoin import trustedcoin
 
@@ -699,7 +701,13 @@ class TestWalletSending(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
+        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
+
+    def tearDown(self):
+        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
+        self._loop_thread.join(timeout=1)
+        super().tearDown()
 
     def create_standard_wallet_from_seed(self, seed_words, *, config=None, gap_limit=2):
         if config is None:
@@ -1369,14 +1377,7 @@ class TestWalletSending(TestCaseForTestnet):
                     raise Exception("unexpected txid")
             def has_internet_connection(self):
                 return True
-            def run_from_another_thread(self, coro, *, timeout=None):
-                loop, stop_loop, loop_thread = create_and_start_event_loop()
-                fut = asyncio.run_coroutine_threadsafe(coro, loop)
-                try:
-                    return fut.result(timeout)
-                finally:
-                    loop.call_soon_threadsafe(stop_loop.set_result, 1)
-                    loop_thread.join(timeout=1)
+            run_from_another_thread = Network.run_from_another_thread
             def get_local_height(self):
                 return 0
             def blockchain(self):
@@ -1429,14 +1430,7 @@ class TestWalletSending(TestCaseForTestnet):
                     raise Exception("unexpected txid")
             def has_internet_connection(self):
                 return True
-            def run_from_another_thread(self, coro, *, timeout=None):
-                loop, stop_loop, loop_thread = create_and_start_event_loop()
-                fut = asyncio.run_coroutine_threadsafe(coro, loop)
-                try:
-                    return fut.result(timeout)
-                finally:
-                    loop.call_soon_threadsafe(stop_loop.set_result, 1)
-                    loop_thread.join(timeout=1)
+            run_from_another_thread = Network.run_from_another_thread
             def get_local_height(self):
                 return 0
             def blockchain(self):
@@ -1844,8 +1838,8 @@ class TestWalletSending(TestCaseForTestnet):
         network = NetworkMock()
         dest_addr = 'tb1q3ws2p0qjk5vrravv065xqlnkckvzcpclk79eu2'
         sweep_coro = sweep(privkeys, network=network, config=self.config, to_address=dest_addr, fee=5000, locktime=1325785, tx_version=1)
-        loop = asyncio.get_event_loop()
-        tx = loop.run_until_complete(sweep_coro)
+        loop = util.get_asyncio_loop()
+        tx = asyncio.run_coroutine_threadsafe(sweep_coro, loop).result()
 
         tx_copy = tx_from_any(tx.serialize())
         self.assertEqual('010000000129349e5641d79915e9d0282fdbaee8c3df0b6731bab9d70bf626e8588bde24ac010000004847304402206bf0d0a93abae0d5873a62ebf277a5dd2f33837821e8b93e74d04e19d71b578002201a6d729bc159941ef5c4c9e5fe13ece9fc544351ba531b00f68ba549c8b38a9a01fdffffff01b82e0f00000000001600148ba0a0bc12b51831f58c7ea8607e76c5982c071fd93a1400',
@@ -2199,14 +2193,7 @@ class TestWalletSending(TestCaseForTestnet):
                     raise Exception("unexpected txid")
             def has_internet_connection(self):
                 return True
-            def run_from_another_thread(self, coro, *, timeout=None):
-                loop, stop_loop, loop_thread = create_and_start_event_loop()
-                fut = asyncio.run_coroutine_threadsafe(coro, loop)
-                try:
-                    return fut.result(timeout)
-                finally:
-                    loop.call_soon_threadsafe(stop_loop.set_result, 1)
-                    loop_thread.join(timeout=1)
+            run_from_another_thread = Network.run_from_another_thread
             def get_local_height(self):
                 return 0
             def blockchain(self):
@@ -3284,7 +3271,13 @@ class TestWalletHistory_DoubleSpend(TestCaseForTestnet):
 
     def setUp(self):
         super().setUp()
+        self.asyncio_loop, self._stop_loop, self._loop_thread = util.create_and_start_event_loop()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
+
+    def tearDown(self):
+        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
+        self._loop_thread.join(timeout=1)
+        super().tearDown()
 
     @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
     def test_restoring_wallet_without_manual_delete(self, mock_save_db):


### PR DESCRIPTION
`asyncio.get_event_loop()` became deprecated in python3.10. (see https://github.com/python/cpython/issues/83710)
```
.../electrum/electrum/daemon.py:470: DeprecationWarning: There is no current event loop
  self.asyncio_loop = asyncio.get_event_loop()
.../electrum/electrum/network.py:276: DeprecationWarning: There is no current event loop
  self.asyncio_loop = asyncio.get_event_loop()
```
Also, according to that thread, "set_event_loop() [... is] not deprecated by oversight".
So, we stop using `get_event_loop()` and `set_event_loop()` in our own code.
Note that libraries we use (such as the stdlib for python <3.10), might call `get_event_loop`,
which then relies on us having called `set_event_loop` e.g. for the GUI thread. To work around
this, a custom event loop policy providing a `get_event_loop` implementation is used.

Previously, we have been using a single asyncio event loop, created with
`util.create_and_start_event_loop`, and code in many places got a reference to this loop
using `asyncio.get_event_loop()`.
Now, we still use a single asyncio event loop, but it is now stored as a global in
`util._asyncio_event_loop` (access with `util.get_asyncio_loop()`).

I believe these changes also fix https://github.com/spesmilo/electrum/issues/5376