### PR TITLE
trezor: optimize signing speed by not serializing transaction in trezor

### DIFF
--- a/electrum/plugins/trezor/trezor.py
+++ b/electrum/plugins/trezor/trezor.py
@@ -363,6 +363,7 @@ class TrezorPlugin(HW_PluginBase):
                                        lock_time=tx.locktime,
                                        version=tx.version,
                                        amount_unit=self.get_trezor_amount_unit(),
+                                       serialize=False,
                                        prev_txes=prev_tx)
         signatures = [(bh2u(x) + '01') for x in signatures]
         tx.update_signatures(signatures)


### PR DESCRIPTION
Since Electrum is not using TxRequestSerializedType.serialized_tx we might ask the device not to serialize transactions by setting SignTx.serialize=False

The trezorlib requirement is bumped to 0.13.4, since that's the version when SignTx.serialize field appeared for the first time.