### PR TITLE
Update @lukechilds server address

### DIFF
--- a/electrum/servers.json
+++ b/electrum/servers.json
@@ -118,7 +118,7 @@
         "t": "50001",
         "version": "1.4.2"
     },
-    "bitcoin.lukechilds.co": {
+    "bitcoin.lu.ke": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",


### PR DESCRIPTION
I migrated from bitcoin.lukechilds.co to bitcoin.lu.ke. I'll keep the old domain up so old versions of electrum still work but it would be great if newer releases use this address.