### PR TITLE
Patch error caused by the method "parse_URI()" being moved to bip21.py and renamed "parse_bip21_URI"

### DIFF
--- a/electrum/plugins/hw_wallet/qt.py
+++ b/electrum/plugins/hw_wallet/qt.py
@@ -40,7 +40,8 @@ from electrum.gui.qt.installwizard import InstallWizard
 
 from electrum.i18n import _
 from electrum.logging import Logger
-from electrum.util import parse_URI, InvalidBitcoinURI, UserCancelled, UserFacingException
+from electrum.util import UserCancelled, UserFacingException
+from electrum.bip21 import parse_bip21_URI, InvalidBitcoinURI
 from electrum.plugin import hook, DeviceUnpairableError
 
 from .plugin import OutdatedHwFirmwareException, HW_PluginBase, HardwareHandlerBase


### PR DESCRIPTION
Error message:

```
Aucun périphérique matériel détecté.
Pour déclencher un nouveau scan, pressez 'Suivant'.

Sur Linux, vous pouvez avoir à ajouter une nouvelle permission à vos règles udev.


Message de débogage
  bitbox02: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading bitbox02 plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  coldcard: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading coldcard plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  digitalbitbox: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading digitalbitbox plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  jade: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading jade plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  keepkey: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading keepkey plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  ledger: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading ledger plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  safe_t: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading safe_t plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  satochip: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading satochip plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
  trezor: (error during plugin init)
    Vous avez peut-être une bibliothèque incompatible.
    Error loading trezor plugin: ImportError("cannot import name 'parse_URI' from 'electrum.util' (/Users/satochip/Documents/github/electrum-satochip/dist/Electrum.app/Contents/MacOS/electrum/util.pyc)")
```