### PR TITLE
partial-writes using jsonpatch

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -7,6 +7,7 @@ aiohttp_socks>=0.3
 certifi
 bitstring
 attrs>=20.1.0
+jsonpatch
 
 # Note that we also need the dnspython[DNSSEC] extra which pulls in cryptography,
 # but as that is not pure-python it cannot be listed in this file!

--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -187,6 +187,8 @@ class Console(QtWidgets.QPlainTextEdit):
             return
 
         if command and (not self.history or self.history[-1] != command):
+            while len(self.history) >= 50:
+                self.history.remove(self.history[0])
             self.history.append(command)
         self.history_index = len(self.history)
 

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1550,7 +1550,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
     def update_console(self):
         console = self.console
-        console.history = self.wallet.db.get("qt-console-history", [])
+        console.history = self.wallet.db.get_stored_item("qt-console-history", [])
         console.history_index = len(console.history)
 
         console.updateNamespace({
@@ -2620,7 +2620,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             g = self.geometry()
             self.wallet.db.put("winpos-qt", [g.left(),g.top(),
                                                   g.width(),g.height()])
-        self.wallet.db.put("qt-console-history", self.console.history[-50:])
         if self.qr_window:
             self.qr_window.close()
         self.close_wallet()

--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -381,10 +381,12 @@ class JsonDB(Logger):
 
     @locked
     def write(self):
-        if self.storage.file_exists() and not self.storage.is_encrypted():
-            self._append_pending_changes()
-        else:
+        if not self.storage.file_exists()\
+           or self.storage.is_encrypted()\
+           or self.storage.needs_consolidation():
             self._write()
+        else:
+            self._append_pending_changes()
 
     @locked
     def _append_pending_changes(self):

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -894,7 +894,8 @@ class Peer(Logger):
             "revocation_store": {},
             "channel_type": channel_type,
         }
-        return StoredDict(chan_dict, self.lnworker.db if self.lnworker else None, [])
+        # set db to None, because we do not want to write updates until channel is saved
+        return StoredDict(chan_dict, None, [])
 
     async def on_open_channel(self, payload):
         """Implements the channel acceptance flow.

--- a/electrum/storage.py
+++ b/electrum/storage.py
@@ -86,12 +86,10 @@ class WalletStorage(Logger):
             f.write(s)
             f.flush()
             os.fsync(f.fileno())
-
         try:
             mode = os.stat(self.path).st_mode
         except FileNotFoundError:
             mode = stat.S_IREAD | stat.S_IWRITE
-
         # assert that wallet file does not exist, to prevent wallet corruption (see issue #5082)
         if not self.file_exists():
             assert not os.path.exists(self.path)
@@ -99,6 +97,15 @@ class WalletStorage(Logger):
         os_chmod(self.path, mode)
         self._file_exists = True
         self.logger.info(f"saved {self.path}")
+
+    def append(self, data: str) -> None:
+        """ append data to file. for the moment, only non-encrypted file"""
+        assert not self.is_encrypted()
+        with open(self.path, "r+") as f:
+            f.seek(0, os.SEEK_END)
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
 
     def file_exists(self) -> bool:
         return self._file_exists
@@ -179,6 +186,7 @@ class WalletStorage(Logger):
     def encrypt_before_writing(self, plaintext: str) -> str:
         s = plaintext
         if self.pubkey:
+            self.decrypted = plaintext
             s = bytes(s, 'utf8')
             c = zlib.compress(s, level=zlib.Z_BEST_SPEED)
             enc_magic = self._get_encryption_magic()

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2828,7 +2828,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self._update_password_for_keystore(old_pw, new_pw)
         encrypt_keystore = self.can_have_keystore_encryption()
         self.db.set_keystore_encryption(bool(new_pw) and encrypt_keystore)
-        self.save_db()
+        ## save changes
+        if self.storage and self.storage.file_exists():
+            self.db._write()
         self.unlock(None)
 
     @abstractmethod


### PR DESCRIPTION
 - partial writes are append only.

 - StoredDict objects will append partial writes to the wallet file when items are added, replaced, removed.

 - Lists in the wallet file that have not been registered as StoredObject are converted to StoredList, which overloads append() and remove(). Those methods too will append partial writes to the wallet file.

 - Unlike the old jsonpatch branch, this branch does not support file encryption. Encrypted files always fully rewritten, even if the change before encryption is a partial write.
 

related: https://github.com/spesmilo/electrum/issues/4823