### PR TITLE
android build: rebase p4a, rebase buildozer, bump targetSdkVersion

### DIFF
--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -50,9 +50,9 @@ RUN curl --location --progress-bar \
 ENV ANDROID_SDK_HOME="${ANDROID_HOME}/android-sdk"
 
 # get the latest version from https://developer.android.com/studio/index.html
-ENV ANDROID_SDK_TOOLS_VERSION="8092744"
-ENV ANDROID_SDK_BUILD_TOOLS_VERSION="30.0.3"
-ENV ANDROID_SDK_HASH="d71f75333d79c9c6ef5c39d3456c6c58c613de30e6a751ea0dbd433e8f8b9cbf"
+ENV ANDROID_SDK_TOOLS_VERSION="8512546"
+ENV ANDROID_SDK_BUILD_TOOLS_VERSION="33.0.0"
+ENV ANDROID_SDK_HASH="2ccbda4302db862a28ada25aa7425d99dce9462046003c1714b059b5c47970d8"
 ENV ANDROID_SDK_TOOLS_ARCHIVE="commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}_latest.zip"
 ENV ANDROID_SDK_TOOLS_DL_URL="https://dl.google.com/android/repository/${ANDROID_SDK_TOOLS_ARCHIVE}"
 ENV ANDROID_SDK_MANAGER="${ANDROID_SDK_HOME}/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_HOME}"
@@ -79,7 +79,7 @@ RUN apt -y update -qq \
 RUN yes | ${ANDROID_SDK_MANAGER} --licenses > /dev/null
 
 # download platforms, API, build tools
-RUN ${ANDROID_SDK_MANAGER} "platforms;android-30" > /dev/null && \
+RUN ${ANDROID_SDK_MANAGER} "platforms;android-31" > /dev/null && \
     ${ANDROID_SDK_MANAGER} "build-tools;${ANDROID_SDK_BUILD_TOOLS_VERSION}" > /dev/null && \
     ${ANDROID_SDK_MANAGER} "extras;android;m2repository" > /dev/null && \
     chmod +x "${ANDROID_SDK_HOME}/cmdline-tools/bin/avdmanager"

--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -28,12 +28,12 @@ RUN apt -y update -qq \
 
 
 ENV ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk"
-ENV ANDROID_NDK_VERSION="22b"
-ENV ANDROID_NDK_HASH="ac3a0421e76f71dd330d0cd55f9d99b9ac864c4c034fc67e0d671d022d4e806b"
+ENV ANDROID_NDK_VERSION="25b"
+ENV ANDROID_NDK_HASH="403ac3e3020dd0db63a848dcaba6ceb2603bf64de90949d5c4361f848e44b005"
 ENV ANDROID_NDK_HOME_V="${ANDROID_NDK_HOME}-r${ANDROID_NDK_VERSION}"
 
 # get the latest version from https://developer.android.com/ndk/downloads/index.html
-ENV ANDROID_NDK_ARCHIVE="android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip"
+ENV ANDROID_NDK_ARCHIVE="android-ndk-r${ANDROID_NDK_VERSION}-linux.zip"
 ENV ANDROID_NDK_DL_URL="https://dl.google.com/android/repository/${ANDROID_NDK_ARCHIVE}"
 
 # download and install Android NDK
@@ -55,7 +55,7 @@ ENV ANDROID_SDK_BUILD_TOOLS_VERSION="30.0.3"
 ENV ANDROID_SDK_HASH="d71f75333d79c9c6ef5c39d3456c6c58c613de30e6a751ea0dbd433e8f8b9cbf"
 ENV ANDROID_SDK_TOOLS_ARCHIVE="commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}_latest.zip"
 ENV ANDROID_SDK_TOOLS_DL_URL="https://dl.google.com/android/repository/${ANDROID_SDK_TOOLS_ARCHIVE}"
-ENV ANDROID_SDK_MANAGER="${ANDROID_SDK_HOME}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_HOME}"
+ENV ANDROID_SDK_MANAGER="${ANDROID_SDK_HOME}/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_HOME}"
 
 # download and install Android SDK
 RUN curl --location --progress-bar \
@@ -64,7 +64,6 @@ RUN curl --location --progress-bar \
     && echo "${ANDROID_SDK_HASH} ${ANDROID_SDK_TOOLS_ARCHIVE}" | sha256sum -c - \
     && mkdir --parents "${ANDROID_SDK_HOME}" \
     && unzip -q "${ANDROID_SDK_TOOLS_ARCHIVE}" -d "${ANDROID_SDK_HOME}" \
