### PR TITLE
lnwatcher: don't add `REDEEMED` channels

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -758,9 +758,11 @@ class LNWallet(LNWorker):
         self.lnrater = LNRater(self, network)
 
         for chan in self.channels.values():
-            self.lnwatcher.add_channel(chan.funding_outpoint.to_str(), chan.get_funding_address())
+            if not chan.is_redeemed():
+                self.lnwatcher.add_channel(chan.funding_outpoint.to_str(), chan.get_funding_address())
         for cb in self.channel_backups.values():
-            self.lnwatcher.add_channel(cb.funding_outpoint.to_str(), cb.get_funding_address())
+            if not cb.is_redeemed():
+                self.lnwatcher.add_channel(cb.funding_outpoint.to_str(), cb.get_funding_address())
 
         for coro in [
                 self.maybe_listen(),


### PR DESCRIPTION
Previously lnworker called LNWatcher.add_channel() on these, and then LNWatcher itself decided to unwatch them.

-----

note: motivation related to https://github.com/spesmilo/electrum/pull/7932#discussion_r945755584 ,
where I have legacy (pre-staticremotekey) redeemed channels in a wallet.