### PR TITLE
channel_db: raise specific exception when channelDB not loaded, allow…

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -79,7 +79,7 @@ from .lnwatcher import LNWalletWatcher
 from .crypto import pw_encode_with_version_and_mac, pw_decode_with_version_and_mac
 from .lnutil import ImportedChannelBackupStorage, OnchainChannelBackupStorage
 from .lnchannel import ChannelBackup
-from .channel_db import UpdateStatus
+from .channel_db import UpdateStatus, ChannelDBNotLoaded
 from .channel_db import get_mychannel_info, get_mychannel_policy
 from .submarine_swaps import SwapManager
 from .channel_db import ChannelInfo, Policy
@@ -1200,6 +1200,9 @@ class LNWallet(LNWorker):
                 channels=channels)
             success = True
         except PaymentFailure as e:
+            self.logger.info(f'payment failure: {e!r}')
+            reason = str(e)
+        except ChannelDBNotLoaded as e:
             self.logger.info(f'payment failure: {e!r}')
             reason = str(e)
         finally:


### PR DESCRIPTION
…ing lnworker to mark payment as failed.

On mobile, it can take a while before channelDB is loaded. If payment is attempted before the DB is fully loaded, this would result in a payment failure, but also leaves the payment attempt in IN_PROGRESS state. This patch adds a more specific ChannelDBNotLoaded exception class, so we can handle this case more gracefully, since we know the payment didn't succeed.