### PR TITLE
Fix #8858: WCHWXPub Access Property on NoneType

### DIFF
--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -1357,7 +1357,7 @@ class WCHWXPub(WalletWizardComponent, Logger):
 
         device_id = _info.device.id_
         client = self.plugins.device_manager.client_by_id(device_id, scan_now=False)
-        if not client.handler:
+        if not getattr(client, 'handler', None):
             client.handler = self.plugin.create_handler(self.wizard)
 
         xtype = cosigner_data['script_type']


### PR DESCRIPTION
# Fix for Issue #8858 
### Problem:
- Atempt to `access` a `property` `on` a potentially `NoneType` value.  
- It actually was *None* in this case, which caused an *AttributeError*.
https://github.com/spesmilo/electrum/blob/67b57da402a849ecc2f94283513467c445bda409/electrum/gui/qt/wizard/wallet.py#L1360

### Solution:
- Continue trying to `access` the *handler* `property`, but `if impossible` `use` `None` for the comparison.
```python
if getattr(client, 'handler', None):
```

---

`client` can be intentionally `None` **(see A)**. The fix allows the program to attempt to create a handler, but I am not sure if the error state was intentional. **If it was intentional, then this fix would allow the program to execute farther than intended.**

---
#### (A)
1. Intentionally return `None` if anything goes wrong. https://github.com/spesmilo/electrum/blob/67b57da402a849ecc2f94283513467c445bda409/electrum/plugin.py#L538

2. The default value for `scan_now` is `True`, but it was intentionally disabled here.
https://github.com/spesmilo/electrum/blob/67b57da402a849ecc2f94283513467c445bda409/electrum/gui/qt/wizard/wallet.py#L1359
https://github.com/spesmilo/electrum/blob/67b57da402a849ecc2f94283513467c445bda409/electrum/plugin.py#L540

3. This part may have prevented the error, but does not run because it was intentionally disabled **(A.2)**.
I did not look into this because it was intentionally eliminated. https://github.com/spesmilo/electrum/blob/67b57da402a849ecc2f94283513467c445bda409/electrum/plugin.py#L544-L545