-    && mv "${ANDROID_SDK_HOME}/cmdline-tools" "${ANDROID_SDK_HOME}/tools" \
     && rm -rf "${ANDROID_SDK_TOOLS_ARCHIVE}"
 
 # update Android SDK, install Android API, Build Tools...
@@ -83,7 +82,7 @@ RUN yes | ${ANDROID_SDK_MANAGER} --licenses > /dev/null
 RUN ${ANDROID_SDK_MANAGER} "platforms;android-30" > /dev/null && \
     ${ANDROID_SDK_MANAGER} "build-tools;${ANDROID_SDK_BUILD_TOOLS_VERSION}" > /dev/null && \
     ${ANDROID_SDK_MANAGER} "extras;android;m2repository" > /dev/null && \
-    chmod +x "${ANDROID_SDK_HOME}/tools/bin/avdmanager"
+    chmod +x "${ANDROID_SDK_HOME}/cmdline-tools/bin/avdmanager"
 
 # download ANT
 ENV APACHE_ANT_VERSION="1.9.4"
@@ -165,8 +164,8 @@ RUN cd /opt \
     && cd buildozer \
     && git remote add sombernight https://github.com/SomberNight/buildozer \
     && git fetch --all \
-    # commit: from branch sombernight/electrum_20210421
-    && git checkout "d570116e88184b0eca0c6b59a25edd49d977da23^{commit}" \
+    # commit: from branch sombernight/202210_sdk_path
+    && git checkout "4267f066e6970b74bbffec63bdf54d3da130dcac^{commit}" \
     && python3 -m pip install --no-build-isolation --no-dependencies --user -e .
 
 # install python-for-android
@@ -176,8 +175,8 @@ RUN cd /opt \
     && git remote add sombernight https://github.com/SomberNight/python-for-android \
     && git remote add accumulator https://github.com/accumulator/python-for-android \
     && git fetch --all \
-    # commit: from branch sombernight/qt5-wip
-    && git checkout "c6e39ae1fb4eb8d547eb70b26b89beda7e6ff4b6^{commit}" \
+    # commit: from branch sombernight/electrum_20221006
+    && git checkout "6b8a15a4b488a2ebee7876576325bed013486983^{commit}" \
     && python3 -m pip install --no-build-isolation --no-dependencies --user -e .
 
 # build env vars

--- a/contrib/android/buildozer_kivy.spec
+++ b/contrib/android/buildozer_kivy.spec
@@ -76,7 +76,7 @@ android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE
 
 # (int) Android API to use  (targetSdkVersion AND compileSdkVersion)
 # note: when changing, Dockerfile also needs to be changed to install corresponding build tools
-android.api = 30
+android.api = 31
 
 # (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
 android.minapi = 21

--- a/contrib/android/buildozer_kivy.spec
+++ b/contrib/android/buildozer_kivy.spec
@@ -82,7 +82,7 @@ android.api = 30
 android.minapi = 21
 
 # (str) Android NDK version to use
-android.ndk = 22b
+android.ndk = 25b
 
 # (int) Android NDK API to use (optional). This is the minimum API your app will support.
 android.ndk_api = 21
@@ -153,9 +153,10 @@ android.manifest.launch_mode = singleTask
 # Don't forget to add the WAKE_LOCK permission if you set this to True
 #android.wakelock = False
 
-# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
-# note: can be overwritten by APP_ANDROID_ARCH env var
-#android.arch = armeabi-v7a
+# (list) The Android archs to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
+# In past, was `android.arch` as we weren't supporting builds for multiple archs at the same time.
+# note: can be overwritten by APP_ANDROID_ARCHS env var
+#android.archs = arm64-v8a, armeabi-v7a
 
 # (list) Android application meta-data to set (key=value format)
 #android.meta_data =

--- a/contrib/android/buildozer_kivy.spec
+++ b/contrib/android/buildozer_kivy.spec
@@ -170,6 +170,15 @@ android.whitelist = lib-dynload/_csv.so
 # (bool) enables Android auto backup feature (Android API >=23)
 android.allow_backup = False
 
+# (bool) disables the compilation of py to pyc/pyo files when packaging
+# android.no-compile-pyo = True
+
+# (str) The format used to package the app for release mode (aab or apk or aar).
+android.release_artifact = apk
+
+# (str) The format used to package the app for debug mode (apk or aar).
+android.debug_artifact = apk
+
 #
 # Python for android (p4a) specific
 #

--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -91,7 +91,7 @@ android.api = 30
 android.minapi = 21
 
 # (str) Android NDK version to use
-android.ndk = 22b
+android.ndk = 25b
 
 # (int) Android NDK API to use (optional). This is the minimum API your app will support.
 android.ndk_api = 21
