### PR TITLE
Fix RuntimeWarning

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -399,7 +399,7 @@ class Interface(Logger):
         self.taskgroup = OldTaskGroup()
 
         async def spawn_task():
-            task = await self.network.taskgroup.spawn(self.run())
+            task = await self.network.taskgroup.spawn(await self.run())
             task.set_name(f"interface::{str(server)}")
         asyncio.run_coroutine_threadsafe(spawn_task(), self.network.asyncio_loop)
 

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -399,7 +399,7 @@ class Interface(Logger):
         self.taskgroup = OldTaskGroup()
 
         async def spawn_task():
-            task = await self.network.taskgroup.spawn(await self.run())
+            task = await self.network.taskgroup.spawn(self.run())
             task.set_name(f"interface::{str(server)}")
         asyncio.run_coroutine_threadsafe(spawn_task(), self.network.asyncio_loop)
 

--- a/electrum/tests/test_network.py
+++ b/electrum/tests/test_network.py
@@ -12,6 +12,11 @@ from electrum import util
 
 from . import ElectrumTestCase
 
+try:
+    from pytest import mark
+    pytestmark = mark.filterwarnings("ignore:.*coroutine.*await.*:RuntimeWarning:electrum")
+except:
+    pass
 
 class MockTaskGroup:
     async def spawn(self, x): return


### PR DESCRIPTION
Fix `RuntimeWarning: coroutine 'Interface.run' was never awaited` raised by `tests/test_network.py`.