### PR TITLE
getconfig/setconfig to use configvars

### DIFF
--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -160,6 +160,15 @@ class Plugins(DaemonThread):
         p.close()
         self.logger.info(f"closed {name}")
 
+    @classmethod
+    def is_plugin_enabler_config_key(cls, key: str) -> bool:
+        if not key.startswith('use_'):
+            return False
+        # note: the 'use_' prefix is not sufficient to check, there are
+        #       non-plugin-related config keys that also have it... hence:
+        name = key[4:]
+        return name in cls.find_all_plugins()
+
     def toggle(self, name: str) -> Optional['BasePlugin']:
         p = self.get(name)
         return self.disable(name) if p else self.enable(name)

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -29,7 +29,7 @@ import time
 import threading
 import sys
 from typing import (NamedTuple, Any, Union, TYPE_CHECKING, Optional, Tuple,
-                    Dict, Iterable, List, Sequence, Callable, TypeVar, Mapping)
+                    Dict, Iterable, List, Sequence, Callable, TypeVar, Mapping, Set)
 import concurrent
 from concurrent import futures
 from functools import wraps, partial
@@ -56,12 +56,13 @@ hooks = {}
 class Plugins(DaemonThread):
 
     LOGGING_SHORTCUT = 'p'
+    pkgpath = os.path.dirname(plugins.__file__)
+    _all_found_plugins = None  # type: Optional[Dict[str, dict]]
 
     @profiler
     def __init__(self, config: SimpleConfig, gui_name):
         DaemonThread.__init__(self)
         self.name = 'Plugins'  # set name of thread
-        self.pkgpath = os.path.dirname(plugins.__file__)
         self.config = config
         self.hw_wallets = {}
         self.plugins = {}  # type: Dict[str, BasePlugin]
@@ -72,21 +73,33 @@ class Plugins(DaemonThread):
         self.add_jobs(self.device_manager.thread_jobs())
         self.start()
 
+    @classmethod
+    def find_all_plugins(cls) -> Mapping[str, dict]:
+        """Return a map of all found plugins: name -> description.
+        Note that plugins not available for the current GUI are also included.
+        """
+        if cls._all_found_plugins is None:
+            cls._all_found_plugins = dict()
+            for loader, name, ispkg in pkgutil.iter_modules([cls.pkgpath]):
+                full_name = f'electrum.plugins.{name}'
+                spec = importlib.util.find_spec(full_name)
+                if spec is None:  # pkgutil found it but importlib can't ?!
+                    raise Exception(f"Error pre-loading {full_name}: no spec")
+                try:
+                    module = importlib.util.module_from_spec(spec)
+                    # sys.modules needs to be modified for relative imports to work
+                    # see https://stackoverflow.com/a/50395128
+                    sys.modules[spec.name] = module
+                    spec.loader.exec_module(module)
+                except Exception as e:
+                    raise Exception(f"Error pre-loading {full_name}: {repr(e)}") from e
+                d = module.__dict__
+                assert name not in cls._all_found_plugins
+                cls._all_found_plugins[name] = d
+        return cls._all_found_plugins
+
     def load_plugins(self):
-        for loader, name, ispkg in pkgutil.iter_modules([self.pkgpath]):
-            full_name = f'electrum.plugins.{name}'
-            spec = importlib.util.find_spec(full_name)
-            if spec is None:  # pkgutil found it but importlib can't ?!
-                raise Exception(f"Error pre-loading {full_name}: no spec")
-            try:
-                module = importlib.util.module_from_spec(spec)
-                # sys.modules needs to be modified for relative imports to work
-                # see https://stackoverflow.com/a/50395128
-                sys.modules[spec.name] = module
-                spec.loader.exec_module(module)
-            except Exception as e:
-                raise Exception(f"Error pre-loading {full_name}: {repr(e)}") from e
-            d = module.__dict__
+        for name, d in self.find_all_plugins().items():
             gui_good = self.gui_name in d.get('available_for', [])
             if not gui_good:
                 continue

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -68,6 +68,7 @@ class ConfigVar(property):
         self._default = default
         self._type = type_
         property.__init__(self, self._get_config_value, self._set_config_value)
+        assert key not in _config_var_from_key, f"duplicate config key str: {key!r}"
         _config_var_from_key[key] = self
 
     def _get_config_value(self, config: 'SimpleConfig'):
@@ -105,8 +106,8 @@ class ConfigVar(property):
         return f"<ConfigVar key={self._key!r}>"
 
     def __deepcopy__(self, memo):
-        cv = ConfigVar(self._key, default=self._default, type_=self._type)
-        return cv
+        # We can be considered ~stateless. State is stored in the config, which is external.
+        return self
 
 
 class ConfigVarWithConfig:

--- a/electrum/tests/test_simple_config.py
+++ b/electrum/tests/test_simple_config.py
@@ -199,6 +199,12 @@ class Test_SimpleConfig(ElectrumTestCase):
         config.NETWORK_MAX_INCOMING_MSG_SIZE = 2_222_222
         self.assertEqual(5_555_555, config.NETWORK_MAX_INCOMING_MSG_SIZE)
 
+    def test_configvars_from_key(self):
+        config = SimpleConfig(self.options)
+        self.assertEqual(config.cv.NETWORK_SERVER, config.cv.from_key("server"))
+        with self.assertRaises(KeyError):
+            config.cv.from_key("server333")
+
     def test_depth_target_to_fee(self):
         config = SimpleConfig(self.options)
         config.mempool_fees = [[49, 100110], [10, 121301], [6, 153731], [5, 125872], [1, 36488810]]


### PR DESCRIPTION
This is an alternative to https://github.com/spesmilo/electrum/pull/8608.

- getconfig and setconfig now both check configvars for existence
- getconfig returns default values when applicable
- setconfig does not side-step type-checks for values

fixes https://github.com/spesmilo/electrum/issues/8607