@@ -165,9 +165,10 @@ android.manifest.launch_mode = singleTask
 # Don't forget to add the WAKE_LOCK permission if you set this to True
 #android.wakelock = False
 
-# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
-# note: can be overwritten by APP_ANDROID_ARCH env var
-#android.arch = armeabi-v7a
+# (list) The Android archs to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
+# In past, was `android.arch` as we weren't supporting builds for multiple archs at the same time.
+# note: can be overwritten by APP_ANDROID_ARCHS env var
+#android.archs = arm64-v8a, armeabi-v7a
 
 # (list) Android application meta-data to set (key=value format)
 #android.meta_data =

--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -85,7 +85,7 @@ android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE
 
 # (int) Android API to use  (targetSdkVersion AND compileSdkVersion)
 # note: when changing, Dockerfile also needs to be changed to install corresponding build tools
-android.api = 30
+android.api = 31
 
 # (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
 android.minapi = 21

--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -182,6 +182,15 @@ android.whitelist = lib-dynload/_csv.so
 # (bool) enables Android auto backup feature (Android API >=23)
 android.allow_backup = False
 
+# (bool) disables the compilation of py to pyc/pyo files when packaging
+# android.no-compile-pyo = True
+
+# (str) The format used to package the app for release mode (aab or apk or aar).
+android.release_artifact = apk
+
+# (str) The format used to package the app for debug mode (apk or aar).
+android.debug_artifact = apk
+
 #
 # Python for android (p4a) specific
 #

--- a/contrib/android/make_apk.sh
+++ b/contrib/android/make_apk.sh
@@ -87,14 +87,14 @@ fi
 
 if [[ "$2" == "all" ]] ; then
     # build all apks
-    export APP_ANDROID_ARCH=armeabi-v7a
+    export APP_ANDROID_ARCHS="armeabi-v7a"
     make $TARGET
-    export APP_ANDROID_ARCH=arm64-v8a
+    export APP_ANDROID_ARCHS="arm64-v8a"
     make $TARGET
-    #export APP_ANDROID_ARCH=x86
+    #export APP_ANDROID_ARCHS="x86"
     #make $TARGET
 else
-    export APP_ANDROID_ARCH=$2
+    export APP_ANDROID_ARCHS="$2"
     make $TARGET
 fi
 

--- a/contrib/android/p4a_recipes/Pillow/__init__.py
+++ b/contrib/android/p4a_recipes/Pillow/__init__.py
@@ -6,13 +6,13 @@ from pythonforandroid.util import load_source
 util = load_source('util', os.path.join(os.path.dirname(os.path.dirname(__file__)), 'util.py'))
 
 
-assert PillowRecipe._version == "7.0.0"
+assert PillowRecipe._version == "8.4.0"
 assert PillowRecipe.depends == ['png', 'jpeg', 'freetype', 'setuptools', 'python3']
 assert PillowRecipe.python_depends == []
 
 
 class PillowRecipePinned(util.InheritedRecipeMixin, PillowRecipe):
-    sha512sum = "187173a525d4f3f01b4898633263b53a311f337aa7b159c64f79ba8c7006fd44798a058e7cc5d8f1116bad008e4142ff303456692329fe73b0e115ef5c225d73"
+    sha512sum = "d395f69ccb37c52a3b6f45836700ffbc3173afae31848cc61d7b47db88ca1594541023beb9a14fd9067aca664e182c7d6e3300ab3e3095c31afe8dcbc6e08233"
 
 
 recipe = PillowRecipePinned()

--- a/contrib/android/p4a_recipes/libffi/__init__.py
+++ b/contrib/android/p4a_recipes/libffi/__init__.py
@@ -6,13 +6,13 @@ from pythonforandroid.util import load_source
 util = load_source('util', os.path.join(os.path.dirname(os.path.dirname(__file__)), 'util.py'))
 
 
-assert LibffiRecipe._version == "v3.3"
+assert LibffiRecipe._version == "v3.4.2"
 assert LibffiRecipe.depends == []
 assert LibffiRecipe.python_depends == []
 
 
 class LibffiRecipePinned(util.InheritedRecipeMixin, LibffiRecipe):
-    sha512sum = "62798fb31ba65fa2a0e1f71dd3daca30edcf745dc562c6f8e7126e54db92572cc63f5aa36d927dd08375bb6f38a2380ebe6c5735f35990681878fc78fc9dbc83"
+    sha512sum = "d399319efcca375fe901b05722e25eca31d11a4261c6a5d5079480bbc552d4e4b42de2026912689d3b2f886ebb3c8bebbea47102e38a2f6acbc526b8d5bba388"
 
 
 recipe = LibffiRecipePinned()

