### PR TITLE
lnchannel: add new states: `WE_ARE_TOXIC`, `REQUESTED_FCLOSE`

### DIFF
--- a/electrum/gui/kivy/uix/dialogs/lightning_channels.py
+++ b/electrum/gui/kivy/uix/dialogs/lightning_channels.py
@@ -8,7 +8,7 @@ from kivy.uix.popup import Popup
 from electrum.util import bh2u
 from electrum.logging import Logger
 from electrum.lnutil import LOCAL, REMOTE, format_short_channel_id
-from electrum.lnchannel import AbstractChannel, Channel, ChannelState
+from electrum.lnchannel import AbstractChannel, Channel, ChannelState, ChanCloseOption
 from electrum.gui.kivy.i18n import _
 from electrum.transaction import PartialTxOutput, Transaction
 from electrum.util import NotEnoughFunds, NoDynamicFeeEstimates, format_fee_satoshis, quantize_feerate
@@ -495,8 +495,8 @@ class ChannelDetailsPopup(Popup, Logger):
         action_dropdown = self.ids.action_dropdown  # type: ActionDropdown
         options = [
             ActionButtonOption(text=_('Backup'), func=lambda btn: self.export_backup()),
-            ActionButtonOption(text=_('Close channel'), func=lambda btn: self.close(), enabled=not self.is_closed),
-            ActionButtonOption(text=_('Force-close'), func=lambda btn: self.force_close(), enabled=not self.is_closed),
+            ActionButtonOption(text=_('Close channel'), func=lambda btn: self.close(), enabled=ChanCloseOption.COOP_CLOSE in self.chan.get_close_options()),
+            ActionButtonOption(text=_('Force-close'), func=lambda btn: self.force_close(), enabled=ChanCloseOption.LOCAL_FCLOSE in self.chan.get_close_options()),
             ActionButtonOption(text=_('Delete'), func=lambda btn: self.remove_channel(), enabled=self.can_be_deleted),
         ]
         if not self.chan.is_closed():
@@ -557,7 +557,8 @@ class ChannelDetailsPopup(Popup, Logger):
         self.app.qr_dialog(_("Channel Backup " + self.chan.short_id_for_GUI()), text, help_text=help_text)
 
     def force_close(self):
-        if self.chan.is_closed():
+        if ChanCloseOption.LOCAL_FCLOSE not in self.chan.get_close_options():
+            # note: likely channel is already closed, or could be unsafe to do local force-close (e.g. we are toxic)
             self.app.show_error(_('Channel already closed'))
             return
         to_self_delay = self.chan.config[REMOTE].to_self_delay

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1049,7 +1049,8 @@ class Peer(Logger):
         chan.set_state(ChannelState.OPENING)
         self.lnworker.add_new_channel(chan)
 
-    async def trigger_force_close(self, channel_id: bytes):
+    async def request_force_close(self, channel_id: bytes):
+        """Try to trigger the remote peer to force-close."""
         await self.initialized
         # First, we intentionally send a "channel_reestablish" msg with an old state.
         # Many nodes (but not all) automatically force-close when seeing this.
@@ -1193,7 +1194,7 @@ class Peer(Logger):
         chan_id = chan.channel_id
         if chan.should_request_force_close:
             chan.set_state(ChannelState.REQUESTED_FCLOSE)
-            await self.trigger_force_close(chan_id)
+            await self.request_force_close(chan_id)
             chan.should_request_force_close = False
             return
         assert ChannelState.PREOPENING < chan.get_state() < ChannelState.FORCE_CLOSING

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -31,7 +31,7 @@ from .lnonion import (new_onion_packet, OnionFailureCode, calc_hops_data_for_pay
                       process_onion_packet, OnionPacket, construct_onion_error, OnionRoutingFailure,
                       ProcessedOnionPacket, UnsupportedOnionPacketVersion, InvalidOnionMac, InvalidOnionPubkey,
                       OnionFailureCodeMetaFlag)
