### PR TITLE
locale amounts: consistently use "." as dec point, and " " as thou sep

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1339,8 +1339,8 @@ class Commands:
         except InvalidOperation:
             raise Exception("from_amount is not a number")
         return {
-            "from_amount": self.daemon.fx.ccy_amount_str(from_amount, False, from_ccy),
-            "to_amount": self.daemon.fx.ccy_amount_str(to_amount, False, to_ccy),
+            "from_amount": self.daemon.fx.ccy_amount_str(from_amount, add_thousands_sep=False, ccy=from_ccy),
+            "to_amount": self.daemon.fx.ccy_amount_str(to_amount, add_thousands_sep=False, ccy=to_ccy),
             "from_ccy": from_ccy,
             "to_ccy": to_ccy,
             "source": self.daemon.fx.exchange.name(),

--- a/electrum/gui/qml/qefx.py
+++ b/electrum/gui/qml/qefx.py
@@ -108,7 +108,7 @@ class QEFX(QObject, QtEventListener):
             except:
                 return ''
         if plain:
-            return self.fx.ccy_amount_str(self.fx.fiat_value(satoshis, rate), False)
+            return self.fx.ccy_amount_str(self.fx.fiat_value(satoshis, rate), add_thousands_sep=False)
         else:
             return self.fx.value_str(satoshis, rate)
 
@@ -133,7 +133,7 @@ class QEFX(QObject, QtEventListener):
             return ''
         dt = datetime.fromtimestamp(int(td))
         if plain:
-            return self.fx.ccy_amount_str(self.fx.historical_value(satoshis, dt), False)
+            return self.fx.ccy_amount_str(self.fx.historical_value(satoshis, dt), add_thousands_sep=False)
         else:
             return self.fx.historical_value_str(satoshis, dt)
 

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -926,7 +926,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
                 else:
                     fiat_e.follows = True
                     fiat_e.setText(self.fx.ccy_amount_str(
-                        amount * Decimal(rate) / COIN, False))
+                        amount * Decimal(rate) / COIN, add_thousands_sep=False))
                     fiat_e.setStyleSheet(ColorScheme.BLUE.as_stylesheet())
                     fiat_e.follows = False
 

--- a/electrum/tests/test_wallet.py
+++ b/electrum/tests/test_wallet.py
@@ -133,19 +133,19 @@ class TestFiat(ElectrumTestCase):
         self.fx = FakeFxThread(FakeExchange(Decimal('1000.001')))
         default_fiat = Abstract_Wallet.default_fiat_value(self.wallet, txid, self.fx, self.value_sat)
         self.assertEqual(Decimal('1000.001'), default_fiat)
-        self.assertEqual('1,000.00', self.fx.ccy_amount_str(default_fiat, commas=True))
+        self.assertEqual('1 000.00', self.fx.ccy_amount_str(default_fiat, add_thousands_sep=True))
 
     def test_save_fiat_and_reset(self):
         self.assertEqual(False, Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '1000.01', self.fx, self.value_sat))
         saved = self.fiat_value[ccy][txid]
-        self.assertEqual('1,000.01', self.fx.ccy_amount_str(Decimal(saved), commas=True))
+        self.assertEqual('1 000.01', self.fx.ccy_amount_str(Decimal(saved), add_thousands_sep=True))
         self.assertEqual(True,       Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '', self.fx, self.value_sat))
         self.assertNotIn(txid, self.fiat_value[ccy])
         # even though we are not setting it to the exact fiat value according to the exchange rate, precision is truncated away
-        self.assertEqual(True, Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '1,000.002', self.fx, self.value_sat))
+        self.assertEqual(True, Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '1 000.002', self.fx, self.value_sat))
 
     def test_too_high_precision_value_resets_with_no_saved_value(self):
-        self.assertEqual(True, Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '1,000.001', self.fx, self.value_sat))
+        self.assertEqual(True, Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '1 000.001', self.fx, self.value_sat))
 
     def test_empty_resets(self):
         self.assertEqual(True, Abstract_Wallet.set_fiat_value(self.wallet, txid, ccy, '', self.fx, self.value_sat))

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -33,7 +33,7 @@ import urllib
 import threading
 import hmac
 import stat
-from locale import localeconv
+import locale
 import asyncio
 import urllib.request, urllib.parse, urllib.error
 import builtins
@@ -698,7 +698,11 @@ def format_satoshis_plain(
 # We enforce that we have at least that available.
 assert decimal.getcontext().prec >= 28, f"PyDecimal precision too low: {decimal.getcontext().prec}"
 
-DECIMAL_POINT = localeconv()['decimal_point']  # type: str
+# DECIMAL_POINT = locale.localeconv()['decimal_point']  # type: str
+DECIMAL_POINT = "."
+THOUSANDS_SEP = " "
+assert len(DECIMAL_POINT) == 1, f"DECIMAL_POINT has unexpected len. {DECIMAL_POINT!r}"
+assert len(THOUSANDS_SEP) == 1, f"THOUSANDS_SEP has unexpected len. {THOUSANDS_SEP!r}"
 
 
 def format_satoshis(
@@ -737,9 +741,9 @@ def format_satoshis(
         sign = integer_part[0] if integer_part[0] in ("+", "-") else ""
         if sign == "-":
             integer_part = integer_part[1:]
-        integer_part = "{:,}".format(int(integer_part)).replace(',', " ")
+        integer_part = "{:,}".format(int(integer_part)).replace(',', THOUSANDS_SEP)
         integer_part = sign + integer_part
-        fract_part = " ".join(fract_part[i:i+3] for i in range(0, len(fract_part), 3))
+        fract_part = THOUSANDS_SEP.join(fract_part[i:i+3] for i in range(0, len(fract_part), 3))
     result = integer_part + DECIMAL_POINT + fract_part
     # add leading/trailing whitespaces so that numbers can be aligned in a column
     if whitespaces:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -612,13 +612,13 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         # and not util, also have fx remove it
         text = fx.remove_thousands_separator(text)
         def_fiat = self.default_fiat_value(txid, fx, value_sat)
-        formatted = fx.ccy_amount_str(def_fiat, commas=False)
+        formatted = fx.ccy_amount_str(def_fiat, add_thousands_sep=False)
         def_fiat_rounded = Decimal(formatted)
         reset = not text
         if not reset:
             try:
                 text_dec = Decimal(text)
-                text_dec_rounded = Decimal(fx.ccy_amount_str(text_dec, commas=False))
+                text_dec_rounded = Decimal(fx.ccy_amount_str(text_dec, add_thousands_sep=False))
                 reset = text_dec_rounded == def_fiat_rounded
             except:
                 # garbage. not resetting, but not saving either


### PR DESCRIPTION
Always use `"."` as decimal point, and `" "` as thousands separator.

Previously,
- for decimal point, we were using
  - `"."` in some places (e.g. AmountEdit, most fiat amounts), and
  - `locale.localeconv()['decimal_point']` in others.
- for thousands separator, we were using
  - `","` in some places (most fiat amounts), and
  - `" "` in others (format_satoshis)

I think it is better to be consistent even if whatever we pick differs from the locale. Using whitespace for thousands separator (vs comma) is probably less confusing for people whose locale would use `"."` for ts and `","` for dp (as in e.g. German).

The alternative option would be to always use the locale. Even if we decide to do that later, this refactoring should be useful.

closes https://github.com/spesmilo/electrum/issues/2629