### PR TITLE
add callback for sync indicator

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -686,11 +686,16 @@ class AddressSynchronizer(Logger, EventListener):
     def up_to_date_changed(self) -> None:
         # fire triggers
         util.trigger_callback('adb_set_up_to_date', self)
+        if self.is_up_to_date():
+            self.pending_txs_changed(False)
 
     def is_up_to_date(self):
         if not self.synchronizer or not self.verifier:
             return False
         return self.synchronizer.is_up_to_date() and self.verifier.is_up_to_date()
+
+    def pending_txs_changed(self, pending) -> None:
+        util.trigger_callback('adb_txs_pending', pending)
 
     def reset_netrequest_counters(self) -> None:
         if self.synchronizer:

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -216,9 +216,9 @@ class Synchronizer(SynchronizerBase):
                 continue  # already have complete tx
             transaction_hashes.append(tx_hash)
             self.requested_tx[tx_hash] = tx_height
-            self.adb.pending_txs_changed(True)
 
         if not transaction_hashes: return
+        self.adb.pending_txs_changed(True)
         async with OldTaskGroup() as group:
             for tx_hash in transaction_hashes:
                 await group.spawn(self._get_transaction(tx_hash, allow_server_not_finding_tx=allow_server_not_finding_tx))

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -216,6 +216,7 @@ class Synchronizer(SynchronizerBase):
                 continue  # already have complete tx
             transaction_hashes.append(tx_hash)
             self.requested_tx[tx_hash] = tx_height
+            self.adb.pending_txs_changed(True)
 
         if not transaction_hashes: return
         async with OldTaskGroup() as group:


### PR DESCRIPTION
Add callback 'adb_pending_txs', which indicates when txs are starting to be
requested from the network (passing True to the callback), and finally
again when AddressSynchronizer is_up_to_date (passing False to the callback).

This pending txs callback is useful to indicate when the wallet is synchronizing
(e.g. initial sync)
