### PR TITLE
AddressSynchronizer: change to use scriptPubKeys instead of addresses

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -25,7 +25,7 @@ import asyncio
 import threading
 import itertools
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple, NamedTuple, Sequence, List
+from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple, NamedTuple, Sequence, List, Iterable
 
 from .crypto import sha256
 from . import bitcoin, util
@@ -37,7 +37,7 @@ from .verifier import SPV
 from .blockchain import hash_header, Blockchain
 from .i18n import _
 from .logging import Logger
-from .util import EventListener, event_listener
+from .util import EventListener, event_listener, is_hex_str
 
 if TYPE_CHECKING:
     from .network import Network
@@ -106,61 +106,65 @@ class AddressSynchronizer(Logger, EventListener):
         self.load_unverified_transactions()
         self.remove_local_transactions_we_dont_have()
 
-    def is_mine(self, address: Optional[str]) -> bool:
-        """Returns whether an address is in our set
-        Note: This class has a larget set of addresses than the wallet
+    def is_mine(self, spk: Optional[str]) -> bool:
+        """Returns whether an scriptPubKey is in our set
+        Note: This class has a larger set of addresses than the wallet
         """
-        if not address: return False
-        return self.db.is_addr_in_history(address)
+        if not spk: return False
+        return self.db.is_spk_in_history(spk)
 
-    def get_addresses(self):
-        return sorted(self.db.get_history())
+    def get_scriptpubkeys(self):
+        return self.db.get_scriptpubkeys()
 
-    def get_address_history(self, addr: str) -> Sequence[Tuple[str, int]]:
-        """Returns the history for the address, in the format that would be returned by a server.
+    def get_spk_history(self, spk: str) -> Sequence[Tuple[str, int]]:
+        """Returns the history for the scriptPubKey, in the format that would be returned by a server.
 
-        Note: The difference between db.get_addr_history and this method is that
-        db.get_addr_history stores the response from a server, so it only includes txns
+        Note: The difference between db.get_spk_history and this method is that
+        db.get_spk_history stores the response from a server, so it only includes txns
         a server sees, i.e. that does not contain local and future txns.
         """
         h = []
         # we need self.transaction_lock but get_tx_height will take self.lock
         # so we need to take that too here, to enforce order of locks
         with self.lock, self.transaction_lock:
-            related_txns = self._history_local.get(addr, set())
+            related_txns = self._history_local.get(spk, set())
             for tx_hash in related_txns:
                 tx_height = self.get_tx_height(tx_hash).height
                 h.append((tx_hash, tx_height))
         return h
 
-    def get_address_history_len(self, addr: str) -> int:
-        """Return number of transactions where address is involved."""
-        return len(self._history_local.get(addr, ()))
+    def get_spk_history_len(self, spk: str) -> int:
+        """Return number of transactions where scriptPubKey is involved."""
+        return len(self._history_local.get(spk, ()))
 
-    def get_txin_address(self, txin: TxInput) -> Optional[str]:
+    def get_txin_spk(self, txin: TxInput) -> Optional[str]:
         if isinstance(txin, PartialTxInput):
-            if txin.address:
-                return txin.address
+            if txin.scriptpubkey:
+                return txin.scriptpubkey.hex()
         prevout_hash = txin.prevout.txid.hex()
         prevout_n = txin.prevout.out_idx
-        for addr in self.db.get_txo_addresses(prevout_hash):
-            d = self.db.get_txo_addr(prevout_hash, addr)
+        for spk in self.db.get_txo_scriptpubkeys(prevout_hash):
+            d = self.db.get_txo_spk(prevout_hash, spk)
             if prevout_n in d:
-                return addr
+                return spk
         tx = self.db.get_transaction(prevout_hash)
         if tx:
-            return tx.outputs()[prevout_n].address
+            return tx.outputs()[prevout_n].scriptpubkey.hex()
         return None
 
-    def get_txin_value(self, txin: TxInput, *, address: str = None) -> Optional[int]:
+    def get_txin_address(self, txin: TxInput) -> Optional[str]:
+        if spk := self.get_txin_spk(txin):
+            return bitcoin.script_to_address(spk)
+
+    def get_txin_value(self, txin: TxInput, *, spk: str = None) -> Optional[int]:
         if txin.value_sats() is not None:
             return txin.value_sats()
         prevout_hash = txin.prevout.txid.hex()
         prevout_n = txin.prevout.out_idx
-        if address is None:
-            address = self.get_txin_address(txin)
-        if address:
-            d = self.db.get_txo_addr(prevout_hash, address)
+        if spk is None:
+            spk = self.get_txin_spk(txin)
+        if spk:
+            d = self.db.get_txo_spk(prevout_hash, spk)
             try:
                 v, cb = d[prevout_n]
                 return v
@@ -173,8 +177,8 @@ class AddressSynchronizer(Logger, EventListener):
 
     def load_unverified_transactions(self):
         # review transactions that are in the history
-        for addr in self.db.get_history():
-            hist = self.db.get_addr_history(addr)
+        for spk in self.db.get_scriptpubkeys():
+            hist = self.db.get_spk_history(spk)
             for tx_hash, tx_height in hist:
                 # add it in case it was previously unconfirmed
                 self.add_unverified_or_unconfirmed_tx(tx_hash, tx_height)
@@ -205,12 +209,16 @@ class AddressSynchronizer(Logger, EventListener):
                 self.unregister_callbacks()
                 self.db.put('stored_height', self.get_local_height())
 
-    def add_address(self, address):
-        if address not in self.db.history:
-            self.db.history[address] = []
+    def add_spk(self, spk: str) -> None:
+        if spk not in self.db.history:
+            self.db.history[spk] = []
         if self.synchronizer:
-            self.synchronizer.add(address)
+            self.synchronizer.add_spk(spk)
         self.up_to_date_changed()
