### PR TITLE
bump libsecp256k1 version (0.4.1->0.5.0)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,10 +35,17 @@ task:
     - git tag
   install_script:
     - apt-get update
-    - apt-get -y install libsecp256k1-dev
     # qml test reqs:
     - apt-get -y install libgl1 libegl1 libxkbcommon0 libdbus-1-3
     - pip install -r $ELECTRUM_REQUIREMENTS_CI
+  libsecp_build_cache:
+    folder: contrib/_saved_secp256k1_build
+    fingerprint_script: sha256sum ./contrib/make_libsecp256k1.sh
+    populate_script:
+      - apt-get -y install automake libtool
+      - ./contrib/make_libsecp256k1.sh
+      - mkdir contrib/_saved_secp256k1_build
+      - cp electrum/libsecp256k1.so.* contrib/_saved_secp256k1_build/
   tox_script:
     - export PYTHONASYNCIODEBUG
     - export PYTHONDEVMODE

--- a/contrib/android/p4a_recipes/libsecp256k1/__init__.py
+++ b/contrib/android/p4a_recipes/libsecp256k1/__init__.py
@@ -6,9 +6,9 @@ assert LibSecp256k1Recipe.python_depends == []
 
 
 class LibSecp256k1RecipePinned(LibSecp256k1Recipe):
-    version = "1ad5185cd42c0636104129fcc9f6a4bf9c67cc40"
+    version = "e3a885d42a7800c1ccebad94ad1e2b82c4df5c65"
     url = "https://github.com/bitcoin-core/secp256k1/archive/{version}.zip"
-    sha512sum = "64080d7c3345fe8117787e328a09a3b493c38880cabf73d34e472ab0db4cb17ff989689f0c785680bdba39c446dc8a64d34587f4a0797b225c5687d0eb2da607"
+    sha512sum = "fef2671fcdcf9a1127597b2db0109279c38053b990bd3b979f863fdb3c92e691df9e2d3bdd22e1bb59100b3d27f27b07df1f0e314f2535148bd250665c8f1370"
 
 
 recipe = LibSecp256k1RecipePinned()

--- a/contrib/make_libsecp256k1.sh
+++ b/contrib/make_libsecp256k1.sh
@@ -14,8 +14,8 @@
 # sudo apt-get install gcc-multilib g++-multilib
 # $ AUTOCONF_FLAGS="--host=i686-linux-gnu CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32" ./contrib/make_libsecp256k1.sh
 
-LIBSECP_VERSION="1ad5185cd42c0636104129fcc9f6a4bf9c67cc40"
-# ^ tag "v0.4.1"
+LIBSECP_VERSION="e3a885d42a7800c1ccebad94ad1e2b82c4df5c65"
+# ^ tag "v0.5.0"
 # note: this version is duplicated in contrib/android/p4a_recipes/libsecp256k1/__init__.py
 
 set -e


### PR DESCRIPTION
- bump libsecp version for build scripts
- have CI run tests with this version, instead of using apt