### PR TITLE
Add support for IPv6 for proxy address/hostname

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1563,11 +1563,20 @@ def add_network_options(parser):
     parser.add_argument("-f", "--serverfingerprint", dest=SimpleConfig.NETWORK_SERVERFINGERPRINT.key(), default=None,
                         help="only allow connecting to servers with a matching SSL certificate SHA256 fingerprint. " +
                              "To calculate this yourself: '$ openssl x509 -noout -fingerprint -sha256 -inform pem -in mycertfile.crt'. Enter as 64 hex chars.")
-    parser.add_argument("-1", "--oneserver", action="store_true", dest=SimpleConfig.NETWORK_ONESERVER.key(), default=None, help="connect to one server only")
-    parser.add_argument("-s", "--server", dest=SimpleConfig.NETWORK_SERVER.key(), default=None, help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
-    parser.add_argument("-p", "--proxy", dest=SimpleConfig.NETWORK_PROXY.key(), default=None, help="set proxy [type:]host[:port] (or 'none' to disable proxy), where type is socks4,socks5 or http")
-    parser.add_argument("--noonion", action="store_true", dest=SimpleConfig.NETWORK_NOONION.key(), default=None, help="do not try to connect to onion servers")
-    parser.add_argument("--skipmerklecheck", action="store_true", dest=SimpleConfig.NETWORK_SKIPMERKLECHECK.key(), default=None, help="Tolerate invalid merkle proofs from server")
+    parser.add_argument("-1", "--oneserver", action="store_true", dest=SimpleConfig.NETWORK_ONESERVER.key(), default=None,
+                        help="connect to one server only")
+    parser.add_argument("-s", "--server", dest=SimpleConfig.NETWORK_SERVER.key(), default=None,
+                        help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
+    parser.add_argument("-p", "--proxy", dest=SimpleConfig.NETWORK_PROXY.key(), default=None,
+                        help="set proxy [type:]host:port (or 'none' to disable proxy), where type is socks4 or socks5")
+    parser.add_argument("--proxyuser", dest=SimpleConfig.NETWORK_PROXY_USER.key(), default=None,
+                        help="set proxy username")
+    parser.add_argument("--proxypassword", dest=SimpleConfig.NETWORK_PROXY_PASSWORD.key(), default=None,
+                        help="set proxy password")
+    parser.add_argument("--noonion", action="store_true", dest=SimpleConfig.NETWORK_NOONION.key(), default=None,
+                        help="do not try to connect to onion servers")
+    parser.add_argument("--skipmerklecheck", action="store_true", dest=SimpleConfig.NETWORK_SKIPMERKLECHECK.key(), default=None,
+                        help="Tolerate invalid merkle proofs from server")
 
 def add_global_options(parser):
     group = parser.add_argument_group('global options')

--- a/electrum/gui/qml/components/NetworkOverview.qml
+++ b/electrum/gui/qml/components/NetworkOverview.qml
@@ -205,7 +205,7 @@ Pane {
                     color: Material.accentColor
                 }
                 Label {
-                    text: 'mode' in Network.proxy ? qsTr('enabled') : qsTr('none')
+                    text: 'mode' in Network.proxy ? qsTr('enabled') : qsTr('disabled')
                 }
 
                 Label {

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -433,8 +433,6 @@ class NetworkChoiceLayout(object):
         if self.proxy_cb.isChecked():
             if not self.proxy_port.hasAcceptableInput():
                 return
-            if ':' in self.proxy_host.text():  # avoid deserialization pitfall
-                return
             proxy = {'mode':str(self.proxy_mode.currentText()).lower(),
                      'host':str(self.proxy_host.text()),
                      'port':str(self.proxy_port.text()),

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -627,7 +627,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
 
     def _set_proxy(self, proxy: Optional[dict]):
         self.proxy = proxy
-        dns_hacks.configure_dns_depending_on_proxy(bool(proxy))
+        dns_hacks.configure_dns_resolver()
         self.logger.info(f'setting proxy {proxy}')
 
         self.tor_proxy = False

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -185,10 +185,9 @@ def deserialize_proxy(s: Optional[str], user: str = None, password: str = None) 
 
     def is_valid_port(ps: str):
         try:
-            assert 0 < int(ps) < 65535
-        except (ValueError, AssertionError):
+            return 0 < int(ps) < 65535
+        except ValueError:
             return False
-        return True
 
     def is_valid_host(ph: str):
         try:

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -926,6 +926,8 @@ class SimpleConfig(Logger):
     NETWORK_AUTO_CONNECT = ConfigVar('auto_connect', default=True, type_=bool)
     NETWORK_ONESERVER = ConfigVar('oneserver', default=False, type_=bool)
     NETWORK_PROXY = ConfigVar('proxy', default=None)
+    NETWORK_PROXY_USER = ConfigVar('proxy_user', default=None)
+    NETWORK_PROXY_PASSWORD = ConfigVar('proxy_password', default=None)
     NETWORK_SERVER = ConfigVar('server', default=None, type_=str)
     NETWORK_NOONION = ConfigVar('noonion', default=False, type_=bool)
     NETWORK_OFFLINE = ConfigVar('offline', default=False, type_=bool)

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -925,9 +925,9 @@ class SimpleConfig(Logger):
     # config variables ----->
     NETWORK_AUTO_CONNECT = ConfigVar('auto_connect', default=True, type_=bool)
     NETWORK_ONESERVER = ConfigVar('oneserver', default=False, type_=bool)
-    NETWORK_PROXY = ConfigVar('proxy', default=None)
-    NETWORK_PROXY_USER = ConfigVar('proxy_user', default=None)
-    NETWORK_PROXY_PASSWORD = ConfigVar('proxy_password', default=None)
+    NETWORK_PROXY = ConfigVar('proxy', default=None, type_=str)
+    NETWORK_PROXY_USER = ConfigVar('proxy_user', default=None, type_=str)
+    NETWORK_PROXY_PASSWORD = ConfigVar('proxy_password', default=None, type_=str)
     NETWORK_SERVER = ConfigVar('server', default=None, type_=str)
     NETWORK_NOONION = ConfigVar('noonion', default=False, type_=bool)
     NETWORK_OFFLINE = ConfigVar('offline', default=False, type_=bool)

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1268,7 +1268,7 @@ def make_aiohttp_session(proxy: Optional[dict], headers=None, timeout=None):
             port=int(proxy['port']),
             username=proxy.get('user', None),
             password=proxy.get('password', None),
-            rdns=True,
+            rdns=True,  # needed to prevent DNS leaks over proxy
             ssl=ssl_context,
         )
     else:
@@ -1885,6 +1885,8 @@ class NetworkRetryManager(Generic[_NetAddrType]):
 
 
 class MySocksProxy(aiorpcx.SOCKSProxy):
+    # note: proxy will not leak DNS as create_connection()
+    # sets (local DNS) resolve=False by default
 
     async def open_connection(self, host=None, port=None, **kwargs):
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
Allows using proxy servers by IPv6 address, and proxy server hostnames that resolve to an IPv6 address.

Splits proxy authentication to --proxyuser and --proxypassword command line options and corresponding config keys, removing them from the single serialized proxy string.

