### PR TITLE
EventListener class to handle callbacks

### DIFF
--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -17,7 +17,7 @@ from . import util
 from .bitcoin import COIN
 from .i18n import _
 from .util import (ThreadJob, make_dir, log_exceptions, OldTaskGroup,
-                   make_aiohttp_session, resource_path)
+                   make_aiohttp_session, resource_path, EventListener, event_listener)
 from .network import Network
 from .simple_config import SimpleConfig
 from .logging import Logger
@@ -496,13 +496,13 @@ def get_exchanges_by_ccy(history=True):
     return dictinvert(d)
 
 
-class FxThread(ThreadJob):
+class FxThread(ThreadJob, EventListener):
 
     def __init__(self, config: SimpleConfig, network: Optional[Network]):
         ThreadJob.__init__(self)
         self.config = config
         self.network = network
-        util.register_callback(self.set_proxy, ['proxy_set'])
+        self.register_callbacks()
         self.ccy = self.get_currency()
         self.history_used_spot = False
         self.ccy_combo = None
@@ -513,7 +513,8 @@ class FxThread(ThreadJob):
         self.set_exchange(self.config_exchange())
         make_dir(self.cache_dir)
 
-    def set_proxy(self, trigger_name, *args):
+    @event_listener
+    def on_event_proxy_set(self, *args):
         self._trigger.set()
 
     @staticmethod

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -102,9 +102,6 @@ class QElectrumApplication(QApplication):
     alias_received_signal = pyqtSignal()
 
 
-class QNetworkUpdatedSignalObject(QObject):
-    network_updated_signal = pyqtSignal(str, object)
-
 
 class ElectrumGui(BaseElectrumGui, Logger):
 
@@ -142,7 +139,6 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.network_dialog = None
         self.lightning_dialog = None
         self.watchtower_dialog = None
-        self.network_updated_signal_obj = QNetworkUpdatedSignalObject()
         self._num_wizards_in_progress = 0
         self._num_wizards_lock = threading.Lock()
         self.dark_icon = self.config.get("dark_icon", False)
@@ -251,7 +247,6 @@ class ElectrumGui(BaseElectrumGui, Logger):
             self.network_dialog.close()
             self.network_dialog.clean_up()
             self.network_dialog = None
-        self.network_updated_signal_obj = None
         if self.lightning_dialog:
             self.lightning_dialog.close()
             self.lightning_dialog = None
@@ -298,14 +293,13 @@ class ElectrumGui(BaseElectrumGui, Logger):
 
     def show_network_dialog(self):
         if self.network_dialog:
-            self.network_dialog.on_update()
+            self.network_dialog.on_event_network_updated()
             self.network_dialog.show()
             self.network_dialog.raise_()
             return
         self.network_dialog = NetworkDialog(
             network=self.daemon.network,
-            config=self.config,
-            network_updated_signal_obj=self.network_updated_signal_obj)
+            config=self.config)
         self.network_dialog.show()
 
     def _create_window_for_wallet(self, wallet):

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -193,12 +193,12 @@ def protected(func):
         return func(self, *args, **kwargs)
     return request_password
 
+from .util import QtEventListener, qt_event_listener, event_listener
 
-class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
+class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
     payment_request_ok_signal = pyqtSignal()
     payment_request_error_signal = pyqtSignal()
-    network_signal = pyqtSignal(str, object)
     #ln_payment_attempt_signal = pyqtSignal(str)
     computing_privkeys_signal = pyqtSignal()
     show_privkeys_signal = pyqtSignal()
@@ -208,7 +208,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
     def __init__(self, gui_object: 'ElectrumGui', wallet: Abstract_Wallet):
         QMainWindow.__init__(self)
-
         self.gui_object = gui_object
         self.config = config = gui_object.config  # type: SimpleConfig
         self.gui_thread = gui_object.gui_thread
@@ -314,21 +313,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.history_list.setFocus(True)
 
         # network callbacks
