### PR TITLE
Update windows and appimage

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update -q && \
         libtool=2.4.6-2 \
         autopoint=0.19.8.1-6ubuntu0.3 \
         xz-utils=5.2.2-1.3 \
-        libssl-dev=1.1.1-1ubuntu2.1~18.04.19 \
-        libssl1.1=1.1.1-1ubuntu2.1~18.04.19 \
-        openssl=1.1.1-1ubuntu2.1~18.04.19 \
+        libssl-dev=1.1.1-1ubuntu2.1~18.04.20 \
+        libssl1.1=1.1.1-1ubuntu2.1~18.04.20 \
+        openssl=1.1.1-1ubuntu2.1~18.04.20 \
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libffi-dev=3.2.1-8 \
         libncurses5-dev=6.1-1ubuntu1.18.04 \

--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -7,8 +7,8 @@ RUN dpkg --add-architecture i386 && \
     apt-get update -q && \
     apt-get install -qy \
         wget=1.20.3-1ubuntu1 \
-        gnupg2=2.2.19-3ubuntu2.1 \
-        dirmngr=2.2.19-3ubuntu2.1 \
+        gnupg2=2.2.19-3ubuntu2.2 \
+        dirmngr=2.2.19-3ubuntu2.2 \
         python3-software-properties=0.98.9.2 \
         software-properties-common=0.98.9.2 \
         && \


### PR DESCRIPTION
appimage: update libssl-dev libssl1.1 openssl
https://launchpad.net/ubuntu/+source/openssl/1.1.1-1ubuntu2.1~18.04.20

Windows image: update gnupg2 dirmngr
https://packages.ubuntu.com/en/focal-updates/utils/dirmngr
https://packages.ubuntu.com/en/focal-updates/gnupg2