--- a/contrib/android/p4a_recipes/libiconv/__init__.py
+++ b/contrib/android/p4a_recipes/libiconv/__init__.py
@@ -6,13 +6,13 @@ from pythonforandroid.util import load_source
 util = load_source('util', os.path.join(os.path.dirname(os.path.dirname(__file__)), 'util.py'))
 
 
-assert LibIconvRecipe._version == "1.15"
+assert LibIconvRecipe._version == "1.16"
 assert LibIconvRecipe.depends == []
 assert LibIconvRecipe.python_depends == []
 
 
 class LibIconvRecipePinned(util.InheritedRecipeMixin, LibIconvRecipe):
-    sha512sum = "1233fe3ca09341b53354fd4bfe342a7589181145a1232c9919583a8c9979636855839049f3406f253a9d9829908816bb71fd6d34dd544ba290d6f04251376b1a"
+    sha512sum = "365dac0b34b4255a0066e8033a8b3db4bdb94b9b57a9dca17ebf2d779139fe935caf51a465d17fd8ae229ec4b926f3f7025264f37243432075e5583925bb77b7"
 
 
 recipe = LibIconvRecipePinned()

--- a/contrib/android/p4a_recipes/pyjnius/__init__.py
+++ b/contrib/android/p4a_recipes/pyjnius/__init__.py
@@ -6,13 +6,13 @@ from pythonforandroid.util import load_source
 util = load_source('util', os.path.join(os.path.dirname(os.path.dirname(__file__)), 'util.py'))
 
 
-assert PyjniusRecipe._version == "1.3.0"
+assert PyjniusRecipe._version == "1.4.2"
 assert PyjniusRecipe.depends == [('genericndkbuild', 'sdl2', 'qt5'), 'six', 'python3']
 assert PyjniusRecipe.python_depends == []
 
 
 class PyjniusRecipePinned(util.InheritedRecipeMixin, PyjniusRecipe):
-    sha512sum = "5a3475afcda5afbef6e1a67bab508e3c24bd564efda5ac38ae7669d39b4bfdbfaaa83f435f26d39b3d849d3a167a9c136c9ac6b2bfcc0bda09ef1c00aa66cf25"
+    sha512sum = "3cf1637f96b71398977c9608ead7261115f198e79de7c601fb86b984fc2c7f193910f14869ea249819211d13249947a632eb1bbf5edb66b98738edbf79acabc7"
 
 
 recipe = PyjniusRecipePinned()

--- a/contrib/android/p4a_recipes/sqlite3/__init__.py
+++ b/contrib/android/p4a_recipes/sqlite3/__init__.py
@@ -6,13 +6,13 @@ from pythonforandroid.util import load_source
 util = load_source('util', os.path.join(os.path.dirname(os.path.dirname(__file__)), 'util.py'))
 
 
-assert Sqlite3Recipe._version == "3.34.1"
+assert Sqlite3Recipe._version == "3.35.5"
 assert Sqlite3Recipe.depends == []
 assert Sqlite3Recipe.python_depends == []
 
 
 class Sqlite3RecipePinned(util.InheritedRecipeMixin, Sqlite3Recipe):
-    sha512sum = "8a936f1c34fc9036cadf5bd53f9ee594135c2efdef1d2c82bd4fdf3e0218afde710fc4c436cfc992687d008e6086a697da0487352ed88809d677e05d824940dd"
+    sha512sum = "9684fee89224f0c975c280cb6b2c64adb040334bc5517dfe0e354b0557459fa3ae642c4289a7a5265f65b3ad5b6747db8068a1e5172fbb8edec7f6d964ecbb20"
 
 
 recipe = Sqlite3RecipePinned()

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -947,7 +947,8 @@ class ElectrumWindow(App, Logger, EventListener):
         # see #6276 (specifically "method 2" and "method 3")
         from jnius import autoclass
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
-        PythonActivity.requestFocusForMainView()
+        activity = PythonActivity.mActivity
+        activity.requestFocusForMainView()
 
     def update_status(self, *dt):
         if not self.wallet:


### PR DESCRIPTION
This PR
- updates the `python-for-android` and `buildozer` versions we use, and rebases our patches,
- bumps the `targetSdkVersion` from 30 to 31
    - the google play store will require 31, starting 2022-11 (next month)

Note that p4a implemented multi-arch apk builds, so we could potentially build a single apk that works on both arm7 and arm8 (but it would be larger, e.g. 40 MB vs 25 MB). This is not used in this PR atm. (see `APP_ANDROID_ARCHS`)

TODO:
- [x] test build repro
- [ ] test qml apk build

EDIT: superseded by https://github.com/spesmilo/electrum/pull/8545