### PR TITLE
bip39: add likely script vs derivation path mistakes

### DIFF
--- a/electrum/bip39_wallet_formats.json
+++ b/electrum/bip39_wallet_formats.json
@@ -36,6 +36,30 @@
         "iterate_accounts": true
     },
     {
+        "description": "Non-standard legacy on BIP84 path",
+        "derivation_path": "m/84'/0'/0'",
+        "script_type": "p2pkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Non-standard compatibility segwit on BIP84 path",
+        "derivation_path": "m/84'/0'/0'",
+        "script_type": "p2wpkh-p2sh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Non-standard legacy on BIP49 path",
+        "derivation_path": "m/49'/0'/0'",
+        "script_type": "p2pkh",
+        "iterate_accounts": true
+    },
+    {
+        "description": "Non-standard native segwit on BIP49 path",
+        "derivation_path": "m/49'/0'/0'",
+        "script_type": "p2wpkh",
+        "iterate_accounts": true
+    },
+    {
         "description": "Copay native segwit",
         "derivation_path": "m/44'/0'/0'",
         "script_type": "p2wpkh",


### PR DESCRIPTION
bip39: add likely script vs derivation path mistakes for BIP49 and BIP84 paths. See e.g.

https://bitcointalk.org/index.php?topic=5454270.0