### PR TITLE
:sparkles: remove thousand separator when copying numbers to clipboard

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -852,11 +852,22 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.send_tab.payto_e.on_timer_check_text()
         self.notify_transactions()
 
-    def format_amount(self, amount_sat, is_diff=False, whitespaces=False) -> str:
+    def format_amount(
+        self,
+        amount_sat,
+        is_diff=False,
+        whitespaces=False,
+        ignore_thousands_sep: bool = False,
+    ) -> str:
         """Formats amount as string, converting to desired unit.
         E.g. 500_000 -> '0.005'
         """
-        return self.config.format_amount(amount_sat, is_diff=is_diff, whitespaces=whitespaces)
+        return self.config.format_amount(
+            amount_sat,
+            is_diff=is_diff,
+            whitespaces=whitespaces,
+            ignore_thousands_sep=ignore_thousands_sep,
+        )
 
     def format_amount_and_units(self, amount_sat, *, timestamp: int = None) -> str:
         """Returns string with both bitcoin and fiat amounts, in desired units.

--- a/electrum/gui/qt/my_treeview.py
+++ b/electrum/gui/qt/my_treeview.py
@@ -24,6 +24,7 @@
 # SOFTWARE.
 
 import asyncio
+import contextlib
 import enum
 import os.path
 import time
@@ -451,6 +452,13 @@ class MyTreeView(QTreeView):
         return cc
 
     def place_text_on_clipboard(self, text: str, *, title: str = None) -> None:
+        if title in {
+            "Amount",
+            "Balance",
+        } or title.endswith(" Value") or title.endswith(" Acquisition price") or title.endswith(" Capital Gains"):
+            with contextlib.suppress(Exception):
+                # remove formatting for numbers
+                text = text.replace(" ", "")
         self.main_window.do_copy(text, title=title)
 
     def showEvent(self, e: 'QShowEvent'):

--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -314,7 +314,7 @@ class TxInOutWidget(QWidget):
                 copy_list += [(_("Copy Address"), lambda: self.main_window.do_copy(addr))]
             txin_value = self.wallet.adb.get_txin_value(txin)
             if txin_value:
-                value_str = self.main_window.format_amount(txin_value)
+                value_str = self.main_window.format_amount(txin_value, ignore_thousands_sep=True)
                 copy_list += [(_("Copy Amount"), lambda: self.main_window.do_copy(value_str))]
 
         for item in show_list:
@@ -356,7 +356,7 @@ class TxInOutWidget(QWidget):
                 show_list += [(_("Address Details"), lambda: self.main_window.show_address(addr, parent=self))]
             copy_list += [(_("Copy Address"), lambda: self.main_window.do_copy(addr))]
         txout_value = self.tx.outputs()[txout_idx].value
-        value_str = self.main_window.format_amount(txout_value)
+        value_str = self.main_window.format_amount(txout_value, ignore_thousands_sep=True)
         copy_list += [(_("Copy Amount"), lambda: self.main_window.do_copy(value_str))]
 
         for item in show_list:

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -785,6 +785,7 @@ class SimpleConfig(Logger):
         is_diff=False,
         whitespaces=False,
         precision=None,
+        ignore_thousands_sep: bool=False,
     ) -> str:
         if precision is None:
             precision = self.amt_precision_post_satoshi
@@ -795,7 +796,7 @@ class SimpleConfig(Logger):
             is_diff=is_diff,
             whitespaces=whitespaces,
             precision=precision,
-            add_thousands_sep=self.amt_add_thousands_sep,
+            add_thousands_sep=False if ignore_thousands_sep else self.amt_add_thousands_sep,
         )
 
     def format_amount_and_units(self, *args, **kwargs) -> str:


### PR DESCRIPTION
# Context

I've been frustrated when copying btc/fiat values from the different windows into other software. Copied amounts contain _thousand separator spaces_ (if the option is set in config) and most other software do not cope well with this format.

# Change

From contextual menus, when copying data from a numerical column, spaces are removed.

Let me know if this should be handled in a different manner