### PR TITLE
use placeholder for better translation

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -717,7 +717,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
         def add_toggle_action(view_menu, tab):
             is_shown = self.config.get('show_{}_tab'.format(tab.tab_name), False)
-            item_name = (_("Hide") if is_shown else _("Show")) + " " + tab.tab_description
+            item_name = (_("Hide {}") if is_shown else _("Show {}")).format(tab.tab_description)
             tab.menu_action = view_menu.addAction(item_name, lambda: self.toggle_tab(tab))
 
         view_menu = menubar.addMenu(_("&View"))


### PR DESCRIPTION
Same change like it was for this line: electrum/gui/qt/main_window.py:343 (see commit 019566b383cf3852897010ddce3e110f4f45e571).