### PR TITLE
[WIP] PoC for deniability plugin

### DIFF
--- a/electrum/plugins/deniability/__init__.py
+++ b/electrum/plugins/deniability/__init__.py
@@ -1,0 +1,5 @@
+from electrum.i18n import _
+
+fullname = 'Deniability'
+description = _("Deny ownership of your coins to improve privacy")
+available_for = ['qt']

--- a/electrum/plugins/deniability/deniability.py
+++ b/electrum/plugins/deniability/deniability.py
@@ -15,7 +15,7 @@ class Deniability(BasePlugin):
         for utxo in wallet.get_utxos():
             utxos.append(float(self.config.format_amount(utxo.value_sats())))
 
-        if all(x < self.budget for x in utxos):
+        if all(x <= self.budget for x in utxos):
             raise Exception("Error: None of the UTXOs are greater than the deniability budget.")
 
     def create_tx(self, wallet):

--- a/electrum/plugins/deniability/deniability.py
+++ b/electrum/plugins/deniability/deniability.py
@@ -1,19 +1,55 @@
 #!/usr/bin/python
 
 from electrum.plugin import hook, BasePlugin
+from electrum.transaction import PartialTransaction, PartialTxInput, PartialTxOutput
 
 class Deniability(BasePlugin):
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
+        self.budget = float(self.config.get('deniability_budget', 0))
+        self.rounded_budget = round(self.budget, 2)
+
+    def check_utxos(self, wallet, window):
+
+        utxos = []
+        for utxo in wallet.get_utxos():
+            utxos.append(float(self.config.format_amount(utxo.value_sats())))
+
+        if all(x < self.budget for x in utxos):
+            raise Exception("Error: None of the UTXOs are greater than the deniability budget.")
+
+    def create_tx(self, wallet, window):
+
+        # Select the UTXO to use as input
+        for utxo in wallet.get_utxos():
+            if float(self.config.format_amount(utxo.value_sats())) > self.budget:
+                selected_utxo = utxo
+                break
+
+        # Create input for the transaction
+        prevout = selected_utxo.prevout
+        txin = PartialTxInput(prevout=prevout)
+        txin._trusted_value_sats = selected_utxo.value_sats()
+
+        # Create new addresses
+        address1 = wallet.create_new_address()
+        address2 = wallet.create_new_address()
+
+        # Create outputs for the transaction
+        outputs = [
+            (address1, int(self.rounded_budget*100000000)),
+            (address2, selected_utxo.value_sats() - int(self.budget*100000000))
+        ]
+        txout = [PartialTxOutput.from_address_and_value(address, int(amount_btc)) for address, amount_btc in outputs]
+
+        # Create the partial transaction
+        tx = PartialTransaction.from_io([txin], txout)
+
+        print(tx.to_json())
+
 
     @hook
     def load_wallet(self, wallet, window):
-        budget = float(self.config.get('deniability_budget', 0))
 
-        self.wallet = window.wallet
-        utxos = []
-        for utxo in self.wallet.get_utxos():
-            utxos.append(float(self.config.format_amount(utxo.value_sats())))
-
-        if all(x < budget for x in utxos):
-            raise Exception("Error: None of the UTXOs are greater than the deniability budget.")
+        self.check_utxos(wallet, window)
+        self.create_tx(wallet, window)

--- a/electrum/plugins/deniability/deniability.py
+++ b/electrum/plugins/deniability/deniability.py
@@ -1,0 +1,7 @@
+#!/usr/bin/python
+
+from electrum.plugin import BasePlugin
+
+class Deniability(BasePlugin):
+    def __init__(self, parent, config, name):
+        BasePlugin.__init__(self, parent, config, name)

--- a/electrum/plugins/deniability/deniability.py
+++ b/electrum/plugins/deniability/deniability.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from electrum.plugin import hook, BasePlugin
-from electrum.transaction import PartialTransaction, PartialTxInput, PartialTxOutput
+from electrum.transaction import Transaction, PartialTransaction, PartialTxInput, PartialTxOutput
 
 class Deniability(BasePlugin):
     def __init__(self, parent, config, name):
@@ -65,6 +65,15 @@ class Deniability(BasePlugin):
 
         return self.signed_tx
 
+    def send_tx(self, wallet):
+
+        self.network = wallet.network
+
+        final_tx = Transaction(self.signed_tx_hex)
+        result = wallet.add_transaction(final_tx)
+
+        return result
+
     @hook
     def load_wallet(self, wallet, window):
 
@@ -73,3 +82,5 @@ class Deniability(BasePlugin):
         self.create_tx(wallet)
 
         self.sign_tx(wallet)
+
+        self.send_tx(wallet)

--- a/electrum/plugins/deniability/deniability.py
+++ b/electrum/plugins/deniability/deniability.py
@@ -38,15 +38,22 @@ class Deniability(BasePlugin):
         # Create outputs for the transaction
         outputs = [
             (address1, int(self.rounded_budget*100000000)),
-            (address2, selected_utxo.value_sats() - int(self.budget*100000000))
+            (address2, 0)
         ]
         txout = [PartialTxOutput.from_address_and_value(address, int(amount_btc)) for address, amount_btc in outputs]
 
         # Create the partial transaction
         tx = PartialTransaction.from_io([txin], txout)
 
-        print(tx.to_json())
+        # Calculate fee
+        fee = 1*tx.estimated_size()
 
