### PR TITLE
ecc: ecdsa_verify to enforce low-S rule

### DIFF
--- a/electrum/ecc.py
+++ b/electrum/ecc.py
@@ -566,6 +566,8 @@ class ECPrivkey(ECPubkey):
         return sig64
 
     def ecdsa_sign_recoverable(self, msg32: bytes, *, is_compressed: bool) -> bytes:
+        assert len(msg32) == 32, len(msg32)
+
         def bruteforce_recid(sig64: bytes):
             for recid in range(4):
                 sig65 = construct_ecdsa_sig65(sig64, recid, is_compressed=is_compressed)

--- a/electrum/ecc.py
+++ b/electrum/ecc.py
@@ -342,7 +342,13 @@ class ECPubkey(object):
         # check message
         return self.ecdsa_verify(sig65[1:], msg32)
 
-    def ecdsa_verify(self, sig64: bytes, msg32: bytes) -> bool:
+    def ecdsa_verify(
+        self,
+        sig64: bytes,
+        msg32: bytes,
+        *,
+        enforce_low_s: bool = True,  # policy/standardness rule
+    ) -> bool:
         assert_bytes(sig64)
         if len(sig64) != 64:
             return False
@@ -353,7 +359,8 @@ class ECPubkey(object):
         ret = _libsecp256k1.secp256k1_ecdsa_signature_parse_compact(_libsecp256k1.ctx, sig, sig64)
         if 1 != ret:
             return False
-        ret = _libsecp256k1.secp256k1_ecdsa_signature_normalize(_libsecp256k1.ctx, sig, sig)
+        if not enforce_low_s:
+            ret = _libsecp256k1.secp256k1_ecdsa_signature_normalize(_libsecp256k1.ctx, sig, sig)
 
         pubkey = self._to_libsecp256k1_pubkey_ptr()
         if 1 != _libsecp256k1.secp256k1_ecdsa_verify(_libsecp256k1.ctx, sig, msg32, pubkey):
@@ -439,7 +446,8 @@ def verify_usermessage_with_address(address: str, sig65: bytes, message: bytes, 
     else:
         return False
     # check message
-    return public_key.ecdsa_verify(sig65[1:], h)
+    # note: `$ bitcoin-cli verifymessage` does NOT enforce the low-S rule for ecdsa sigs
+    return public_key.ecdsa_verify(sig65[1:], h, enforce_low_s=False)
 
 
 def is_secret_within_curve_range(secret: Union[int, bytes]) -> bool:

--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -246,6 +246,15 @@ class Test_bitcoin(ElectrumTestCase):
         self.assertFalse(ecc.verify_usermessage_with_address(addr1, b'wrong', msg1))
         self.assertFalse(ecc.verify_usermessage_with_address(addr1, sig2, msg1))
 
+    def test_signmessage_low_s(self):
+        """`$ bitcoin-cli verifymessage` does NOT enforce the low-S rule for ecdsa sigs. This tests we do the same."""
+        addr = "15hETetDmcXm1mM4sEf7U2KXC9hDHFMSzz"
+        sig_low_s = b'Hzsu0U/THAsPz/MSuXGBKSULz2dTfmrg1NsAhFp+wH5aKfmX4Db7ExLGa7FGn0m6Mf43KsbEOWpvUUUBTM3Uusw='
+        sig_high_s = b'IDsu0U/THAsPz/MSuXGBKSULz2dTfmrg1NsAhFp+wH5a1gZoH8kE7O05lE65YLZFzLx3sh/rDzXMbo1dQAJhhnU='
+        msg = b'Chancellor on brink of second bailout for banks'
+        self.assertTrue(ecc.verify_usermessage_with_address(address=addr, sig65=base64.b64decode(sig_low_s), message=msg))
+        self.assertTrue(ecc.verify_usermessage_with_address(address=addr, sig65=base64.b64decode(sig_high_s), message=msg))
+
     def test_signmessage_segwit_witness_v0_address(self):
         msg = b'Electrum'
         # p2wpkh-p2sh


### PR DESCRIPTION
This is mainly an API change, which I think makes behaviour simpler to reason about.

-----

The low-S rule for ecdsa signatures is mandated by Bitcoin Core policy/standardness (though not by consensus). If we get signatures from untrusted sources, we should mandate they obey the policy rules. (e.g. from LN peers)

Note that we normalize the signatures in the sig format conversion methods (DER <-> (r,s) <-> sig64).

The BOLTs treat high-S signatures as invalid, and this changes our behaviour to that.
(previously we would silently normalize the `s` value)

Note that `$ bitcoin-cli verifymessage` does NOT enforce the low-S rule for ecdsa sigs, and we make sure to do the same. (so no change for that)

see https://github.com/bitcoin/bitcoin/pull/6769
see https://github.com/lightning/bolts/pull/807
