### PR TITLE
android: add setting to enable debug logs

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -208,6 +208,10 @@ class ElectrumWindow(App, Logger, EventListener):
                 self.network.run_from_another_thread(
                     self.network.stop_gossip())
 
+    enable_debug_logs = BooleanProperty(False)
+    def on_enable_debug_logs(self, instance, x):
+        self.electrum_config.set_key('gui_enable_debug_logs', self.enable_debug_logs, True)
+
     use_change = BooleanProperty(False)
     def on_use_change(self, instance, x):
         if self.wallet:
@@ -435,6 +439,7 @@ class ElectrumWindow(App, Logger, EventListener):
         self.use_rbf = config.get('use_rbf', True)
         self.use_gossip = config.get('use_gossip', False)
         self.use_unconfirmed = not config.get('confirmed_only', False)
+        self.enable_debug_logs = config.get('gui_enable_debug_logs', False)
 
         # create triggers so as to minimize updating a max of 2 times a sec
         self._trigger_update_wallet = Clock.create_trigger(self.update_wallet, .5)

--- a/electrum/gui/kivy/uix/dialogs/settings.py
+++ b/electrum/gui/kivy/uix/dialogs/settings.py
@@ -102,6 +102,13 @@ Builder.load_string('''
                     title: _('Lightning Routing') + ': ' + self.status
                     description: _("Use trampoline routing or gossip.")
                     action: partial(root.routing_dialog, self)
+                CardSeparator
+                SettingsItem:
+                    disabled: bool(app.electrum_config.get('verbosity')) and not app.enable_debug_logs
+                    status: 'ON' if (bool(app.electrum_config.get('verbosity')) or app.enable_debug_logs) else 'OFF'
+                    title: _('Enable debug logs') + ': ' + self.status
+                    description: "(developer) Log to stderr, to inspect with logcat."
+                    action: partial(root.boolean_dialog, 'enable_debug_logs', _('Debug Logs'), self.description)
 
                 # disabled: there is currently only one coin selection policy
                 #CardSeparator

--- a/electrum/gui/qml/components/Preferences.qml
+++ b/electrum/gui/qml/components/Preferences.qml
@@ -235,6 +235,17 @@ Pane {
                         }
                     }
 
+                    Switch {
+                        id: enableDebugLogs
+                        text: qsTr('Enable debug logs (for developers)')
+                        Layout.columnSpan: 2
+                        onCheckedChanged: {
+                            if (activeFocus)
+                                Config.enableDebugLogs = checked
+                        }
+                        enabled: Config.canToggleDebugLogs
+                    }
+
                 }
 
             }
@@ -257,6 +268,7 @@ Pane {
         spendUnconfirmed.checked = Config.spendUnconfirmed
         lnRoutingType.currentIndex = Config.useGossip ? 0 : 1
         useFallbackAddress.checked = Config.useFallbackAddress
+        enableDebugLogs.checked = Config.enableDebugLogs
         useRbf.checked = Config.useRbf
     }
 }

--- a/electrum/gui/qml/qeconfig.py
+++ b/electrum/gui/qml/qeconfig.py
@@ -130,6 +130,22 @@ class QEConfig(AuthMixin, QObject):
         self.config.set_key('bolt11_fallback', use_fallback)
         self.useFallbackAddressChanged.emit()
 
+    enableDebugLogsChanged = pyqtSignal()
+    @pyqtProperty(bool, notify=enableDebugLogsChanged)
+    def enableDebugLogs(self):
+        gui_setting = self.config.get('gui_enable_debug_logs', False)
+        return gui_setting or bool(self.config.get('verbosity'))
+
+    @pyqtProperty(bool, notify=enableDebugLogsChanged)
+    def canToggleDebugLogs(self):
+        gui_setting = self.config.get('gui_enable_debug_logs', False)
+        return not self.config.get('verbosity') or gui_setting
+
+    @enableDebugLogs.setter
+    def enableDebugLogs(self, enable):
+        self.config.set_key('gui_enable_debug_logs', enable)
+        self.enableDebugLogsChanged.emit()
+
     useRbfChanged = pyqtSignal()
     @pyqtProperty(bool, notify=useRbfChanged)
     def useRbf(self):

--- a/electrum/logging.py
+++ b/electrum/logging.py
@@ -314,6 +314,9 @@ def configure_logging(config: 'SimpleConfig', *, log_to_file: Optional[bool] = N
 
     verbosity = config.get('verbosity')
     verbosity_shortcuts = config.get('verbosity_shortcuts')
+    if not verbosity:
+        if config.get('gui_enable_debug_logs') or is_android_debug_apk():
+            verbosity = '*'
     _configure_stderr_logging(verbosity=verbosity, verbosity_shortcuts=verbosity_shortcuts)
 
     if log_to_file is None:

--- a/run_electrum
+++ b/run_electrum
@@ -325,7 +325,6 @@ def main():
         import importlib.util
         android_gui = 'kivy' if importlib.util.find_spec('kivy') else 'qml'
         config_options = {
-            'verbosity': '*' if util.is_android_debug_apk() else '',
             'cmd': 'gui',
             'gui': android_gui,
             'single_password':True,


### PR DESCRIPTION
This PR adds a setting to the kivy and qml guis to enable debug logs to stderr.
If enabled, we log to stderr, which can get inspected via logcat.
Not user-friendly at all - but previously there was no way to get logs from a release build.

- without this change
    - debug build apks always log
    - release build apks do not log -> impossible to get logs even for programmers
- with this change
    - debug build apks always log
    - release build apks
        - do not log by default
        - but there is an option in settings to enable logs
 
(note I am talking about stderr logs here only, not file logging)

-----

A new config key, `gui_enable_debug_logs` is introduced here.
Alternatively we could tweak `verbosity` directly.

Introducing the new config key allows greying out the gui setting in certain cases, e.g.:
- if running with `-v` passed on the cli, the setting is greyed out (shown ON but cannot be disabled)
- if running a debug apk, the setting is greyed out (shown ON but cannot be disabled)

-----

closes https://github.com/spesmilo/electrum/issues/7409