### PR TITLE
build: docker scripts to work even if host user id != 1000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,14 +34,10 @@ contrib/build-wine/build/
 contrib/build-wine/.cache/
 contrib/build-wine/dist/
 contrib/build-wine/signed/
-contrib/build-wine/fresh_clone/
-contrib/build-linux/sdist/fresh_clone/
 contrib/build-linux/appimage/build/
 contrib/build-linux/appimage/.cache/
-contrib/build-linux/appimage/fresh_clone/
 contrib/osx/.cache/
 contrib/osx/build-venv/
-contrib/android/fresh_clone
 contrib/android/android_debug.keystore
 contrib/secp256k1/
 contrib/zbar/

--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM debian:bullseye@sha256:43ef0c6c3585d5b406caa7a0f232ff5a19c1402aeb415f68bcd1cf9d10180af8
 
+ARG UID=1000
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV ANDROID_HOME="/opt/android"
@@ -145,7 +147,7 @@ ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
-RUN useradd --create-home --shell /bin/bash ${USER}
+RUN useradd --uid $UID --create-home --shell /bin/bash ${USER}
 RUN usermod -append --groups sudo ${USER}
 RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 WORKDIR ${WORK_DIR}

--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -2,8 +2,6 @@
 
 FROM debian:bullseye@sha256:43ef0c6c3585d5b406caa7a0f232ff5a19c1402aeb415f68bcd1cf9d10180af8
 
-ARG UID=1000
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV ANDROID_HOME="/opt/android"
@@ -143,6 +141,7 @@ RUN apt -y update -qq \
 
 
 # create new user to avoid using root; but with sudo access and no password for convenience.
+ARG UID=1000
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \

--- a/contrib/android/build.sh
+++ b/contrib/android/build.sh
@@ -37,10 +37,13 @@ if [ ! -z "$ELECBUILD_NOCACHE" ] ; then
     DOCKER_BUILD_FLAGS="--pull --no-cache"
 fi
 
+if [ -z "$ELECBUILD_COMMIT" ] ; then  # local dev build
+    DOCKER_BUILD_FLAGS="$DOCKER_BUILD_FLAGS --build-arg UID=$BUILD_UID"
+fi
+
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
-    --build-arg UID=$BUILD_UID \
     -t electrum-android-builder-img \
     --file "$CONTRIB_ANDROID/Dockerfile" \
     "$PROJECT_ROOT"

--- a/contrib/android/build.sh
+++ b/contrib/android/build.sh
@@ -52,11 +52,11 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE="$CONTRIB_ANDROID/fresh_clone/electrum" && \
-        rm -rf "$FRESH_CLONE" && \
-        umask 0022 && \
-        git clone "$PROJECT_ROOT" "$FRESH_CLONE" && \
-        cd "$FRESH_CLONE"
+    FRESH_CLONE="/tmp/electrum_build/android/fresh_clone/electrum"
+    rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
+    umask 0022
+    git clone "$PROJECT_ROOT" "$FRESH_CLONE"
+    cd "$FRESH_CLONE"
     git checkout "$ELECBUILD_COMMIT"
     PROJECT_ROOT_OR_FRESHCLONE_ROOT="$FRESH_CLONE"
 else
@@ -72,6 +72,13 @@ fi
 
 info "building binary..."
 mkdir --parents "$PROJECT_ROOT_OR_FRESHCLONE_ROOT"/.buildozer/.gradle
+# check uid and maybe chown. see #8261
+if [ ! -z "$ELECBUILD_COMMIT" ] ; then  # fresh clone (reproducible build)
+    if [ $(id -u) != "1000" ] || [ $(id -g) != "1000" ] ; then
+        info "need to chown -R FRESH_CLONE dir. prompting for sudo."
+        sudo chown -R 1000:1000 "$FRESH_CLONE"
+    fi
+fi
 docker run -it --rm \
     --name electrum-android-builder-cont \
     -v "$PROJECT_ROOT_OR_FRESHCLONE_ROOT":/home/user/wspace/electrum \

