### PR TITLE
fix recv for text gui

### DIFF
--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -857,7 +857,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         req = self.wallet.get_request(key)
         addr = req.get_address() or ''
         URI = self.wallet.get_request_URI(req) or ''
-        lnaddr = req.lightning_invoice or ''
+        lnaddr = self.wallet.get_bolt11_invoice(req) or ''
         w = curses.newwin(self.maxy - 2, self.maxx - 2, 1, 1)
         pos = 4
         while True:


### PR DESCRIPTION
Today the text GUI crashes when you create an invoice (Receive tab): 

```
$ ./build/electrum gui -g text
/tmp/electrum/./build/electrum:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('Electrum==4.4.6')
Password:
 14.19 | E | daemon.Daemon | GUI raised exception: AttributeError("'Request' object has no attribute 'lightning_invoice'"). shutting down.
 15.03 | E | __main__ | daemon.run_gui errored
Traceback (most recent call last):
  File "/tmp/electrum/electrum/electrum", line 456, in handle_cmd
    d.run_gui()
  File "/tmp/electrum/electrum/daemon.py", line 625, in run_gui
    self.gui_object.main()
  File "/tmp/electrum/electrum/gui/text.py", line 528, in main
    self.run_tab(2, self.print_receive_tab,   self.run_receive_tab)
  File "/tmp/electrum/electrum/gui/text.py", line 465, in run_tab
    if c: exec_func(c)
          ^^^^^^^^^^^^
  File "/tmp/electrum/electrum/gui/text.py", line 237, in run_receive_tab
    self.buttons[self.pos]()
  File "/tmp/electrum/electrum/gui/text.py", line 567, in do_create_request
    self.show_request(key)
  File "/tmp/electrum/electrum/gui/text.py", line 860, in show_request
    lnaddr = req.lightning_invoice or ''
             ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Request' object has no attribute 'lightning_invoice'
```

Steps to reproduce:

0. Build electrum from this repo's `master` branch
1. Open the GUI as above
3. Navigate to the Receive tab
4. Create a request
5. The GUI crashes

Re-do the stpes after applying the suggested patch and it does not crash and shows the address correctly.

<details>

I've used the qt gui as reference, which used to do the same as the text gui but now uses `self.wallet.get_bolt11_invoice(req)` for `lnaddr` since 719b468eee8b3e13680f6e7b90194d618181fe0c, which reads "wallet_db update: separate Invoices and Requests" which seems to be related to this issue as it used to be that `req` from the text GUI was an Invoice (https://github.com/spesmilo/electrum/blob/43ab4a779afa339c5295aa1bab61c3915d2df2b9/electrum/wallet.py#L315) and not a Request as it is today (https://github.com/spesmilo/electrum/blob/98cecb305ea2aa9629fe6cba6db794a6d283b69f/electrum/wallet.py#L343)

</details>