### PR TITLE
Privacy analysis

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -349,7 +349,7 @@ class AddressSynchronizer(Logger, EventListener):
             self.db.add_transaction(tx_hash, tx)
             self.db.add_num_inputs_to_tx(tx_hash, len(tx.inputs()))
             if is_new:
-                util.trigger_callback('adb_added_tx', self, tx_hash)
+                util.trigger_callback('adb_added_tx', self, tx_hash, tx)
             return True
 
     def remove_transaction(self, tx_hash: str) -> None:
@@ -401,6 +401,7 @@ class AddressSynchronizer(Logger, EventListener):
                     scripthash = bitcoin.script_to_scripthash(txo.scriptpubkey.hex())
                     prevout = TxOutpoint(bfh(tx_hash), idx)
                     self.db.remove_prevout_by_scripthash(scripthash, prevout=prevout, value=txo.value)
+        util.trigger_callback('adb_removed_tx', self, tx_hash, tx)
 
     def get_depending_transactions(self, tx_hash: str) -> Set[str]:
         """Returns all (grand-)children of tx_hash in this wallet."""

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1065,6 +1065,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         d = address_dialog.AddressDialog(self, addr, parent=parent)
         d.exec_()
 
+    def show_utxo(self, utxo):
+        from . import utxo_dialog
+        d = utxo_dialog.UTXODialog(self, utxo)
+        d.exec_()
+
     def show_channel_details(self, chan):
         from .channel_details import ChannelDetailsDialog
         ChannelDetailsDialog(self, chan).show()

--- a/electrum/gui/qt/utxo_dialog.py
+++ b/electrum/gui/qt/utxo_dialog.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2023 The Electrum Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import TYPE_CHECKING
+
+from PyQt5.QtCore import Qt, QUrl
+from PyQt5.QtGui import QTextCharFormat, QFont
+from PyQt5.QtWidgets import QVBoxLayout, QLabel, QTextBrowser
+
+from electrum.i18n import _
+
+from .util import WindowModalDialog, ButtonsLineEdit, ShowQRLineEdit, ColorScheme, Buttons, CloseButton, MONOSPACE_FONT, WWLabel
+from .history_list import HistoryList, HistoryModel
+from .qrtextedit import ShowQRTextEdit
+
+if TYPE_CHECKING:
+    from .main_window import ElectrumWindow
+
+# todo:
+#  - edit label in tx detail window
+
+
+class UTXODialog(WindowModalDialog):
+
+    def __init__(self, window: 'ElectrumWindow', utxo):
+        WindowModalDialog.__init__(self, window, _("Coin Privacy Analysis"))
+        self.main_window = window
+        self.config = window.config
+        self.wallet = window.wallet
+        self.utxo = utxo
+
+        txid = self.utxo.prevout.txid.hex()
+        parents = self.wallet.get_tx_parents(txid)
+        out = []
+        for _txid, _list in sorted(parents.items()):
+            tx_height, tx_pos = self.wallet.adb.get_txpos(_txid)
+            label = self.wallet.get_label_for_txid(_txid) or "<no label>"
+            out.append((tx_height, tx_pos, _txid, label, _list))
+
+        self.parents_list = QTextBrowser()
+        self.parents_list.setOpenLinks(False)  # disable automatic link opening
+        self.parents_list.anchorClicked.connect(self.open_tx)  # send links to our handler
+        self.parents_list.setFont(QFont(MONOSPACE_FONT))
+        self.parents_list.setReadOnly(True)
+        self.parents_list.setTextInteractionFlags(self.parents_list.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard)
+        self.parents_list.setMinimumWidth(900)
+        self.parents_list.setMinimumHeight(400)
+        self.parents_list.setLineWrapMode(QTextBrowser.NoWrap)
+
+        cursor = self.parents_list.textCursor()
+        ext = QTextCharFormat()
+
+        for tx_height, tx_pos, _txid, label, _list in reversed(sorted(out)):
+            key = "%dx%d"%(tx_height, tx_pos) if tx_pos >= 0 else _txid[0:8]
+            list_str = ','.join(filter(None, _list))
+            lnk = QTextCharFormat()
+            lnk.setToolTip(_('Click to open, right-click for menu'))
+            lnk.setAnchorHref(_txid)
+            #lnk.setAnchorNames([a_name])
+            lnk.setAnchor(True)
+            lnk.setUnderlineStyle(QTextCharFormat.SingleUnderline)
+            cursor.insertText(key, lnk)
+            cursor.insertText("\t", ext)
+            cursor.insertText("%-32s\t<-  "%label[0:32], ext)
+            cursor.insertText(list_str, ext)
+            cursor.insertBlock()
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(QLabel(_("Output point") + ": " + str(self.utxo.short_id)))
+        vbox.addWidget(QLabel(_("Amount") + ": " + self.main_window.format_amount_and_units(self.utxo.value_sats())))
+        vbox.addWidget(QLabel(_("This UTXO has {} parent transactions in your wallet").format(len(parents))))
+        vbox.addWidget(self.parents_list)
+        msg = ' '.join([
+            _("Note: This analysis only shows parent transactions, and does not take address reuse into consideration."),
+            _("If you reuse addresses, more links can be established between your transactions, that are not displayed here.")
+        ])
+        vbox.addWidget(WWLabel(msg))
+        vbox.addLayout(Buttons(CloseButton(self)))
+        self.setLayout(vbox)
+        # set cursor to top
+        cursor.setPosition(0)
+        self.parents_list.setTextCursor(cursor)
+
+    def open_tx(self, txid):
+        if isinstance(txid, QUrl):
+            txid = txid.toString(QUrl.None_)
+        tx = self.wallet.adb.get_transaction(txid)
+        if not tx:
+            return
+        label = self.wallet.get_label_for_txid(txid)
+        self.main_window.show_transaction(tx, tx_desc=label)


### PR DESCRIPTION
I have decided not to display the list of parent labels in the `utxo` tab, because it was getting too crowded. 
Only the direct parent tx label is displayed, as it was the case before (note that I dropped the `get_label_for_address` fallback).
The number of parents is displayed in a new column of the `utxo` tab, and it already a good indicator of privacy.

For now, `get_tx_parents` only does what its name says: it returns parents, and it does not consider address reuse.
The reason is that results need to be cached, and caching becomes complicated if we include address reuse to the analysis.

After a reverse swap, the number of parents is displayed 2, then it goes down to 1 once the swap funding address is dropped by `lnwatcher`. This is weird, and should probably be addressed. I suppose the same issue may exist with channel sweeps.

I do not have a good GUI representation of the parents list, so it is just a list.
I think a graphical representation is desirable, but out of scope for the moment.
A graphical representation should be able to handle address reuse.
