### PR TITLE
bip21: fail bip21 uri if unsupported req-* parameter is present. 

### DIFF
--- a/electrum/bip21.py
+++ b/electrum/bip21.py
@@ -43,6 +43,9 @@ def parse_bip21_URI(uri: str) -> dict:
     for k, v in pq.items():
         if len(v) != 1:
             raise InvalidBitcoinURI(f'Duplicate Key: {repr(k)}')
+        if k.startswith('req-'):
+            # we have no support for any req-* query parameters
+            raise InvalidBitcoinURI(f'Unsupported Key: {repr(k)}')
 
     out = {k: v[0] for k, v in pq.items()}
     if address:


### PR DESCRIPTION
fixes #8781