### PR TITLE
android build: bump targetSdkVersion from 30 to 31

### DIFF
--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -50,12 +50,12 @@ RUN curl --location --progress-bar \
 ENV ANDROID_SDK_HOME="${ANDROID_HOME}/android-sdk"
 
 # get the latest version from https://developer.android.com/studio/index.html
-ENV ANDROID_SDK_TOOLS_VERSION="8092744"
-ENV ANDROID_SDK_BUILD_TOOLS_VERSION="30.0.3"
-ENV ANDROID_SDK_HASH="d71f75333d79c9c6ef5c39d3456c6c58c613de30e6a751ea0dbd433e8f8b9cbf"
+ENV ANDROID_SDK_TOOLS_VERSION="8512546"
+ENV ANDROID_SDK_BUILD_TOOLS_VERSION="33.0.0"
+ENV ANDROID_SDK_HASH="2ccbda4302db862a28ada25aa7425d99dce9462046003c1714b059b5c47970d8"
 ENV ANDROID_SDK_TOOLS_ARCHIVE="commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}_latest.zip"
 ENV ANDROID_SDK_TOOLS_DL_URL="https://dl.google.com/android/repository/${ANDROID_SDK_TOOLS_ARCHIVE}"
-ENV ANDROID_SDK_MANAGER="${ANDROID_SDK_HOME}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_HOME}"
+ENV ANDROID_SDK_MANAGER="${ANDROID_SDK_HOME}/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_HOME}"
 
 # download and install Android SDK
 RUN curl --location --progress-bar \
@@ -64,7 +64,6 @@ RUN curl --location --progress-bar \
     && echo "${ANDROID_SDK_HASH} ${ANDROID_SDK_TOOLS_ARCHIVE}" | sha256sum -c - \
     && mkdir --parents "${ANDROID_SDK_HOME}" \
     && unzip -q "${ANDROID_SDK_TOOLS_ARCHIVE}" -d "${ANDROID_SDK_HOME}" \
-    && mv "${ANDROID_SDK_HOME}/cmdline-tools" "${ANDROID_SDK_HOME}/tools" \
     && rm -rf "${ANDROID_SDK_TOOLS_ARCHIVE}"
 
 # update Android SDK, install Android API, Build Tools...
@@ -80,10 +79,10 @@ RUN apt -y update -qq \
 RUN yes | ${ANDROID_SDK_MANAGER} --licenses > /dev/null
 
 # download platforms, API, build tools
-RUN ${ANDROID_SDK_MANAGER} "platforms;android-30" > /dev/null && \
+RUN ${ANDROID_SDK_MANAGER} "platforms;android-31" > /dev/null && \
     ${ANDROID_SDK_MANAGER} "build-tools;${ANDROID_SDK_BUILD_TOOLS_VERSION}" > /dev/null && \
     ${ANDROID_SDK_MANAGER} "extras;android;m2repository" > /dev/null && \
-    chmod +x "${ANDROID_SDK_HOME}/tools/bin/avdmanager"
+    chmod +x "${ANDROID_SDK_HOME}/cmdline-tools/bin/avdmanager"
 
 # download ANT
 ENV APACHE_ANT_VERSION="1.9.4"
@@ -166,7 +165,7 @@ RUN cd /opt \
     && git remote add sombernight https://github.com/SomberNight/buildozer \
     && git fetch --all \
     # commit: from branch sombernight/electrum_20210421
-    && git checkout "d570116e88184b0eca0c6b59a25edd49d977da23^{commit}" \
+    && git checkout "8791a52a02d1c6279504f402098bf6536824ea1c^{commit}" \
     && python3 -m pip install --no-build-isolation --no-dependencies --user -e .
 
 # install python-for-android
@@ -176,8 +175,8 @@ RUN cd /opt \
     && git remote add sombernight https://github.com/SomberNight/python-for-android \
     && git remote add accumulator https://github.com/accumulator/python-for-android \
     && git fetch --all \
-    # commit: from branch sombernight/qt5-wip
-    && git checkout "c6e39ae1fb4eb8d547eb70b26b89beda7e6ff4b6^{commit}" \
+    # commit: from branch sombernight/electrum_20210421c
+    && git checkout "89e39324b42a31cc365c2a47ba5380673c343704^{commit}" \
     && python3 -m pip install --no-build-isolation --no-dependencies --user -e .
 
 # build env vars

--- a/contrib/android/buildozer_kivy.spec
+++ b/contrib/android/buildozer_kivy.spec
@@ -76,7 +76,7 @@ android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE
 
 # (int) Android API to use  (targetSdkVersion AND compileSdkVersion)
 # note: when changing, Dockerfile also needs to be changed to install corresponding build tools
-android.api = 30
+android.api = 31
 
 # (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
 android.minapi = 21
@@ -156,6 +156,10 @@ android.manifest.launch_mode = singleTask
 # (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
 # note: can be overwritten by APP_ANDROID_ARCH env var
 #android.arch = armeabi-v7a
+
+# (int) overrides automatic versionCode computation (used in build.gradle)
+# this is not the same as app version and should only be edited if you know what you're doing
+# android.numeric_version = 1
 
 # (list) Android application meta-data to set (key=value format)
 #android.meta_data =

--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -85,7 +85,7 @@ android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE
 
 # (int) Android API to use  (targetSdkVersion AND compileSdkVersion)
 # note: when changing, Dockerfile also needs to be changed to install corresponding build tools
-android.api = 30
+android.api = 31
 
 # (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
 android.minapi = 21
@@ -168,6 +168,10 @@ android.manifest.launch_mode = singleTask
 # (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
 # note: can be overwritten by APP_ANDROID_ARCH env var
 #android.arch = armeabi-v7a
+
+# (int) overrides automatic versionCode computation (used in build.gradle)
+# this is not the same as app version and should only be edited if you know what you're doing
+# android.numeric_version = 1
 
 # (list) Android application meta-data to set (key=value format)
 #android.meta_data =


### PR DESCRIPTION
Re the Android build, this PR bumps the `targetSdkVersion` from 30 to 31, and upgrades the sdk tools used.
(the google play store will require 31, starting 2022-11 (next month))
A few commits are cherry-picked onto our forks of p4a and buildozer from upstream, but the forks are not rebased.

This was split from the more ambitious https://github.com/spesmilo/electrum/pull/8002, which also tried to rebase the forks.