+
+    def add_address(self, address: str) -> None:
+        spk = bitcoin.address_to_script(address)
+        self.add_spk(spk)
 
     def get_conflicting_transactions(self, tx_hash, tx: Transaction, include_self=False):
         """Returns a set of transaction hashes from the wallet history that are
@@ -271,8 +279,8 @@ class AddressSynchronizer(Logger, EventListener):
                 # note that during sync, if the transactions are not properly sorted,
                 # it could happen that we think tx is unrelated but actually one of the inputs is is_mine.
                 # this is the main motivation for allow_unrelated
-                is_mine = any([self.is_mine(self.get_txin_address(txin)) for txin in tx.inputs()])
-                is_for_me = any([self.is_mine(txo.address) for txo in tx.outputs()])
+                is_mine = any([self.is_mine(self.get_txin_spk(txin)) for txin in tx.inputs()])
+                is_for_me = any([self.is_mine(txo.scriptpubkey.hex()) for txo in tx.outputs()])
                 if not is_mine and not is_for_me:
                     raise UnrelatedTransactionException()
             # Find all conflicting transactions.
@@ -302,15 +310,15 @@ class AddressSynchronizer(Logger, EventListener):
             # add inputs
             def add_value_from_prev_output():
                 # note: this takes linear time in num is_mine outputs of prev_tx
-                addr = self.get_txin_address(txi)
-                if addr and self.is_mine(addr):
-                    outputs = self.db.get_txo_addr(prevout_hash, addr)
+                spk = self.get_txin_spk(txi)
+                if spk and self.is_mine(spk):
+                    outputs = self.db.get_txo_spk(prevout_hash, spk)
                     try:
                         v, is_cb = outputs[prevout_n]
                     except KeyError:
                         pass
                     else:
-                        self.db.add_txi_addr(tx_hash, addr, ser, v)
+                        self.db.add_txi_spk(tx_hash, spk, ser, v)
                         self._get_balance_cache.clear()  # invalidate cache
             for txi in tx.inputs():
                 if txi.is_coinbase_input():
@@ -326,14 +334,14 @@ class AddressSynchronizer(Logger, EventListener):
                 ser = tx_hash + ':%d'%n
                 scripthash = bitcoin.script_to_scripthash(txo.scriptpubkey.hex())
                 self.db.add_prevout_by_scripthash(scripthash, prevout=TxOutpoint.from_str(ser), value=v)
-                addr = txo.address
-                if addr and self.is_mine(addr):
-                    self.db.add_txo_addr(tx_hash, addr, n, v, is_coinbase)
+                spk = txo.scriptpubkey.hex()
+                if spk and self.is_mine(spk):
+                    self.db.add_txo_spk(tx_hash, spk, n, v, is_coinbase)
                     self._get_balance_cache.clear()  # invalidate cache
                     # give v to txi that spends me
                     next_tx = self.db.get_spent_outpoint(tx_hash, n)
                     if next_tx is not None:
-                        self.db.add_txi_addr(next_tx, addr, ser, v)
+                        self.db.add_txi_spk(next_tx, spk, ser, v)
                         self._add_tx_to_local_history(next_tx)
             # add to local history
             self._add_tx_to_local_history(tx_hash)
@@ -380,7 +388,7 @@ class AddressSynchronizer(Logger, EventListener):
             tx = self.db.remove_transaction(tx_hash)
             remove_from_spent_outpoints()
             self._remove_tx_from_local_history(tx_hash)
-            for addr in itertools.chain(self.db.get_txi_addresses(tx_hash), self.db.get_txo_addresses(tx_hash)):
+            for spk in itertools.chain(self.db.get_txi_scriptpubkeys(tx_hash), self.db.get_txo_scriptpubkeys(tx_hash)):
                 self._get_balance_cache.clear()  # invalidate cache
             self.db.remove_txi(tx_hash)
             self.db.remove_txo(tx_hash)
@@ -408,9 +416,10 @@ class AddressSynchronizer(Logger, EventListener):
         self.add_unverified_or_unconfirmed_tx(tx_hash, tx_height)
         self.add_transaction(tx, allow_unrelated=True)
 
-    def receive_history_callback(self, addr: str, hist, tx_fees: Dict[str, int]):
+    def receive_history_callback(self, spk: str, hist, tx_fees: Dict[str, int]):
+        assert is_hex_str(spk)
         with self.lock:
-            old_hist = self.get_address_history(addr)
+            old_hist = self.get_spk_history(spk)
             for tx_hash, height in old_hist:
                 if (tx_hash, height) not in hist:
                     # make tx local
@@ -419,12 +428,12 @@ class AddressSynchronizer(Logger, EventListener):
                     self.db.remove_verified_tx(tx_hash)
                     if self.verifier:
                         self.verifier.remove_spv_proof_for_tx(tx_hash)
-            self.db.set_addr_history(addr, hist)
+            self.db.set_spk_history(spk, hist)
 
         for tx_hash, tx_height in hist:
             # add it in case it was previously unconfirmed
             self.add_unverified_or_unconfirmed_tx(tx_hash, tx_height)
-            # if addr is new, we have to recompute txi and txo
+            # if spk is new, we have to recompute txi and txo
             tx = self.db.get_transaction(tx_hash)
             if tx is None:
                 continue
@@ -436,21 +445,21 @@ class AddressSynchronizer(Logger, EventListener):
 
     @profiler
     def load_local_history(self):
-        self._history_local = {}  # type: Dict[str, Set[str]]  # address -> set(txid)
-        self._address_history_changed_events = defaultdict(asyncio.Event)  # address -> Event
+        self._history_local = {}  # type: Dict[str, Set[str]]  # spk -> set(txid)
+        self._spk_history_changed_events = defaultdict(asyncio.Event)  # spk -> Event
         for txid in itertools.chain(self.db.list_txi(), self.db.list_txo()):
             self._add_tx_to_local_history(txid)
 
     @profiler
     def check_history(self):
-        hist_addrs_mine = list(filter(lambda k: self.is_mine(k), self.db.get_history()))
-        hist_addrs_not_mine = list(filter(lambda k: not self.is_mine(k), self.db.get_history()))
-        for addr in hist_addrs_not_mine:
-            self.db.remove_addr_history(addr)
-        for addr in hist_addrs_mine:
-            hist = self.db.get_addr_history(addr)
+        hist_spks_mine = list(filter(lambda k: self.is_mine(k), self.db.get_scriptpubkeys()))
+        hist_spks_not_mine = list(filter(lambda k: not self.is_mine(k), self.db.get_scriptpubkeys()))
+        for spk in hist_spks_not_mine:
+            self.db.remove_spk_history(spk)
+        for spk in hist_spks_mine:
+            hist = self.db.get_spk_history(spk)
             for tx_hash, tx_height in hist:
-                if self.db.get_txi_addresses(tx_hash) or self.db.get_txo_addresses(tx_hash):
+                if self.db.get_txi_scriptpubkeys(tx_hash) or self.db.get_txo_scriptpubkeys(tx_hash):
                     continue
                 tx = self.db.get_transaction(tx_hash)
                 if tx is not None:
@@ -505,15 +514,15 @@ class AddressSynchronizer(Logger, EventListener):
     @with_lock
     @with_transaction_lock
     @with_local_height_cached
-    def get_history(self, domain) -> Sequence[HistoryItem]:
+    def _get_history(self, *, domain) -> Sequence[HistoryItem]:
         domain = set(domain)
         # 1. Get the history of each address in the domain, maintain the
         #    delta of a tx as the sum of its deltas on domain addresses
         tx_deltas = defaultdict(int)  # type: Dict[str, int]
-        for addr in domain:
-            h = self.get_address_history(addr)
+        for spk in domain:
+            h = self.get_spk_history(spk)
             for tx_hash, height in h:
-                tx_deltas[tx_hash] += self.get_tx_delta(tx_hash, addr)
+                tx_deltas[tx_hash] += self.get_tx_delta(tx_hash, spk)
         # 2. create sorted history
         history = []
         for tx_hash in tx_deltas:
@@ -534,50 +543,54 @@ class AddressSynchronizer(Logger, EventListener):
                 fee=fee,
                 balance=balance))
         # sanity check
-        c, u, x = self.get_balance(domain)
+        c, u, x = self._get_balance(domain=domain)
         if balance != c + u + x:
             self.logger.error(f'sanity check failed! c={c},u={u},x={x} while history balance={balance}')
             raise Exception("wallet.get_history() failed balance sanity-check")
         return h2
 
+    def get_history(self, *, domain_addrs) -> Sequence[HistoryItem]:
+        domain = set(bitcoin.address_to_script(addr) for addr in domain_addrs)
+        return self._get_history(domain=domain)
+
     def _add_tx_to_local_history(self, txid):
         with self.transaction_lock:
-            for addr in itertools.chain(self.db.get_txi_addresses(txid), self.db.get_txo_addresses(txid)):
-                cur_hist = self._history_local.get(addr, set())
+            for spk in itertools.chain(self.db.get_txi_scriptpubkeys(txid), self.db.get_txo_scriptpubkeys(txid)):
+                cur_hist = self._history_local.get(spk, set())
                 cur_hist.add(txid)
-                self._history_local[addr] = cur_hist
-                self._mark_address_history_changed(addr)
+                self._history_local[spk] = cur_hist
+                self._mark_spk_history_changed(spk)
 
     def _remove_tx_from_local_history(self, txid):
         with self.transaction_lock:
-            for addr in itertools.chain(self.db.get_txi_addresses(txid), self.db.get_txo_addresses(txid)):
-                cur_hist = self._history_local.get(addr, set())
+            for spk in itertools.chain(self.db.get_txi_scriptpubkeys(txid), self.db.get_txo_scriptpubkeys(txid)):
+                cur_hist = self._history_local.get(spk, set())
                 try:
                     cur_hist.remove(txid)
                 except KeyError:
                     pass
                 else:
-                    self._history_local[addr] = cur_hist
-                    self._mark_address_history_changed(addr)
+                    self._history_local[spk] = cur_hist
+                    self._mark_spk_history_changed(spk)
 
-    def _mark_address_history_changed(self, addr: str) -> None:
+    def _mark_spk_history_changed(self, spk: str) -> None:
         def set_and_clear():
-            event = self._address_history_changed_events[addr]
-            # history for this address changed, wake up coroutines:
+            event = self._spk_history_changed_events[spk]
+            # history for this spk changed, wake up coroutines:
             event.set()
             # clear event immediately so that coroutines can wait() for the next change:
             event.clear()
         if self.asyncio_loop:
             self.asyncio_loop.call_soon_threadsafe(set_and_clear)
 
-    async def wait_for_address_history_to_change(self, addr: str) -> None:
-        """Wait until the server tells us about a new transaction related to addr.
+    async def wait_for_spk_history_to_change(self, spk: str) -> None:
+        """Wait until the server tells us about a new transaction related to spk.
 
         Unconfirmed and confirmed transactions are not distinguished, and so e.g. SPV
         is not taken into account.
         """
