### PR TITLE
Just in time channels

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1137,7 +1137,7 @@ class Commands:
         } for p in lnworker.peers.values()]
 
     @command('wpnl')
-    async def open_channel(self, connection_string, amount, push_amount=0, public=False, password=None, wallet: Abstract_Wallet = None):
+    async def open_channel(self, connection_string, amount, push_amount=0, public=False, zeroconf=False, password=None, wallet: Abstract_Wallet = None):
         funding_sat = satoshis(amount)
         push_sat = satoshis(push_amount)
         peer = await wallet.lnworker.add_peer(connection_string)
@@ -1145,6 +1145,7 @@ class Commands:
             peer, funding_sat,
             push_sat=push_sat,
             public=public,
+            zeroconf=zeroconf,
             password=password)
         return chan.funding_outpoint.to_str()
 
@@ -1449,6 +1450,7 @@ command_options = {
     'force':       (None, "Create new address beyond gap limit, if no more addresses are available."),
     'pending':     (None, "Show only pending requests."),
     'push_amount': (None, 'Push initial amount (in BTC)'),
+    'zeroconf':    (None, 'request zeroconf channel'),
     'expired':     (None, "Show only expired requests."),
     'paid':        (None, "Show only paid requests."),
     'show_addresses': (None, "Show input and output addresses"),

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -639,7 +639,8 @@ class Channel(AbstractChannel):
     def __repr__(self):
         return "Channel(%s)"%self.get_id_for_log()
 
-    def __init__(self, state: 'StoredDict', *, name=None, lnworker=None, initial_feerate=None):
+    def __init__(self, state: 'StoredDict', *, name=None, lnworker=None, initial_feerate=None, opening_fee=None):
+        self.opening_fee = opening_fee
         self.name = name
         self.channel_id = bfh(state["channel_id"])
         self.short_channel_id = ShortChannelID.normalize(state["short_channel_id"])

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1484,6 +1484,12 @@ class LNPeerAddr:
     def __str__(self):
         return '{}@{}'.format(self.pubkey.hex(), self.net_addr_str())
 
+    @classmethod
+    def from_str(cls, s):
+        node_id, rest = extract_nodeid(s)
+        host, port = split_host_port(rest)
+        return LNPeerAddr(host, int(port), node_id)
+
     def __repr__(self):
         return f'<LNPeerAddr host={self.host} port={self.port} pubkey={self.pubkey.hex()}>'
 

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1206,6 +1206,13 @@ class LnFeatures(IntFlag):
     _ln_feature_contexts[OPTION_SCID_ALIAS_REQ] = (LNFC.INIT | LNFC.NODE_ANN)
     _ln_feature_contexts[OPTION_SCID_ALIAS_OPT] = (LNFC.INIT | LNFC.NODE_ANN)
 
+    OPTION_ZEROCONF_REQ = 1 << 50
+    OPTION_ZEROCONF_OPT = 1 << 51
+
+    _ln_feature_direct_dependencies[OPTION_ZEROCONF_OPT] = {OPTION_SCID_ALIAS_OPT}
+    _ln_feature_contexts[OPTION_ZEROCONF_REQ] = (LNFC.INIT | LNFC.NODE_ANN)
+    _ln_feature_contexts[OPTION_ZEROCONF_OPT] = (LNFC.INIT | LNFC.NODE_ANN)
+
     def validate_transitive_dependencies(self) -> bool:
         # for all even bit set, set corresponding odd bit:
         features = self  # copy

--- a/electrum/lnwire/peer_wire.csv
+++ b/electrum/lnwire/peer_wire.csv
@@ -61,6 +61,8 @@ tlvtype,open_channel_tlvs,upfront_shutdown_script,0
 tlvdata,open_channel_tlvs,upfront_shutdown_script,shutdown_scriptpubkey,byte,...
 tlvtype,open_channel_tlvs,channel_type,1
 tlvdata,open_channel_tlvs,channel_type,type,byte,...
+tlvtype,open_channel_tlvs,channel_opening_fee,10000
+tlvdata,open_channel_tlvs,channel_opening_fee,channel_opening_fee,u64,
 msgtype,accept_channel,33
 msgdata,accept_channel,temporary_channel_id,byte,32
 msgdata,accept_channel,dust_limit_satoshis,u64,

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2831,7 +2831,9 @@ class LNWallet(LNWorker):
             if self.stopping_soon:
                 return
             if self.config.ZEROCONF_TRUSTED_NODE:
-                await self.add_peer(self.config.ZEROCONF_TRUSTED_NODE)
+                peer = LNPeerAddr.from_str(self.config.ZEROCONF_TRUSTED_NODE)
+                if self._can_retry_addr(peer, urgent=True):
+                    await self._add_peer(peer.host, peer.port, peer.pubkey)
             for chan in self.channels.values():
                 if chan.is_closed():
                     continue

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -1169,9 +1169,10 @@ This will result in longer routes; it might increase your fees and decrease the 
     SWAPSERVER_PORT = ConfigVar('swapserver_port', default=5455, type_=int)
     TEST_SWAPSERVER_REFUND = ConfigVar('test_swapserver_refund', default=False, type_=bool)
 
-    # zeroconf
+    # zeroconf channels
     ACCEPT_ZEROCONF_CHANNELS = ConfigVar('accept_zeroconf_channels', default=False, type_=bool)
     ZEROCONF_TRUSTED_NODE = ConfigVar('zeroconf_trusted_node', default='', type_=str)
+    ZEROCONF_MIN_OPENING_FEE = ConfigVar('zeroconf_min_opening_fee', default=5000, type_=int)
 
     # connect to remote WT
     WATCHTOWER_CLIENT_ENABLED = ConfigVar(

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -1169,6 +1169,10 @@ This will result in longer routes; it might increase your fees and decrease the 
     SWAPSERVER_PORT = ConfigVar('swapserver_port', default=5455, type_=int)
     TEST_SWAPSERVER_REFUND = ConfigVar('test_swapserver_refund', default=False, type_=bool)
 
+    # zeroconf
+    ACCEPT_ZEROCONF_CHANNELS = ConfigVar('accept_zeroconf_channels', default=False, type_=bool)
+    ZEROCONF_TRUSTED_NODE = ConfigVar('zeroconf_trusted_node', default='', type_=str)
+
     # connect to remote WT
     WATCHTOWER_CLIENT_ENABLED = ConfigVar(
         'use_watchtower', default=False, type_=bool,

--- a/electrum/tests/regtest.py
+++ b/electrum/tests/regtest.py
@@ -111,3 +111,39 @@ class TestLightningWatchtower(TestLightning):
 
     def test_watchtower(self):
         self.run_shell(['watchtower'])
+
+
+class TestLightningJIT(TestLightning):
+    agents = {
+        'alice':{
+            'accept_zeroconf_channels': 'true',
+        },
+        'bob':{
+            'lightning_listen': 'localhost:9735',
+            'lightning_forward_payments': 'true',
+            'accept_zeroconf_channels': 'true',
+        },
+        'carol':{
+        }
+    }
+
+    def test_just_in_time(self):
+        self.run_shell(['just_in_time'])
+
+
+class TestLightningJITTrampoline(TestLightningJIT):
+    agents = {
+        'alice':{
+            'use_gossip': 'false',
+            'accept_zeroconf_channels': 'true',
+        },
+        'bob':{
+            'lightning_listen': 'localhost:9735',
+            'lightning_forward_payments': 'true',
+            'lightning_forward_trampoline_payments': 'true',
+            'accept_zeroconf_channels': 'true',
+        },
+        'carol':{
+            'use_gossip': 'false',
+        }
+    }

--- a/electrum/tests/regtest/regtest.sh
+++ b/electrum/tests/regtest/regtest.sh
@@ -440,6 +440,21 @@ if [[ $1 == "watchtower" ]]; then
     wait_until_spent $ctx_id 1  # alice's to_local gets punished immediately
 fi
 
+if [[ $1 == "just_in_time" ]]; then
+    bob_node=$($bob nodeid)
+    $alice setconfig zeroconf_trusted_node $bob_node
+    $alice setconfig use_recoverable_channels false
+    wait_for_balance carol 1
+    echo "carol opens channel with bob"
+    $carol open_channel $bob_node 0.15 --password=''
+    new_blocks 3
+    wait_until_channel_open carol
+    echo "carol pays alice"
+    # note: set amount to 0.001 to test failure: 'payment too low'
+    invoice=$($alice add_request 0.01 -m "invoice" | jq -r ".lightning_invoice")
+    $carol lnpay $invoice
+fi
+
 if [[ $1 == "unixsockets" ]]; then
     # This looks different because it has to run the entire daemon
     # Test domain socket behavior


### PR DESCRIPTION
The first commit add support for zeroconf channels (follows the BOLTs). 
It requires a trusted node to be set in the config.

The second commit adds support for just-in-time channels. 
It differs significantly from LSPS2:
 - the scid alias is derived for the node ID.
 - a channel opening fee field is added to `open_channel`
 - the server requires htlc settlement before broadcasting (server does not trust client)

This is not activated for the moment (and not ready to be activated), but I think we can merge it to the code now.
One issue that bothers me is that tests are performed using `regtest`. It would be better to be able to test this with python.
