### PR TITLE
fix #8607, and add existence checks to setconfig/getconfig

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -61,7 +61,7 @@ from .lnutil import extract_nodeid
 from .lnpeer import channel_id_from_funding_tx
 from .plugin import run_hook, DeviceMgr
 from .version import ELECTRUM_VERSION
-from .simple_config import SimpleConfig
+from .simple_config import SimpleConfig, config_vars
 from .invoices import Invoice
 from . import submarine_swaps
 from . import GuiImportError
@@ -305,6 +305,8 @@ class Commands:
     @command('')
     async def getconfig(self, key):
         """Return a configuration variable. """
+        if key not in config_vars:
+            raise Exception(f'Unknown config variable: {key}')
         return self.config.get(key)
 
     @classmethod
@@ -321,6 +323,8 @@ class Commands:
     @command('')
     async def setconfig(self, key, value):
         """Set a configuration variable. 'value' may be a string or a Python expression."""
+        if key not in config_vars:
+            raise Exception(f'Unknown config variable: {key}')
         value = self._setconfig_normalize_value(key, value)
         if self.daemon and key == SimpleConfig.RPC_USERNAME.key():
             self.daemon.commands_server.rpc_user = value

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -51,6 +51,7 @@ _logger = get_logger(__name__)
 
 FINAL_CONFIG_VERSION = 3
 
+config_vars = {}
 
 class ConfigVar(property):
 
@@ -65,6 +66,7 @@ class ConfigVar(property):
         self._default = default
         self._type = type_
         property.__init__(self, self._get_config_value, self._set_config_value)
+        config_vars[key] = self
 
     def _get_config_value(self, config: 'SimpleConfig'):
         with config.lock:
@@ -283,6 +285,10 @@ class SimpleConfig(Logger):
             out = self.cmdline_options.get(key)
             if out is None:
                 out = self.user_config.get(key, default)
+                if out is None:
+                    cv = config_vars.get(key)
+                    if cv:
+                        out = cv._get_config_value(self)
         return out
 
     def is_set(self, key: Union[str, ConfigVar, ConfigVarWithConfig]) -> bool:


### PR DESCRIPTION
I am not happy with it. The whole simple_config module has become extremely convoluted. In addition, this patch threatens to trigger an infinite loop, because SimpleConfig.get() and ConfigVar._get_config_value() call eachother.

closes https://github.com/spesmilo/electrum/issues/8607