### PR TITLE
qml wizard: run navmap[view]['accept'] handler a final time on finish

### DIFF
--- a/electrum/gui/qml/components/wizard/Wizard.qml
+++ b/electrum/gui/qml/components/wizard/Wizard.qml
@@ -134,6 +134,10 @@ ElDialog {
             function finish() {
                 currentItem.accept()
                 _setWizardData(pages.contentChildren[currentIndex].wizard_data)
+                // run wizard.resolve_next() a final time, so that the navmap[view]['accept'] handler can run (if any)
+                var newview = wiz.submit(wizard_data)
+                _setWizardData(newview.wizard_data)
+                // finish wizard
                 wizard.doAccept()
             }
 


### PR DESCRIPTION
If there is an `accept` handler in the wizard navmap, we need that to run even for the `last` view.
For example, see
https://github.com/spesmilo/electrum/blob/061c8211281d6c0b50166e4075656ce0fb2c89f5/electrum/plugins/trustedcoin/trustedcoin.py#L623-L626
Even if `navmap[view]['last']` is True, we still want the `navmap[view]['accept']` handler to run.

fixes https://github.com/spesmilo/electrum/issues/8861

---

Note that an analogous issue does not exist for the desktop qt gui, see https://github.com/spesmilo/electrum/blob/061c8211281d6c0b50166e4075656ce0fb2c89f5/electrum/gui/qt/wizard/wizard.py#L205-L212
There, `wizard.resolve_next` is called regardless of `is_last`.

---

Or we could do something like this:
```diff
diff --git a/electrum/gui/qml/components/wizard/Wizard.qml b/electrum/gui/qml/components/wizard/Wizard.qml
index f2be0a6427..603168ebe5 100644
--- a/electrum/gui/qml/components/wizard/Wizard.qml
+++ b/electrum/gui/qml/components/wizard/Wizard.qml
@@ -134,6 +134,11 @@ ElDialog {
             function finish() {
                 currentItem.accept()
                 _setWizardData(pages.contentChildren[currentIndex].wizard_data)
+                // run wizard.resolve_next() a final time, so that the navmap[view]['accept'] handler can run (if any)
+                currentItem.next()
+                currentIndex = currentIndex + 1
+                _setWizardData(pages.contentChildren[currentIndex].wizard_data)
+                // finish wizard
                 wizard.doAccept()
             }
 
```