### PR TITLE
 Revert "wine build: build win-iconv-mingw, instead of using debian sid"

### DIFF
--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -24,12 +24,12 @@ RUN dpkg --add-architecture i386 && \
         make \
         mingw-w64 \
         mingw-w64-tools \
+        win-iconv-mingw-w64-dev \
         autotools-dev \
         autoconf \
         autopoint \
         libtool \
         gettext \
-        sudo \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-wine/apt.preferences
+++ b/contrib/build-wine/apt.preferences
@@ -1,3 +1,7 @@
 Package: *
-Pin: origin "snapshot.debian.org"
+Pin: release n=bullseye
+Pin-Priority: 1001
+
+Package: win-iconv-mingw-w64-dev
+Pin: release a=unstable
 Pin-Priority: 1001

--- a/contrib/build-wine/apt.sources.list
+++ b/contrib/build-wine/apt.sources.list
@@ -1,2 +1,3 @@
 deb https://snapshot.debian.org/archive/debian/20220811T031049Z/ bullseye main non-free contrib
 deb-src https://snapshot.debian.org/archive/debian/20220811T031049Z/ bullseye main non-free contrib
+deb https://snapshot.debian.org/archive/debian/20220811T031049Z/ sid main non-free contrib

--- a/contrib/build-wine/apt.sources.list
+++ b/contrib/build-wine/apt.sources.list
@@ -1,3 +1,3 @@
 deb https://snapshot.debian.org/archive/debian/20220811T031049Z/ bullseye main non-free contrib
 deb-src https://snapshot.debian.org/archive/debian/20220811T031049Z/ bullseye main non-free contrib
-deb https://snapshot.debian.org/archive/debian/20220811T031049Z/ sid main non-free contrib
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20220811T031049Z/ sid main non-free contrib

--- a/contrib/build-wine/make_win.sh
+++ b/contrib/build-wine/make_win.sh
@@ -50,28 +50,6 @@ fi
 if [ -f "$DLL_TARGET_DIR/libzbar-0.dll" ]; then
     info "libzbar already built, skipping"
 else
-    (
-        # As debian bullseye doesn't provide win-iconv-mingw-w64-dev, we need to build it:
-        WIN_ICONV_COMMIT="c9df88a284d448da5434c6ad2737b54a907f888c"
-        # ^ tag "v0.0.8"
-        info "Building win-iconv..."
-        cd "$CACHEDIR"
-        if [ ! -d win-iconv ]; then
-            git clone https://github.com/win-iconv/win-iconv.git
-        fi
-        cd win-iconv
-        if ! $(git cat-file -e ${WIN_ICONV_COMMIT}) ; then
-            info "Could not find requested version $WIN_ICONV_COMMIT in local clone; fetching..."
-            git fetch --all
-        fi
-        git reset --hard
-        git clean -dfxq
-        git checkout "${WIN_ICONV_COMMIT}^{commit}"
-
-        CC="${GCC_TRIPLET_HOST}-gcc" make -j4 || fail "Could not build win-iconv"
-        # FIXME avoid using sudo
-        sudo make install prefix="/usr/${GCC_TRIPLET_HOST}"  || fail "Could not install win-iconv"
-    )
     "$CONTRIB"/make_zbar.sh || fail "Could not build zbar"
 fi
 

--- a/contrib/freeze_containers_distro.sh
+++ b/contrib/freeze_containers_distro.sh
@@ -39,7 +39,7 @@ echo "deb-src ${DEBIAN_SNAPSHOT} ${DEBIAN_APPIMAGE_DISTRO} main non-free contrib
 echo "deb ${DEBIAN_SNAPSHOT} ${DEBIAN_WINE_DISTRO} main non-free contrib" >$contrib/build-wine/apt.sources.list
 echo "deb-src ${DEBIAN_SNAPSHOT} ${DEBIAN_WINE_DISTRO} main non-free contrib" >>$contrib/build-wine/apt.sources.list
 # we need win-iconv-mingw-w64-dev which is only in sid/unstable
-echo "deb ${DEBIAN_SNAPSHOT} unstable main non-free contrib" >>$contrib/build-wine/apt.sources.list
+echo "deb [check-valid-until=no] ${DEBIAN_SNAPSHOT} unstable main non-free contrib" >>$contrib/build-wine/apt.sources.list
 
 # android
 echo "deb ${DEBIAN_SNAPSHOT} ${DEBIAN_ANDROID_DISTRO} main non-free contrib" >$contrib/android/apt.sources.list

--- a/contrib/freeze_containers_distro.sh
+++ b/contrib/freeze_containers_distro.sh
@@ -38,6 +38,8 @@ echo "deb-src ${DEBIAN_SNAPSHOT} ${DEBIAN_APPIMAGE_DISTRO} main non-free contrib
 # build-wine
 echo "deb ${DEBIAN_SNAPSHOT} ${DEBIAN_WINE_DISTRO} main non-free contrib" >$contrib/build-wine/apt.sources.list
 echo "deb-src ${DEBIAN_SNAPSHOT} ${DEBIAN_WINE_DISTRO} main non-free contrib" >>$contrib/build-wine/apt.sources.list
+# we need win-iconv-mingw-w64-dev which is only in sid/unstable
+echo "deb ${DEBIAN_SNAPSHOT} unstable main non-free contrib" >>$contrib/build-wine/apt.sources.list
 
 # android
 echo "deb ${DEBIAN_SNAPSHOT} ${DEBIAN_ANDROID_DISTRO} main non-free contrib" >$contrib/android/apt.sources.list


### PR DESCRIPTION
This reverts commit b8240bec3ef531167c794e48453770fc9ac63e4e.

Looks like the win-iconv build is not deterministic...
Reverting this for now, will have to debug later.