### PR TITLE
qml: QETxDetails: defer to wallet.get_tx_info() for rbf/cpfp

### DIFF
--- a/electrum/gui/qml/qetxdetails.py
+++ b/electrum/gui/qml/qetxdetails.py
@@ -350,10 +350,10 @@ class QETxDetails(QObject, QtEventListener):
         self._is_unrelated = txinfo.amount is None and self._lnamount.isEmpty
         self._is_lightning_funding_tx = txinfo.is_lightning_funding_tx
         self._can_broadcast = txinfo.can_broadcast
-        self._can_bump = txinfo.can_bump and not txinfo.can_remove
-        self._can_dscancel = txinfo.can_dscancel and not txinfo.can_remove
-        self._can_cpfp = txinfo.can_cpfp and not txinfo.can_remove
-        self._can_save_as_local = txinfo.can_save_as_local and not txinfo.can_remove
+        self._can_bump = txinfo.can_bump
+        self._can_dscancel = txinfo.can_dscancel
+        self._can_cpfp = txinfo.can_cpfp
+        self._can_save_as_local = txinfo.can_save_as_local
         self._can_remove = txinfo.can_remove
         self._can_sign = (
             not self._is_complete


### PR DESCRIPTION
I think this logic should be encapsulated in the wallet.

Looks like the extra guards were added in https://github.com/spesmilo/electrum/commit/84cb210e7eed547f28bbd4e948500547fd01213e
(except for `can_save_as_local` -- added in https://github.com/spesmilo/electrum/commit/9cb8dea3435e6a5cdb16a08fc6523198d027031c)

I don't really see a reason why this logic should be GUI-specific.
Also, note that it can make sense to allow bump_fee on a local tx, and so wallet.get_tx_info() allows it (and hence so does the qt gui). For example, if your tx falls out of the mempool, you might want to bump it. (though it could also make sense to allow dscancel in the same scenario but we don't allow that)
For cpfp, as long as there is no package relay, it does not make sense to allow it for a local tx.

I don't really understand the guard on can_save_as_local - maybe @accumulator can comment if he remembers why it was added.

(My direct motivation is simply that I sometimes manually test rbf/cpfp and it would be easier to only have to patch a single localised thing.)