### PR TITLE
Favor first output address in invoice/request

### DIFF
--- a/electrum/invoices.py
+++ b/electrum/invoices.py
@@ -119,10 +119,13 @@ class Invoice(StoredObject):
 
     def get_address(self) -> Optional[str]:
         """returns the first address, to be displayed in GUI"""
-        if self.is_lightning():
-            return self._lnaddr.get_fallback_address() or None
-        else:
-            return self.outputs[0].address
+        address = None
+        if self.outputs:
+            address = self.outputs[0].address if len(self.outputs) > 0 else None
+        if not address:
+            if self.is_lightning():
+                address = self._lnaddr.get_fallback_address() or None
+        return address
 
     def get_outputs(self):
         if self.is_lightning():


### PR DESCRIPTION
Favor first output address in invoice/request instead of fallback address in LN invoice.

Without this change, when configuring electrum with `bolt11_fallback` disabled, and calling `invoice.get_address()` on a lightning enabled invoice, it will return `None`, thereby disabling retrieving BIP21 uri or address from the invoice/request.