-        if self.network:
-            self.network_signal.connect(self.on_network_qt)
-            interests = ['wallet_updated', 'network_updated', 'blockchain_updated',
-                         'new_transaction', 'status',
-                         'banner', 'verified', 'fee', 'fee_histogram', 'on_quotes',
-                         'on_history', 'channel', 'channels_updated',
-                         'payment_failed', 'payment_succeeded',
-                         'invoice_status', 'request_status', 'ln_gossip_sync_progress',
-                         'cert_mismatch', 'gossip_db_loaded']
-            # To avoid leaking references to "self" that prevent the
-            # window from being GC-ed when closed, callbacks should be
-            # methods of this class only, and specifically not be
-            # partials, lambdas or methods of subobjects.  Hence...
-            util.register_callback(self.on_network, interests)
-            # set initial message
+        self.register_callbacks()
+        # banner may already be there
+        if self.network and self.network.banner:
             self.console.showMessage(self.network.banner)
 
         # update fee slider in case we missed the callback
@@ -463,74 +450,75 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                 pass  # see #4418
             self.show_error(repr(e))
 
-    def on_network(self, event, *args):
-        # Handle in GUI thread
-        self.network_signal.emit(event, args)
+    @event_listener
+    def on_event_wallet_updated(self, wallet):
+        if wallet == self.wallet:
+            self.need_update.set()
 
-    def on_network_qt(self, event, args=None):
-        # Handle a network message in the GUI thread
-        # note: all windows get events from all wallets!
-        if event == 'wallet_updated':
-            wallet = args[0]
-            if wallet == self.wallet:
-                self.need_update.set()
-        elif event == 'network_updated':
-            self.gui_object.network_updated_signal_obj.network_updated_signal \
-                .emit(event, args)
-            self.network_signal.emit('status', None)
-        elif event == 'blockchain_updated':
-            # to update number of confirmations in history
-            self.refresh_tabs()
-        elif event == 'new_transaction':
-            wallet, tx = args
-            if wallet == self.wallet:
-                self.tx_notification_queue.put(tx)
-        elif event == 'on_quotes':
-            self.on_fx_quotes()
-        elif event == 'on_history':
-            self.on_fx_history()
-        elif event == 'gossip_db_loaded':
-            self.channels_list.gossip_db_loaded.emit(*args)
-        elif event == 'channels_updated':
-            wallet = args[0]
-            if wallet == self.wallet:
-                self.channels_list.update_rows.emit(*args)
-        elif event == 'channel':
-            wallet = args[0]
-            if wallet == self.wallet:
-                self.channels_list.update_single_row.emit(*args)
-                self.update_status()
-        elif event == 'request_status':
-            self.on_request_status(*args)
-        elif event == 'invoice_status':
-            self.on_invoice_status(*args)
-        elif event == 'payment_succeeded':
-            # sent by lnworker, redundant with invoice_status
-            wallet = args[0]
-            if wallet == self.wallet:
-                self.on_payment_succeeded(*args)
-        elif event == 'payment_failed':
-            wallet = args[0]
-            if wallet == self.wallet:
-                self.on_payment_failed(*args)
-        elif event == 'status':
+    @event_listener
+    def on_event_new_transaction(self, wallet, tx):
+        if wallet == self.wallet:
+            self.tx_notification_queue.put(tx)
+
+    @qt_event_listener
+    def on_event_status(self):
+        self.update_status()
+
+    @qt_event_listener
+    def on_event_network_updated(self, *args):
+        self.update_status()
+
+    @qt_event_listener
+    def on_event_blockchain_updated(self, *args):
+        # update the number of confirmations in history
+        self.refresh_tabs()
+
+    @qt_event_listener
+    def on_event_on_quotes(self, *args):
+        self.on_fx_quotes()
+
+    @qt_event_listener
+    def on_event_on_history(self, *args):
+        self.on_fx_history()
+
+    @qt_event_listener
+    def on_event_gossip_db_loaded(self, *args):
+        self.channels_list.gossip_db_loaded.emit(*args)
+
+    @qt_event_listener
+    def on_event_channels_updated(self, *args):
+        wallet = args[0]
+        if wallet == self.wallet:
+            self.channels_list.update_rows.emit(*args)
+
+    @qt_event_listener
+    def on_event_channel(self, *args):
+        wallet = args[0]
+        if wallet == self.wallet:
+            self.channels_list.update_single_row.emit(*args)
             self.update_status()
