### PR TITLE
wallet: add get_label_for_address, and make get_label private

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -836,7 +836,7 @@ class Commands:
             if balance:
                 item += (format_satoshis(sum(wallet.get_addr_balance(addr))),)
             if labels:
-                item += (repr(wallet.get_label(addr)),)
+                item += (repr(wallet.get_label_for_address(addr)),)
             out.append(item)
         return out
 

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -304,7 +304,7 @@ class ElectrumWindow(App, Logger, EventListener):
     def on_event_payment_succeeded(self, wallet, key):
         if wallet != self.wallet:
             return
-        description = self.wallet.get_label(key)
+        description = self.wallet.get_label_for_rhash(key)
         self.show_info(_('Payment succeeded') + '\n\n' + description)
         self._trigger_update_history()
 

--- a/electrum/gui/kivy/uix/dialogs/addresses.py
+++ b/electrum/gui/kivy/uix/dialogs/addresses.py
@@ -262,7 +262,7 @@ class AddressesDialog(Factory.Popup):
         n = 0
         cards = []
         for address in _list:
-            label = wallet.get_label(address)
+            label = wallet.get_label_for_address(address)
             balance = sum(wallet.get_addr_balance(address))
             is_used_and_empty = wallet.adb.is_used(address) and balance == 0
             if self.show_used == 1 and (balance or is_used_and_empty):

--- a/electrum/gui/qml/qeaddressdetails.py
+++ b/electrum/gui/qml/qeaddressdetails.py
@@ -117,7 +117,7 @@ class QEAddressDetails(QObject):
         self.frozenChanged.emit()
 
         self._scriptType = self._wallet.wallet.get_txin_type(self._address)
-        self._label = self._wallet.wallet.get_label(self._address)
+        self._label = self._wallet.wallet.get_label_for_address(self._address)
         c, u, x = self._wallet.wallet.get_addr_balance(self._address)
         self._balance = QEAmount(amount_sat=c + u + x)
         self._pubkeys = self._wallet.wallet.get_public_keys(self._address)

--- a/electrum/gui/qml/qeaddresslistmodel.py
+++ b/electrum/gui/qml/qeaddresslistmodel.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from PyQt5.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 from PyQt5.QtCore import Qt, QAbstractListModel, QModelIndex
 
@@ -6,8 +8,12 @@ from electrum.util import Satoshis
 
 from .qetypes import QEAmount
 
+if TYPE_CHECKING:
+    from electrum.wallet import Abstract_Wallet
+
+
 class QEAddressListModel(QAbstractListModel):
-    def __init__(self, wallet, parent=None):
+    def __init__(self, wallet: 'Abstract_Wallet', parent=None):
         super().__init__(parent)
         self.wallet = wallet
         self.init_model()
@@ -48,7 +54,7 @@ class QEAddressListModel(QAbstractListModel):
         item = {}
         item['address'] = address
         item['numtx'] = self.wallet.adb.get_address_history_len(address)
-        item['label'] = self.wallet.get_label(address)
+        item['label'] = self.wallet.get_label_for_address(address)
         c, u, x = self.wallet.get_addr_balance(address)
         item['balance'] = QEAmount(amount_sat=c + u + x)
         item['held'] = self.wallet.is_frozen_address(address)

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -2,7 +2,7 @@ import asyncio
 import queue
 import threading
 import time
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject, QTimer
 
@@ -21,6 +21,10 @@ from .qeinvoicelistmodel import QEInvoiceListModel, QERequestListModel
 from .qetransactionlistmodel import QETransactionListModel
 from .qetypes import QEAmount
 from .util import QtEventListener, qt_event_listener
+
+if TYPE_CHECKING:
+    from electrum.wallet import Abstract_Wallet
+
 
 class QEWallet(AuthMixin, QObject, QtEventListener):
     __instances = []
@@ -62,7 +66,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     _synchronizing = False
     _synchronizing_progress = ''
 
