### PR TITLE
CI: bump available memory for unit tests (1G->2G)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   container:
     image: $ELECTRUM_IMAGE
     cpu: 1
-    memory: 1G
+    memory: 2G
   matrix:
     - name: Tox Python $ELECTRUM_PYTHON_VERSION
       env:


### PR DESCRIPTION
Tasks recently started spuriously getting killed with "Container errored with 'OOMKilled'". Not sure what changed, but this seems like the easiest fix.