-        assert self.is_mine(addr), "address needs to be is_mine to be watched"
-        await self._address_history_changed_events[addr].wait()
+        assert self.is_mine(spk), "spk needs to be is_mine to be watched"
+        await self._spk_history_changed_events[spk].wait()
 
     def add_unverified_or_unconfirmed_tx(self, tx_hash, tx_height):
         if self.db.is_in_verified_tx(tx_hash):
@@ -703,15 +716,15 @@ class AddressSynchronizer(Logger, EventListener):
         return nsent, nans
 
     @with_transaction_lock
-    def get_tx_delta(self, tx_hash: str, address: str) -> int:
-        """effect of tx on address"""
+    def get_tx_delta(self, tx_hash: str, spk: str) -> int:
+        """effect of tx on scriptPubKey"""
         delta = 0
-        # subtract the value of coins sent from address
-        d = self.db.get_txi_addr(tx_hash, address)
+        # subtract the value of coins sent from spk
+        d = self.db.get_txi_spk(tx_hash, spk)
         for n, v in d:
             delta -= v
-        # add the value of the coins received at address
-        d = self.db.get_txo_addr(tx_hash, address)
+        # add the value of the coins received at spk
+        d = self.db.get_txo_spk(tx_hash, spk)
         for n, (v, cb) in d.items():
             delta += v
         return delta
@@ -745,8 +758,8 @@ class AddressSynchronizer(Logger, EventListener):
         v_in = v_out = 0
         with self.lock, self.transaction_lock:
             for txin in tx.inputs():
-                addr = self.get_txin_address(txin)
-                value = self.get_txin_value(txin, address=addr)
+                spk = self.get_txin_spk(txin)
+                value = self.get_txin_value(txin, spk=spk)
                 if value is None:
                     v_in = None
                 elif v_in is not None:
@@ -762,29 +775,29 @@ class AddressSynchronizer(Logger, EventListener):
         self.db.add_num_inputs_to_tx(txid, len(tx.inputs()))
         return fee
 
-    def get_addr_io(self, address):
+    def get_spk_io(self, spk: str):
         with self.lock, self.transaction_lock:
-            h = self.get_address_history(address)
+            h = self.get_spk_history(spk)
             received = {}
             sent = {}
             for tx_hash, height in h:
-                d = self.db.get_txo_addr(tx_hash, address)
+                d = self.db.get_txo_spk(tx_hash, spk)
                 for n, (v, is_cb) in d.items():
                     received[tx_hash + ':%d'%n] = (height, v, is_cb)
             for tx_hash, height in h:
-                l = self.db.get_txi_addr(tx_hash, address)
+                l = self.db.get_txi_spk(tx_hash, spk)
                 for txi, v in l:
                     sent[txi] = tx_hash, height
         return received, sent
 
-    def get_addr_outputs(self, address: str) -> Dict[TxOutpoint, PartialTxInput]:
-        coins, spent = self.get_addr_io(address)
+    def get_spk_outputs(self, spk: str) -> Dict[TxOutpoint, PartialTxInput]:
+        coins, spent = self.get_spk_io(spk)
         out = {}
         for prevout_str, v in coins.items():
             tx_height, value, is_cb = v
             prevout = TxOutpoint.from_str(prevout_str)
             utxo = PartialTxInput(prevout=prevout, is_coinbase_output=is_cb)
-            utxo._trusted_address = address
+            utxo._trusted_scriptpubkey = bytes.fromhex(spk)
             utxo._trusted_value_sats = value
             utxo.block_height = tx_height
             if prevout_str in spent:
@@ -797,31 +810,36 @@ class AddressSynchronizer(Logger, EventListener):
             out[prevout] = utxo
         return out
 
-    def get_addr_utxo(self, address: str) -> Dict[TxOutpoint, PartialTxInput]:
-        out = self.get_addr_outputs(address)
+    def get_spk_utxo(self, spk: str) -> Dict[TxOutpoint, PartialTxInput]:
+        out = self.get_spk_outputs(spk)
         for k, v in list(out.items()):
             if v.spent_height is not None:
                 out.pop(k)
         return out
 
