### PR TITLE
add network name to getinfo()

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -204,7 +204,7 @@ class Commands:
         """ network info """
         net_params = self.network.get_parameters()
         response = {
-			'network': globals()['constants'].net.NET_NAME,
+			'network': constants.net.NET_NAME,
             'path': self.network.config.path,
             'server': net_params.server.host,
             'blockchain_height': self.network.get_local_height(),

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -65,7 +65,7 @@ from .invoices import Invoice
 from . import submarine_swaps
 from . import GuiImportError
 from . import crypto
-
+from . import constants
 
 if TYPE_CHECKING:
     from .network import Network
@@ -204,6 +204,7 @@ class Commands:
         """ network info """
         net_params = self.network.get_parameters()
         response = {
+			'network': globals()['constants'].net.NET_NAME,
             'path': self.network.config.path,
             'server': net_params.server.host,
             'blockchain_height': self.network.get_local_height(),


### PR DESCRIPTION
$ ./run_electrum --testnet getinfo
{
"auto_connect": true,
"blockchain_height": 2378672,
"connected": true,
"default_wallet": "/home/user/.electrum/testnet/wallets/default_wallet",
"fee_per_kb": 1000,
"network": "testnet",
"path": "/home/user/.electrum/testnet",
"server": "testnet.server.org",
"server_height": 2378672,
"spv_nodes": 7,
"version": "4.3.2"
}