### PR TITLE
Cirrus: Mark E722 linter as mandatory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,7 +141,7 @@ task:
         # - https://flake8.pycqa.org/en/latest/user/error-codes.html
         # - https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
         # - https://github.com/PyCQA/flake8-bugbear/tree/8c0e7eb04217494d48d0ab093bf5b31db0921989#list-of-warnings
-        ELECTRUM_LINTERS: E9,E101,E129,E273,E274,E703,E71,F63,F7,F82,W191,W29,B
+        ELECTRUM_LINTERS: E9,E101,E129,E273,E274,E703,E71,E722,F63,F7,F82,W191,W29,B
         ELECTRUM_LINTERS_IGNORE: B007,B009,B010,B019
     - name: "linter: Flake8 Non-Mandatory"
       env:


### PR DESCRIPTION
These linter warnings were all fixed in 312f2641e7284dc9ed7bde99a61060b4d9e35dd9, so making CI enforce them will reduce the risk of regressions.