### PR TITLE
Store file creation date and version in db

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1733,6 +1733,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         grid.addWidget(WWLabel(_("Wallet name")+ ':'), cur_row, 0)
         grid.addWidget(WWLabel(basename), cur_row, 1)
         cur_row += 1
+        if db_metadata := self.wallet.db.get_db_metadata():
+            grid.addWidget(WWLabel(_("File created") + ':'), cur_row, 0)
+            grid.addWidget(WWLabel(db_metadata.to_str()), cur_row, 1)
+            cur_row += 1
         grid.addWidget(WWLabel(_("Wallet type")+ ':'), cur_row, 0)
         grid.addWidget(WWLabel(wallet_type), cur_row, 1)
         cur_row += 1


### PR DESCRIPTION
Store the electrum version used to create a wallet file and a timestamp, in the file itself. This can be useful for debugging.