--- a/contrib/android/build.sh
+++ b/contrib/android/build.sh
@@ -11,6 +11,7 @@ PROJECT_ROOT_OR_FRESHCLONE_ROOT="$PROJECT_ROOT"
 CONTRIB="$PROJECT_ROOT/contrib"
 CONTRIB_ANDROID="$CONTRIB/android"
 DISTDIR="$PROJECT_ROOT/dist"
+BUILD_UID=$(/usr/bin/stat -c %u "$PROJECT_ROOT")
 
 . "$CONTRIB"/build_tools_util.sh
 
@@ -39,6 +40,7 @@ fi
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
+    --build-arg UID=$BUILD_UID \
     -t electrum-android-builder-img \
     --file "$CONTRIB_ANDROID/Dockerfile" \
     "$PROJECT_ROOT"

--- a/contrib/build-linux/appimage/.dockerignore
+++ b/contrib/build-linux/appimage/.dockerignore
@@ -1,3 +1,2 @@
 build/
 .cache/
-fresh_clone/

--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM debian:buster@sha256:233c3bbc892229c82da7231980d50adceba4db56a08c0b7053a4852782703459
 
+ARG UID=1000
+
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -75,7 +77,7 @@ ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
-RUN useradd --create-home --shell /bin/bash ${USER}
+RUN useradd --uid $UID --create-home --shell /bin/bash ${USER}
 RUN usermod -append --groups sudo ${USER}
 RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 WORKDIR ${WORK_DIR}

--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -4,8 +4,6 @@
 
 FROM debian:buster@sha256:233c3bbc892229c82da7231980d50adceba4db56a08c0b7053a4852782703459
 
-ARG UID=1000
-
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -73,6 +71,7 @@ RUN apt-get update -q && \
     apt-get clean
 
 # create new user to avoid using root; but with sudo access and no password for convenience.
+ARG UID=1000
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -11,6 +11,7 @@ PROJECT_ROOT_OR_FRESHCLONE_ROOT="$PROJECT_ROOT"
 CONTRIB="$PROJECT_ROOT/contrib"
 CONTRIB_APPIMAGE="$CONTRIB/build-linux/appimage"
 DISTDIR="$PROJECT_ROOT/dist"
+BUILD_UID=$(/usr/bin/stat -c %u "$PROJECT_ROOT")
 
 . "$CONTRIB"/build_tools_util.sh
 
@@ -24,6 +25,7 @@ fi
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
+    --build-arg UID=$BUILD_UID \
     -t electrum-appimage-builder-img \
     "$CONTRIB_APPIMAGE"
 

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -35,11 +35,11 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE="$CONTRIB_APPIMAGE/fresh_clone/electrum" && \
-        rm -rf "$FRESH_CLONE" && \
-        umask 0022 && \
-        git clone "$PROJECT_ROOT" "$FRESH_CLONE" && \
-        cd "$FRESH_CLONE"
+    FRESH_CLONE="/tmp/electrum_build/appimage/fresh_clone/electrum"
+    rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
+    umask 0022
+    git clone "$PROJECT_ROOT" "$FRESH_CLONE"
+    cd "$FRESH_CLONE"
     git checkout "$ELECBUILD_COMMIT"
     PROJECT_ROOT_OR_FRESHCLONE_ROOT="$FRESH_CLONE"
 else
@@ -47,6 +47,13 @@ else
 fi
 
 info "building binary..."
+# check uid and maybe chown. see #8261
+if [ ! -z "$ELECBUILD_COMMIT" ] ; then  # fresh clone (reproducible build)
+    if [ $(id -u) != "1000" ] || [ $(id -g) != "1000" ] ; then
+        info "need to chown -R FRESH_CLONE dir. prompting for sudo."
+        sudo chown -R 1000:1000 "$FRESH_CLONE"
+    fi
+fi
 docker run -it \
     --name electrum-appimage-builder-cont \
     -v "$PROJECT_ROOT_OR_FRESHCLONE_ROOT":/opt/electrum \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -22,10 +22,13 @@ if [ ! -z "$ELECBUILD_NOCACHE" ] ; then
     DOCKER_BUILD_FLAGS="--pull --no-cache"
 fi
 
