### PR TITLE
README: refer to `libsecp256k1-dev` instead of `libsecp256k1-0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ but not everything. The following sections describe how to run from source, but 
 is a TL;DR:
 
 ```
-$ sudo apt-get install libsecp256k1-0
+$ sudo apt-get install libsecp256k1-dev
 $ python3 -m pip install --user ".[gui,crypto]"
 ```
 
@@ -37,7 +37,7 @@ For elliptic curve operations,
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1)
 is a required dependency:
 ```
-$ sudo apt-get install libsecp256k1-0
+$ sudo apt-get install libsecp256k1-dev
 ```
 
 Alternatively, when running from a cloned repository, a script is provided to build


### PR DESCRIPTION
We don't actually need the development headers, instead using this as a hack to be agnostic to the version scheme and pull in the latest.

related:
https://github.com/spesmilo/electrum/issues/8328#issuecomment-1518061250
https://github.com/spesmilo/electrum/pull/8185
https://github.com/spesmilo/electrum/pull/8320

- debian 11 (stable) only has `libsecp256k1-0`
- debian 12 (testing) atm only has `libsecp256k1-1`
- ubuntu 23.04 only has `libsecp256k1-1`
- I expect `libsecp256k1-2` might soon get packaged too, now that upstream libsecp256k1 [released v0.3.0](https://github.com/bitcoin-core/secp256k1/blob/1f33bb2b1c5e65cab5720a174b15c499d99b1cfc/CHANGELOG.md).

So what do we tell users to install? well, turns out most distros have `libsecp256k1-dev`, which just pulls in the latest secp.
Caveat: if there is a new secp release that actually gets packaged on a distro before we can react, then this new instruction will not work.

I think we should similarly update the website:
https://github.com/spesmilo/electrum-web/blob/58755abe49fcbcf295aed67ae3c3d52c1902b07b/panel-download.html.template#L126