### PR TITLE
Restore ability to pass wallet in-memory

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -140,9 +140,9 @@ def command(s):
                 if cmd.requires_wallet and kwargs.get('wallet') is None:
                     kwargs['wallet'] = daemon.config.get_wallet_path()
                 if 'wallet' in cmd.options:
-                    wallet_path = kwargs.get('wallet', None)
-                    if isinstance(wallet_path, str):
-                        wallet = daemon.get_wallet(wallet_path)
+                    wallet = kwargs.get('wallet', None)
+                    if isinstance(wallet, str):
+                        wallet = daemon.get_wallet(wallet)
                         if wallet is None:
                             raise Exception('wallet not loaded')
                         kwargs['wallet'] = wallet


### PR DESCRIPTION
Hello! This pull request restore the ability to pass wallet directly, avoiding loading it in daemon beforehand. This is used with e.g. custom daemons, or in this case specifically when implementing a diskless mode, which does not load the wallet anywhere except memory. As wallet doesn't have storage associated with it, it can't be added to daemon. Before I was able to pass it just fine, but due to added check here: 4e80ef818df0295fa46ee50bbe695b7e6eab1eda I no longer can
When passing wallet object directly as before, I now get that wallet object is not defined. When passing a wallet path it works, but it defeats the purpose of passing wallet object directly and breaks this special in-memory mode