+if [ -z "$ELECBUILD_COMMIT" ] ; then  # local dev build
+    DOCKER_BUILD_FLAGS="$DOCKER_BUILD_FLAGS --build-arg UID=$BUILD_UID"
+fi
+
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
-    --build-arg UID=$BUILD_UID \
     -t electrum-appimage-builder-img \
     "$CONTRIB_APPIMAGE"
 

--- a/contrib/build-linux/sdist/.dockerignore
+++ b/contrib/build-linux/sdist/.dockerignore
@@ -1,1 +1,0 @@
-fresh_clone/

--- a/contrib/build-linux/sdist/Dockerfile
+++ b/contrib/build-linux/sdist/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye@sha256:43ef0c6c3585d5b406caa7a0f232ff5a19c1402aeb415f68bcd1cf9d10180af8
 
+ARG UID=1000
+
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -22,7 +24,7 @@ ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
-RUN useradd --create-home --shell /bin/bash ${USER}
+RUN useradd --uid $UID --create-home --shell /bin/bash ${USER}
 RUN usermod -append --groups sudo ${USER}
 RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 WORKDIR ${WORK_DIR}

--- a/contrib/build-linux/sdist/Dockerfile
+++ b/contrib/build-linux/sdist/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:bullseye@sha256:43ef0c6c3585d5b406caa7a0f232ff5a19c1402aeb415f68bcd1cf9d10180af8
 
-ARG UID=1000
-
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -20,6 +18,7 @@ RUN apt-get update -q && \
     apt-get clean
 
 # create new user to avoid using root; but with sudo access and no password for convenience.
+ARG UID=1000
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \

--- a/contrib/build-linux/sdist/build.sh
+++ b/contrib/build-linux/sdist/build.sh
@@ -11,6 +11,7 @@ PROJECT_ROOT_OR_FRESHCLONE_ROOT="$PROJECT_ROOT"
 CONTRIB="$PROJECT_ROOT/contrib"
 CONTRIB_SDIST="$CONTRIB/build-linux/sdist"
 DISTDIR="$PROJECT_ROOT/dist"
+BUILD_UID=$(/usr/bin/stat -c %u "$PROJECT_ROOT")
 
 . "$CONTRIB"/build_tools_util.sh
 
@@ -24,6 +25,7 @@ fi
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
+    --build-arg UID=$BUILD_UID \
     -t electrum-sdist-builder-img \
     "$CONTRIB_SDIST"
 

--- a/contrib/build-linux/sdist/build.sh
+++ b/contrib/build-linux/sdist/build.sh
@@ -35,11 +35,11 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE="$CONTRIB_SDIST/fresh_clone/electrum" && \
-        rm -rf "$FRESH_CLONE" && \
-        umask 0022 && \
-        git clone "$PROJECT_ROOT" "$FRESH_CLONE" && \
-        cd "$FRESH_CLONE"
+    FRESH_CLONE="/tmp/electrum_build/sdist/fresh_clone/electrum"
+    rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
+    umask 0022
+    git clone "$PROJECT_ROOT" "$FRESH_CLONE"
+    cd "$FRESH_CLONE"
     git checkout "$ELECBUILD_COMMIT"
     PROJECT_ROOT_OR_FRESHCLONE_ROOT="$FRESH_CLONE"
 else
@@ -47,6 +47,13 @@ else
 fi
 
 info "building binary..."
+# check uid and maybe chown. see #8261
+if [ ! -z "$ELECBUILD_COMMIT" ] ; then  # fresh clone (reproducible build)
+    if [ $(id -u) != "1000" ] || [ $(id -g) != "1000" ] ; then
+        info "need to chown -R FRESH_CLONE dir. prompting for sudo."
+        sudo chown -R 1000:1000 "$FRESH_CLONE"
+    fi
+fi
 docker run -it \
     --name electrum-sdist-builder-cont \
     -v "$PROJECT_ROOT_OR_FRESHCLONE_ROOT":/opt/electrum \

