### PR TITLE
qt bump fee: disallow targeting an abs fee. only allow setting feerate

### DIFF
--- a/electrum/gui/qt/rbf_dialog.py
+++ b/electrum/gui/qt/rbf_dialog.py
@@ -49,6 +49,7 @@ class _BaseRBFDialog(TxEditor):
             title=title,
             make_tx=self.rbf_func)
 
+        self.fee_e.setFrozen(True)  # disallow setting absolute fee for now, as wallet.bump_fee can only target feerate
         new_fee_rate = self.old_fee_rate + max(1, self.old_fee_rate // 20)
         self.feerate_e.setAmount(new_fee_rate)
         self.update()


### PR DESCRIPTION
`wallet.bump_fee()` only allows targeting a feerate.
Prior to this commit, `_BaseRBFDialog(TxEditor)` allowed setting either a feerate or an abs fee. When setting an abs fee, `TxEditor.update_fee_fields()` tries to adjust the feerate accordingly, and then via side-effecting, `wallet.bump_fee()` will get called with the derived feerate. This seems really buggy[0] atm. I think it is best to disable setting abs fees, and if we want to enable it later, targeting needs to be implemented in `wallet.bump_fee()` - just like how it works in `ConfirmTxDialog(TxEditor)` and `wallet.make_unsigned_transaction()`.

[0]: due to how the side-effecting works, changing the abs fee only affects the actual tx created one tick later.
Errors are sticky: try setting the abs fee to zero and then to something sane. Or try setting it to too high, and then something sane.

I can't see a clean way to fix this besides making `wallet.bump_fee()` more generic and putting the logic there, but I don't want to do that now. @ecdsa if you don't want to do it now either, let's just merge this.