### PR TITLE
util: make os_chmod best-effort, unless critical=True is specified

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1111,7 +1111,7 @@ def write_json_file(path, data):
         raise FileExportFailed(e)
 
 
-def os_chmod(path, mode):
+def os_chmod(path, mode, critical=False):
     """os.chmod aware of tmpfs"""
     try:
         os.chmod(path, mode)
@@ -1120,7 +1120,9 @@ def os_chmod(path, mode):
         if xdg_runtime_dir and is_subpath(path, xdg_runtime_dir):
             _logger.info(f"Tried to chmod in tmpfs. Skipping... {e!r}")
         else:
-            raise
+            if critical:
+                raise
+            _logger.info(f"Best-effort chmod failed: {e!r}")
 
 
 def make_dir(path, allow_symlink=True):


### PR DESCRIPTION
A successful `chmod` is not strictly necessary. Changing the default to best-effort, with override option.