### PR TITLE
Fix graceful shutdown for lightning swaps

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -968,6 +968,8 @@ class LNWallet(LNWorker):
         if self.lnwatcher:
             await self.lnwatcher.stop()
             self.lnwatcher = None
+        if self.swap_manager:  # may not be present in tests
+            await self.swap_manager.stop()
 
     async def wait_for_received_pending_htlcs_to_get_removed(self):
         assert self.stopping_soon is True

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -210,6 +210,9 @@ class SwapManager(Logger):
         coro = self.pay_pending_invoices()
         asyncio.run_coroutine_threadsafe(self.taskgroup.spawn(coro), self.network.asyncio_loop)
 
+    async def stop(self):
+        await self.taskgroup.cancel_remaining()
+
     async def pay_invoice(self, key):
         self.logger.info(f'trying to pay invoice {key}')
         self.invoices_to_pay[key] = 1000000000000 # lock

--- a/electrum/tests/test_lnpeer.py
+++ b/electrum/tests/test_lnpeer.py
@@ -147,6 +147,7 @@ class MockLNWallet(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         self.network = MockNetwork(tx_queue, config=self.config)
         self.taskgroup = OldTaskGroup()
         self.lnwatcher = None
+        self.swap_manager = None
         self.listen_server = None
         self._channels = {chan.channel_id: chan for chan in chans}
         self.payment_info = {}


### PR DESCRIPTION
This pull request fixes slow shutdown issues when lightning wallets are loaded. 
Basically when `lnworker` is created, a `SwapManager` object is created. And `lnworker.start_network` calls `swap_manager.start_network`. Which in turn uses it's new taskgroup to spawn an infinite task.
68be7688185affc870fb01226061cbff4936b3f0 made swap manager use it's own taskgroup instead of network one. But network taskgroup is being properly stopped, while SwapManager has no stop method or something, so `self.taskgroup.cancel_remaining()` is not called anywhere
This pull request fixes this
