### PR TITLE
Return list of tx hashes for partially paid invoices too

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2400,8 +2400,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             d['URI'] = self.get_request_URI(x)
             # if request was paid onchain, add relevant fields
             # note: addr is reused when getting paid on LN! so we check for that.
-            is_paid, conf, tx_hashes = self._is_onchain_invoice_paid(x)
-            if is_paid and (not self.lnworker or self.lnworker.get_invoice_status(x) != PR_PAID):
+            _, conf, tx_hashes = self._is_onchain_invoice_paid(x)
+            if not self.lnworker or self.lnworker.get_invoice_status(x) != PR_PAID:
                 if conf is not None:
                     d['confirmations'] = conf
                 d['tx_hashes'] = tx_hashes


### PR DESCRIPTION
Before the PR, if you paid an invoice partially, it would return status unpaid and an empty list of `tx_hashes`

Now it allows to inspect the list of tx hashes even for partial payments