### PR TITLE
qml: don't unbind/unregister the ActivityResultListener from within the ActivityResultListener handler func

### DIFF
--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -413,7 +413,7 @@ ApplicationWindow
     Component {
         id: _scanDialog
         QRScanner {
-            //onClosed: destroy()
+            onFinished: destroy()
         }
     }
     Component {


### PR DESCRIPTION
don't unbind/unregister the ActivityResultListener from within the ActivityResultListener handler func. instead, schedule a queued finished signal to unregister the listener after the handler has finished. See PythonActivity.java in P4A for why this probably causes the most often occurring crash we see on the Play Store:

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5164)
  at android.app.ActivityThread.handleSendResult (ActivityThread.java:5205)
  at android.app.servertransaction.ActivityResultItem.execute (ActivityResultItem.java:51)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:135)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:95)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2136)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:236)
  at android.app.ActivityThread.main (ActivityThread.java:8061)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:656)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:967)
Caused by java.util.ConcurrentModificationException:
  at java.util.ArrayList$Itr.next (ArrayList.java:860)
  at org.kivy.android.PythonActivity.onActivityResult (PythonActivity.java:218)
  at android.app.Activity.dispatchActivityResult (Activity.java:8501)
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5157)
```