### PR TITLE
qml: initial show private key in address details

### DIFF
--- a/electrum/gui/qml/components/AddressDetails.qml
+++ b/electrum/gui/qml/components/AddressDetails.qml
@@ -172,13 +172,67 @@ Pane {
                 }
 
                 Label {
+                    Layout.columnSpan: 2
+                    Layout.topMargin: constants.paddingSmall
+                    visible: !Daemon.currentWallet.isWatchOnly
+                    text: qsTr('Private key')
+                    color: Material.accentColor
+                }
+
+                TextHighlightPane {
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
+                    visible: !Daemon.currentWallet.isWatchOnly
+                    RowLayout {
+                        width: parent.width
+                        Label {
+                            id: privateKeyText
+                            Layout.fillWidth: true
+                            visible: addressdetails.privkey
+                            text: addressdetails.privkey
+                            wrapMode: Text.Wrap
+                            font.pixelSize: constants.fontSizeLarge
+                            font.family: FixedFont
+                        }
+                        Label {
+                            id: showPrivateKeyText
+                            Layout.fillWidth: true
+                            visible: !addressdetails.privkey
+                            horizontalAlignment: Text.AlignHCenter
+                            text: qsTr('Tap to show private key')
+                            wrapMode: Text.Wrap
+                            font.pixelSize: constants.fontSizeLarge
+                        }
+                        ToolButton {
+                            icon.source: '../../icons/share.png'
+                            visible: addressdetails.privkey
+                            onClicked: {
+                                var dialog = app.genericShareDialog.createObject(root, {
+                                    title: qsTr('Private key'),
+                                    text: addressdetails.privkey
+                                })
+                                dialog.open()
+                            }
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            enabled: !addressdetails.privkey
+                            onClicked: addressdetails.requestShowPrivateKey()
+                        }
+                    }
+                }
+
+                Label {
+                    Layout.topMargin: constants.paddingSmall
                     text: qsTr('Script type')
                     color: Material.accentColor
                 }
 
                 Label {
-                    text: addressdetails.scriptType
+                    Layout.topMargin: constants.paddingSmall
                     Layout.fillWidth: true
+                    text: addressdetails.scriptType
                 }
 
                 Label {
@@ -235,5 +289,8 @@ Pane {
         address: root.address
         onFrozenChanged: addressDetailsChanged()
         onLabelChanged: addressDetailsChanged()
+        onAuthRequired: {
+            app.handleAuthRequired(addressdetails, method, authMessage)
+        }
     }
 }

--- a/electrum/gui/qml/components/AddressDetails.qml
+++ b/electrum/gui/qml/components/AddressDetails.qml
@@ -44,10 +44,18 @@ Pane {
                     text: qsTr('Address details')
                 }
 
-                Label {
-                    text: qsTr('Address')
+                RowLayout {
                     Layout.columnSpan: 2
-                    color: Material.accentColor
+                    Label {
+                        text: qsTr('Address')
+                        color: Material.accentColor
+                    }
+
+                    Tag {
+                        visible: addressdetails.isFrozen
+                        text: qsTr('Frozen')
+                        labelcolor: 'white'
+                    }
                 }
 
                 TextHighlightPane {
@@ -74,6 +82,24 @@ Pane {
                             }
                         }
                     }
+                }
+
+                Label {
+                    text: qsTr('Balance')
+                    color: Material.accentColor
+                }
+
+                FormattedAmount {
+                    amount: addressdetails.balance
+                }
+
+                Label {
+                    text: qsTr('Transactions')
+                    color: Material.accentColor
+                }
+
+                Label {
+                    text: addressdetails.numTx
                 }
 
                 Label {
@@ -133,6 +159,34 @@ Pane {
                             onClicked: labelContent.editmode = false
                         }
                     }
+                }
+
+                Heading {
+                    Layout.columnSpan: 2
+                    text: qsTr('Technical Properties')
+                }
+
+                Label {
+                    Layout.topMargin: constants.paddingSmall
+                    text: qsTr('Script type')
+                    color: Material.accentColor
+                }
+
+                Label {
+                    Layout.topMargin: constants.paddingSmall
+                    Layout.fillWidth: true
+                    text: addressdetails.scriptType
+                }
+
+                Label {
+                    visible: addressdetails.derivationPath
+                    text: qsTr('Derivation path')
+                    color: Material.accentColor
+                }
+
+                Label {
+                    visible: addressdetails.derivationPath
+                    text: addressdetails.derivationPath
                 }
 
                 Label {
@@ -221,56 +275,6 @@ Pane {
                             onClicked: addressdetails.requestShowPrivateKey()
                         }
                     }
-                }
-
-                Label {
-                    Layout.topMargin: constants.paddingSmall
-                    text: qsTr('Script type')
-                    color: Material.accentColor
-                }
-
-                Label {
-                    Layout.topMargin: constants.paddingSmall
-                    Layout.fillWidth: true
-                    text: addressdetails.scriptType
-                }
-
-                Label {
-                    text: qsTr('Balance')
-                    color: Material.accentColor
-                }
-
-                FormattedAmount {
-                    amount: addressdetails.balance
-                }
-
-                Label {
-                    text: qsTr('Transactions')
-                    color: Material.accentColor
-                }
-
-                Label {
-                    text: addressdetails.numTx
-                }
-
-                Label {
-                    visible: addressdetails.derivationPath
-                    text: qsTr('Derivation path')
-                    color: Material.accentColor
-                }
-
-                Label {
-                    visible: addressdetails.derivationPath
-                    text: addressdetails.derivationPath
-                }
-
-                Label {
-                    text: qsTr('Frozen')
-                    color: Material.accentColor
-                }
-
-                Label {
-                    text: addressdetails.isFrozen ? qsTr('Frozen') : qsTr('Not frozen')
                 }
             }
         }

--- a/electrum/gui/qml/qeaddressdetails.py
+++ b/electrum/gui/qml/qeaddressdetails.py
@@ -2,12 +2,13 @@ from PyQt5.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 
 from electrum.logging import get_logger
 
+from .auth import auth_protect, AuthMixin
 from .qetransactionlistmodel import QETransactionListModel
 from .qetypes import QEAmount
 from .qewallet import QEWallet
 
 
-class QEAddressDetails(QObject):
+class QEAddressDetails(AuthMixin, QObject):
     _logger = get_logger(__name__)
 
     detailsChanged = pyqtSignal()
@@ -67,6 +68,10 @@ class QEAddressDetails(QObject):
         return self._pubkeys
 
     @pyqtProperty(str, notify=detailsChanged)
+    def privkey(self):
+        return self._privkey
+
+    @pyqtProperty(str, notify=detailsChanged)
     def derivationPath(self):
         return self._derivationPath
 
@@ -107,6 +112,19 @@ class QEAddressDetails(QObject):
             self._historyModel = QETransactionListModel(self._wallet.wallet,
                                                         onchain_domain=[self._address], include_lightning=False)
         return self._historyModel
+
+    @pyqtSlot()
+    def requestShowPrivateKey(self):
+        self.retrieve_private_key()
+
+    @auth_protect(method='wallet')
+    def retrieve_private_key(self):
+        try:
+            self._privkey = self._wallet.wallet.export_private_key(self._address, self._wallet.password)
+        except Exception:
+            self._privkey = ''
+
+        self.detailsChanged.emit()
 
     def update(self):
         if self._wallet is None:


### PR DESCRIPTION
Only single private key still, no multiple private keys when multiple keystores with secrets present.