### PR TITLE
android build: we always want apks, as we want to use our own privkey

### DIFF
--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -202,6 +202,12 @@ android.whitelist = lib-dynload/_csv.so
 # (bool) enables Android auto backup feature (Android API >=23)
 android.allow_backup = False
 
+# (str) The format used to package the app for release mode (aab or apk or aar).
+android.release_artifact = apk
+
+# (str) The format used to package the app for debug mode (apk or aar).
+android.debug_artifact = apk
+
 #
 # Python for android (p4a) specific
 #


### PR DESCRIPTION
ThomasV reported contrib/release.sh generating .aab artifacts.
aabs are shady business... best to avoid handing privkeys to big G (or any 3rd party!).

This must be a consequence of the recent p4a rebase, e.g. https://github.com/kivy/buildozer/commit/04bb63bbf05302a5eb6f24016aa42aadd49c6470

(untested)