### PR TITLE
Fix UI hang when selecting 'Ok' on change password window on a hardware wallet when no hardware is connected

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2553,6 +2553,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                 hw_dev_pw = self.wallet.keystore.get_password_for_storage_encryption()
             except UserCancelled:
                 return
+            except ValueError:
+                self.show_error('No hardware device detected')
+                return
             except BaseException as e:
                 self.logger.exception('')
                 self.show_error(repr(e))

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2554,7 +2554,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             except UserCancelled:
                 return
             except ValueError:
-                self.show_error('No hardware device detected')
+                self.show_error(_('No hardware device detected'))
                 return
             except BaseException as e:
                 self.logger.exception('')

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -841,7 +841,10 @@ class Hardware_KeyStore(Xpub, KeyStore):
         return False
 
     def get_password_for_storage_encryption(self) -> str:
-        client = self.plugin.get_client(self)
+        client = self.plugin.get_client(self, allow_user_interaction=False)
+        if client is None:
+            # Use a custom exception?
+            raise ValueError()
         return client.get_password_for_storage_encryption()
 
     def has_usable_connection_with_device(self) -> bool:


### PR DESCRIPTION
I specifically noticed this on my ledger device; pressing 'ok' when no ledger is connected leads to an infinite hang.

This pr puts the `get_client` method in no interaction mode which raises a failure when no devices are found and then raises a relevant pop up to the user.