### PR TITLE
qml: WCServerConfig.qml: only disable autoconnect if given server

### DIFF
--- a/electrum/gui/qml/components/wizard/WCServerConfig.qml
+++ b/electrum/gui/qml/components/wizard/WCServerConfig.qml
@@ -9,7 +9,7 @@ WizardComponent {
     last: true
 
     function apply() {
-        wizard_data['autoconnect'] = false
+        wizard_data['autoconnect'] = sc.address == ""
         wizard_data['server'] = sc.address
     }
 


### PR DESCRIPTION
if the user entered the server select screen and immediately clicked next, a random server would get set but with auto_connect disabled.