### PR TITLE
walletdb: chan dict: small clean-up (incl db upgrade)

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -662,7 +662,8 @@ class Channel(AbstractChannel):
         self.onion_keys = state['onion_keys']  # type: Dict[int, bytes]
         self.data_loss_protect_remote_pcp = state['data_loss_protect_remote_pcp']
         self.hm = HTLCManager(log=state['log'], initial_feerate=initial_feerate)
-        self.unfulfilled_htlcs = state["unfulfilled_htlcs"]
+        self.unfulfilled_htlcs = state["unfulfilled_htlcs"]  # type: Dict[int, Tuple[str, Optional[str]]]
+        # ^ htlc_id -> onion_packet_hex, forwarding_key
         self._state = ChannelState[state['state']]
         self.peer_state = PeerState.DISCONNECTED
         self._sweep_info = {}
@@ -1058,11 +1059,8 @@ class Channel(AbstractChannel):
             htlc = attr.evolve(htlc, htlc_id=self.hm.get_next_htlc_id(REMOTE))
         with self.db_lock:
             self.hm.recv_htlc(htlc)
-            local_ctn = self.get_latest_ctn(LOCAL)
-            remote_ctn = self.get_latest_ctn(REMOTE)
             if onion_packet:
-                # TODO neither local_ctn nor remote_ctn are used anymore... no point storing them.
-                self.unfulfilled_htlcs[htlc.htlc_id] = local_ctn, remote_ctn, onion_packet.hex(), False
+                self.unfulfilled_htlcs[htlc.htlc_id] = onion_packet.hex(), None
 
         self.logger.info("receive_htlc")
         return htlc

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -950,8 +950,7 @@ class Peer(Logger):
             'onion_keys': {},
             'data_loss_protect_remote_pcp': {},
             "log": {},
-            "fail_htlc_reasons": {},  # htlc_id -> onion_packet
-            "unfulfilled_htlcs": {},  # htlc_id -> error_bytes, failure_message
+            "unfulfilled_htlcs": {},
             "revocation_store": {},
             "channel_type": channel_type,
         }
@@ -2610,10 +2609,9 @@ class Peer(Logger):
                 self.maybe_send_commitment(chan)
                 done = set()
                 unfulfilled = chan.unfulfilled_htlcs
-                for htlc_id, (local_ctn, remote_ctn, onion_packet_hex, forwarding_key) in unfulfilled.items():
+                for htlc_id, (onion_packet_hex, forwarding_key) in unfulfilled.items():
                     if not chan.hm.is_htlc_irrevocably_added_yet(htlc_proposer=REMOTE, htlc_id=htlc_id):
                         continue
-                    forwarding_key = forwarding_key or None  # type: Optional[str]
                     htlc = chan.hm.get_htlc_by_id(REMOTE, htlc_id)
                     error_reason = None  # type: Optional[OnionRoutingFailure]
                     error_bytes = None  # type: Optional[bytes]
@@ -2634,7 +2632,7 @@ class Peer(Logger):
                                 onion_packet=onion_packet)
                             if _forwarding_key:
                                 assert forwarding_key is None
-                                unfulfilled[htlc_id] = local_ctn, remote_ctn, onion_packet_hex, _forwarding_key
+                                unfulfilled[htlc_id] = onion_packet_hex, _forwarding_key
                         except OnionRoutingFailure as e:
                             error_bytes = construct_onion_error(e, onion_packet.public_key, our_onion_private_key=self.privkey)
                         if error_bytes:

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -108,7 +108,6 @@ def create_channel_state(funding_txid, funding_index, funding_sat, is_initiator,
             'data_loss_protect_remote_pcp': {},
             'state': 'PREOPENING',
             'log': {},
-            'fail_htlc_reasons': {},
             'unfulfilled_htlcs': {},
             'revocation_store': {},
             'channel_type': lnutil.ChannelType.OPTION_STATIC_REMOTEKEY


### PR DESCRIPTION
- "fail_htlc_reasons" was removed in 9b1c40e3964ba7036600cbb0f8bd5938cb3edb22
- "unfulfilled_htlcs": rm 2 dead items from the 4-tuple, and convert False value of forwarding_key