### PR TITLE
Add Vendor/Device IDs for CH340 based DIY Jade devices.

### DIFF
--- a/electrum/plugins/jade/jade.py
+++ b/electrum/plugins/jade/jade.py
@@ -350,7 +350,10 @@ class Jade_KeyStore(Hardware_KeyStore):
 class JadePlugin(HW_PluginBase):
     keystore_class = Jade_KeyStore
     minimum_library = (0, 0, 1)
-    DEVICE_IDS = [(0x10c4, 0xea60), (0x1a86, 0x55d4), (0x0403, 0x6001), (0x1a86, 0x7523)]
+    DEVICE_IDS = [(0x10c4, 0xea60), # Development Jade device
+                  (0x1a86, 0x55d4), # Retail Blockstream Jade (And some DIY devices)
+                  (0x0403, 0x6001), # DIY FTDI Based Devices (Eg: M5StickC-Plus)
+                  (0x1a86, 0x7523)] # DIY CH40 Based devices (Eg: ESP32-Wrover)
     SUPPORTED_XTYPES = ('standard', 'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')
     MIN_SUPPORTED_FW_VERSION = (0, 1, 32)
 

--- a/electrum/plugins/jade/jade.py
+++ b/electrum/plugins/jade/jade.py
@@ -353,7 +353,7 @@ class JadePlugin(HW_PluginBase):
     DEVICE_IDS = [(0x10c4, 0xea60), # Development Jade device
                   (0x1a86, 0x55d4), # Retail Blockstream Jade (And some DIY devices)
                   (0x0403, 0x6001), # DIY FTDI Based Devices (Eg: M5StickC-Plus)
-                  (0x1a86, 0x7523)] # DIY CH40 Based devices (Eg: ESP32-Wrover)
+                  (0x1a86, 0x7523)] # DIY CH340 Based devices (Eg: ESP32-Wrover)
     SUPPORTED_XTYPES = ('standard', 'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')
     MIN_SUPPORTED_FW_VERSION = (0, 1, 32)
 

--- a/run_electrum
+++ b/run_electrum
@@ -338,8 +338,8 @@ def main():
         config_options = args.__dict__
         f = lambda key: config_options[key] is not None and key not in config_variables.get(args.cmd, {}).keys()
         config_options = {key: config_options[key] for key in filter(f, config_options.keys())}
-        if config_options.get('server'):
-            config_options['auto_connect'] = False
+        if config_options.get(SimpleConfig.NETWORK_SERVER.key()):
+            config_options[SimpleConfig.NETWORK_AUTO_CONNECT.key()] = False
 
     config_options['cwd'] = cwd = os.getcwd()
 


### PR DESCRIPTION
Allows use with DIY Jade + Camera based on common, low cost boards like those based on ESP32-Wrover and ESP32-CAM.