### PR TITLE
qml: fix handling of channel backup import on lightning-disabled wallets

### DIFF
--- a/electrum/gui/qml/components/SendDialog.qml
+++ b/electrum/gui/qml/components/SendDialog.qml
@@ -56,7 +56,9 @@ ElDialog {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            hint: qsTr('Scan an Invoice, an Address, an LNURL-pay, a PSBT or a Channel backup')
+            hint: Daemon.currentWallet.isLightning
+                ? qsTr('Scan an Invoice, an Address, an LNURL-pay, a PSBT or a Channel Backup')
+                : qsTr('Scan an Invoice, an Address, an LNURL-pay or a PSBT')
             onFound: dialog.dispatch(scanData)
         }
 

--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -43,7 +43,9 @@ Item {
 
         // Android based send dialog if on android
         var scanner = app.scanDialog.createObject(mainView, {
-            hint: qsTr('Scan an Invoice, an Address, an LNURL-pay, a PSBT or a Channel backup'),
+            hint: Daemon.currentWallet.isLightning
+                ? qsTr('Scan an Invoice, an Address, an LNURL-pay, a PSBT or a Channel Backup')
+                : qsTr('Scan an Invoice, an Address, an LNURL-pay or a PSBT')
         })
         scanner.onFound.connect(function() {
             var data = scanner.scanData
@@ -52,7 +54,7 @@ Item {
                 app.stack.push(Qt.resolvedUrl('TxDetails.qml'), { rawtx: data })
             } else if (Daemon.currentWallet.isValidChannelBackup(data)) {
                 var dialog = app.messageDialog.createObject(app, {
-                    title: qsTr('Import Channel backup?'),
+                    title: qsTr('Import Channel Backup?'),
                     yesno: true
                 })
                 dialog.accepted.connect(function() {
@@ -508,13 +510,21 @@ Item {
             width: parent.width
             height: parent.height
 
-            onTxFound: {
+            onTxFound: (data) => {
                 app.stack.push(Qt.resolvedUrl('TxDetails.qml'), { rawtx: data })
                 close()
             }
-            onChannelBackupFound: {
+            onChannelBackupFound: (data) => {
+                if (!Daemon.currentWallet.isLightning) {
+                    var dialog = app.messageDialog.createObject(app, {
+                        title: qsTr('Cannot import Channel Backup, Lightning not enabled.')
+                    })
+                    dialog.open()
+                    return
+                }
+
                 var dialog = app.messageDialog.createObject(app, {
-                    title: qsTr('Import Channel backup?'),
+                    title: qsTr('Import Channel Backup?'),
                     yesno: true
                 })
                 dialog.accepted.connect(function() {


### PR DESCRIPTION
importing a channel backup to a second bip39/xprv wallet with lightning disabled now shows proper message instead of exception text.

We could also provide the option to the user here to enable lightning?