### PR TITLE
add .gitattributes file for end-of-line normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Auto detect text files and perform end-of-line normalization (to LF)
+*        text=auto
+
+# These Windows files should have CRLF line endings in checkout
+*.bat    text eol=crlf
+*.ps1    text eol=crlf
+
+# Never perform LF normalization on these files
+*.ico    binary
+*.jar    binary
+*.png    binary
+*.zip    binary


### PR DESCRIPTION
This should prevent accidentally committing files with CRLF line endings to the repo.

related: https://github.com/spesmilo/electrum/issues/8025

see https://git-scm.com/docs/gitattributes#_end_of_line_conversion :
> If you want to ensure that text files that any contributor introduces to the repository have their line endings normalized, you can set the text attribute to "auto" for all files.
> ```
> * text=auto
> ```
>
> From a clean working directory:
> ```
> $ echo "* text=auto" >.gitattributes
> $ git add --renormalize .
> $ git status    # Show files that will be normalized
> $ git commit -m "Introduce end-of-line normalization"
> ```

-----

I have tried to find some large cross-platform projects that use git for EOL normalisation. Notably the golang/go project recommends against it, but the others have it in some form:

- https://github.com/python/cpython/blob/4ec9ed8fde8e285a3eea97c199f7bbf7c95c8881/.gitattributes
- https://github.com/golang/go/blob/160bb0e66b96e24120deba5fed927acc47b59b1a/.gitattributes
- https://github.com/kovidgoyal/calibre/blob/7fda097623fdf87d5c88179dab281762151bb229/.gitattributes
- https://github.com/flutter/flutter/blob/103a5c98b8cac6bdcc8c8af1094d1e6f98453fe6/.gitattributes
- https://github.com/microsoft/calculator/blob/0990046d8d0b2281865f942f8b02dfc5c1ef749f/.gitattributes
- https://github.com/qbittorrent/qBittorrent/blob/1c2dc79f51d407477de062c8f637ba7f556c99d2/.gitattributes
- https://github.com/apache/hive/blob/0d65a985b953e6a50a9f2d239ee0254ccf3e9402/.gitattributes
- https://github.com/JetBrains/intellij-community/blob/d3bafb8b6e2bb48a677dc005abed70f46c953df1/.gitattributes
