### PR TITLE
:bug: fix #8469 - fiat balance sorting in address list window

### DIFF
--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -262,6 +262,7 @@ class AddressList(MyTreeView):
         address_item[self.Columns.COIN_BALANCE].setText(balance_text)
         address_item[self.Columns.COIN_BALANCE].setData(balance, self.ROLE_SORT_ORDER)
         address_item[self.Columns.FIAT_BALANCE].setText(fiat_balance_str)
+        address_item[self.Columns.FIAT_BALANCE].setData(balance, self.ROLE_SORT_ORDER)
         address_item[self.Columns.NUM_TXS].setText("%d"%num)
         c = ColorScheme.BLUE.as_color(True) if self.wallet.is_frozen_address(address) else self._default_bg_brush
         address_item[self.Columns.ADDRESS].setBackground(c)


### PR DESCRIPTION
# Context
As reported in #8469, in v4.4.4, sorting on the FIAT_BALANCE column of the Address list window is done with amounts considered as text.

# Change
This PR  `setData` on the FIAT_BALANCE column with the numerical value so that sorting works as expected