### PR TITLE
qt: wizard: move page.on_ready() to just after construction

### DIFF
--- a/electrum/gui/qt/wizard/wizard.py
+++ b/electrum/gui/qt/wizard/wizard.py
@@ -46,8 +46,10 @@ class QEAbstractWizard(QDialog, MessageBoxMixin):
 
         self.back_button = QPushButton(_("Back"), self)
         self.back_button.clicked.connect(self.on_back_button_clicked)
+        self.back_button.setEnabled(False)
         self.next_button = QPushButton(_("Next"), self)
         self.next_button.clicked.connect(self.on_next_button_clicked)
+        self.next_button.setEnabled(False)
         self.next_button.setDefault(True)
         self.requestPrev.connect(self.on_back_button_clicked)
         self.requestNext.connect(self.on_next_button_clicked)
@@ -144,12 +146,14 @@ class QEAbstractWizard(QDialog, MessageBoxMixin):
             raise e
         page.wizard_data = copy.deepcopy(wdata)
         page.params = params
-        page.updated.connect(self.on_page_updated)
+        page.on_ready()  # call before component emits any signals
+
         self._logger.debug(f'load_next_component: {page=!r}')
+
+        page.updated.connect(self.on_page_updated)
 
         # add to stack and update wizard
         self.main_widget.setCurrentIndex(self.main_widget.addWidget(page))
-        page.on_ready()
         page.apply()
         self.update()
 


### PR DESCRIPTION
qt: wizard: move page.on_ready() to just after construction to avoid triggering signal/slots that might assume on_ready() has run.

A number of reports that Shouldn't Happen™ are triggered in similar ways, after `on_next_button_clicked`/`load_next_component`.

Interestingly, these all happen on Windows and MacOS, not on Linux.

- https://github.com/spesmilo/electrum/issues/8834
- https://github.com/spesmilo/electrum/issues/8856
- https://github.com/spesmilo/electrum/issues/8848
- https://github.com/spesmilo/electrum/issues/8815
- https://github.com/spesmilo/electrum/issues/8809

I suspect the event queue handling in Qt is implemented slightly differently on each platform, leading to triggered signals earlier than expected.

