### PR TITLE
Fix Weak Cryptography Issues

### DIFF
--- a/electrum/plugins/digitalbitbox/digitalbitbox.py
+++ b/electrum/plugins/digitalbitbox/digitalbitbox.py
@@ -132,6 +132,8 @@ class DigitalBitbox_Client(HardwareClientBase):
 
 
     def stretch_key(self, key: bytes):
+        # The 'hashlib.pbkdf2_hmac' method uses a non-random salt.
+        # Hash function without an unpredictable salt increases the likelihood that an attacker could successfully find the hash value in databases of precomputed hashes (called rainbow-tables).
         return to_hexstr(hashlib.pbkdf2_hmac('sha512', key, b'Digital Bitbox', iterations = 20480))
 
 


### PR DESCRIPTION
In file: digitalbitbox.py, method: stretch_key, the hashing algorithms used a non-random salt. Hash function without an unpredictable salt increases the risk of a Rainbow Table attack (https://en.wikipedia.org/wiki/Rainbow_table). CWE 759 and CWE 760 provide more information about this. I suggested that a secure random number generator should be used to generate a salt. 

Same coding pattern is found in storage.py file line 151.