### PR TITLE
Add command for currency conversions

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1323,23 +1323,20 @@ class Commands:
         }
 
     @command('n')
-    async def convert_currency(self, from_amount=1, from_ccy = None, to_ccy = None):
+    async def convert_currency(self, from_amount=1, from_ccy = '', to_ccy = ''):
         """Converts the given amount of currency to another using the
         configured exchange rate source.
         """
         if not self.daemon.fx.is_enabled():
             raise Exception("FX is disabled. To enable, run: 'electrum setconfig use_exchange_rate true'")
-        # Default currencies
-        if from_ccy is None and to_ccy is None:
-            from_ccy = 'BTC'
-            to_ccy = self.daemon.fx.ccy
-        elif from_ccy is None:
-            from_ccy = 'BTC'
-        elif to_ccy is None:
-            to_ccy = 'BTC'
         # Currency codes are uppercase
         from_ccy = from_ccy.upper()
         to_ccy = to_ccy.upper()
+        # Default currencies
+        if from_ccy == '':
+            from_ccy = "BTC" if to_ccy != "BTC" else self.daemon.fx.ccy
+        if to_ccy == '':
+            to_ccy = "BTC" if from_ccy != "BTC" else self.daemon.fx.ccy
         # Get current rates
         rate_from = self.daemon.fx.exchange.get_cached_spot_quote(from_ccy)
         rate_to = self.daemon.fx.exchange.get_cached_spot_quote(to_ccy)

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1327,6 +1327,8 @@ class Commands:
         """Converts the given amount of currency to another using the
         configured exchange rate source.
         """
+        if not self.daemon.fx.is_enabled():
+            raise Exception("FX is disabled. To enable, run: 'electrum setconfig use_exchange_rate true'")
         # Currency codes are uppercase
         from_ccy = self.daemon.fx.ccy if from_ccy is None else from_ccy.upper()
         to_ccy = to_ccy.upper()
@@ -1335,9 +1337,9 @@ class Commands:
         rate_to = self.daemon.fx.exchange.get_cached_spot_quote(to_ccy)
         # Test if currencies exist
         if rate_from.is_nan():
-              raise Exception('Currency to convert from is unknown')
+            raise Exception(f'Currency to convert from ({from_ccy}) is unknown or rate is unavailable')
         if rate_to.is_nan():
-              raise Exception('Currency to convert to is unknown')
+            raise Exception(f'Currency to convert to ({to_ccy}) is unknown or rate is unavailable')
         # Conversion
         try:
             amount = Decimal(from_amount) / rate_from * rate_to

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -176,6 +176,8 @@ class ExchangeBase(Logger):
 
     def get_cached_spot_quote(self, ccy: str) -> Decimal:
         """Returns the cached exchange rate as a Decimal"""
+        if ccy == 'BTC':
+            return Decimal(1)
         rate = self._quotes.get(ccy)
         if rate is None:
             return Decimal('NaN')

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -34,7 +34,10 @@ CCY_PRECISIONS = {'BHD': 3, 'BIF': 0, 'BYR': 0, 'CLF': 4, 'CLP': 0,
                   'JOD': 3, 'JPY': 0, 'KMF': 0, 'KRW': 0, 'KWD': 3,
                   'LYD': 3, 'MGA': 1, 'MRO': 1, 'OMR': 3, 'PYG': 0,
                   'RWF': 0, 'TND': 3, 'UGX': 0, 'UYI': 0, 'VND': 0,
-                  'VUV': 0, 'XAF': 0, 'XAU': 4, 'XOF': 0, 'XPF': 0}
+                  'VUV': 0, 'XAF': 0, 'XAU': 4, 'XOF': 0, 'XPF': 0,
+                  # Cryptocurrencies
+                  'BTC': 8, 'LTC': 8, 'XRP': 6, 'ETH': 18,
+                  }
 
 
 def to_decimal(x: Union[str, float, int, Decimal]) -> Decimal:

--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -554,8 +554,8 @@ class FxThread(ThreadJob, EventListener):
     def remove_thousands_separator(text):
         return text.replace(',', '') # FIXME use THOUSAND_SEPARATOR in util
 
-    def ccy_amount_str(self, amount, commas):
-        prec = CCY_PRECISIONS.get(self.ccy, 2)
+    def ccy_amount_str(self, amount, commas, ccy=None):
+        prec = CCY_PRECISIONS.get(self.ccy if ccy is None else ccy, 2)
         fmt_str = "{:%s.%df}" % ("," if commas else "", max(0, prec)) # FIXME use util.THOUSAND_SEPARATOR and util.DECIMAL_POINT
         try:
             rounded_amount = round(amount, prec)


### PR DESCRIPTION
This adds command convert_currency which allows command line and RPC users to access the currency conversions already existing in Electrum.