### PR TITLE
Fix issues with payment requests system

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2348,7 +2348,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if not reqs:
             return
         # filter out expired
-        reqs = [req for req in reqs if self.get_invoice_status(req) != PR_EXPIRED]
+        reqs = [req for req in reqs if not req.has_expired()]
         # filter out paid-with-lightning
         if self.lnworker:
             reqs = [req for req in reqs
@@ -2395,8 +2395,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             d['URI'] = self.get_request_URI(x)
             # if request was paid onchain, add relevant fields
             # note: addr is reused when getting paid on LN! so we check for that.
-            is_paid, conf, tx_hashes = self._is_onchain_invoice_paid(x)
-            if is_paid and (not self.lnworker or self.lnworker.get_invoice_status(x) != PR_PAID):
+            _, conf, tx_hashes = self._is_onchain_invoice_paid(x)
+            if not self.lnworker or self.lnworker.get_invoice_status(x) != PR_PAID:
                 if conf is not None:
                     d['confirmations'] = conf
                 d['tx_hashes'] = tx_hashes


### PR DESCRIPTION
Should potentially fix #8113

`get_invoice_status` checks invoice payment first, so in case you have an invoice created, expired, and then another created, both will be "paid" while one of them is actually expired

The second fix allows to return tx hashes of partially paid invoice before it got fully paid