### PR TITLE
qml: add support for ln address and openalias

### DIFF
--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -309,6 +309,7 @@ Item {
                 Layout.preferredWidth: 1
                 icon.source: '../../icons/tab_send.png'
                 text: qsTr('Send')
+                enabled: !invoiceParser.busy
                 onClicked: openSendDialog()
                 onPressAndHold: {
                     Config.userKnowsPressAndHold = true
@@ -329,6 +330,7 @@ Item {
         wallet: Daemon.currentWallet
         onValidationError: (code, message) => {
             var dialog = app.messageDialog.createObject(app, {
+                title: qsTr('Error'),
                 text: message
             })
             dialog.closed.connect(function() {


### PR DESCRIPTION
add support for ln address and openalias, fix lnurl finalize step, avoid overloading invoiceParser with new payment identifiers while potentially long-running resolve/finalize steps are ongoing, show errors inresolve/finalize steps to user.

Note: Lightning address and Openalias might benefit from a manual entry dialog instead of just paste and qr scan options currently implemented. This is not part of this PR.