-    # return the total amount ever received by an address
-    def get_addr_received(self, address):
-        received, sent = self.get_addr_io(address)
+    def get_spk_received(self, spk: str) -> int:
+        """Return the total amount ever received by a spk."""
+        received, sent = self.get_spk_io(spk)
         return sum([v for height, v, is_cb in received.values()])
 
     @with_local_height_cached
-    def get_balance(self, domain, *, excluded_addresses: Set[str] = None,
-                    excluded_coins: Set[str] = None) -> Tuple[int, int, int]:
-        """Return the balance of a set of addresses:
+    def _get_balance(
+        self,
+        *,
+        domain: Iterable[str],
+        excluded_spks: Set[str] = None,
+        excluded_coins: Set[str] = None,
+    ) -> Tuple[int, int, int]:
+        """Return the balance of a set of scriptPubKeys:
         confirmed and matured, unconfirmed, unmatured
         """
-        if excluded_addresses is None:
-            excluded_addresses = set()
-        assert isinstance(excluded_addresses, set), f"excluded_addresses should be set, not {type(excluded_addresses)}"
-        domain = set(domain) - excluded_addresses
+        if excluded_spks is None:
+            excluded_spks = set()
+        assert isinstance(excluded_spks, set), f"excluded_spks should be a set, not {type(excluded_spks)}"
+        domain = set(domain) - excluded_spks
         if excluded_coins is None:
             excluded_coins = set()
-        assert isinstance(excluded_coins, set), f"excluded_coins should be set, not {type(excluded_coins)}"
+        assert isinstance(excluded_coins, set), f"excluded_coins should be a set, not {type(excluded_coins)}"
 
         cache_key = sha256(','.join(sorted(domain)) + ';'
                            + ','.join(sorted(excluded_coins)))
@@ -830,8 +848,8 @@ class AddressSynchronizer(Logger, EventListener):
             return cached_value
 
         coins = {}
-        for address in domain:
-            coins.update(self.get_addr_outputs(address))
+        for spk in domain:
+            coins.update(self.get_spk_outputs(spk))
 
         c = u = x = 0
         mempool_height = self.get_local_height() + 1  # height of next block
@@ -850,7 +868,7 @@ class AddressSynchronizer(Logger, EventListener):
             else:
                 txid = utxo.prevout.txid.hex()
                 tx = self.db.get_transaction(txid)
-                assert tx is not None # txid comes from get_addr_io
+                assert tx is not None  # txid comes from get_spk_io
                 # we look at the outputs that are spent by this transaction
                 # if those outputs are ours and confirmed, we count this coin as confirmed
                 confirmed_spent_amount = 0
@@ -873,17 +891,28 @@ class AddressSynchronizer(Logger, EventListener):
         self._get_balance_cache[cache_key] = result
         return result
 
+    def get_balance(
+        self,
+        *,
+        domain_addrs: Iterable[str],
+        excluded_addresses: Set[str] = None,
+        **kwargs,
+    ) -> Tuple[int, int, int]:
+        domain = set(bitcoin.address_to_script(addr) for addr in domain_addrs)
+        excluded_spks = set(bitcoin.address_to_script(addr) for addr in (excluded_addresses or set()))
+        return self._get_balance(domain=domain, excluded_spks=excluded_spks, **kwargs)
+
     @with_local_height_cached
-    def get_utxos(
-            self,
-            domain,
-            *,
-            excluded_addresses=None,
-            mature_only: bool = False,
-            confirmed_funding_only: bool = False,
-            confirmed_spending_only: bool = False,
-            nonlocal_only: bool = False,
-            block_height: int = None,
+    def _get_utxos(
+        self,
+        *,
+        domain: Iterable[str],
+        excluded_spks: Set[str] = None,
+        mature_only: bool = False,
+        confirmed_funding_only: bool = False,
+        confirmed_spending_only: bool = False,
+        nonlocal_only: bool = False,
+        block_height: int = None,
     ) -> Sequence[PartialTxInput]:
         if block_height is not None:
             # caller wants the UTXOs we had at a given height; check other parameters
@@ -894,11 +923,11 @@ class AddressSynchronizer(Logger, EventListener):
             block_height = self.get_local_height()
         coins = []
         domain = set(domain)
-        if excluded_addresses:
-            domain = set(domain) - set(excluded_addresses)
+        if excluded_spks:
+            domain = set(domain) - set(excluded_spks)
         mempool_height = block_height + 1  # height of next block
-        for addr in domain:
-            txos = self.get_addr_outputs(addr)
+        for spk in domain:
+            txos = self.get_spk_outputs(spk)
             for txo in txos.values():
                 if txo.spent_height is not None:
                     if not confirmed_spending_only:
@@ -916,20 +945,36 @@ class AddressSynchronizer(Logger, EventListener):
                 continue
         return coins
 
-    def is_used(self, address: str) -> bool:
-        return self.get_address_history_len(address) != 0
+    def get_utxos(
+        self,
+        *,
+        domain_addrs: Iterable[str],
+        excluded_addresses: Set[str] = None,
+        **kwargs,
+    ) -> Sequence[PartialTxInput]:
+        domain = set(bitcoin.address_to_script(addr) for addr in domain_addrs)
+        excluded_spks = set(bitcoin.address_to_script(addr) for addr in (excluded_addresses or set()))
+        return self._get_utxos(domain=domain, excluded_spks=excluded_spks, **kwargs)
 
-    def is_empty(self, address: str) -> bool:
-        coins = self.get_addr_utxo(address)
+    def is_used(self, spk: str) -> bool:
+        assert is_hex_str(spk)
+        return self.get_spk_history_len(spk) != 0
+
+    def is_addr_used(self, addr: str) -> bool:
+        spk = bitcoin.address_to_script(addr)
+        return self.is_used(spk)
+
+    def is_empty(self, spk: str) -> bool:
+        coins = self.get_spk_utxo(spk)
         return not bool(coins)
 
     @with_local_height_cached
-    def address_is_old(self, address: str, *, req_conf: int = 3) -> bool:
-        """Returns whether address has any history that is deeply confirmed.
+    def is_spk_old(self, *, spk: str, req_conf: int = 3) -> bool:
+        """Returns whether spk has any history that is deeply confirmed.
         Used for reorg-safe(ish) gap limit roll-forward.
         """
         max_conf = -1
-        h = self.db.get_addr_history(address)
+        h = self.db.get_spk_history(spk)
         needs_spv_check = not self.config.get("skipmerklecheck", False)
         for tx_hash, tx_height in h:
             if needs_spv_check:
@@ -941,3 +986,7 @@ class AddressSynchronizer(Logger, EventListener):
                     tx_age = self.get_local_height() - tx_height + 1
             max_conf = max(max_conf, tx_age)
         return max_conf >= req_conf
+
+    def is_address_old(self, address: str, **kwargs) -> bool:
+        spk = bitcoin.address_to_script(address)
+        return self.is_spk_old(spk=spk, **kwargs)