--- a/contrib/build-linux/sdist/build.sh
+++ b/contrib/build-linux/sdist/build.sh
@@ -22,10 +22,13 @@ if [ ! -z "$ELECBUILD_NOCACHE" ] ; then
     DOCKER_BUILD_FLAGS="--pull --no-cache"
 fi
 
+if [ -z "$ELECBUILD_COMMIT" ] ; then  # local dev build
+    DOCKER_BUILD_FLAGS="$DOCKER_BUILD_FLAGS --build-arg UID=$BUILD_UID"
+fi
+
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
-    --build-arg UID=$BUILD_UID \
     -t electrum-sdist-builder-img \
     "$CONTRIB_SDIST"
 

--- a/contrib/build-wine/.dockerignore
+++ b/contrib/build-wine/.dockerignore
@@ -3,4 +3,3 @@ build/
 .cache/
 dist/
 signed/
-fresh_clone/

--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:bullseye@sha256:43ef0c6c3585d5b406caa7a0f232ff5a19c1402aeb415f68bcd1cf9d10180af8
 
-ARG UID=1000
-
 # need ca-certificates before using snapshot packages
 RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
     ca-certificates
@@ -61,6 +59,7 @@ RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
     apt-get clean
 
 # create new user to avoid using root; but with sudo access and no password for convenience.
+ARG UID=1000
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \

--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye@sha256:43ef0c6c3585d5b406caa7a0f232ff5a19c1402aeb415f68bcd1cf9d10180af8
 
+ARG UID=1000
+
 # need ca-certificates before using snapshot packages
 RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
     ca-certificates
@@ -63,7 +65,7 @@ ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/wspace" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
-RUN useradd --create-home --shell /bin/bash ${USER}
+RUN useradd --uid $UID --create-home --shell /bin/bash ${USER}
 RUN usermod -append --groups sudo ${USER}
 RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 WORKDIR ${WORK_DIR}

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -24,10 +24,13 @@ if [ ! -z "$ELECBUILD_NOCACHE" ] ; then
     DOCKER_BUILD_FLAGS="--pull --no-cache"
 fi
 
+if [ -z "$ELECBUILD_COMMIT" ] ; then  # local dev build
+    DOCKER_BUILD_FLAGS="$DOCKER_BUILD_FLAGS --build-arg UID=$BUILD_UID"
+fi
+
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
-    --build-arg UID=$BUILD_UID \
     -t electrum-wine-builder-img \
     "$CONTRIB_WINE"
 

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -10,6 +10,7 @@ PROJECT_ROOT="$(dirname "$(readlink -e "$0")")/../.."
 PROJECT_ROOT_OR_FRESHCLONE_ROOT="$PROJECT_ROOT"
 CONTRIB="$PROJECT_ROOT/contrib"
 CONTRIB_WINE="$CONTRIB/build-wine"
+BUILD_UID=$(/usr/bin/stat -c %u "$PROJECT_ROOT")
 
 . "$CONTRIB"/build_tools_util.sh
 
@@ -26,6 +27,7 @@ fi
 info "building docker image."
 docker build \
     $DOCKER_BUILD_FLAGS \
+    --build-arg UID=$BUILD_UID \
     -t electrum-wine-builder-img \
     "$CONTRIB_WINE"
 


### PR DESCRIPTION
closes https://github.com/spesmilo/electrum/issues/8261

See commit messages for individual commits.

In short, we distinguish "local dev builds" and "reproducible builds":
- local dev builds use the host userid inside the container, directly operate on the project dir
  - do not need sudo
- repro builds create a fresh git clone, chown it to 1000, and use userid=1000 inside the container
  - if the host userid is 1000, do not need sudo
  - otherwise, need sudo
