### PR TITLE
Qt AddressList: mark address if some coins are frozen

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1330,6 +1330,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     def set_frozen_state_of_coins(self, utxos: Sequence[PartialTxInput], freeze: bool):
         utxos_str = {utxo.prevout.to_str() for utxo in utxos}
         self.wallet.set_frozen_state_of_coins(utxos_str, freeze)
+        self.address_list.refresh_all()
         self.utxo_list.refresh_all()
         self.utxo_list.selectionModel().clearSelection()
 


### PR DESCRIPTION
If some coins are frozen in the wallet (but not addresses), the Addresses tab of the Qt GUI does not give any clues to the user about this. I think if there is an address which is not frozen itself but some related UTXOs are, the interface should show that somehow.

I don't know *how* to do it nicely though... In this PR, as before, a frozen address has a solid blue background colour; and now if there are some frozen coins, the address has a background in a different style.

![pic1](https://user-images.githubusercontent.com/29142493/198382165-a3f099d0-9a9a-4dae-8725-02d2c3f19e4a.PNG)

related: https://github.com/spesmilo/electrum/pull/8035#issuecomment-1293535818

-----

I've done some benchmarking on large wallets, and this makes `AddressList.refresh_all()` around 2x slower.
(due to calculating the utxos for an address: `wallet.adb.get_addr_utxo(address)`)
Regardless, I think the slowdown is acceptable.