### PR TITLE
update trampoline feature bits. fixes #7801

### DIFF
--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1090,11 +1090,26 @@ class LnFeatures(IntFlag):
     _ln_feature_contexts[OPTION_SUPPORT_LARGE_CHANNEL_OPT] = (LNFC.INIT | LNFC.NODE_ANN)
     _ln_feature_contexts[OPTION_SUPPORT_LARGE_CHANNEL_REQ] = (LNFC.INIT | LNFC.NODE_ANN)
 
-    OPTION_TRAMPOLINE_ROUTING_REQ = 1 << 24
-    OPTION_TRAMPOLINE_ROUTING_OPT = 1 << 25
+    # This is still a temporary number. Also used by Eclair.
+    OPTION_TRAMPOLINE_ROUTING_REQ = 1 << 148
+    OPTION_TRAMPOLINE_ROUTING_OPT = 1 << 149
 
     _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_REQ] = (LNFC.INIT | LNFC.NODE_ANN | LNFC.INVOICE)
     _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_OPT] = (LNFC.INIT | LNFC.NODE_ANN | LNFC.INVOICE)
+
+    # allow old Electrum wallets to pay us with trampoline
+    OPTION_TRAMPOLINE_ROUTING_REQ_COMPAT_ELECTRUM = 1 << 24
+    OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ELECTRUM = 1 << 25
+
+    _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_REQ_COMPAT_ELECTRUM] = (LNFC.INVOICE)
+    _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ELECTRUM] = (LNFC.INVOICE)
+
+    # allow old Phoenix wallets to pay us with trampoline
+    OPTION_TRAMPOLINE_ROUTING_REQ_COMPAT_ECLAIR = 1 << 50
+    OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ECLAIR = 1 << 51
+
+    _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_REQ_COMPAT_ECLAIR] = (LNFC.INVOICE)
+    _ln_feature_contexts[OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ECLAIR] = (LNFC.INVOICE)
 
     OPTION_SHUTDOWN_ANYSEGWIT_REQ = 1 << 26
     OPTION_SHUTDOWN_ANYSEGWIT_OPT = 1 << 27
@@ -1107,10 +1122,6 @@ class LnFeatures(IntFlag):
 
     _ln_feature_contexts[OPTION_CHANNEL_TYPE_REQ] = (LNFC.INIT | LNFC.NODE_ANN)
     _ln_feature_contexts[OPTION_CHANNEL_TYPE_OPT] = (LNFC.INIT | LNFC.NODE_ANN)
-
-    # temporary
-    OPTION_TRAMPOLINE_ROUTING_REQ_ECLAIR = 1 << 50
-    OPTION_TRAMPOLINE_ROUTING_OPT_ECLAIR = 1 << 51
 
     def validate_transitive_dependencies(self) -> bool:
         # for all even bit set, set corresponding odd bit:

--- a/electrum/trampoline.py
+++ b/electrum/trampoline.py
@@ -106,10 +106,11 @@ def is_legacy_relay(invoice_features, r_tags) -> Tuple[bool, Optional[bytes]]:
     """
     invoice_features = LnFeatures(invoice_features)
     # trampoline-supporting wallets:
-    # OPTION_TRAMPOLINE_ROUTING_OPT_ECLAIR: these are Phoenix/Eclair wallets
-    # OPTION_TRAMPOLINE_ROUTING_OPT: these are Electrum wallets
+    # OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ECLAIR: old Phoenix/Eclair wallets
+    # OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ELECTRUM: old Electrum wallets
     if (invoice_features.supports(LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT)
-            or invoice_features.supports(LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT_ECLAIR)):
+        or invoice_features.supports(LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ECLAIR)
+        or invoice_features.supports(LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT_COMPAT_ELECTRUM)):
         # If there are no r_tags (routing hints) included, the wallet doesn't have
         # private channels and is probably directly connected to a trampoline node.
         # Any trampoline node should be able to figure out a path to the receiver and


### PR DESCRIPTION
This PR uses the same temporary bits as Eclair (148/149).

The reason why we did not use the same bits as Eclair last time (50/51) was to prevent ACINQ attempting pay-to-open with Electrum clients. I suppose it is fine now.