### PR TITLE
Add 3xpl.com to the list of explorers

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -884,6 +884,8 @@ def age(
             return _("in over {} years").format(round(distance_in_minutes / 525600))
 
 mainnet_block_explorers = {
+    '3xpl.com': ('https://3xpl.com/bitcoin/',
+                        {'tx': 'transaction/', 'addr': 'address/'}),
     'Bitupper Explorer': ('https://bitupper.com/en/explorer/bitcoin/',
                         {'tx': 'transactions/', 'addr': 'addresses/'}),
     'Bitflyer.jp': ('https://chainflyer.bitflyer.jp/',


### PR DESCRIPTION
[3xpl](https://3xpl.com/bitcoin) is fast, private, its core is open-source (MIT license), and, most importantly, there are no ads.
It also supports Omni Layer.