### PR TITLE
CI: AppImage build is failing with `Container errored with 'OOMKilled'`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -258,7 +258,7 @@ task:
   container:
     dockerfile: contrib/build-linux/appimage/Dockerfile
     cpu: 2
-    memory: 1G
+    memory: 2G
   pip_cache:
     folder: contrib/build-linux/appimage/.cache/pip_cache
     fingerprint_script:

--- a/contrib/build_tools_util.sh
+++ b/contrib/build_tools_util.sh
@@ -130,6 +130,7 @@ fi
 
 export GCC_STRIP_BINARIES="${GCC_STRIP_BINARIES:-0}"
 export CPU_COUNT="$(nproc 2> /dev/null || sysctl -n hw.ncpu)"
+info "Found $CPU_COUNT CPUs, which we might use for building."
 
 
 function break_legacy_easy_install() {


### PR DESCRIPTION
"AppImage build" on the CI is failing with "Container errored with 'OOMKilled'" since 65ae2811809315c48ecc1eb9ae2fa52d9a72a252:
- https://cirrus-ci.com/task/6506466559918080
- https://cirrus-ci.com/task/6518283422662656

Apparently, when running in a Cirrus CI container, `nproc` returns the number of host CPUs, instead of the number of cpus available to the container. Opened upstream issue: https://github.com/cirruslabs/cirrus-ci-docs/issues/1115