--- a/electrum/bitcoin.py
+++ b/electrum/bitcoin.py
@@ -453,7 +453,7 @@ def redeem_script_to_address(txin_type: str, scriptcode: str, *, net=None) -> st
         raise NotImplementedError(txin_type)
 
 
-def script_to_address(script: str, *, net=None) -> str:
+def script_to_address(script: str, *, net=None) -> Optional[str]:
     from .transaction import get_address_from_output_script
     return get_address_from_output_script(bfh(script), net=net)
 

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -808,15 +808,16 @@ class Commands:
         """List wallet addresses. Returns the list of all addresses in your wallet. Use optional arguments to filter the results."""
         out = []
         for addr in wallet.get_addresses():
+            spk = bitcoin.address_to_script(addr)
             if frozen and not wallet.is_frozen_address(addr):
                 continue
             if receiving and wallet.is_change(addr):
                 continue
             if change and not wallet.is_change(addr):
                 continue
-            if unused and wallet.adb.is_used(addr):
+            if unused and wallet.adb.is_used(spk):
                 continue
-            if funded and wallet.adb.is_empty(addr):
+            if funded and wallet.adb.is_empty(spk):
                 continue
             item = addr
             if labels or balance:
@@ -1006,9 +1007,9 @@ class Commands:
         if not hasattr(self, "_notifier"):
             self._notifier = Notifier(self.network)
         if URL:
-            await self._notifier.start_watching_addr(address, URL)
+            await self._notifier.start_watching_spk(address, URL)
         else:
-            await self._notifier.stop_watching_addr(address)
+            await self._notifier.stop_watching_spk(address)
         return True
 
     @command('wn')

--- a/electrum/gui/kivy/uix/dialogs/addresses.py
+++ b/electrum/gui/kivy/uix/dialogs/addresses.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from kivy.uix.popup import Popup
 
 from electrum.gui.kivy.i18n import _
-from ...util import address_colors
+from electrum.gui.kivy.util import address_colors
 
 if TYPE_CHECKING:
     from ...main_window import ElectrumWindow
@@ -264,7 +264,7 @@ class AddressesDialog(Factory.Popup):
         for address in _list:
             label = wallet.get_label_for_address(address)
             balance = sum(wallet.get_addr_balance(address))
-            is_used_and_empty = wallet.adb.is_used(address) and balance == 0
+            is_used_and_empty = wallet.adb.is_addr_used(address) and balance == 0
             if self.show_used == 1 and (balance or is_used_and_empty):
                 continue
             if self.show_used == 2 and balance == 0:

--- a/electrum/gui/qml/qeaddressdetails.py
+++ b/electrum/gui/qml/qeaddressdetails.py
@@ -1,5 +1,6 @@
 from PyQt5.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 
+from electrum import bitcoin
 from electrum.logging import get_logger
 
 from .qetransactionlistmodel import QETransactionListModel
@@ -112,6 +113,7 @@ class QEAddressDetails(QObject):
         if self._wallet is None:
             self._logger.error('wallet undefined')
             return
+        spk = bitcoin.address_to_script(self._address)
 
         self._frozen = self._wallet.wallet.is_frozen_address(self._address)
         self.frozenChanged.emit()
@@ -124,6 +126,6 @@ class QEAddressDetails(QObject):
         self._derivationPath = self._wallet.wallet.get_address_path_str(self._address)
         if self._wallet.derivationPrefix:
             self._derivationPath = self._derivationPath.replace('m', self._wallet.derivationPrefix)
-        self._numtx = self._wallet.wallet.adb.get_address_history_len(self._address)
+        self._numtx = self._wallet.wallet.adb.get_spk_history_len(spk)
         assert self._numtx == self.historyModel.rowCount(0)
         self.detailsChanged.emit()

--- a/electrum/gui/qml/qeaddresslistmodel.py
+++ b/electrum/gui/qml/qeaddresslistmodel.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from PyQt5.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 from PyQt5.QtCore import Qt, QAbstractListModel, QModelIndex
 
+from electrum import bitcoin
 from electrum.logging import get_logger
 from electrum.util import Satoshis
 
@@ -52,9 +53,10 @@ class QEAddressListModel(QAbstractListModel):
         self.endResetModel()
 
     def addr_to_model(self, address):
+        spk = bitcoin.address_to_script(address)
         item = {}
         item['address'] = address
-        item['numtx'] = self.wallet.adb.get_address_history_len(address)
+        item['numtx'] = self.wallet.adb.get_spk_history_len(spk)
         item['label'] = self.wallet.get_label_for_address(address)
         c, u, x = self.wallet.get_addr_balance(address)
         item['balance'] = QEAmount(amount_sat=c + u + x)

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -391,14 +391,14 @@ class ElectrumGui(BaseElectrumGui, Logger):
     def _start_wizard_to_select_or_create_wallet(self, path) -> Optional[Abstract_Wallet]:
         wizard = InstallWizard(self.config, self.app, self.plugins, gui_object=self)
         try:
-            path, storage = wizard.select_storage(path, self.daemon.get_wallet)
+            path, storage = wizard.select_storage(path, self.daemon.get_wallet)  #
             # storage is None if file does not exist
             if storage is None:
                 wizard.path = path  # needed by trustedcoin plugin
                 wizard.run('new')
                 storage, db = wizard.create_storage(path)
             else:
-                db = WalletDB(storage.read(), manual_upgrades=False)
+                db = WalletDB(storage.read(), manual_upgrades=False)  #
                 wizard.run_upgrades(storage, db)
         except (UserCancelled, GoBack):
             return

--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -29,6 +29,7 @@ from PyQt5.QtCore import Qt, QPersistentModelIndex, QModelIndex
 from PyQt5.QtGui import QStandardItemModel, QStandardItem, QFont
 from PyQt5.QtWidgets import QAbstractItemView, QComboBox, QLabel, QMenu
 
+from electrum import bitcoin
 from electrum.i18n import _
 from electrum.util import block_explorer_URL, profiler
 from electrum.plugin import run_hook
@@ -167,7 +168,7 @@ class AddressList(MyTreeView):
         for address in addr_list:
             c, u, x = self.wallet.get_addr_balance(address)
             balance = c + u + x
-            is_used_and_empty = self.wallet.adb.is_used(address) and balance == 0
+            is_used_and_empty = self.wallet.adb.is_addr_used(address) and balance == 0
             if self.show_used == AddressUsageStateFilter.UNUSED and (balance or is_used_and_empty):
                 continue
             if self.show_used == AddressUsageStateFilter.FUNDED and balance == 0:
@@ -217,8 +218,9 @@ class AddressList(MyTreeView):
     def refresh_row(self, key, row):
         assert row is not None
         address = key
+        spk = bitcoin.address_to_script(address)
         label = self.wallet.get_label_for_address(address)
