### PR TITLE
add invoice status to invoice_status callback

### DIFF
--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -288,13 +288,13 @@ class ElectrumWindow(App, Logger, EventListener):
             self._trigger_update_history()
 
     @event_listener
-    def on_event_invoice_status(self, wallet, key):
+    def on_event_invoice_status(self, wallet, key, status):
         if wallet != self.wallet:
             return
         req = self.wallet.get_invoice(key)
         if req is None:
             return
-        status = self.wallet.get_invoice_status(req)
+        # status = self.wallet.get_invoice_status(req)
         if self.send_screen:
             if status == PR_PAID:
                 self.send_screen.update()

--- a/electrum/gui/kivy/main_window.py
+++ b/electrum/gui/kivy/main_window.py
@@ -294,7 +294,6 @@ class ElectrumWindow(App, Logger, EventListener):
         req = self.wallet.get_invoice(key)
         if req is None:
             return
-        # status = self.wallet.get_invoice_status(req)
         if self.send_screen:
             if status == PR_PAID:
                 self.send_screen.update()

--- a/electrum/gui/qml/qeinvoicelistmodel.py
+++ b/electrum/gui/qml/qeinvoicelistmodel.py
@@ -140,16 +140,10 @@ class QEInvoiceListModel(QEAbstractInvoiceListModel, QtEventListener):
         self.unregister_callbacks()
 
     @qt_event_listener
-    def on_event_invoice_status(self, wallet, key):
+    def on_event_invoice_status(self, wallet, key, status):
         if wallet == self.wallet:
-            self._logger.debug('invoice status update for key %s' % key)
-            # FIXME event doesn't pass the new status, so we need to retrieve
-            invoice = self.wallet.get_invoice(key)
-            if invoice:
-                status = self.wallet.get_invoice_status(invoice)
-                self.updateInvoice(key, status)
-            else:
-                self._logger.debug(f'No invoice found for key {key}')
+            self._logger.debug(f'invoice status update for key {key} to {status}')
+            self.updateInvoice(key, status)
 
     def invoice_to_model(self, invoice: Invoice):
         item = super().invoice_to_model(invoice)
@@ -181,7 +175,7 @@ class QERequestListModel(QEAbstractInvoiceListModel, QtEventListener):
     @qt_event_listener
     def on_event_request_status(self, wallet, key, status):
         if wallet == self.wallet:
-            self._logger.debug('request status update for key %s' % key)
+            self._logger.debug(f'request status update for key {key} to {status}')
             self.updateRequest(key, status)
 
     def invoice_to_model(self, invoice: Invoice):

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -160,14 +160,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     @event_listener
     def on_event_invoice_status(self, wallet, key, status):
         if wallet == self.wallet:
-            self._logger.debug('invoice status update for key %s' % key)
-            # FIXME event doesn't pass the new status, so we need to retrieve
-            # invoice = self.wallet.get_invoice(key)
-            # if invoice:
-            #     status = self.wallet.get_invoice_status(invoice)
-            #     self.invoiceStatusChanged.emit(key, status)
-            # else:
-            #     self._logger.debug(f'No invoice found for key {key}')
+            self._logger.debug(f'invoice status update for key {key} to {status}')
             self.invoiceStatusChanged.emit(key, status)
 
     @qt_event_listener

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -158,16 +158,17 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
                 self.historyModel.init_model()
 
     @event_listener
-    def on_event_invoice_status(self, wallet, key):
+    def on_event_invoice_status(self, wallet, key, status):
         if wallet == self.wallet:
             self._logger.debug('invoice status update for key %s' % key)
             # FIXME event doesn't pass the new status, so we need to retrieve
-            invoice = self.wallet.get_invoice(key)
-            if invoice:
-                status = self.wallet.get_invoice_status(invoice)
-                self.invoiceStatusChanged.emit(key, status)
-            else:
-                self._logger.debug(f'No invoice found for key {key}')
+            # invoice = self.wallet.get_invoice(key)
+            # if invoice:
+            #     status = self.wallet.get_invoice_status(invoice)
+            #     self.invoiceStatusChanged.emit(key, status)
+            # else:
+            #     self._logger.debug(f'No invoice found for key {key}')
+            self.invoiceStatusChanged.emit(key, status)
 
     @qt_event_listener
     def on_event_new_transaction(self, wallet, tx):

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1157,13 +1157,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             self.receive_tab.request_list.refresh_item(key)
 
     @qt_event_listener
-    def on_event_invoice_status(self, wallet, key):
+    def on_event_invoice_status(self, wallet, key, status):
         if wallet != self.wallet:
             return
