### PR TITLE
daemon.load_wallet to raise if given redundant password

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3268,8 +3268,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def unlock(self, password):
         self.logger.info(f'unlocking wallet')
-        if self.has_password():
-            self.check_password(password)
+        self.check_password(password)
         self._password_in_memory = password
 
     def get_unlocked_password(self):


### PR DESCRIPTION
- for a wallet with no password, running commands with a pw given should raise InvalidPassword, instead of ignoring the provided pw
- and for wallet.unlock, it is very confusing to save the given pw in memory, if the wallet does not actually use a pw

(let's see if tests pass on CI)