### PR TITLE
qml: "wallet_else_pin" auth should only use the wallet pw if is unified

### DIFF
--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -631,11 +631,12 @@ ApplicationWindow
         console.log('auth using method ' + method)
 
         if (method == 'wallet_else_pin') {
-            // if no wallet loaded, delegate to pin auth, else use wallet password auth
-            if (!Daemon.currentWallet) {
-                method = 'pin'
-            } else {
+            // if there is a loaded wallet and all wallets use the same password, use that
+            // else delegate to pin auth
+            if (Daemon.currentWallet && Daemon.singlePasswordEnabled) {
                 method = 'wallet'
+            } else {
+                method = 'pin'
             }
         }
 


### PR DESCRIPTION
The config PIN is a global, while the wallet passwords are per wallet (unless the passwords have been unified).
Knowing the per-wallet password should not be sufficient to change the global config PIN.

related https://github.com/spesmilo/electrum/pull/9074