-    def __init__(self, wallet, parent=None):
+    def __init__(self, wallet: 'Abstract_Wallet', parent=None):
         super().__init__(parent)
         self.wallet = wallet
 

--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -217,7 +217,7 @@ class AddressList(MyTreeView):
     def refresh_row(self, key, row):
         assert row is not None
         address = key
-        label = self.wallet.get_label(address)
+        label = self.wallet.get_label_for_address(address)
         num = self.wallet.adb.get_address_history_len(address)
         c, u, x = self.wallet.get_addr_balance(address)
         balance = c + u + x

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1169,7 +1169,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         # sent by lnworker, redundant with invoice_status
         if wallet != self.wallet:
             return
-        description = self.wallet.get_label(key)
+        description = self.wallet.get_label_for_rhash(key)
         self.notify(_('Payment sent') + '\n\n' + description)
         self.need_update.set()
 

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -118,7 +118,7 @@ class UTXOList(MyTreeView):
         utxo = self._utxo_dict[key]
         utxo_item = [self.std_model.item(row, col) for col in self.Columns]
         address = utxo.address
-        label = self.wallet.get_label_for_txid(utxo.prevout.txid.hex()) or self.wallet.get_label(address)
+        label = self.wallet.get_label_for_txid(utxo.prevout.txid.hex()) or self.wallet.get_label_for_address(address)
         utxo_item[self.Columns.LABEL].setText(label)
         SELECTED_TO_SPEND_TOOLTIP = _('Coin selected to be spent')
         if key in (self._spend_set or set()):

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -146,7 +146,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         self.print_list(messages, "%19s  %25s "%("Key", "Value"))
 
     def print_addresses(self):
-        messages = map(lambda addr: "%30s    %30s       "%(addr, self.wallet.get_label(addr)), self.wallet.get_addresses())
+        messages = map(lambda addr: "%30s    %30s       "%(addr, self.wallet.get_label_for_address(addr)), self.wallet.get_addresses())
         self.print_list(messages, "%19s  %25s "%("Address", "Label"))
 
     def print_order(self):

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -310,7 +310,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         fmt = self.format_column_width(x, [-50, '*', 15])
         messages = [ fmt % (
             addr,
-            self.wallet.get_label(addr),
+            self.wallet.get_label_for_address(addr),
             self.config.format_amount(sum(self.wallet.get_addr_balance(addr)), whitespaces=True)
         ) for addr in self.wallet.get_addresses() ]
         self.print_list(2, x, messages, fmt % ("Address", "Description", "Balance"))
@@ -321,7 +321,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         utxos = self.wallet.get_utxos()
         messages = [ fmt % (
             utxo.prevout.to_str(),
-            self.wallet.get_label(utxo.prevout.txid.hex()),
+            self.wallet.get_label_for_txid(utxo.prevout.txid.hex()),
             self.config.format_amount(utxo.value_sats(), whitespaces=True)
         ) for utxo in utxos]
         self.print_list(2, x, sorted(messages), fmt % ("Outpoint", "Description", "Balance"))

--- a/electrum/plugins/labels/labels.py
+++ b/electrum/plugins/labels/labels.py
@@ -154,7 +154,7 @@ class LabelsPlugin(BasePlugin):
                 result[key] = value
 
         for key, value in result.items():
-            if force or not wallet.get_label(key):
+            if force or not wallet._get_label(key):
                 wallet._set_label(key, value)
 
         self.logger.info(f"received {len(response)} labels")


### PR DESCRIPTION
fixes https://github.com/spesmilo/electrum/issues/7919

In the past, when creating payment requests, we keyed them by on-chain address,
and set/saved the msg of the request as label for the address.
Many places in the code were calling `wallet.get_label(addr)` with the expectation that
relevant payment requests are found and their message/description (if any) is considered.

`wallet.get_label(key)` is now made private, and instead the explicit non-polymorphic
`wallet.get_label_for_{address,rhash,txid}` alternatives should be used.