### PR TITLE
wallet: add config setting "wallet_fullrbf"

### DIFF
--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -949,6 +949,15 @@ class SimpleConfig(Logger):
             _('If you check this box, your unconfirmed transactions will be consolidated into a single transaction.') + '\n' +
             _('This will save fees, but might have unwanted effects in terms of privacy')),
     )
+    WALLET_FULLRBF = ConfigVar(
+        'wallet_fullrbf', default=False, type_=bool,
+        short_desc=lambda: _('Allow replacing non-RBF transactions'),
+        long_desc=lambda: (
+            _("Allow replacing any transaction, not just those that signal BIP-125 replace-by-fee.\n"
+              "Note that to broadcast replacements for non-RBF transactions, you need to connect\n"
+              "to an electrum server that allows as such. Further, only a small percentage of miners\n"
+              "accept such replacements, so it might take a long time for the transaction to get mined.")),
+    )
     WALLET_MERGE_DUPLICATE_OUTPUTS = ConfigVar(
         'wallet_merge_duplicate_outputs', default=False, type_=bool,
         short_desc=lambda: _('Merge duplicate outputs'),

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2352,6 +2352,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         # do not mutate LN funding txs, as that would change their txid
         if not is_dscancel and self.is_lightning_funding_tx(tx.txid()):
             return False
+        if self.config.WALLET_FULLRBF:
+            return True
         return tx.is_rbf_enabled()
 
     def cpfp(self, tx: Transaction, fee: int) -> Optional[PartialTransaction]:


### PR DESCRIPTION
This adds a config variable "wallet_fullrbf", which (if enabled) lets the user ignore the BIP-125 signalling rules and try to RBF any tx.
Because of the need to connect to an electrum server that sets `mempoolfullrbf=1`, and the related tx-propagation and miner-hashrate-fraction issue (as also mentioned in the config var description added here), this is atm not exposed to the GUI.

related https://github.com/spesmilo/electrum/issues/8088#issuecomment-1338381458