### PR TITLE
submarine swap server plugin

### DIFF
--- a/electrum/bitcoin.py
+++ b/electrum/bitcoin.py
@@ -317,10 +317,13 @@ def construct_witness(items: Sequence[Union[str, int, bytes]]) -> str:
     return witness
 
 
-def construct_script(items: Sequence[Union[str, int, bytes, opcodes]]) -> str:
+def construct_script(items: Sequence[Union[str, int, bytes, opcodes]], values=None) -> str:
     """Constructs bitcoin script from given items."""
     script = ''
-    for item in items:
+    values = values or {}
+    for i, item in enumerate(items):
+        if i in values:
+            item = values[i]
         if isinstance(item, opcodes):
             script += item.hex()
         elif type(item) is int:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1191,10 +1191,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             return
         invoice = self.wallet.get_invoice(key)
         if invoice and invoice.is_lightning() and invoice.get_address():
+            # fixme: we should display this popup only if the user initiated the payment
             if self.question(_('Payment failed') + '\n\n' + reason + '\n\n'+ 'Fallback to onchain payment?'):
                 self.send_tab.pay_onchain_dialog(invoice.get_outputs())
         else:
-            self.show_error(_('Payment failed') + '\n\n' + reason)
+            self.notify(_('Payment failed') + '\n\n' + reason)
 
     def get_coins(self, **kwargs) -> Sequence[PartialTxInput]:
         coins = self.get_manually_selected_coins()

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1831,6 +1831,12 @@ class Peer(Logger):
                     coro = self.lnworker.swap_manager.start_normal_swap(swap, None, None)
                     asyncio.run_coroutine_threadsafe(coro, self.network.asyncio_loop)
             return None, None
+
+        if self.lnworker.is_part_of_bundle(htlc.payment_hash):
+            self.lnworker.set_bundle_part_ready(htlc.payment_hash)
+            if not self.lnworker.is_bundle_ready(htlc.payment_hash):
+                return None, None
+
         self.logger.info(f"maybe_fulfill_htlc. will FULFILL HTLC: chan {chan.short_channel_id}. htlc={str(htlc)}")
         self.lnworker.set_request_status(htlc.payment_hash, PR_PAID)
         return preimage, None

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1521,6 +1521,7 @@ class LnKeyFamily(IntEnum):
     REVOCATION_ROOT = 5 | BIP32_PRIME
     NODE_KEY = 6
     BACKUP_CIPHER = 7 | BIP32_PRIME
+    PAYMENT_SECRET_KEY = 8 | BIP32_PRIME
 
 
 def generate_keypair(node: BIP32Node, key_family: LnKeyFamily) -> Keypair:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1873,6 +1873,10 @@ class LNWallet(LNWorker):
                 amount_msat, direction, status = self.payment_info[key]
                 return PaymentInfo(payment_hash, amount_msat, direction, status)
 
+    def add_payment_info_for_hold_invoice(self, payment_hash, lightning_amount_sat):
+        info = PaymentInfo(payment_hash, lightning_amount_sat * 1000, RECEIVED, PR_UNPAID)
+        self.save_payment_info(info, write_to_disk=False)
+
     def save_payment_info(self, info: PaymentInfo, *, write_to_disk: bool = True) -> None:
         key = info.payment_hash.hex()
         assert info.status in SAVED_PR_STATUS

--- a/electrum/plugins/swapserver/__init__.py
+++ b/electrum/plugins/swapserver/__init__.py
@@ -1,0 +1,6 @@
+from electrum.i18n import _
+
+fullname = _('SwapServer')
+description = ''
+
+available_for = ['qt', 'cmdline']

--- a/electrum/plugins/swapserver/cmdline.py
+++ b/electrum/plugins/swapserver/cmdline.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#
+# Electrum - Lightweight Bitcoin Client
+# Copyright (C) 2023 The Electrum Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from .swapserver import SwapServerPlugin
+
+class Plugin(SwapServerPlugin):
+    pass
+

--- a/electrum/plugins/swapserver/qt.py
+++ b/electrum/plugins/swapserver/qt.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#
+# Electrum - Lightweight Bitcoin Client
+# Copyright (C) 2023 The Electrum Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from .swapserver import SwapServerPlugin
+
+class Plugin(SwapServerPlugin):
+    pass
+

