### PR TITLE
Update status bar when preference "Zeros after decimal point" is changed

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -101,6 +101,7 @@ class SettingsDialog(QDialog, QtEventListener):
                 self.config.num_zeros = value
                 self.config.set_key('num_zeros', value, True)
                 self.app.refresh_tabs_signal.emit()
+                self.app.update_status_signal.emit()
         nz.valueChanged.connect(on_nz)
 
         # invoices


### PR DESCRIPTION
This updates the balance in the status bar when the preference "Zeros after decimal point" is changed.