### PR TITLE
locale: strip context from strings extracted by lupdate and propagate…

### DIFF
--- a/contrib/push_locale
+++ b/contrib/push_locale
@@ -46,7 +46,15 @@ cmd = "lconvert -of po -o electrum/locale/messages_qml.pot electrum/locale/qml.t
 print('Convert to gettext')
 subprocess.check_output(cmd, shell=True)
 
-cmd = "msgcat -u -o electrum/locale/messages.pot electrum/locale/messages_gettext.pot electrum/locale/messages_qml.pot"
+cmd = "grep -v ^msgctxt electrum/locale/messages_qml.pot >electrum/locale/messages_qml_stripped.pot"
+print('Strip msgctxt')
+subprocess.check_output(cmd, shell=True)
+
+cmd = "msguniq electrum/locale/messages_qml_stripped.pot >electrum/locale/messages_qml_stripped_uniq.pot"
+print('Remove duplicates')
+subprocess.check_output(cmd, shell=True)
+
+cmd = "msgcat -o electrum/locale/messages.pot electrum/locale/messages_gettext.pot electrum/locale/messages_qml_stripped_uniq.pot"
 print('Generate template')
 subprocess.check_output(cmd, shell=True)
 


### PR DESCRIPTION
…d to gettext by `lconvert`.

This fixes an issue whereby translations that are unique to QML did not get translated because of a required `context` identifier, which is currently not passed to the underlying `gettext` translator (only strings extracted from QML were assigned a context).

These strings are recognizable by the extra `msgctxt` field in `messages.pot`, e.g.

```
#: ../gui/qml/components/About.qml:61
msgctxt "About|"
msgid "MIT License"
msgstr ""
```

For such a string to be translated, one needs to explicitly pass a context identifier `About|` to a `pgettext` call.

As alternative, we can decide to use `context` and pass a translation context string from `QTranslator` to `gettext`, but that needs a bit messy mangling of the context string we get from `QTranslator`. I can add that implementation in a separate PR if needed, but let's discuss first.