### PR TITLE
qml: fix channelopener.connectStr qr scan popping under

### DIFF
--- a/electrum/gui/qml/components/OpenChannelDialog.qml
+++ b/electrum/gui/qml/components/OpenChannelDialog.qml
@@ -107,13 +107,13 @@ ElDialog {
                         icon.width: constants.iconSizeMedium
                         scale: 1.2
                         onClicked: {
-                            var page = app.stack.push(Qt.resolvedUrl('Scan.qml'))
-                            page.onFound.connect(function() {
-                                if (channelopener.validate_connect_str(page.scanData)) {
-                                    channelopener.connectStr = page.scanData
+                            var scan = qrscan.createObject(root.contentItem)
+                            scan.onFound.connect(function() {
+                                if (channelopener.validate_connect_str(scan.scanData)) {
+                                    channelopener.connectStr = scan.scanData
                                     node.text = channelopener.connectStr
                                 }
-                                app.stack.pop()
+                                scan.destroy()
                             })
                         }
                     }
@@ -203,6 +203,25 @@ ElDialog {
             amountLabelText: qsTr('Channel capacity')
             sendButtonText: qsTr('Open Channel')
             finalizer: channelopener.finalizer
+        }
+    }
+
+    Component {
+        id: qrscan
+        QRScan {
+            width: root.contentItem.width
+            height: root.contentItem.height
+
+            ToolButton {
+                icon.source: '../../icons/closebutton.png'
+                icon.height: constants.iconSizeMedium
+                icon.width: constants.iconSizeMedium
+                anchors.right: parent.right
+                anchors.top: parent.top
+                onClicked: {
+                    parent.destroy()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
With gossip enabled, trying to open a channel in qml. I try to scan a QR code of a connect-string (node id), seemingly the scan dialog pops under the OpenChannelDialog: pointing the device at a QR code results in a successful scan (so the camera is active despite the image not being shown).

This changes the scanning code in OpenChannelDialog to be similar to other dialogs.

@accumulator see if this looks ok. Feel free to close and fix differently if not.