-        elif event == 'banner':
-            self.console.showMessage(args[0])
-        elif event == 'verified':
-            wallet, tx_hash, tx_mined_status = args
-            if wallet == self.wallet:
-                self.history_model.update_tx_mined_status(tx_hash, tx_mined_status)
-        elif event == 'fee':
-            pass
-        elif event == 'fee_histogram':
-            self.history_model.on_fee_histogram()
-        elif event == 'ln_gossip_sync_progress':
-            self.update_lightning_icon()
-        elif event == 'cert_mismatch':
-            self.show_cert_mismatch_error()
-        else:
-            self.logger.info(f"unexpected network event: {event} {args}")
+
+    @qt_event_listener
+    def on_event_banner(self, *args):
+        self.console.showMessage(args[0])
+
+    @qt_event_listener
+    def on_event_verified(self, *args):
+        wallet, tx_hash, tx_mined_status = args
+        if wallet == self.wallet:
+            self.history_model.update_tx_mined_status(tx_hash, tx_mined_status)
+
+    @qt_event_listener
+    def on_event_fee_histogram(self, *args):
+        self.history_model.on_fee_histogram()
+
+    @qt_event_listener
+    def on_event_ln_gossip_sync_progress(self, *args):
+        self.update_lightning_icon()
+
+    @qt_event_listener
+    def on_event_cert_mismatch(self, *args):
+        self.show_cert_mismatch_error()
 
     def close_wallet(self):
         if self.wallet:
@@ -1821,7 +1809,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         d = SwapDialog(self, is_reverse=is_reverse, recv_amount_sat=recv_amount_sat, channels=channels)
         return d.run()
 
-    def on_request_status(self, wallet, key, status):
+    @qt_event_listener
+    def on_event_request_status(self, wallet, key, status):
         if wallet != self.wallet:
             return
         req = self.wallet.receive_requests.get(key)
@@ -1840,7 +1829,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         else:
             self.request_list.refresh_item(key)
 
-    def on_invoice_status(self, wallet, key):
+    @qt_event_listener
+    def on_event_invoice_status(self, wallet, key):
         if wallet != self.wallet:
             return
         invoice = self.wallet.get_invoice(key)
@@ -1852,12 +1842,19 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         else:
             self.invoice_list.refresh_item(key)
 
-    def on_payment_succeeded(self, wallet, key):
+    @qt_event_listener
+    def on_event_payment_succeeded(self, wallet, key):
+        # sent by lnworker, redundant with invoice_status
+        if wallet != self.wallet:
+            return
         description = self.wallet.get_label(key)
         self.notify(_('Payment sent') + '\n\n' + description)
         self.need_update.set()
 
-    def on_payment_failed(self, wallet, key, reason):
+    @qt_event_listener
+    def on_event_payment_failed(self, wallet, key, reason):
+        if wallet != self.wallet:
+            return
         invoice = self.wallet.get_invoice(key)
         if invoice and invoice.is_lightning() and invoice.get_address():
             if self.question(_('Payment failed') + '\n\n' + reason + '\n\n'+ 'Fallback to onchain payment?'):
@@ -3497,7 +3494,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.thread = None
         for fut in self._coroutines_scheduled.keys():
             fut.cancel()
-        util.unregister_callback(self.on_network)
+        self.unregister_callbacks()
         self.config.set_key("is_maximized", self.isMaximized())
         if not self.isMaximized():
             g = self.geometry()