+        # Update the transaction based on fee
+
+        outputs[1] = (address2, selected_utxo.value_sats() - int(self.rounded_budget*100000000) - fee)
+        txout = [PartialTxOutput.from_address_and_value(address, int(amount_btc)) for address, amount_btc in outputs]
+
+        self.tx = PartialTransaction.from_io([txin], txout)
 
     @hook
     def load_wallet(self, wallet, window):

--- a/electrum/plugins/deniability/deniability.py
+++ b/electrum/plugins/deniability/deniability.py
@@ -1,7 +1,19 @@
 #!/usr/bin/python
 
-from electrum.plugin import BasePlugin
+from electrum.plugin import hook, BasePlugin
 
 class Deniability(BasePlugin):
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
+
+    @hook
+    def load_wallet(self, wallet, window):
+        budget = float(self.config.get('deniability_budget', 0))
+
+        self.wallet = window.wallet
+        utxos = []
+        for utxo in self.wallet.get_utxos():
+            utxos.append(float(self.config.format_amount(utxo.value_sats())))
+
+        if all(x < budget for x in utxos):
+            raise Exception("Error: None of the UTXOs are greater than the deniability budget.")

--- a/electrum/plugins/deniability/qt.py
+++ b/electrum/plugins/deniability/qt.py
@@ -18,6 +18,7 @@ class Plugin(Deniability):
     def settings_dialog(self, window):
 
         saved_budget = float(self.config.get('deniability_budget', 0))
+        rounded_budget = round(saved_budget, 2)
 
         d = WindowModalDialog(window, _("Deniability Budget"))
         self.d = d
@@ -25,7 +26,7 @@ class Plugin(Deniability):
         self.slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.slider.setMinimum(0)
         self.slider.setMaximum(10)
-        self.slider.setValue(saved_budget * 100)
+        self.slider.setValue(int(rounded_budget * 100))
         self.slider.valueChanged.connect(self.change_budget)
         self.current_label = QtWidgets.QLabel(str(saved_budget) + " BTC")
         self.slider.valueChanged.connect(self.update_current_label)

--- a/electrum/plugins/deniability/qt.py
+++ b/electrum/plugins/deniability/qt.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+from PyQt5 import QtWidgets, QtCore, QtGui
+from electrum.i18n import _
+from electrum.gui.qt.util import WindowModalDialog
+from .deniability import Deniability
+
+class Plugin(Deniability):
+
+    def requires_settings(self):
+        return True
+
+    def settings_widget(self, window):
+        btn = QtWidgets.QPushButton(_("Settings"))
+        btn.clicked.connect(lambda: self.settings_dialog(window))
+        return btn
+
+    def settings_dialog(self, window):
+
+        saved_budget = float(self.config.get('deniability_budget', 0))
+
+        d = WindowModalDialog(window, _("Deniability Budget"))
+        self.d = d
+        layout = QtWidgets.QVBoxLayout(d)
+        self.slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.slider.setMinimum(0)
+        self.slider.setMaximum(10)
+        self.slider.setValue(saved_budget * 100)
+        self.slider.valueChanged.connect(self.change_budget)
+        self.current_label = QtWidgets.QLabel(str(saved_budget) + " BTC")
+        self.slider.valueChanged.connect(self.update_current_label)
+        layout.addWidget(self.slider)
+        layout.addWidget(self.current_label)
+        ok_button  = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok, d)
+        layout.addWidget(ok_button)
+        ok_button.accepted.connect(self.ok_clicked)
+        d.exec_()
+
+    def ok_clicked(self):
+
+        self.budget = self.slider.value()/100
+        self.config.set_key('deniability_budget',self.budget,True)
+        self.d.accept()
+
+    def update_current_label(self):
+        self.current_label.setText(f"{self.budget:.2f} BTC")
+
+    def change_budget(self, value):
+        self.budget = value / 100


### PR DESCRIPTION
It is based on https://www.truthcoin.info/blog/deniability/

- Budget slider in plugin settings

![image](https://user-images.githubusercontent.com/94559964/219986911-a86f7870-414f-4a16-a374-c93a578b17a5.png)


- Deniability budget in config

```diff
{
    "auto_connect": true,
    "blockchain_preferred_block": {
        "hash": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
        "height": 0
    },
    "check_updates": false,
    "config_version": 3,
    "decimal_point": 8,
+    "deniability_budget": 0.01,
    "dont_show_testnet_warning": true,
    "gui_last_wallet": "/home/test/.electrum/signet/wallets/default_wallet",
    "is_maximized": false,
    "log_to_file": true,
    "qt_gui_color_theme": "dark",
    "recently_open": [
        "/home/test/.electrum/signet/wallets/default_wallet"
    ],
    "rpcpassword": "PCoNA_SV261nEPBiPnv7kg==",
    "rpcuser": "user",
    "show_addresses_tab": true,
    "show_channels_tab": true,
    "show_console_tab": true,
    "show_utxo_tab": true,
+    "use_deniability": true
```

---

TODO:

- [x] Check all unspent transaction outputs from wallet and return an error if none of them are larger than the deniability budget 
- [x] Else create a transaction with 2 outputs (new addresses from our wallet). Use budget amount for one output
- [x] Sign and broadcast the transaction
- [x] Add a label to new outputs (coins) that increments each time they are used in a deniability transaction

Note: This process should happen every time wallet is loaded and total amount for `deny=true` coins is less than denial budget

