### PR TITLE
remove trailing decimal point in format_satoshis

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -753,6 +753,7 @@ def format_satoshis(
         # add leading whitespaces
         target_total_len = target_integer_len + 1 + target_fract_len
         result = " " * (target_total_len - len(result)) + result
+    result = result.removesuffix('.')
     return result
 
 


### PR DESCRIPTION
If "Zeros after decimal point" in Preferences is set to 0 and the amount is an integer (e.g. 1), it is currently displayed as `1.` which looks weird. This pull request removes the trailing decimal point in this case.

I noticed the help dialog for "Zeros after decimal point" says explicitly "1." too, so not sure if this was on purpose? I'd strongly suggest to drop the . in this case...