--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -34,12 +34,12 @@ from PyQt5.QtWidgets import (QComboBox,  QTabWidget, QDialog,
 
 from electrum.i18n import _, languages
 from electrum import util, coinchooser, paymentrequest
-from electrum.util import base_units_list
+from electrum.util import base_units_list, event_listener
 
 from electrum.gui import messages
 
 from .util import (ColorScheme, WindowModalDialog, HelpLabel, Buttons,
-                   CloseButton)
+                   CloseButton, QtEventListener)
 
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from .main_window import ElectrumWindow
 
 
-class SettingsDialog(QDialog):
+class SettingsDialog(QDialog, QtEventListener):
 
     def __init__(self, window: 'ElectrumWindow', config: 'SimpleConfig'):
         QDialog.__init__(self)
@@ -60,7 +60,7 @@ class SettingsDialog(QDialog):
         self.fx = window.fx
         self.wallet = window.wallet
 
-        util.register_callback(self.on_network_callback, ['alias_received'])
+        self.register_callbacks()
         self.app.alias_received_signal.connect(self.set_alias_color)
 
         vbox = QVBoxLayout()
@@ -559,10 +559,10 @@ class SettingsDialog(QDialog):
         vbox.addStretch(1)
         vbox.addLayout(Buttons(CloseButton(self)))
         self.setLayout(vbox)
