### PR TITLE
add DEB package for Electrum Wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.swp
 build/
 dist/
+deb_dist/
 *.egg/
 Electrum.egg-info/
 electrum/locale/

--- a/contrib/requirements/requirements-build-deb.txt
+++ b/contrib/requirements/requirements-build-deb.txt
@@ -1,0 +1,4 @@
+dbhelper
+pip
+stdeb
+libsecp256k1-1


### PR DESCRIPTION
I'm drafting a PR to build the DEB package for the Electrum wallet.

⚠️ INB4: For some reason, it builds without the `libsecp256k1-1`, but the package fails to execute. I had to manually add the dependency ([It is from the official deb repo](https://packages.debian.org/search?searchon=sourcenames&keywords=libsecp256k1))

`stdeb` is the only python3 dependency that it is required since we already have the `setup.py` structured. 

The current command line to build it is: 

```
setup.py --command-packages=stdeb.command bdist_deb
```

I'm not the most prominent Linux developer, so feel free to speak up.