### PR TITLE
lnpeer: async `maybe_send_commitment`

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -194,7 +194,7 @@ class Peer(Logger):
             self.pong_event.clear()
             await self.pong_event.wait()
 
-    def process_message(self, message):
+    async def process_message(self, message: bytes) -> None:
         try:
             message_type, payload = decode_msg(message)
         except UnknownOptionalMsgType as e:
@@ -226,9 +226,19 @@ class Peer(Logger):
             # raw message is needed to check signature
             if message_type in ['node_announcement', 'channel_announcement', 'channel_update']:
                 payload['raw'] = message
-            execution_result = f(*args)
+            # note: the message handler might be async or non-async. In either case, by default,
+            #       we wait for it to complete before we return, i.e. before the next message is processed.
             if asyncio.iscoroutinefunction(f):
-                asyncio.ensure_future(self.taskgroup.spawn(execution_result))
+                await f(*args)
+            else:
+                f(*args)
+
+    def runs_in_taskgroup(func):
+        assert asyncio.iscoroutinefunction(func), 'func needs to be a coroutine'
+        @functools.wraps(func)
+        async def wrapper(self: 'Peer', *args, **kwargs):
+            return await self.taskgroup.spawn(func(self, *args, **kwargs))
+        return wrapper
 
     def on_warning(self, payload):
         chan_id = payload.get("channel_id")
@@ -576,7 +586,7 @@ class Peer(Logger):
         except (OSError, asyncio.TimeoutError, HandshakeFailed) as e:
             raise GracefulDisconnect(f'initialize failed: {repr(e)}') from e
         async for msg in self.transport.read_messages():
-            self.process_message(msg)
+            await self.process_message(msg)
             if self.DELAY_INC_MSG_PROCESSING_SLEEP:
                 # rate-limit message-processing a bit, to make it harder
                 # for a single peer to bog down the event loop / cpu:
@@ -899,6 +909,7 @@ class Peer(Logger):
         }
         return StoredDict(chan_dict, self.lnworker.db if self.lnworker else None, [])
 
+    @runs_in_taskgroup
     async def on_open_channel(self, payload):
         """Implements the channel acceptance flow.
 
@@ -1912,6 +1923,7 @@ class Peer(Logger):
                 raise Exception('The remote peer did not send their final signature. The channel may not have been be closed')
         return txid
 
+    @runs_in_taskgroup
     async def on_shutdown(self, chan: Channel, payload):
         # TODO: A receiving node: if it hasn't received a funding_signed (if it is a
         #  funder) or a funding_created (if it is a fundee):

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1322,7 +1322,7 @@ class LNWallet(LNWorker):
         if not peer:
             raise PaymentFailure('Dropped peer')
         await peer.initialized
-        htlc = peer.pay(
+        htlc = await peer.pay(
             route=route,
             chan=chan,
             amount_msat=amount_msat,


### PR DESCRIPTION
this builds on top of https://github.com/spesmilo/electrum/pull/7835 (first commit is from there)

This is re https://github.com/spesmilo/electrum/commit/cc1b4a5c903ac82d20d8107f45d829d8d1270a80#commitcomment-74922012
>  - Await pong before sending commitment_signed (per BOLT-2)

We `await self.ping_if_required()` inside `maybe_send_commitment()`.
This needed making `maybe_send_commitment` async, which really quite snowballed o.O

Anyway, this is a separate PR from https://github.com/spesmilo/electrum/pull/7835, as that PR is useful in itself.