-from .lnchannel import Channel, RevokeAndAck, RemoteCtnTooFarInFuture, ChannelState, PeerState
+from .lnchannel import Channel, RevokeAndAck, RemoteCtnTooFarInFuture, ChannelState, PeerState, ChanCloseOption
 from . import lnutil
 from .lnutil import (Outpoint, LocalConfig, RECEIVED, UpdateAddHtlc, ChannelConfig,
                      RemoteConfig, OnlyPubkeyKeypair, ChannelConstraints, RevocationStore,
@@ -1075,10 +1075,14 @@ class Peer(Logger):
         channels_with_peer.extend(self.temp_id_to_id.values())
         if channel_id not in channels_with_peer:
             raise ValueError(f"channel {channel_id.hex()} does not belong to this peer")
-        if channel_id in self.channels:
+        chan = self.channels.get(channel_id)
+        if not chan:
+            self.logger.warning(f"tried to force-close channel {channel_id.hex()} but it is not in self.channels yet")
+        if ChanCloseOption.LOCAL_FCLOSE in chan.get_close_options():
             self.lnworker.schedule_force_closing(channel_id)
         else:
-            self.logger.warning(f"tried to force-close channel {channel_id.hex()} but it is not in self.channels yet")
+            self.logger.info(f"tried to force-close channel {chan.get_id_for_log()} "
+                             f"but close option is not allowed. {chan.get_state()=!r}")
 
     def on_channel_reestablish(self, chan, msg):
         their_next_local_ctn = msg["next_commitment_number"]
@@ -1171,6 +1175,7 @@ class Peer(Logger):
                 f"remote is ahead of us! They should force-close. Remote PCP: {bh2u(their_local_pcp)}")
             # data_loss_protect_remote_pcp is used in lnsweep
             chan.set_data_loss_protect_remote_pcp(their_next_local_ctn - 1, their_local_pcp)
+            chan.set_state(ChannelState.WE_ARE_TOXIC)
             self.lnworker.save_channel(chan)
             chan.peer_state = PeerState.BAD
             # raise after we send channel_reestablish, so the remote can realize they are ahead
@@ -1187,6 +1192,7 @@ class Peer(Logger):
         await self.initialized
         chan_id = chan.channel_id
         if chan.should_request_force_close:
+            chan.set_state(ChannelState.REQUESTED_FCLOSE)
             await self.trigger_force_close(chan_id)
             chan.should_request_force_close = False
             return

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2440,7 +2440,7 @@ class LNWallet(LNWorker):
             peer.close_and_cleanup()
         elif connect_str:
             peer = await self.add_peer(connect_str)
-            await peer.trigger_force_close(channel_id)
+            await peer.request_force_close(channel_id)
         elif channel_id in self.channel_backups:
             await self._request_force_close_from_backup(channel_id)
         else:
@@ -2516,7 +2516,7 @@ class LNWallet(LNWorker):
             try:
                 async with OldTaskGroup(wait=any) as group:
                     await group.spawn(peer._message_loop())
-                    await group.spawn(peer.trigger_force_close(channel_id))
+                    await group.spawn(peer.request_force_close(channel_id))
                 return
             except Exception as e:
                 self.logger.info(f'failed to connect {host} {e}')


### PR DESCRIPTION
The `WE_ARE_TOXIC` state is added as a sanity check to ensure that if
the remote has proven that we have lost state we do not accidentally
do a local force-close. E.g. if we receive an "error" message for the
channel, we might normally do an automatic force-close. Manually
force-closing in such a state is not offered anymore by the GUI.

The `REQUESTED_FCLOSE` state is added as it is quite likely that
we receive an error message from the remote after requesting a fclose,
e.g. during a later chan-reestablish. In such a scenario, we should
not do an auto-local-fclose, however the manual option of a local-fclose
should still be offered.