### PR TITLE
wallet db: deduplicate "seed_type" field

### DIFF
--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -366,7 +366,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
 
     @pyqtProperty(str, notify=dataChanged)
     def seedType(self):
-        return self.wallet.db.get('seed_type')
+        return self.wallet.get_seed_type()
 
     @pyqtProperty(bool, notify=dataChanged)
     def isWatchOnly(self):

--- a/electrum/gui/qt/wallet_info_dialog.py
+++ b/electrum/gui/qt/wallet_info_dialog.py
@@ -36,9 +36,7 @@ class WalletInfoDialog(WindowModalDialog):
         seed_available = _('False')
         if wallet.has_seed():
             seed_available = _('True')
-            ks = wallet.keystore
-            assert isinstance(ks, keystore.Deterministic_KeyStore)
-            seed_available += f" ({ks.get_seed_type()})"
+            seed_available += f" ({wallet.get_seed_type()})"
         keystore_types = [k.get_type_text() for k in wallet.get_keystores()]
         grid = QGridLayout()
         basename = os.path.basename(wallet.storage.path)
@@ -74,7 +72,7 @@ class WalletInfoDialog(WindowModalDialog):
                 label = IconLabel(text='Enabled, non-recoverable channels')
                 label.setIcon(read_QIcon('cloud_no'))
                 grid.addWidget(label, cur_row, 1)
-                if wallet.db.get('seed_type') == 'segwit':
+                if wallet.get_seed_type() == 'segwit':
                     msg = _("Your channels cannot be recovered from seed, because they were created with an old version of Electrum. "
                             "This means that you must save a backup of your wallet everytime you create a new channel.\n\n"
                             "If you want this wallet to have recoverable channels, you must close your existing channels and restore this wallet from seed")

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2984,6 +2984,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     def has_seed(self) -> bool:
         pass
 
+    def get_seed_type(self) -> Optional[str]:
+        return None
+
     @abstractmethod
     def get_all_known_addresses_beyond_gap_limit(self) -> Set[str]:
         pass
@@ -3511,6 +3514,12 @@ class Deterministic_Wallet(Abstract_Wallet):
 
     def get_seed(self, password):
         return self.keystore.get_seed(password)
+
+    def get_seed_type(self) -> Optional[str]:
+        if not self.has_seed():
+            return None
+        assert isinstance(self.keystore, keystore.Deterministic_KeyStore), type(self.keystore)
+        return self.keystore.get_seed_type()
 
     def change_gap_limit(self, value):
         '''This method is not called in the code, it is kept for console use'''

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -67,7 +67,7 @@ class WalletUnfinished(WalletFileException):
 # seed_version is now used for the version of the wallet file
 OLD_SEED_VERSION = 4        # electrum versions < 2.0
 NEW_SEED_VERSION = 11       # electrum versions >= 2.0
-FINAL_SEED_VERSION = 56     # electrum >= 2.7 will set this to prevent
+FINAL_SEED_VERSION = 57     # electrum >= 2.7 will set this to prevent
                             # old versions from overwriting new format
 
 
@@ -227,6 +227,7 @@ class WalletDBUpgrader(Logger):
         self._convert_version_54()
         self._convert_version_55()
         self._convert_version_56()
+        self._convert_version_57()
         self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
 
     def _convert_wallet_type(self):
@@ -1095,6 +1096,14 @@ class WalletDBUpgrader(Logger):
                 item[c]['announcement_bitcoin_sig'] = ''
             item['local_config'].pop('was_announced')
         self.data['seed_version'] = 56
+
+    def _convert_version_57(self):
+        if not self._is_upgrade_method_needed(56, 56):
+            return
+        # The 'seed_type' field could be present both at the top-level and inside keystores.
+        # We delete the one that is top-level.
+        self.data.pop('seed_type', None)
+        self.data['seed_version'] = 57
 
     def _convert_imported(self):
         if not self._is_upgrade_method_needed(0, 13):

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -591,8 +591,6 @@ class NewWalletWizard(AbstractWizard):
         db.set_keystore_encryption(bool(data['password']) and data['encrypt'])
 
         db.put('wallet_type', data['wallet_type'])
-        if 'seed_type' in data:
-            db.put('seed_type', data['seed_type'])
 
         if data['wallet_type'] == 'standard':
             db.put('keystore', k.dump())


### PR DESCRIPTION
In the db, the 'seed_type' field could be present both at the top-level and inside keystores.

Note:
- both fields had usages
- the top-level field was added in 2.8 re "initial segwit support" (3a64ec0f2ed9c845b5c01daa07fafcbfa26c3cb7)
  - there was no db upgrade for it, so older files are missing it
  - if present, valid values can be electrum types but also other types supported by the wizard, e.g. "bip39"
- the keystore-level field was added in 4.1 (7b7bba22992eca4536a91249758f178b4a7e044a)
  - there was a db upgrade when it was introduced, so old files also have it
  - if present, valid values can only be electrum types
- there is not much value in the top-level one having a non-electrum value, and those values were never used by other parts of the code
  - note that when creating a standard wallet from a bip39 seed, the seed is discarded. Only the derived xprv and the derivation path are kept. If we changed this and also kept the seed, e.g. to display it to the user, then it would make sense to save the seed type (e.g. "bip39"). However storing that seed_type would make more sense at the keystore level (not top-level).

We delete the top-level 'seed_type' field.

```
{
    "keystore": {
        "seed_type": "segwit",
        ...
    },
    "seed_type": "segwit",
    ...
}
```