-        num = self.wallet.adb.get_address_history_len(address)
+        num = self.wallet.adb.get_spk_history_len(spk)
         c, u, x = self.wallet.get_addr_balance(address)
         balance = c + u + x
         balance_text = self.parent.format_amount(balance, whitespaces=True)

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -104,7 +104,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         + "%d"%(width[2]+delta)+"s"+"%"+"%d"%(width[3]+delta)+"s"
         messages = []
         domain = self.wallet.get_addresses()
-        for hist_item in reversed(self.wallet.adb.get_history(domain)):
+        for hist_item in reversed(self.wallet.adb.get_history(domain_addrs=domain)):
             if hist_item.tx_mined_status.conf:
                 timestamp = hist_item.tx_mined_status.timestamp
                 try:

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -35,6 +35,7 @@ import attr
 
 from . import ecc
 from . import constants, util
+from . import bitcoin
 from .util import bfh, bh2u, chunks, TxMinedInfo
 from .invoices import PR_PAID
 from .bitcoin import redeem_script_to_address
@@ -503,7 +504,8 @@ class ChannelBackup(AbstractChannel):
         lnwatcher = self.lnworker.lnwatcher
         if lnwatcher:
             # fixme: we should probably not call that method here
-            return lnwatcher.adb.get_tx_delta(self.funding_outpoint.txid, self.cb.funding_address)
+            spk = bitcoin.address_to_script(self.cb.funding_address)
+            return lnwatcher.adb.get_tx_delta(self.funding_outpoint.txid, spk)
         return None
 
     def is_backup(self):

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -10,7 +10,7 @@ import attr
 from .crypto import sha256, hash_160
 from .ecc import ECPrivkey
 from .bitcoin import (script_to_p2wsh, opcodes, p2wsh_nested_script, push_script,
-                      is_segwit_address, construct_witness)
+                      is_segwit_address, construct_witness, address_to_script)
 from .transaction import PartialTxInput, PartialTxOutput, PartialTransaction, Transaction, TxInput, TxOutpoint
 from .transaction import script_GetOp, match_script_against_template, OPPushDataGeneric, OPPushDataPubkey
 from .util import log_exceptions
@@ -182,7 +182,7 @@ class SwapManager(Logger):
             return
         current_height = self.network.get_local_height()
         delta = current_height - swap.locktime
-        txos = self.lnwatcher.adb.get_addr_outputs(swap.lockup_address)
+        txos = self.lnwatcher.adb.get_spk_outputs(address_to_script(swap.lockup_address))
         for txin in txos.values():
             if swap.is_reverse and txin.value_sats() < swap.onchain_amount:
                 self.logger.info('amount too low, we should not reveal the preimage')

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -32,8 +32,8 @@ from aiorpcx import run_in_thread, RPCError
 
 from . import util
 from .transaction import Transaction, PartialTransaction
-from .util import bh2u, make_aiohttp_session, NetworkJobOnDefaultServer, random_shuffled_copy, OldTaskGroup
-from .bitcoin import address_to_scripthash, is_address
+from .util import bh2u, make_aiohttp_session, NetworkJobOnDefaultServer, random_shuffled_copy, OldTaskGroup, is_hex_str
+from .bitcoin import script_to_scripthash, address_to_script
 from .logging import Logger
 from .interface import GracefulDisconnect, NetworkTimeout
 
@@ -65,10 +65,10 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
 
     def _reset(self):
         super()._reset()
-        self._adding_addrs = set()
-        self.requested_addrs = set()
-        self._handling_addr_statuses = set()
-        self.scripthash_to_address = {}
+        self._adding_spks = set()
+        self.requested_scriptpubkeys = set()
+        self._handling_spk_statuses = set()
+        self.scripthash_to_spk = {}
         self._processed_some_notifications = False  # so that we don't miss them
         # Queues
         self.status_queue = asyncio.Queue()
@@ -83,29 +83,27 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
             # we are being cancelled now
             self.session.unsubscribe(self.status_queue)
 
-    def add(self, addr):
-        if not is_address(addr): raise ValueError(f"invalid bitcoin address {addr}")
-        self._adding_addrs.add(addr)  # this lets is_up_to_date already know about addr
-        asyncio.run_coroutine_threadsafe(self._add_address(addr), self.asyncio_loop)
+    def add_spk(self, spk: str) -> None:
+        assert is_hex_str(spk)
+        self._adding_spks.add(spk)  # this lets is_up_to_date already know about spk
+        asyncio.run_coroutine_threadsafe(self._add_spk(spk), self.asyncio_loop)
 
-    async def _add_address(self, addr: str):
+    async def _add_spk(self, spk: str):
         try:
-            if not is_address(addr): raise ValueError(f"invalid bitcoin address {addr}")
-            if addr in self.requested_addrs: return
-            self.requested_addrs.add(addr)
-            await self.taskgroup.spawn(self._subscribe_to_address, addr)
+            assert is_hex_str(spk)
+            if spk in self.requested_scriptpubkeys: return
+            self.requested_scriptpubkeys.add(spk)
+            await self.taskgroup.spawn(self._subscribe_to_address, spk)
         finally:
-            self._adding_addrs.discard(addr)  # ok for addr not to be present
+            self._adding_spks.discard(spk)  # ok for addr not to be present
 
-    async def _on_address_status(self, addr, status):
-        """Handle the change of the status of an address.
-        Should remove addr from self._handling_addr_statuses when done.
-        """
+    async def _on_spk_status(self, spk, status):
+        """Handle the change of the status of a scriptPubKey."""
         raise NotImplementedError()  # implemented by subclasses
 
-    async def _subscribe_to_address(self, addr):
-        h = address_to_scripthash(addr)
-        self.scripthash_to_address[h] = addr
+    async def _subscribe_to_address(self, spk):
+        h = script_to_scripthash(spk)
+        self.scripthash_to_spk[h] = spk
         self._requests_sent += 1
         try:
             async with self._network_request_semaphore:
@@ -119,10 +117,10 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
     async def handle_status(self):
         while True:
             h, status = await self.status_queue.get()
-            addr = self.scripthash_to_address[h]
-            self._handling_addr_statuses.add(addr)
-            self.requested_addrs.discard(addr)  # ok for addr not to be present
-            await self.taskgroup.spawn(self._on_address_status, addr, status)
+            spk = self.scripthash_to_spk[h]
+            self._handling_spk_statuses.add(spk)
+            self.requested_scriptpubkeys.discard(spk)  # ok for addr not to be present
+            await self.taskgroup.spawn(self._on_spk_status, spk, status)
             self._processed_some_notifications = True
 
     async def main(self):
