### PR TITLE
callback for sync indicator

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -686,11 +686,16 @@ class AddressSynchronizer(Logger, EventListener):
     def up_to_date_changed(self) -> None:
         # fire triggers
         util.trigger_callback('adb_set_up_to_date', self)
+        if self.is_up_to_date():
+            self.pending_txs_changed(False)
 
     def is_up_to_date(self):
         if not self.synchronizer or not self.verifier:
             return False
         return self.synchronizer.is_up_to_date() and self.verifier.is_up_to_date()
+
+    def pending_txs_changed(self, pending) -> None:
+        util.trigger_callback('adb_txs_pending', pending)
 
     def reset_netrequest_counters(self) -> None:
         if self.synchronizer:

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -148,6 +148,9 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
             self._isUpToDate = uptodate
             self.isUptodateChanged.emit()
 
+            if uptodate:
+                self.historyModel.init_model()
+
         if self.wallet.network.is_connected():
             server_height = self.wallet.network.get_server_height()
             server_lag = self.wallet.network.get_local_height() - server_height
@@ -187,7 +190,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
             self._logger.info(f'new transaction {tx.txid()}')
             self.add_tx_notification(tx)
             self.addressModel.setDirty()
-            self.historyModel.init_model() # TODO: be less dramatic
+            self.historyModel.setDirty() # assuming wallet.is_up_to_date triggers after
 
     @event_listener
     def on_event_wallet_updated(self, wallet):

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -216,6 +216,7 @@ class Synchronizer(SynchronizerBase):
                 continue  # already have complete tx
             transaction_hashes.append(tx_hash)
             self.requested_tx[tx_hash] = tx_height
+            self.adb.pending_txs_changed(True)
 
         if not transaction_hashes: return
         async with OldTaskGroup() as group:


### PR DESCRIPTION
add callback 'adb_pending_txs', which indicates when txs are starting to be
requested from the network (passing True to the callback), and finally
again when AddressSynchronizer is_up_to_date (passing False to the callback).

This pending txs callback is useful to indicate when the wallet is synchronizing
(e.g. initial sync)