### PR TITLE
Add `tx_hashes` to exported payment requests

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2414,7 +2414,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             # if request was paid onchain, add relevant fields
             # note: addr is reused when getting paid on LN! so we check for that.
             is_paid, conf, tx_hashes = self._is_onchain_invoice_paid(x)
-            if is_paid and self.lnworker.get_invoice_status(x) != PR_PAID:
+            if is_paid and (not self.lnworker or self.lnworker.get_invoice_status(x) != PR_PAID):
                 if conf is not None:
                     d['confirmations'] = conf
                 d['tx_hashes'] = tx_hashes

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2408,13 +2408,16 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             if self.lnworker and status == PR_UNPAID:
                 d['can_receive'] = self.lnworker.can_receive_invoice(x)
         if address:
-            paid, conf, tx_hashes = self._is_onchain_invoice_paid(x)
-            d["tx_hashes"] = tx_hashes
             d['amount_sat'] = int(x.get_amount_sat())
             d['address'] = address
             d['URI'] = self.get_request_URI(x)
-            if conf is not None:
-                d['confirmations'] = conf
+            # if request was paid onchain, add relevant fields
+            # note: addr is reused when getting paid on LN! so we check for that.
+            is_paid, conf, tx_hashes = self._is_onchain_invoice_paid(x)
+            if is_paid and self.lnworker.get_invoice_status(x) != PR_PAID:
+                if conf is not None:
+                    d['confirmations'] = conf
+                d['tx_hashes'] = tx_hashes
         run_hook('wallet_export_request', d, key)
         return d
 

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2399,6 +2399,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             'status': status,
             'status_str': status_str,
             'request_id': key,
+            "tx_hashes": []
         }
         if is_lightning:
             d['rhash'] = x.rhash
@@ -2407,7 +2408,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             if self.lnworker and status == PR_UNPAID:
                 d['can_receive'] = self.lnworker.can_receive_invoice(x)
         if address:
-            paid, conf = self.is_onchain_invoice_paid(x)
+            paid, conf, tx_hashes = self._is_onchain_invoice_paid(x)
+            d["tx_hashes"] = tx_hashes
             d['amount_sat'] = int(x.get_amount_sat())
             d['address'] = address
             d['URI'] = self.get_request_URI(x)


### PR DESCRIPTION
This pull request adds a new field, `tx_hashes` to payment requests output

This is useful to know which transactions were used to pay an invoice.

It should work as it relies on existing logic, the only question is: are payments via lightning network to be included here too somehow?

P.S. Failing LN tests in CI are obviously flaky and not caused by this PR