@@ -131,7 +129,7 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
 
 class Synchronizer(SynchronizerBase):
     '''The synchronizer keeps the wallet up-to-date with its set of
-    addresses and their transactions.  It subscribes over the network
+    scriptPubKeys and their transactions.  It subscribes over the network
     to wallet addresses, gets the wallet to generate new addresses
     when necessary, requests the transaction history of any addresses
     we don't have the full history of, and requests binary transaction
@@ -153,34 +151,34 @@ class Synchronizer(SynchronizerBase):
 
     def is_up_to_date(self):
         return (self._init_done
-                and not self._adding_addrs
-                and not self.requested_addrs
-                and not self._handling_addr_statuses
+                and not self._adding_spks
+                and not self.requested_scriptpubkeys
+                and not self._handling_spk_statuses
                 and not self.requested_histories
                 and not self.requested_tx
                 and not self._stale_histories
                 and self.status_queue.empty())
 
-    async def _on_address_status(self, addr, status):
+    async def _on_spk_status(self, spk, status):
         try:
-            history = self.adb.db.get_addr_history(addr)
+            history = self.adb.db.get_spk_history(spk)
             if history_status(history) == status:
                 return
             # No point in requesting history twice for the same announced status.
             # However if we got announced a new status, we should request history again:
-            if (addr, status) in self.requested_histories:
+            if (spk, status) in self.requested_histories:
                 return
             # request address history
-            self.requested_histories.add((addr, status))
-            self._stale_histories.pop(addr, asyncio.Future()).cancel()
+            self.requested_histories.add((spk, status))
+            self._stale_histories.pop(spk, asyncio.Future()).cancel()
         finally:
-            self._handling_addr_statuses.discard(addr)
-        h = address_to_scripthash(addr)
+            self._handling_spk_statuses.discard(spk)
+        h = script_to_scripthash(spk)
         self._requests_sent += 1
         async with self._network_request_semaphore:
             result = await self.interface.get_history_for_scripthash(h)
         self._requests_answered += 1
-        self.logger.info(f"receiving history {addr} {len(result)}")
+        self.logger.info(f"receiving history {spk} {len(result)}")
         hist = list(map(lambda item: (item['tx_hash'], item['height']), result))
         # tx_fees
         tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
@@ -188,23 +186,23 @@ class Synchronizer(SynchronizerBase):
         # Check that the status corresponds to what was announced
         if history_status(hist) != status:
             # could happen naturally if history changed between getting status and history (race)
-            self.logger.info(f"error: status mismatch: {addr}. we'll wait a bit for status update.")
+            self.logger.info(f"error: status mismatch: {spk}. we'll wait a bit for status update.")
             # The server is supposed to send a new status notification, which will trigger a new
             # get_history. We shall wait a bit for this to happen, otherwise we disconnect.
             async def disconnect_if_still_stale():
                 timeout = self.network.get_network_timeout_seconds(NetworkTimeout.Generic)
                 await asyncio.sleep(timeout)
-                raise SynchronizerFailure(f"timeout reached waiting for addr {addr}: history still stale")
-            self._stale_histories[addr] = await self.taskgroup.spawn(disconnect_if_still_stale)
+                raise SynchronizerFailure(f"timeout reached waiting for spk {spk}: history still stale")
+            self._stale_histories[spk] = await self.taskgroup.spawn(disconnect_if_still_stale)
         else:
-            self._stale_histories.pop(addr, asyncio.Future()).cancel()
+            self._stale_histories.pop(spk, asyncio.Future()).cancel()
             # Store received history
-            self.adb.receive_history_callback(addr, hist, tx_fees)
+            self.adb.receive_history_callback(spk, hist, tx_fees)
             # Request transactions we don't have
             await self._request_missing_txs(hist)
 
         # Remove request; this allows up_to_date to be True
-        self.requested_histories.discard((addr, status))
+        self.requested_histories.discard((spk, status))
 
     async def _request_missing_txs(self, hist, *, allow_server_not_finding_tx=False):
         # "hist" is a list of [tx_hash, tx_height] lists
@@ -247,15 +245,15 @@ class Synchronizer(SynchronizerBase):
     async def main(self):
         self.adb.up_to_date_changed()
         # request missing txns, if any
-        for addr in random_shuffled_copy(self.adb.db.get_history()):
-            history = self.adb.db.get_addr_history(addr)
+        for spk in random_shuffled_copy(self.adb.db.get_scriptpubkeys()):
+            history = self.adb.db.get_spk_history(spk)
             # Old electrum servers returned ['*'] when all history for the address
             # was pruned. This no longer happens but may remain in old wallets.
             if history == ['*']: continue
             await self._request_missing_txs(history, allow_server_not_finding_tx=True)
         # add addresses to bootstrap
-        for addr in random_shuffled_copy(self.adb.get_addresses()):
-            await self._add_address(addr)
+        for spk in random_shuffled_copy(self.adb.get_scriptpubkeys()):
+            await self._add_spk(spk)
         # main loop
         self._init_done = True
         prev_uptodate = False
@@ -276,33 +274,46 @@ class Notifier(SynchronizerBase):
     """
     def __init__(self, network):
         SynchronizerBase.__init__(self, network)
-        self.watched_addresses = defaultdict(list)  # type: Dict[str, List[str]]
+        self.watched_scriptpubkeys = defaultdict(list)  # type: Dict[str, List[str]]
         self._start_watching_queue = asyncio.Queue()  # type: asyncio.Queue[Tuple[str, str]]
+        self._spk_to_addr = {}  # type: Dict[str, str]
 
     async def main(self):
         # resend existing subscriptions if we were restarted
-        for addr in self.watched_addresses:
-            await self._add_address(addr)
+        for spk in self.watched_scriptpubkeys:
+            await self._add_spk(spk)
         # main loop
         while True:
-            addr, url = await self._start_watching_queue.get()
-            self.watched_addresses[addr].append(url)
-            await self._add_address(addr)
+            spk, url = await self._start_watching_queue.get()
+            self.watched_scriptpubkeys[spk].append(url)
+            await self._add_spk(spk)
 
     async def start_watching_addr(self, addr: str, url: str):
-        await self._start_watching_queue.put((addr, url))
+        spk = address_to_script(addr)
+        self._spk_to_addr[spk] = addr
+        await self.start_watching_spk(spk=spk, url=url)
 
-    async def stop_watching_addr(self, addr: str):
-        self.watched_addresses.pop(addr, None)
+    async def stop_watching_spk(self, spk: str):
+        self.watched_scriptpubkeys.pop(spk, None)
         # TODO blockchain.scripthash.unsubscribe
 
-    async def _on_address_status(self, addr, status):
-        if addr not in self.watched_addresses:
+    async def stop_watching_addr(self, addr: str):
+        spk = address_to_script(addr)
+        await self.stop_watching_spk(spk=spk)
+        self._spk_to_addr.pop(spk, None)
+
+    async def _on_spk_status(self, spk, status):
+        if spk not in self.watched_scriptpubkeys:
             return
-        self.logger.info(f'new status for addr {addr}')
+        addr = self._spk_to_addr.get(spk, None)
+        self.logger.info(f'new status for spk {spk}. (addr={addr})')
         headers = {'content-type': 'application/json'}
-        data = {'address': addr, 'status': status}
-        for url in self.watched_addresses[addr]:
+        data = {'spk': spk, 'status': status}
+        if addr:
+            data['address'] = addr
+        for url in self.watched_scriptpubkeys[spk]:
+            if not url:
+                continue
             try:
                 async with make_aiohttp_session(proxy=self.network.proxy, headers=headers) as session:
                     async with session.post(url, json=data, headers=headers) as resp:
@@ -310,4 +321,4 @@ class Notifier(SynchronizerBase):
             except Exception as e:
                 self.logger.info(repr(e))
             else:
-                self.logger.info(f'Got Response for {addr}')
+                self.logger.info(f'Got Response for spk {spk}. (addr={addr})')

--- a/electrum/tests/test_wallet_vertical.py
+++ b/electrum/tests/test_wallet_vertical.py
@@ -3356,29 +3356,31 @@ class TestWalletHistory_EvilGapLimit(TestCaseForTestnet):
         for txid in self.transactions:
             tx = Transaction(self.transactions[txid])
             w.adb.add_transaction(tx)
+        to_spk = bitcoin.address_to_script
         # txn A is an external incoming txn paying to addr (3) and (15)
         # txn B is an external incoming txn paying to addr (4) and (25)
         # txn C is an internal transfer txn from addr (25) -- to -- (1) and (25)
-        w.adb.receive_history_callback('tb1qgh5c088he4d559wl0hw27hrdeg8p2z96pefn4q',  # HD index 1
-                                   [('268fce617aaaa4847835c2212b984d7b7741fdab65de22813288341819bc5656', 1316917)],
-                                   {})
+        w.adb.receive_history_callback(
+            to_spk('tb1qgh5c088he4d559wl0hw27hrdeg8p2z96pefn4q'),  # HD index 1
+            [('268fce617aaaa4847835c2212b984d7b7741fdab65de22813288341819bc5656', 1316917)], {})
         w.synchronize()
-        w.adb.receive_history_callback('tb1qm0ejr6g964zt2jux5te7m9ds43n28hdsdz9ull',  # HD index 3
-                                   [('511a35e240f4c8855de4c548dad932d03611a37e94e9203fdb6fc79911fe1dd4', 1316912)],
-                                   {})
+        w.adb.receive_history_callback(
+            to_spk('tb1qm0ejr6g964zt2jux5te7m9ds43n28hdsdz9ull'),  # HD index 3
+            [('511a35e240f4c8855de4c548dad932d03611a37e94e9203fdb6fc79911fe1dd4', 1316912)], {})
         w.synchronize()
-        w.adb.receive_history_callback('tb1qj4pnq958k89zcem3342lhcgyz0rnmhkzl6x0cl',  # HD index 4
-                                   [('fde0b68938709c4979827caa576e9455ded148537fdb798fd05680da64dc1b4f', 1316917)],
-                                   {})
+        w.adb.receive_history_callback(
+            to_spk('tb1qj4pnq958k89zcem3342lhcgyz0rnmhkzl6x0cl'),  # HD index 4
+            [('fde0b68938709c4979827caa576e9455ded148537fdb798fd05680da64dc1b4f', 1316917)], {})
         w.synchronize()
-        w.adb.receive_history_callback('tb1q3pyjwpm8wxgvquak240mprfhaydmkawcsl25je',  # HD index 15
-                                   [('511a35e240f4c8855de4c548dad932d03611a37e94e9203fdb6fc79911fe1dd4', 1316912)],
-                                   {})
+        w.adb.receive_history_callback(
+            to_spk('tb1q3pyjwpm8wxgvquak240mprfhaydmkawcsl25je'),  # HD index 15
+            [('511a35e240f4c8855de4c548dad932d03611a37e94e9203fdb6fc79911fe1dd4', 1316912)], {})
         w.synchronize()
-        w.adb.receive_history_callback('tb1qr0qjp99ygawul0eylxfqmt7alygye22mj33vej',  # HD index 25
-                                   [('fde0b68938709c4979827caa576e9455ded148537fdb798fd05680da64dc1b4f', 1316917),
-                                    ('268fce617aaaa4847835c2212b984d7b7741fdab65de22813288341819bc5656', 1316917)],
-                                   {})
+        w.adb.receive_history_callback(
+            to_spk('tb1qr0qjp99ygawul0eylxfqmt7alygye22mj33vej'),  # HD index 25
+            [('fde0b68938709c4979827caa576e9455ded148537fdb798fd05680da64dc1b4f', 1316917),
+             ('268fce617aaaa4847835c2212b984d7b7741fdab65de22813288341819bc5656', 1316917)],
+            {})
         w.synchronize()
         self.assertEqual(9999788, sum(w.get_balance()))
 

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1226,7 +1226,7 @@ class PartialTxInput(TxInput, PSBTSection):
         self.num_sig = 0  # type: int  # num req sigs for multisig
         self.pubkeys = []  # type: List[bytes]  # note: order matters
         self._trusted_value_sats = None  # type: Optional[int]
-        self._trusted_address = None  # type: Optional[str]
+        self._trusted_scriptpubkey = None  # type: Optional[bytes]
         self.block_height = None  # type: Optional[int]  # height at which the TXO is mined; None means unknown
         self.spent_height = None  # type: Optional[int]  # height at which the TXO got spent
         self.spent_txid = None  # type: Optional[str]  # txid of the spender
@@ -1420,17 +1420,14 @@ class PartialTxInput(TxInput, PSBTSection):
 
     @property
     def address(self) -> Optional[str]:
-        if self._trusted_address is not None:
-            return self._trusted_address
-        scriptpubkey = self.scriptpubkey
-        if scriptpubkey:
+        if scriptpubkey := self.scriptpubkey:
             return get_address_from_output_script(scriptpubkey)
         return None
 
     @property
     def scriptpubkey(self) -> Optional[bytes]:
-        if self._trusted_address is not None:
-            return bfh(bitcoin.address_to_script(self._trusted_address))
+        if self._trusted_scriptpubkey is not None:
+            return self._trusted_scriptpubkey
         if self.utxo:
             out_idx = self.prevout.out_idx
             return self.utxo.outputs()[out_idx].scriptpubkey


### PR DESCRIPTION
This changes the AddressSynchronizer to use scriptPubKeys ("SPKs") instead of addresses.
- will allow subscribing to scripts that do not have a corresponding address, e.g. OP_RETURNS, p2pk, or bare-multisig
  - in particular, this allows supporting the `pk()`, `raw()`, and top-level `multi()` [output script descriptors](https://github.com/bitcoin/bitcoin/blob/f3bc1a72825fe2b51f4bc20e004cef464f05b965/doc/descriptors.md#reference)
- the wallet still has addresses, but adb has spks now
  - this results in some awkwardness, e.g. see `AddressSynchronizer.get_history`, `.get_balance`, `.get_utxos` methods
    - I think this is acceptable
  - especially during initial history sync of a wallet, there are lots of address->spk conversions
    - I was seeing noticeably worse performance (CPU load) when syncing wallets, so I made some fixes on master:
      - https://github.com/spesmilo/electrum/commit/0037053d73746d8cc535fe07c8fb483ed87a4b91, and especially https://github.com/spesmilo/electrum/commit/61f2654f31701f82bf57df1fb12fee880bccdf6e
    - now the performance looks comparable to old master