### PR TITLE
build: bump some security-sensitive packages (py3, ssl)

### DIFF
--- a/contrib/android/p4a_recipes/certifi/__init__.py
+++ b/contrib/android/p4a_recipes/certifi/__init__.py
@@ -6,8 +6,8 @@ assert PythonRecipe.python_depends == []
 
 
 class CertifiRecipePinned(PythonRecipe):
-    version = "2020.12.5"
-    sha512sum = "3425d98f19025e70d885458629071c8531271d93d1461fadea6afbaafc763881a42b3c05be391a938d84a0d1ab729c3ac5df4f3328e8ef63a7b56ead1445bddd"
+    version = "2023.11.17"
+    sha512sum = "e359b4062d42e19ce6d16b25c17696f09ff5c35e7c92626b4eb15130cfa55941817db456d1c27d1188e0a6ff5f52db37607c0b15c1e438da3ea6d514c0d3443e"
     url = "https://pypi.python.org/packages/source/c/certifi/certifi-{version}.tar.gz"
     depends = ["setuptools"]
 

--- a/contrib/android/p4a_recipes/hostpython3/__init__.py
+++ b/contrib/android/p4a_recipes/hostpython3/__init__.py
@@ -11,8 +11,8 @@ assert HostPython3Recipe.python_depends == []
 
 
 class HostPython3RecipePinned(util.InheritedRecipeMixin, HostPython3Recipe):
-    version = "3.8.16"
-    sha512sum = "59940a0f646e9ec320c3ee40b1a960da6418e4365ba05c179f36235a3a50fd151ddd5f5d295c40ab291a9e7cb760abe1f61511a2460336f08189297d1c22f09c"
+    version = "3.8.18"
+    sha512sum = "2b98575763e21ba54428eb3e93418a3ea244f1dcdb4729ff0d17ac2d76cb45d228f0f97a2a24e59a7f0428234415e8bd129bbc0e8f2067bfd054d03df1641cf0"
 
 
 recipe = HostPython3RecipePinned()

--- a/contrib/android/p4a_recipes/openssl/__init__.py
+++ b/contrib/android/p4a_recipes/openssl/__init__.py
@@ -11,8 +11,8 @@ assert OpenSSLRecipe.python_depends == []
 
 
 class OpenSSLRecipePinned(util.InheritedRecipeMixin, OpenSSLRecipe):
-    url_version = "1.1.1t"
-    sha512sum = "628676c9c3bc1cf46083d64f61943079f97f0eefd0264042e40a85dbbd988f271bfe01cd1135d22cc3f67a298f1d078041f8f2e97b0da0d93fe172da573da18c"
+    url_version = "1.1.1w"
+    sha512sum = "b4c625fe56a4e690b57b6a011a225ad0cb3af54bd8fb67af77b5eceac55cc7191291d96a660c5b568a08a2fbf62b4612818e7cca1bb95b2b6b4fc649b0552b6d"
 
 
 recipe = OpenSSLRecipePinned()

--- a/contrib/android/p4a_recipes/python3/__init__.py
+++ b/contrib/android/p4a_recipes/python3/__init__.py
@@ -11,8 +11,8 @@ assert Python3Recipe.python_depends == []
 
 
 class Python3RecipePinned(util.InheritedRecipeMixin, Python3Recipe):
-    version = "3.8.16"
-    sha512sum = "59940a0f646e9ec320c3ee40b1a960da6418e4365ba05c179f36235a3a50fd151ddd5f5d295c40ab291a9e7cb760abe1f61511a2460336f08189297d1c22f09c"
+    version = "3.8.18"
+    sha512sum = "2b98575763e21ba54428eb3e93418a3ea244f1dcdb4729ff0d17ac2d76cb45d228f0f97a2a24e59a7f0428234415e8bd129bbc0e8f2067bfd054d03df1641cf0"
 
 
 recipe = Python3RecipePinned()

--- a/contrib/build-linux/appimage/make_appimage.sh
+++ b/contrib/build-linux/appimage/make_appimage.sh
@@ -19,7 +19,7 @@ git -C "$PROJECT_ROOT" rev-parse 2>/dev/null || fail "Building outside a git clo
 export GCC_STRIP_BINARIES="1"
 
 # pinned versions
-PYTHON_VERSION=3.10.11
+PYTHON_VERSION=3.10.13
 PY_VER_MAJOR="3.10"  # as it appears in fs paths
 PKG2APPIMAGE_COMMIT="a9c85b7e61a3a883f4a35c41c5decb5af88b6b5d"
 
@@ -41,7 +41,7 @@ download_if_not_exist "$CACHEDIR/appimagetool" "https://github.com/AppImage/AppI
 verify_hash "$CACHEDIR/appimagetool" "df3baf5ca5facbecfc2f3fa6713c29ab9cefa8fd8c1eac5d283b79cab33e4acb"
 
 download_if_not_exist "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz"
-verify_hash "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" "3c3bc3048303721c904a03eb8326b631e921f11cc3be2988456a42f115daf04c"
+verify_hash "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" "5c88848668640d3e152b35b4536ef1c23b2ca4bd2c957ef1ecbb053f571dd3f6"
 
 
 


### PR DESCRIPTION
- just a conservative bump of patch version deps only
- let's see the CI build

---

- not included:
  - we will have to do a large bump of python3 for win and mac, to at least 3.11.x, as 3.10 is now in source-release only mode
  - also, android is stuck in the past atm, maybe we should bump all to 3.11.x