### PR TITLE
qt wizard: (fix) during 2fa wallet creation, shared QR to be drawn

### DIFF
--- a/electrum/gui/qt/qrcodewidget.py
+++ b/electrum/gui/qt/qrcodewidget.py
@@ -18,13 +18,13 @@ from .util import WindowModalDialog, WWLabel, getSaveFileName
 
 class QRCodeWidget(QWidget):
 
-    def __init__(self, data = None):
+    def __init__(self, data=None, *, manual_size: bool = False):
         QWidget.__init__(self)
         self.data = None
         self.qr = None
         self._framesize = None  # type: Optional[int]
+        self._manual_size = manual_size
         self.setData(data)
-
 
     def setData(self, data):
         if self.data != data:
@@ -36,6 +36,9 @@ class QRCodeWidget(QWidget):
                 border=0,
             )
             self.qr.add_data(self.data)
+            if not self._manual_size:
+                k = len(self.qr.get_matrix())
+                self.setMinimumSize(k * 5, k * 5)
         else:
             self.qr = None
 
@@ -120,7 +123,7 @@ class QRDialog(WindowModalDialog):
 
         vbox = QVBoxLayout()
 
-        qrw = QRCodeWidget(data)
+        qrw = QRCodeWidget(data, manual_size=True)
         qrw.setMinimumSize(250, 250)
         vbox.addWidget(qrw, 1)
 

--- a/electrum/gui/qt/receive_tab.py
+++ b/electrum/gui/qt/receive_tab.py
@@ -135,9 +135,9 @@ class ReceiveTab(QWidget, MessageBoxMixin, Logger):
         self.receive_lightning_help = FramedWidget()
         self.receive_lightning_help.setVisible(False)
         self.receive_lightning_help.setLayout(vbox)
-        self.receive_address_qr = QRCodeWidget()
-        self.receive_URI_qr = QRCodeWidget()
-        self.receive_lightning_qr = QRCodeWidget()
+        self.receive_address_qr = QRCodeWidget(manual_size=True)
+        self.receive_URI_qr = QRCodeWidget(manual_size=True)
+        self.receive_lightning_qr = QRCodeWidget(manual_size=True)
 
         for e in [self.receive_address_e, self.receive_URI_e, self.receive_lightning_e]:
             e.setFont(QFont(MONOSPACE_FONT))


### PR DESCRIPTION
fixes https://github.com/spesmilo/electrum/issues/8071

This was a regression from 2a31f80d0962197780a2f45c279c83236051e4de, before which, when using the default `QRCodeWidget()` constructor, there had been a min size set on the widget. I like that old behaviour: reasonable size should be set by default, and if you want to set the size manually, opt-in to that.