### PR TITLE
fix adding coins to coincontrol from address list (fixes #8155)

### DIFF
--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -288,7 +288,10 @@ class AddressList(MyTreeView):
 
         coins = self.wallet.get_spendable_coins(addrs)
         if coins:
-            menu.addAction(_("Spend from"), lambda: self.parent.utxo_list.set_spend_list(coins))
+            if self.parent.utxo_list.are_in_coincontrol(coins):
+                menu.addAction(_("Remove from coin control"), lambda: self.parent.utxo_list.remove_from_coincontrol(coins))
+            else:
+                menu.addAction(_("Add to coin control"), lambda: self.parent.utxo_list.add_to_coincontrol(coins))
 
         run_hook('receive_menu', menu, addrs, self.wallet)
         menu.exec_(self.viewport().mapToGlobal(position))

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -149,6 +149,9 @@ class UTXOList(MyTreeView):
                      not self.wallet.is_frozen_coin(utxo))]
         return coins
 
+    def are_in_coincontrol(self, coins: List[PartialTxInput]) -> bool:
+        return all([utxo.prevout.to_str() in self._spend_set for utxo in coins])
+
     def add_to_coincontrol(self, coins: List[PartialTxInput]):
         coins = self._filter_frozen_coins(coins)
         for utxo in coins:
@@ -192,7 +195,7 @@ class UTXOList(MyTreeView):
         coins = [self._utxo_dict[name] for name in selected]
         # coin control
         if coins:
-            if all([utxo.prevout.to_str() in self._spend_set for utxo in coins]):
+            if self.are_in_coincontrol(coins):
                 menu.addAction(_("Remove from coin control"), lambda: self.remove_from_coincontrol(coins))
             else:
                 menu.addAction(_("Add to coin control"), lambda: self.add_to_coincontrol(coins))


### PR DESCRIPTION
This RP attempts to fix #8155 by replacing "Spend from" context menu option with "Add to coin control"/"Remove from coin control" options, similar to how it is done in UTXO list.