### PR TITLE
Test payment requests

### DIFF
--- a/electrum/tests/regtest.py
+++ b/electrum/tests/regtest.py
@@ -1,19 +1,39 @@
-import os
+import asyncio
+import queue
+import subprocess
 import sys
 import unittest
-import subprocess
+from decimal import Decimal
+
+from electrum import util
+from electrum.commands import Commands
+from electrum.constants import set_regtest
+from electrum.daemon import Daemon
+from electrum.simple_config import SimpleConfig
+from electrum.storage import WalletStorage
+from electrum.wallet import Wallet
+from electrum.wallet_db import WalletDB
+
 
 class TestLightning(unittest.TestCase):
 
     @staticmethod
     def run_shell(args, timeout=30):
-        process = subprocess.Popen(['electrum/tests/regtest/regtest.sh'] + args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, universal_newlines=True)
+        process = subprocess.Popen(
+            ['electrum/tests/regtest/regtest.sh'] + args,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        output = ''
         for line in iter(process.stdout.readline, ''):
+            output += line + '\n'
             sys.stdout.write(line)
             sys.stdout.flush()
         process.wait(timeout=timeout)
         process.stdout.close()
         assert process.returncode == 0
+        return output.strip()
 
     def setUp(self):
         test_name = self.id().split('.')[-1]
@@ -71,3 +91,64 @@ class TestLightningABC(TestLightning):
 
     def test_watchtower(self):
         self.run_shell(['watchtower'])
+
+
+class TestPaymentRequests(TestLightning):
+    agents = ['wallet']
+    INVOICE_AMOUNT = '0.01'
+
+    def setUp(self):
+        super().setUp()
+        set_regtest()
+        (
+            self.asyncio_loop,
+            self._stop_loop,
+            self._loop_thread,
+        ) = util.create_and_start_event_loop()
+        self.config = SimpleConfig(
+            {'electrum_path': '/tmp/wallet', 'server': '127.0.0.1:51001:t'}
+        )
+        self.daemon = Daemon(self.config, listen_jsonrpc=False)
+        self.network = self.daemon.network
+        self.queue = queue.Queue()
+
+    def tearDown(self):
+        self.asyncio_loop.call_soon_threadsafe(self._stop_loop.set_result, 1)
+        self._loop_thread.join(timeout=1)
+        super().tearDown()
+
+    def test_payment_requests(self):
+
+        commands = Commands(
+            config=self.config, network=self.network, daemon=self.daemon
+        )
+        storage = WalletStorage('/tmp/wallet/regtest/wallets/default_wallet')
+        db = WalletDB(storage.read(), manual_upgrades=False)
+        wallet = Wallet(db=db, storage=storage, config=self.config)
+        util.register_callback(self.process_callbacks, ['request_status'])
+        wallet.start_network(self.network)
+        self.daemon.add_wallet(wallet)
+
+        async def main_test():
+            req = await commands.add_request(0.01, wallet=wallet)
+            address = req['address']
+            tx_hash = self.run_shell(['sendtoaddress', address, self.INVOICE_AMOUNT])
+            while True:
+                balance = (await commands.getaddressbalance(address))['unconfirmed']
+                if Decimal(balance) >= Decimal(self.INVOICE_AMOUNT):
+                    break
+                await asyncio.sleep(1)
+            # wait a bit more for electrum to sync state
+            await asyncio.sleep(1)
+            assert self.queue.qsize() == 1
+            assert self.queue.get() == (wallet, req['request_id'], 7)
+            req = await commands.get_request(req['request_id'], wallet=wallet)
+            assert req['status'] == 7
+            assert req['tx_hashes'] == [tx_hash]
+
+        asyncio.run_coroutine_threadsafe(
+            main_test(), loop=util.get_asyncio_loop()
+        ).result()
+
+    async def process_callbacks(self, *args):
+        self.queue.put(args)

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -15,6 +15,11 @@ function new_blocks()
     $bitcoin_cli generatetoaddress $1 $($bitcoin_cli getnewaddress) > /dev/null
 }
 
+function send_to()
+{
+    $bitcoin_cli sendtoaddress $1 $2
+}
+
 function wait_for_balance()
 {
     msg="wait until $1's balance reaches $2"
@@ -63,7 +68,7 @@ function wait_until_spent()
 }
 
 if [[ $# -eq 0 ]]; then
-    echo "syntax: init|start|open|status|pay|close|stop"
+    echo "syntax: init|start|open|status|pay|close|stop|sendtoaddress"
     exit 1
 fi
 
@@ -85,8 +90,13 @@ if [[ $1 == "init" ]]; then
         $bob setconfig --offline lightning_listen localhost:9735
     else
         echo "funding $2"
-        $bitcoin_cli sendtoaddress $($agent getunusedaddress -o) 1
+        send_to $($agent getunusedaddress -o) 1
     fi
+fi
+
+
+if [[ $1 == "sendtoaddress" ]]; then
+    send_to $2 $3
 fi
 
 


### PR DESCRIPTION
This PR adds basic regtest tests for payment request functionality. It tests 3 main things: request_status event is fired, getrequest returns correct status and tx_hashes includes the tx hash which paid the request

Note that it still doesn't catch the bug in #8113 because it requires a custom order of conditions to be tested, but at least this provides basic foundation for the existing functionality not to break

cc @SomberNight 