### PR TITLE
Qt receive_tab: fix receive_tabs widget on macOS

### DIFF
--- a/electrum/gui/qt/receive_tab.py
+++ b/electrum/gui/qt/receive_tab.py
@@ -155,7 +155,7 @@ class ReceiveTab(QWidget, MessageBoxMixin, Logger):
 
         from .util import VTabWidget
         self.receive_tabs = VTabWidget()
-        self.receive_tabs.setMinimumHeight(ReceiveTabWidget.min_size.height() + 4) # for margins
+        #self.receive_tabs.setMinimumHeight(ReceiveTabWidget.min_size.height() + 4) # for margins
         self.receive_tabs.addTab(self.receive_URI_widget, read_QIcon("link.png"), _('URI'))
         self.receive_tabs.addTab(self.receive_address_widget, read_QIcon("bitcoin.png"), _('Address'))
         self.receive_tabs.addTab(self.receive_lightning_widget, read_QIcon("lightning.png"), _('Lightning'))
@@ -392,7 +392,7 @@ class ReceiveTab(QWidget, MessageBoxMixin, Logger):
 class ReceiveTabWidget(QWidget):
     min_size = QSize(200, 200)
 
-    def __init__(self, receive_tab: 'ReceiveTab', textedit, qr, help_widget):
+    def __init__(self, receive_tab: 'ReceiveTab', textedit: QWidget, qr: QWidget, help_widget: QWidget):
         self.textedit = textedit
         self.qr = qr
         self.help_widget = help_widget


### PR DESCRIPTION
QTabWidget with "West" tab pos and horizontal text looks completely broken on macOS
(despite looking good on e.g. Ubuntu GNOME and Windows).

The alternative here looks ok on all three OSes.

Instead of using QTabWidget with "west" tabs, and hacking the tab text to be horizontal;
this is using QTabWidget with default "north" tabs, but with the north tabs hidden and instead with our own vertical-box of push-buttons added on the left. 

fixes https://github.com/spesmilo/electrum/issues/7908

-----

<details>
 <summary>macOS pics</summary>

![Capture](https://user-images.githubusercontent.com/29142493/181862893-37d02593-dbaa-4ae0-9e5f-8779c4e8bc5b.PNG)
![Capture2](https://user-images.githubusercontent.com/29142493/181862895-584e5acd-c4ba-4cab-ae5f-94d97710eeaa.PNG)
![Capture](https://user-images.githubusercontent.com/29142493/181862897-7ee81c26-4962-4b54-9e06-b67c2a4f3bb0.PNG)
![Capture2](https://user-images.githubusercontent.com/29142493/181862898-ee71d3e1-46ee-47c4-894a-e169a5b0abd9.PNG)
</details>

<details>
 <summary>Ubuntu GNOME pics</summary>

![Capture](https://user-images.githubusercontent.com/29142493/181862945-64555acf-d1f9-4303-8e76-1013b1b9527a.PNG)
![Capture2](https://user-images.githubusercontent.com/29142493/181862948-e346f93a-ed04-4f9e-8c0d-4ff516dcf7a1.PNG)
![Capture](https://user-images.githubusercontent.com/29142493/181862954-82055bfe-7599-42ef-a3b1-9959ae92953e.PNG)
![Capture2](https://user-images.githubusercontent.com/29142493/181862957-b98d3ba2-ca3f-4fc5-a3c5-b49f13fa386c.PNG)
</details>

<details>
 <summary>Windows pics</summary>

![Capture](https://user-images.githubusercontent.com/29142493/181862965-208594f4-6a33-48cc-af19-8eed86b003d5.PNG)
![Capture2](https://user-images.githubusercontent.com/29142493/181862968-468a30e7-c8e9-478d-b2c0-f054c316db27.PNG)
![Capture2](https://user-images.githubusercontent.com/29142493/181862970-a980f236-c379-4fa3-8721-149edae19c8f.PNG)
![Capture](https://user-images.githubusercontent.com/29142493/181862972-697303c4-3bd6-4d5a-bb0b-4b8790df5541.PNG)
</details>