-        
-    def on_network_callback(self, cb):
-        if cb == 'alias_received':
-            self.app.alias_received_signal.emit()
+
+    @event_listener
+    def on_event_alias_received(self):
+        self.app.alias_received_signal.emit()
 
     def set_alias_color(self):
         if not self.config.get('alias'):

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (QPushButton, QLabel, QMessageBox, QHBoxLayout,
 
 from electrum.i18n import _, languages
 from electrum.util import FileImportFailed, FileExportFailed, make_aiohttp_session, resource_path
+from electrum.util import EventListener, event_listener
 from electrum.invoices import PR_UNPAID, PR_PAID, PR_EXPIRED, PR_INFLIGHT, PR_UNKNOWN, PR_FAILED, PR_ROUTING, PR_UNCONFIRMED
 from electrum.logging import Logger
 from electrum.qrreader import MissingQrDetectionLib
@@ -1503,8 +1504,6 @@ class VTabWidget(QtWidgets.QTabWidget):
         return super().resizeEvent(e)
 
 
-from electrum.util import EventListener, event_listener
-
 class QtEventListener(EventListener):
 
     qt_callback_signal = QtCore.pyqtSignal(tuple)
@@ -1523,8 +1522,7 @@ class QtEventListener(EventListener):
 
 # decorator for members of the QtEventListener class
 def qt_event_listener(func):
-    assert func.__name__.startswith('on_event_')
-    func._is_event_listener = True
+    func = event_listener(func)
     @wraps(func)
     def decorator(self, *args):
         self.qt_callback_signal.emit( (func,) + args)

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -9,7 +9,7 @@ from electrum import util
 from electrum import WalletStorage, Wallet
 from electrum.wallet import Abstract_Wallet
 from electrum.wallet_db import WalletDB
-from electrum.util import format_satoshis
+from electrum.util import format_satoshis, EventListener, event_listener
 from electrum.bitcoin import is_address, COIN
 from electrum.transaction import PartialTxOutput
 from electrum.network import TxBroadcastError, BestEffortRequestFailed
@@ -20,7 +20,7 @@ _ = lambda x:x  # i18n
 # written by rofl0r, with some bits stolen from the text gui (ncurses)
 
 
-class ElectrumGui(BaseElectrumGui):
+class ElectrumGui(BaseElectrumGui, EventListener):
 
     def __init__(self, *, config, daemon, plugins):
         BaseElectrumGui.__init__(self, config=config, daemon=daemon, plugins=plugins)
@@ -47,7 +47,7 @@ class ElectrumGui(BaseElectrumGui):
         self.wallet.start_network(self.network)
         self.contacts = self.wallet.contacts
 
-        util.register_callback(self.on_network, ['wallet_updated', 'network_updated', 'banner'])
+        self.register_callbacks()
         self.commands = [_("[h] - displays this help text"), \
                          _("[i] - display transaction history"), \
                          _("[o] - enter payment order"), \
@@ -59,11 +59,17 @@ class ElectrumGui(BaseElectrumGui):
                          _("[q] - quit")]
         self.num_commands = len(self.commands)
 
-    def on_network(self, event, *args):
-        if event in ['wallet_updated', 'network_updated']:
-            self.updated()
-        elif event == 'banner':
-            self.print_banner()
+    @event_listener
+    def on_event_wallet_updated(self, wallet):
+        self.updated()
+
+    @event_listener
+    def on_event_network_updated(self):
+        self.updated()
+
+    @event_listener
+    def on_event_banner(self):
+        self.print_banner()
 
     def main_command(self):
         self.print_balance()

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -12,6 +12,7 @@ import electrum
 from electrum.gui import BaseElectrumGui
 from electrum import util
 from electrum.util import format_satoshis
+from electrum.util import EventListener, event_listener
 from electrum.bitcoin import is_address, COIN
 from electrum.transaction import PartialTxOutput
 from electrum.wallet import Wallet, Abstract_Wallet
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 _ = lambda x:x  # i18n
 
 
-class ElectrumGui(BaseElectrumGui):
+class ElectrumGui(BaseElectrumGui, EventListener):
 
     def __init__(self, *, config: 'SimpleConfig', daemon: 'Daemon', plugins: 'Plugins'):
         BaseElectrumGui.__init__(self, config=config, daemon=daemon, plugins=plugins)
@@ -74,11 +75,19 @@ class ElectrumGui(BaseElectrumGui):
         self.history = None
         self.txid = []
 
-        util.register_callback(self.update, ['wallet_updated', 'network_updated'])
+        self.register_callbacks()
 
         self.tab_names = [_("History"), _("Send"), _("Receive"), _("Addresses"), _("Contacts"), _("Banner")]
         self.num_tabs = len(self.tab_names)
 
+
+    @event_listener
+    def on_event_wallet_updated(self, wallet):
+        self.update()
+
+    @event_listener
+    def on_event_network_updated(self):
+        self.update()
 
     def set_cursor(self, x):
         try:
@@ -101,7 +110,7 @@ class ElectrumGui(BaseElectrumGui):
         self.set_cursor(0)
         return s
 
-    def update(self, event, *args):
+    def update(self):
         self.update_history()
         if self.tab == 0:
             self.print_history()

--- a/electrum/tests/test_lnpeer.py
+++ b/electrum/tests/test_lnpeer.py
@@ -22,7 +22,7 @@ from electrum.ecc import ECPrivkey
 from electrum import simple_config, lnutil
 from electrum.lnaddr import lnencode, LnAddr, lndecode
 from electrum.bitcoin import COIN, sha256
-from electrum.util import bh2u, NetworkRetryManager, bfh, OldTaskGroup
+from electrum.util import bh2u, NetworkRetryManager, bfh, OldTaskGroup, EventListener
 from electrum.lnpeer import Peer
 from electrum.lnutil import LNPeerAddr, Keypair, privkey_to_pubkey
 from electrum.lnutil import PaymentFailure, LnFeatures, HTLCOwner
@@ -124,7 +124,7 @@ class MockWallet:
         return True
 
 
-class MockLNWallet(Logger, NetworkRetryManager[LNPeerAddr]):
+class MockLNWallet(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
     MPP_EXPIRY = 2  # HTLC timestamps are cast to int, so this cannot be 1
     PAYMENT_TIMEOUT = 120
     TIMEOUT_SHUTDOWN_FAIL_PENDING_HTLCS = 0
@@ -255,7 +255,7 @@ class MockLNWallet(Logger, NetworkRetryManager[LNPeerAddr]):
     handle_error_code_from_failed_htlc = LNWallet.handle_error_code_from_failed_htlc
     is_trampoline_peer = LNWallet.is_trampoline_peer
     wait_for_received_pending_htlcs_to_get_removed = LNWallet.wait_for_received_pending_htlcs_to_get_removed
-    on_proxy_changed = LNWallet.on_proxy_changed
+    #on_event_proxy_set = LNWallet.on_event_proxy_set
     _decode_channel_update_msg = LNWallet._decode_channel_update_msg
     _handle_chanupd_from_failed_htlc = LNWallet._handle_chanupd_from_failed_htlc
     _on_maybe_forwarded_htlc_resolved = LNWallet._on_maybe_forwarded_htlc_resolved

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1594,10 +1594,10 @@ class CallbackManager:
         self.callbacks = defaultdict(list)      # note: needs self.callback_lock
         self.asyncio_loop = None
 
-    def register_callback(self, callback, events):
+    def register_callback(self, func, events):
         with self.callback_lock:
             for event in events:
-                self.callbacks[event].append(callback)
+                self.callbacks[event].append(func)
 
     def unregister_callback(self, callback):
         with self.callback_lock:
@@ -1618,19 +1618,51 @@ class CallbackManager:
         for callback in callbacks:
             # FIXME: if callback throws, we will lose the traceback
             if asyncio.iscoroutinefunction(callback):
-                asyncio.run_coroutine_threadsafe(callback(event, *args), self.asyncio_loop)
+                asyncio.run_coroutine_threadsafe(callback(*args), self.asyncio_loop)
             elif get_running_loop() == self.asyncio_loop:
                 # run callback immediately, so that it is guaranteed
                 # to have been executed when this method returns
-                callback(event, *args)
+                callback(*args)
             else:
-                self.asyncio_loop.call_soon_threadsafe(callback, event, *args)
+                self.asyncio_loop.call_soon_threadsafe(callback, *args)
 
 
 callback_mgr = CallbackManager()
 trigger_callback = callback_mgr.trigger_callback
 register_callback = callback_mgr.register_callback
 unregister_callback = callback_mgr.unregister_callback
+
+
+
+class EventListener:
+
+    def _list_callbacks(self):
+        for method_name in dir(self):
+            # Fixme: getattr executes the code of methods decorated by @property.
+            # This if why we shield with startswith
+            if not method_name.startswith('on_event_'):
+                continue
+            method = getattr(self, method_name)
+            if not getattr(method, '_is_event_listener', False):
+                continue
+            assert callable(method)
+            yield method_name[len('on_event_'):], method
+
+    def register_callbacks(self):
+        for name, method in self._list_callbacks():
+             _logger.info(f'registering callback {method}')
+             register_callback(method, [name])
+
+    def unregister_callbacks(self):
+        for name, method in self._list_callbacks():
+            _logger.info(f'unregistering callback {method}')
+            unregister_callback(method)
+
+
+def event_listener(func):
+    assert func.__name__.startswith('on_event_')
+    func._is_event_listener = True
+    return func
 
 
 _NetAddrType = TypeVar("_NetAddrType")

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1633,7 +1633,6 @@ register_callback = callback_mgr.register_callback
 unregister_callback = callback_mgr.unregister_callback
 
 
-
 class EventListener:
 
     def _list_callbacks(self):
@@ -1650,8 +1649,8 @@ class EventListener:
 
     def register_callbacks(self):
         for name, method in self._list_callbacks():
-             _logger.info(f'registering callback {method}')
-             register_callback(method, [name])
+            _logger.info(f'registering callback {method}')
+            register_callback(method, [name])
 
     def unregister_callbacks(self):
         for name, method in self._list_callbacks():


### PR DESCRIPTION
This is a refactoring of callbacks in `util.py.` Event listeners must be methods of the EventListener class, and named `'on_event_' + event_name`

It is still a draft, a few things need to be decided:
1. We could add a `@event_listener` decorator to all event listeners, that does nothing but asserts their name starts with `on_event_`, for pedagogic purposes.
2. Alternatively, we could allow arbitrary names, and add a decorator that takes the event's name as parameter.
3. We could try to add a filtering option to the decorator (to avoid starting methods with `if self.wallet != wallet: return`). Not sure if it can be done in a way that removes the current quadratic complexity ("everyone listens to everyone")
4. I am not sure to understand how `QNetworkUpdatedSignalObject` worked before this commit. I might have broken something there.