--- a/electrum/plugins/swapserver/server.py
+++ b/electrum/plugins/swapserver/server.py
@@ -1,0 +1,130 @@
+import os
+import asyncio
+import attr
+import random
+from collections import defaultdict
+
+from aiohttp import ClientResponse
+from aiohttp import web, client_exceptions
+from aiorpcx import timeout_after, TaskTimeout, ignore_after
+from aiorpcx import NetAddress
+
+
+from electrum.util import log_exceptions, ignore_exceptions
+from electrum.logging import Logger
+from electrum.util import EventListener, event_listener
+from electrum.invoices import PR_PAID, PR_EXPIRED
+
+
+class SwapServer(Logger, EventListener):
+    """
+    public API:
+    - getpairs
+    - createswap
+    """
+
+    WWW_DIR = os.path.join(os.path.dirname(__file__), 'www')
+
+    def __init__(self, config, wallet):
+        Logger.__init__(self)
+        self.config = config
+        self.wallet = wallet
+        self.addr = NetAddress.from_string(self.config.SWAPSERVER_ADDRESS)
+        self.register_callbacks() # eventlistener
+
+        self.pending = defaultdict(asyncio.Event)
+        self.pending_msg = {}
+
+    @ignore_exceptions
+    @log_exceptions
+    async def run(self):
+        self.root = '/root'
+        app = web.Application()
+        app.add_routes([web.get('/api/getpairs', self.get_pairs)])
+        app.add_routes([web.post('/api/createswap', self.create_swap)])
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, host=str(self.addr.host), port=self.addr.port, ssl_context=self.config.get_ssl_context())
+        await site.start()
+        self.logger.info(f"now running and listening. addr={self.addr}")
+
+    async def get_pairs(self, r):
+        sm = self.wallet.lnworker.swap_manager
+        sm.init_pairs()
+        pairs = {
+            "info": [],
+            "warnings": [],
+            "pairs": {
+                "BTC/BTC": {
+                    "hash": "dfe692a026d6964601bfd79703611af333d1d5aa49ef5fedd288f5a620fced60",
+                    "rate": 1,
+                    "limits": {
+                        "maximal": sm._max_amount,
+                        "minimal": sm._min_amount,
+                        "maximalZeroConf": {
+                            "baseAsset": 0,
+                            "quoteAsset": 0
+                        }
+                    },
+                    "fees": {
+                        "percentage": 0.5,
+                        "minerFees": {
+                            "baseAsset": {
+                                "normal": sm.normal_fee,
+                                "reverse": {
+                                    "claim": sm.claim_fee,
+                                    "lockup": sm.lockup_fee
+                                }
+                            },
+                            "quoteAsset": {
+                                "normal": sm.normal_fee,
+                                "reverse": {
+                                    "claim": sm.claim_fee,
+                                    "lockup": sm.lockup_fee
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return web.json_response(pairs)
+
+    async def create_swap(self, r):
+        sm = self.wallet.lnworker.swap_manager
+        sm.init_pairs()
+        request = await r.json()
+        req_type = request['type']
+        assert request['pairId'] == 'BTC/BTC'
+        if req_type == 'reversesubmarine':
+            swap, payment_hash, invoice = sm.add_server_swap(
+                lightning_amount_sat=request['invoiceAmount'],
+                payment_hash=bytes.fromhex(request['preimageHash']),
+                their_pubkey=bytes.fromhex(request['claimPublicKey'])
+            )
+            response = {
+                'id': payment_hash.hex(),
+                'invoice': invoice,
+                'minerFeeInvoice': None,
+                'lockupAddress': swap.lockup_address,
+                'redeemScript': swap.redeem_script.hex(),
+                'timeoutBlockHeight': swap.locktime,
+                "onchainAmount": swap.onchain_amount,
+            }
+        elif req_type == 'submarine':
+            swap, payment_hash, invoice = sm.add_server_swap(
+                invoice=request['invoice'],
+                their_pubkey=request['refundPublicKey']
+            )
+            response = {
+                "id": payment_hash.hex(),
+                "acceptZeroConf": False,
+                "expectedAmount": swap.onchain_amount,
+                "timeoutBlockHeight": swap.locktime,
+                "address": swap.lockup_address,
+                "redeemScript": swap.redeem_script.hex()
+            }
+        else:
+            raise Exception('unsupported request type:' + req_type)
+        return web.json_response(response)

--- a/electrum/plugins/swapserver/server.py
+++ b/electrum/plugins/swapserver/server.py
@@ -98,10 +98,15 @@ class SwapServer(Logger, EventListener):
         req_type = request['type']
         assert request['pairId'] == 'BTC/BTC'
         if req_type == 'reversesubmarine':
+            lightning_amount_sat=request['invoiceAmount']
+            payment_hash=bytes.fromhex(request['preimageHash'])
+            their_pubkey=bytes.fromhex(request['claimPublicKey'])
+            assert len(payment_hash) == 32
+            assert len(their_pubkey) == 33
             swap, payment_hash, invoice, prepay_invoice = sm.add_server_swap(
-                lightning_amount_sat=request['invoiceAmount'],
-                payment_hash=bytes.fromhex(request['preimageHash']),
-                their_pubkey=bytes.fromhex(request['claimPublicKey'])
+                lightning_amount_sat=lightning_amount_sat,
+                payment_hash=payment_hash,
+                their_pubkey=their_pubkey
             )
             response = {
                 'id': payment_hash.hex(),
@@ -113,9 +118,12 @@ class SwapServer(Logger, EventListener):
                 "onchainAmount": swap.onchain_amount,
             }
         elif req_type == 'submarine':
+            their_invoice=request['invoice']
+            their_pubkey=bytes.fromhex(request['refundPublicKey'])
+            assert len(their_pubkey) == 33
             swap, payment_hash, invoice, prepay_invoice = sm.add_server_swap(
-                invoice=request['invoice'],
-                their_pubkey=request['refundPublicKey']
+                invoice=their_invoice,
+                their_pubkey=their_pubkey
             )
             response = {
                 "id": payment_hash.hex(),

--- a/electrum/plugins/swapserver/server.py
+++ b/electrum/plugins/swapserver/server.py
@@ -98,7 +98,7 @@ class SwapServer(Logger, EventListener):
         req_type = request['type']
         assert request['pairId'] == 'BTC/BTC'
         if req_type == 'reversesubmarine':
-            swap, payment_hash, invoice = sm.add_server_swap(
+            swap, payment_hash, invoice, prepay_invoice = sm.add_server_swap(
                 lightning_amount_sat=request['invoiceAmount'],
                 payment_hash=bytes.fromhex(request['preimageHash']),
                 their_pubkey=bytes.fromhex(request['claimPublicKey'])
@@ -106,14 +106,14 @@ class SwapServer(Logger, EventListener):
             response = {
                 'id': payment_hash.hex(),
                 'invoice': invoice,
-                'minerFeeInvoice': None,
+                'minerFeeInvoice': prepay_invoice,
                 'lockupAddress': swap.lockup_address,
                 'redeemScript': swap.redeem_script.hex(),
                 'timeoutBlockHeight': swap.locktime,
                 "onchainAmount": swap.onchain_amount,
             }
         elif req_type == 'submarine':
-            swap, payment_hash, invoice = sm.add_server_swap(
+            swap, payment_hash, invoice, prepay_invoice = sm.add_server_swap(
                 invoice=request['invoice'],
                 their_pubkey=request['refundPublicKey']
             )

--- a/electrum/plugins/swapserver/swapserver.py
+++ b/electrum/plugins/swapserver/swapserver.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Electrum - Lightweight Bitcoin Client
+# Copyright (C) 2023 The Electrum Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import asyncio
+import os
+import random
+from electrum.plugin import BasePlugin, hook
+from electrum.util import log_exceptions, ignore_exceptions
+from electrum import ecc
+
+from .server import SwapServer
+
+
+class SwapServerPlugin(BasePlugin):
+
+    def __init__(self, parent, config, name):
+        BasePlugin.__init__(self, parent, config, name)
+        self.config = config
+        self.server = None
+
+    @hook
+    def daemon_wallet_loaded(self, daemon, wallet):
+        # we use the first wallet loaded
+        if self.server is not None:
+            return
+        if self.config.get('offline'):
+            return
+
+        self.server = SwapServer(self.config, wallet)
+        sm = wallet.lnworker.swap_manager
+        jobs = [
+            sm.pay_pending_invoices(),
+            self.server.run(),
+        ]
+        asyncio.run_coroutine_threadsafe(daemon._run(jobs=jobs), daemon.asyncio_loop)

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -966,6 +966,8 @@ class SimpleConfig(Logger):
     PAYSERVER_ROOT = ConfigVar('payserver_root', default='/r', type_=str)
     PAYSERVER_ALLOW_CREATE_INVOICE = ConfigVar('payserver_allow_create_invoice', default=False, type_=bool)
 
+    SWAPSERVER_ADDRESS = ConfigVar('swapserver_address', default='localhost:5455', type_=str)
+
     PLUGIN_TRUSTEDCOIN_NUM_PREPAY = ConfigVar('trustedcoin_prepay', default=20, type_=int)
 
 

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -219,11 +219,11 @@ class SwapManager(Logger):
             swap.funding_txid = txin.prevout.txid.hex()
             swap._funding_prevout = txin.prevout
             self._add_or_reindex_swap(swap)  # to update _swaps_by_funding_outpoint
-            funding_height = txin.block_height
+            funding_conf = self.lnwatcher.adb.get_tx_height(txin.prevout.txid.hex()).conf
             spent_height = txin.spent_height
 
             if swap.is_reverse and swap.preimage is None:
-                if funding_height <= 0:
+                if funding_conf <= 0:
                     continue
                 preimage = self.lnworker.get_preimage(swap.payment_hash)
                 if preimage is None:

--- a/electrum/tests/regtest.py
+++ b/electrum/tests/regtest.py
@@ -47,6 +47,9 @@ class TestLightningAB(TestLightning):
     def test_collaborative_close(self):
         self.run_shell(['collaborative_close'])
 
+    def test_submarine_swap(self):
+        self.run_shell(['reverse_swap'])
+
     def test_backup(self):
         self.run_shell(['backup'])
 

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -83,10 +83,11 @@ if [[ $1 == "init" ]]; then
     # alice is funded, bob is listening
     if [[ $2 == "bob" ]]; then
         $bob setconfig --offline lightning_listen localhost:9735
-    else
-        echo "funding $2"
-        $bitcoin_cli sendtoaddress $($agent getunusedaddress -o) 1
+        $bob setconfig --offline use_swapserver true
+    #else
     fi
+    echo "funding $2"
+    $bitcoin_cli sendtoaddress $($agent getunusedaddress -o) 1
 fi
 
 
@@ -167,6 +168,24 @@ if [[ $1 == "collaborative_close" ]]; then
     wait_until_channel_open alice
     echo "alice closes channel"
     request=$($bob close_channel $channel)
+fi
+
+
+if [[ $1 == "reverse_swap" ]]; then
+    wait_for_balance alice 1
+    echo "alice opens channel"
+    bob_node=$($bob nodeid)
+    channel=$($alice open_channel $bob_node 0.15)
+    new_blocks 3
+    wait_until_channel_open alice
+    echo "alice initiates swap"
+    dryrun=$($alice reverse_swap 0.02 dryrun)
+    echo $dryrun | jq
+    onchain_amount=$(echo $dryrun| jq -r ".onchain_amount")
+    $alice reverse_swap 0.02 $onchain_amount
+    new_blocks 1
+    sleep 1
+    new_blocks 1
 fi
 
 

--- a/electrum/tests/test_lnpeer.py
+++ b/electrum/tests/test_lnpeer.py
@@ -138,6 +138,7 @@ class MockLNWallet(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         Logger.__init__(self)
         NetworkRetryManager.__init__(self, max_retry_delay_normal=1, init_retry_delay_normal=1)
         self.node_keypair = local_keypair
+        self.payment_secret_key = os.urandom(256) # does not need to be deterministic in tests
         self._user_dir = tempfile.mkdtemp(prefix="electrum-lnpeer-test-")
         self.config = SimpleConfig({}, read_user_dir_function=lambda: self._user_dir)
         self.network = MockNetwork(tx_queue, config=self.config)
@@ -239,6 +240,7 @@ class MockLNWallet(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
             full_path=full_path)]
 
     get_payments = LNWallet.get_payments
+    get_payment_secret = LNWallet.get_payment_secret
     get_payment_info = LNWallet.get_payment_info
     save_payment_info = LNWallet.save_payment_info
     set_invoice_status = LNWallet.set_invoice_status


### PR DESCRIPTION
 - uses the same web API as the Boltz backend
 - lnworker and lnpeer are modified to create and handle invoices for which we do not have the preimage (aka 'hold invoices')
 - payment_secret is random for hold invoices, must be persisted
 - for the moment, server fees are hardcoded