### PR TITLE
Space between pie chart and balance fix

### DIFF
--- a/electrum/gui/qt/balance_dialog.py
+++ b/electrum/gui/qt/balance_dialog.py
@@ -107,7 +107,7 @@ class BalanceToolButton(QToolButton, PieChartObject):
 
     def setText(self, text):
         # this is a hack
-        QToolButton.setText(self, '      ' + text)
+        QToolButton.setText(self, '       ' + text)
 
     def paintEvent(self, event):
         QToolButton.paintEvent(self, event)


### PR DESCRIPTION
On Windows the space between pie chart and balance in the status bar was too little, so I added a space char. Looks still ok on Linux, see screenshots.

Before (Windows):
![windows_before](https://user-images.githubusercontent.com/77545287/211424040-a624ddf5-c65e-4458-a056-4a04675f1c0a.PNG)

Now (Windows):
![winfows_fixed](https://user-images.githubusercontent.com/77545287/211424080-eab93bae-edf5-4cfb-8e9d-cf7a58ab2e8f.PNG)


Now (Linux):
![linux](https://user-images.githubusercontent.com/77545287/211424109-bab78ff2-72fb-43e2-a027-c72cf08853b4.PNG)
