### PR TITLE
document disabling utxo_freeze_threshold

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1715,6 +1715,13 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         In particular, this test triggers for large "dusting transactions"
         that are used for advertising purposes by some entities.
         see #6960
+        To disable this test, set
+        ```
+            "unconf_utxo_freeze_threshold": 0
+        ```
+        in ~/.electrum/config. Make sure to back up your config file first as
+        JSON syntax is somewhat difficult to get right, and the config file
+        will be overwritten with defaults if you get it wrong.
         """
         # confirmed UTXOs are fine; check this first for performance:
         block_height = utxo.block_height


### PR DESCRIPTION
Add documentation to the docstring of the appropriate function
explaining how to disable the #6960 test for dusting transactions

Why this is a problem: when testing new wallet configurations it is helpful to
make some very low value test transactions to ensure everything works (without
losing too much money if something is not correctly set up and the private key
is not recoverable).

In this case the test transaction may fall below the threshold.


TODO:
1. it may make sense to document passing this option on the command
line as well, since editing the config file by hand is a recipe for
trouble.
Unfortunately this is not as simple as doing:
```
electrum --unconf_utxo_freeze_threshold=0
```
and I can't find how electrum takes config arguments on the command
line. Maybe someone else knows?

2. this is pretty deep in the codebase. Most users who run into this behaviour
and find it to be erroneous may not read this far into the code. An alternate
way to document it would be to include a note about the freezing behaviour in
the error that pops up, if frozen funds are the reason a transaction cannot be
sent.