### PR TITLE
Revert "CI: bump available memory for unit tests (1G->2G)"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   container:
     image: $ELECTRUM_IMAGE
     cpu: 1
-    memory: 2G
+    memory: 1G
   matrix:
     - name: Tox Python $ELECTRUM_PYTHON_VERSION
       env:


### PR DESCRIPTION
Reverts spesmilo/electrum#8166