### PR TITLE
build: split make_osx.sh script into two: "build" and "sign" parts

### DIFF
--- a/contrib/osx/README.md
+++ b/contrib/osx/README.md
@@ -86,18 +86,18 @@ Let brew install the Xcode CLI tools.
     cd electrum
     ./contrib/osx/make_osx.sh
 
-This creates both a folder named Electrum.app and the .dmg file.
+This creates both a folder named Electrum.app and the .dmg file (both unsigned).
 
 ##### 2.1. For release binaries, here be dragons
 
 If you want the binaries codesigned for macOS and notarised by Apple's central server,
-provide these env vars to the `make_osx.sh` script:
+also run the `make_osx2.sh` script:
 
     CODESIGN_CERT="Developer ID Application: Electrum Technologies GmbH (L6P37P7P56)" \
     APPLE_TEAM_ID="L6P37P7P56" \
     APPLE_ID_USER="me@email.com" \
     APPLE_ID_PASSWORD="1234" \
-    ./contrib/osx/make_osx.sh
+    ./contrib/osx/make_osx2.sh
 
 (note: `APPLE_ID_PASSWORD` is an app-specific password, *not* the account password)
 

--- a/contrib/osx/make_osx.sh
+++ b/contrib/osx/make_osx.sh
@@ -31,44 +31,6 @@ git -C "$PROJECT_ROOT" rev-parse 2>/dev/null || fail "Building outside a git clo
 which brew > /dev/null 2>&1 || fail "Please install brew from https://brew.sh/ to continue"
 which xcodebuild > /dev/null 2>&1 || fail "Please install xcode command line tools to continue"
 
-# Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
-if [ -n "$CODESIGN_CERT" ]; then
-    # Test the identity is valid for signing by doing this hack. There is no other way to do this.
-    cp -f /bin/ls ./CODESIGN_TEST
-    set +e
-    codesign -s "$CODESIGN_CERT" --dryrun -f ./CODESIGN_TEST > /dev/null 2>&1
-    res=$?
-    set -e
-    rm -f ./CODESIGN_TEST
-    if ((res)); then
-        fail "Code signing identity \"$CODESIGN_CERT\" appears to be invalid."
-    fi
-    unset res
-    info "Code signing enabled using identity \"$CODESIGN_CERT\""
-else
-    warn "Code signing DISABLED. Specify a valid macOS Developer identity installed on the system to enable signing."
-fi
-
-
-function DoCodeSignMaybe { # ARGS: infoName fileOrDirName
-    infoName="$1"
-    file="$2"
-    deep=""
-    if [ -z "$CODESIGN_CERT" ]; then
-        # no cert -> we won't codesign
-        return
-    fi
-    if [ -d "$file" ]; then
-        deep="--deep"
-    fi
-    if [ -z "$infoName" ] || [ -z "$file" ] || [ ! -e "$file" ]; then
-        fail "Argument error to internal function DoCodeSignMaybe()"
-    fi
-    hardened_arg="--entitlements=${CONTRIB_OSX}/entitlements.plist -o runtime"
-
-    info "Code signing ${infoName}..."
-    codesign -f -v $deep -s "$CODESIGN_CERT" $hardened_arg "$file" || fail "Could not code sign ${infoName}"
-}
 
 info "Installing Python $PYTHON_VERSION"
 PKG_FILE="python-${PYTHON_VERSION}-macos11.pkg"
@@ -247,23 +209,8 @@ ELECTRUM_VERSION=$VERSION pyinstaller --noconfirm --ascii --clean contrib/osx/os
 info "Finished building unsigned dist/${PACKAGE}.app. This hash should be reproducible:"
 find "dist/${PACKAGE}.app" -type f -print0 | sort -z | xargs -0 shasum -a 256 | shasum -a 256
 
-DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app"
+info "Creating unsigned .DMG"
+hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION-unsigned.dmg || fail "Could not create .DMG"
 
-if [ ! -z "$CODESIGN_CERT" ]; then
-    if [ ! -z "$APPLE_ID_USER" ]; then
-        info "Notarizing .app with Apple's central server..."
-        "${CONTRIB_OSX}/notarize_app.sh" "dist/${PACKAGE}.app" || fail "Could not notarize binary."
-    else
-        warn "AppleID details not set! Skipping Apple notarization."
-    fi
-fi
-
-info "Creating .DMG"
-hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"
-
-DoCodeSignMaybe ".DMG" "dist/electrum-${VERSION}.dmg"
-
-if [ -z "$CODESIGN_CERT" ]; then
-    warn "App was built successfully but was not code signed. Users may get security warnings from macOS."
-    warn "Specify a valid code signing identity to enable code signing."
-fi
+info "App was built successfully but was not code signed. Users may get security warnings from macOS."
+info "Now you also need to run make_osx2.sh to codesign/notarize the binary."

--- a/contrib/osx/make_osx2.sh
+++ b/contrib/osx/make_osx2.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+PACKAGE=Electrum
+
+
+. "$(dirname "$0")/../build_tools_util.sh"
+
+
+CONTRIB_OSX="$(dirname "$(realpath "$0")")"
+CONTRIB="$CONTRIB_OSX/.."
+PROJECT_ROOT="$CONTRIB/.."
+CACHEDIR="$CONTRIB_OSX/.cache"
+
+
+cd "$PROJECT_ROOT"
+
+
+# Code Signing: See https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
+if [ -n "$CODESIGN_CERT" ]; then
+    # Test the identity is valid for signing by doing this hack. There is no other way to do this.
+    cp -f /bin/ls ./CODESIGN_TEST
+    set +e
+    codesign -s "$CODESIGN_CERT" --dryrun -f ./CODESIGN_TEST > /dev/null 2>&1
+    res=$?
+    set -e
+    rm -f ./CODESIGN_TEST
+    if ((res)); then
+        fail "Code signing identity \"$CODESIGN_CERT\" appears to be invalid."
+    fi
+    unset res
+    info "Code signing enabled using identity \"$CODESIGN_CERT\""
+else
+    fail "Code signing DISABLED. Specify a valid macOS Developer identity installed on the system to enable signing."
+fi
+
+
+function DoCodeSignMaybe { # ARGS: infoName fileOrDirName
+    infoName="$1"
+    file="$2"
+    deep=""
+    if [ -z "$CODESIGN_CERT" ]; then
+        # no cert -> we won't codesign
+        return
+    fi
+    if [ -d "$file" ]; then
+        deep="--deep"
+    fi
+    if [ -z "$infoName" ] || [ -z "$file" ] || [ ! -e "$file" ]; then
+        fail "Argument error to internal function DoCodeSignMaybe()"
+    fi
+    hardened_arg="--entitlements=${CONTRIB_OSX}/entitlements.plist -o runtime"
+
+    info "Code signing ${infoName}..."
+    codesign -f -v $deep -s "$CODESIGN_CERT" $hardened_arg "$file" || fail "Could not code sign ${infoName}"
+}
+
+VERSION=$(git describe --tags --dirty --always)
+
+DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app"
+
+if [ ! -z "$CODESIGN_CERT" ]; then
+    if [ ! -z "$APPLE_ID_USER" ]; then
+        info "Notarizing .app with Apple's central server..."
+        "${CONTRIB_OSX}/notarize_app.sh" "dist/${PACKAGE}.app" || fail "Could not notarize binary."
+    else
+        warn "AppleID details not set! Skipping Apple notarization."
+    fi
+fi
+
+info "Creating .DMG"
+hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"
+
+DoCodeSignMaybe ".DMG" "dist/electrum-${VERSION}.dmg"


### PR DESCRIPTION
(untested)