### PR TITLE
qml: pressing "Esc" on desktop to ~simulate "back" button

### DIFF
--- a/electrum/gui/qml/components/Pin.qml
+++ b/electrum/gui/qml/components/Pin.qml
@@ -23,7 +23,7 @@ ElDialog {
 
     focus: true
 
-    closePolicy: canCancel ? Popup.CloseOnEscape | Popup.CloseOnPressOutside : Popup.NoAutoClose
+    closePolicy: canCancel ? Popup.CloseOnPressOutside : Popup.NoAutoClose
 
     property bool canCancel: true
 

--- a/electrum/gui/qml/components/controls/ElDialog.qml
+++ b/electrum/gui/qml/components/controls/ElDialog.qml
@@ -19,7 +19,7 @@ Dialog {
     }
 
     closePolicy: allowClose
-        ? Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        ? Popup.CloseOnPressOutside
         : Popup.NoAutoClose
 
     onOpenedChanged: {

--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -430,6 +430,14 @@ ApplicationWindow
         }
     }
 
+    Shortcut {
+        context: Qt.ApplicationShortcut
+        sequence: "Esc"
+        onActivated: {
+            close()
+        }
+    }
+
     Connections {
         target: Daemon
         function onWalletRequiresPassword(name, path) {


### PR DESCRIPTION
Pressing "Esc" on kivy when testing on desktop closes the active popup/dialog/window/application, similar to what pressing the hw/OS "back" button on Android would do.
I want the same behaviour on qml, as it makes testing more convenient.

This change seems to work; and it seems not to break Android either.
The `Popup.CloseOnEscape` modifiers need to be removed as they are catching the signal before it could get to the application-level `Shortcut`, and if I leave them in, one needs to press Esc multiple times to trigger.