### PR TITLE
qml: don't rely on wallet when deactivating PIN and no wallet loaded (fixes #8366)

### DIFF
--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -629,6 +629,16 @@ ApplicationWindow
 
     function handleAuthRequired(qtobject, method, authMessage) {
         console.log('auth using method ' + method)
+
+        if (method == 'wallet_else_pin') {
+            // if no wallet loaded, delegate to pin auth, else use wallet password auth
+            if (!Daemon.currentWallet) {
+                method = 'pin'
+            } else {
+                method = 'wallet'
+            }
+        }
+
         if (method == 'wallet') {
             if (Daemon.currentWallet.verifyPassword('')) {
                 // wallet has no password

--- a/electrum/gui/qml/qeconfig.py
+++ b/electrum/gui/qml/qeconfig.py
@@ -138,7 +138,7 @@ class QEConfig(AuthMixin, QObject):
             self.config.CONFIG_PIN_CODE = pin_code
             self.pinCodeChanged.emit()
 
-    @auth_protect(method='wallet')
+    @auth_protect(method='wallet_else_pin')
     def pinCodeRemoveAuth(self):
         self.config.CONFIG_PIN_CODE = ""
         self.pinCodeChanged.emit()


### PR DESCRIPTION
ref #8366 