### PR TITLE
Fix double quote escaping in desktop entry (#4300)

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update -q && \
         libc6-dev \
         libc6 \
         libc-dev-bin \
+        libglib2.0-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-linux/appimage/make_appimage.sh
+++ b/contrib/build-linux/appimage/make_appimage.sh
@@ -59,7 +59,7 @@ tar xf "$CACHEDIR/desktop-file-utils-$DESKTOP_FILE_UTILS_VERSION.tar.xz" -C "$CA
     cd "$CACHEDIR/desktop-file-utils-$DESKTOP_FILE_UTILS_VERSION"
 
     ./autogen.sh --silent
-    make "-j$CPU_CPOUNT" -s
+    make "-j$CPU_COUNT" -s
 ) || fail "could not build desktop-file-utils"
 
 info "building python."

--- a/electrum.desktop
+++ b/electrum.desktop
@@ -3,7 +3,7 @@
 
 [Desktop Entry]
 Comment=Lightweight Bitcoin Client
-Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum %u"
+Exec=sh -c "PATH=\\"\\$HOME/.local/bin:\\$PATH\\" electrum %u"
 GenericName[en_US]=Bitcoin Wallet
 GenericName=Bitcoin Wallet
 Icon=electrum
@@ -18,5 +18,5 @@ MimeType=x-scheme-handler/bitcoin;x-scheme-handler/lightning;
 Actions=Testnet;
 
 [Desktop Action Testnet]
-Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum --testnet %u"
+Exec=sh -c "PATH=\\"\\$HOME/.local/bin:\\$PATH\\" electrum --testnet %u"
 Name=Testnet mode


### PR DESCRIPTION
In the Exec= value, double quotes (") inside a quoted argument must be escaped with two backslashes (just like the dollar sign).
Moreover, this fixes the following errors, also reported in the issue, when launching electrum.desktop with kioclient5 (KDE plasma program runner):
```
$ kioclient exec /usr/share/applications/electrum.desktop 
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 6: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 6: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 21: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 21: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 6: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 6: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 21: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 21: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 6: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 6: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 21: " "Invalid escape sequence \"\\\"\"."
kf.config.core: "KConfigIni: In file /usr/share/applications/electrum.desktop, line 21: " "Invalid escape sequence \"\\\"\"."
```

I have tested this modification with kioclient5 version 5.27.4 and gtk-launch version 3.24.37, with both launchers electrum is starting correctly without errors and with $HOME/.local/bin prepended to $PATH.

Relevant parts of the freedesktop Desktop Entry Specification:

[https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html)
>  Arguments may be quoted in whole. If an argument contains a reserved character the argument must be quoted. The rules for quoting of arguments is also applicable to the executable name or path of the executable program as provided.

> Quoting must be done by enclosing the argument between double quotes and escaping the double quote character, backtick character ("\`"), dollar sign ("$") and backslash character ("\\") by preceding it with an additional backslash character. Implementations must undo quoting before expanding field codes and before passing the argument to the executable program. Reserved characters are space (" "), tab, newline, double quote, single quote ("'"), backslash character ("\\"), greater-than sign (">"), less-than sign ("<"), tilde ("~"), vertical bar ("|"), ampersand ("&"), semicolon (";"), dollar sign ("$"), asterisk ("*"), question mark ("?"), hash mark ("#"), parenthesis ("(") and (")") and backtick character ("\`").

> Note that the general escape rule for values of type string states that the backslash character can be escaped as ("\\\\") as well and that this escape rule is applied before the quoting rule. As such, to unambiguously represent a literal backslash character in a quoted argument in a desktop entry file requires the use of four successive backslash characters ("\\\\\\\\"). Likewise, a literal dollar sign in a quoted argument in a desktop entry file is unambiguously represented with ("\\\\$"). 