### PR TITLE
qt, qml: use lowercase bolt11 when copying or sharing

### DIFF
--- a/electrum/gui/qml/components/ReceiveDialog.qml
+++ b/electrum/gui/qml/components/ReceiveDialog.qml
@@ -244,7 +244,7 @@ ElDialog {
                 text: 'Copy'
                 onClicked: {
                     if (request.isLightning && rootLayout.state == 'bolt11')
-                        AppController.textToClipboard(_bolt11)
+                        AppController.textToClipboard(_bolt11.toLowerCase())
                     else if (rootLayout.state == 'bip21uri')
                         AppController.textToClipboard(_bip21uri)
                     else
@@ -261,7 +261,7 @@ ElDialog {
                 onClicked: {
                     enabled = false
                     if (request.isLightning && rootLayout.state == 'bolt11')
-                        AppController.doShare(_bolt11, qsTr('Payment Request'))
+                        AppController.doShare(_bolt11.toLowerCase(), qsTr('Payment Request'))
                     else if (rootLayout.state == 'bip21uri')
                         AppController.doShare(_bip21uri, qsTr('Payment Request'))
                     else

--- a/electrum/gui/qt/receive_tab.py
+++ b/electrum/gui/qt/receive_tab.py
@@ -223,14 +223,14 @@ class ReceiveTab(QWidget, MessageBoxMixin, Logger):
 
     def on_tab_changed(self):
         text, data, help_text, title = self.get_tab_data()
-        self.window.do_copy(data, title=title)
+        self.window.do_copy(text, title=title)
         self.update_receive_qr_window()
 
     def do_copy(self, e):
         if e.button() != Qt.LeftButton:
             return
         text, data, help_text, title = self.get_tab_data()
-        self.window.do_copy(data, title=title)
+        self.window.do_copy(text, title=title)
 
     def toggle_receive_qr(self):
         b = not self.config.GUI_QT_RECEIVE_TAB_QR_VISIBLE


### PR DESCRIPTION
Be more compatible, uppercase is a QR optimization