-        invoice = self.wallet.get_invoice(key)
-        if invoice is None:
-            return
-        status = self.wallet.get_invoice_status(invoice)
+        # invoice = self.wallet.get_invoice(key)
+        # if invoice is None:
+        #     return
+        # status = self.wallet.get_invoice_status(invoice)
         if status == PR_PAID:
             self.send_tab.invoice_list.delete_item(key)
         else:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1160,10 +1160,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     def on_event_invoice_status(self, wallet, key, status):
         if wallet != self.wallet:
             return
-        # invoice = self.wallet.get_invoice(key)
-        # if invoice is None:
-        #     return
-        # status = self.wallet.get_invoice_status(invoice)
         if status == PR_PAID:
             self.send_tab.invoice_list.delete_item(key)
         else:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1268,7 +1268,9 @@ class LNWallet(LNWorker):
                         trampoline_onion=trampoline_onion,
                         trampoline_fee_level=self.trampoline_fee_level,
                         trampoline_route=trampoline_route)
-                util.trigger_callback('invoice_status', self.wallet, payment_hash.hex())
+                util.trigger_callback('invoice_status', self.wallet, payment_hash.hex(), PR_INFLIGHT)
+                s = self.wallet.get_invoice_status(self.wallet.get_invoice(payment_hash.hex()))
+                self.logger.info(f"invoice status triggered (1) for key {payment_hash.hex()} and status {s}")
             # 3. await a queue
             self.logger.info(f"amount inflight {amount_inflight}")
             htlc_log = await self.sent_htlcs[payment_hash].get()
@@ -1900,7 +1902,8 @@ class LNWallet(LNWorker):
             self.inflight_payments.remove(key)
         if status in SAVED_PR_STATUS:
             self.set_payment_status(bfh(key), status)
-        util.trigger_callback('invoice_status', self.wallet, key)
+        util.trigger_callback('invoice_status', self.wallet, key, status)
+        self.logger.info(f"invoice status triggered (2) for key {key} and status {status}")
 
     def set_request_status(self, payment_hash: bytes, status: int) -> None:
         if self.get_payment_status(payment_hash) == status:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1269,8 +1269,8 @@ class LNWallet(LNWorker):
                         trampoline_fee_level=self.trampoline_fee_level,
                         trampoline_route=trampoline_route)
                 util.trigger_callback('invoice_status', self.wallet, payment_hash.hex(), PR_INFLIGHT)
-                s = self.wallet.get_invoice_status(self.wallet.get_invoice(payment_hash.hex()))
-                self.logger.info(f"invoice status triggered (1) for key {payment_hash.hex()} and status {s}")
+                # s = self.wallet.get_invoice_status(self.wallet.get_invoice(payment_hash.hex()))
+                # self.logger.info(f"invoice status triggered (1) for key {payment_hash.hex()} and status {s}")
             # 3. await a queue
             self.logger.info(f"amount inflight {amount_inflight}")
             htlc_log = await self.sent_htlcs[payment_hash].get()

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1268,9 +1268,10 @@ class LNWallet(LNWorker):
                         trampoline_onion=trampoline_onion,
                         trampoline_fee_level=self.trampoline_fee_level,
                         trampoline_route=trampoline_route)
+                # invoice_status is triggered in self.set_invoice_status when it actally changes.
+                # It is also triggered here to update progress for a lightning payment in the GUI
+                # (e.g. attempt counter)
                 util.trigger_callback('invoice_status', self.wallet, payment_hash.hex(), PR_INFLIGHT)
-                # s = self.wallet.get_invoice_status(self.wallet.get_invoice(payment_hash.hex()))
-                # self.logger.info(f"invoice status triggered (1) for key {payment_hash.hex()} and status {s}")
             # 3. await a queue
             self.logger.info(f"amount inflight {amount_inflight}")
             htlc_log = await self.sent_htlcs[payment_hash].get()


### PR DESCRIPTION
This patch adds the invoice status to the `invoice_status` callback;
1) analog to `request_status` callback
2) all consumers of the callback do the `wallet.get_invoice_status(wallet.get_invoice(key))` dance anyway

There's some commented lines in this patch, and some logging, to makes this patch easier to review (will clean up after review).
Also, I've made one assumption here, the `PR_INFLIGHT` status in the `lnworker.pay_to_node()` route loop. As far as I can see, there's no code path that sets a different status while in this loop. If this assumption is incorrrect, we can retrieve the current status from `self.get_invoice_status()` at this point.
