### PR TITLE
qml/android: set max screen brightness when displaying QR codes

### DIFF
--- a/electrum/gui/qml/components/controls/QRImage.qml
+++ b/electrum/gui/qml/components/controls/QRImage.qml
@@ -24,7 +24,7 @@ Item {
         source: qrdata && render ? 'image://qrgen/' + qrdata : ''
         visible: !isTextState
 
-        Rectangle {
+        Rectangle {  // container for logo inside qr code
             visible: root.render && _qrprops.valid
             color: 'white'
             x: (parent.width - width) / 2
@@ -72,6 +72,15 @@ Item {
             if (enableToggleText) {
                 root.isTextState = !root.isTextState
             }
+        }
+    }
+
+    onVisibleChanged: {
+        if (root.visible) {
+            // set max brightness to make qr code easier to scan
+            AppController.setMaxScreenBrightness()
+        } else {
+            AppController.resetScreenBrightness()
         }
     }
 

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -206,6 +206,30 @@ class QEAppController(BaseCrashReporter, QObject):
         it = jIntent.createChooser(sendIntent, cast('java.lang.CharSequence', jString(title)))
         jpythonActivity.startActivity(it)
 
+    @pyqtSlot()
+    def setMaxScreenBrightness(self):
+        self._set_screen_brightness(1.0)
+
+    @pyqtSlot()
+    def resetScreenBrightness(self):
+        self._set_screen_brightness(-1.0)
+
+    def _set_screen_brightness(self, br: float) -> None:
+        """br is the desired screen brightness, a value in the [0, 1] interval.
+        A negative value, e.g. -1.0, means a "reset" back to the system preferred value.
+        """
+        if not self.isAndroid():
+            return
+        from android.runnable import run_on_ui_thread
+
+        @run_on_ui_thread
+        def set_br():
+            window = jpythonActivity.getWindow()
+            attrs = window.getAttributes()
+            attrs.screenBrightness = br
+            window.setAttributes(attrs)
+        set_br()
+
     @pyqtSlot('QString')
     def textToClipboard(self, text):
         QGuiApplication.clipboard().setText(text)


### PR DESCRIPTION
When displaying a QR code on Android, this sets the screen brightness to max. In some cases this makes it much easier to successfully scan it.

I was trying to scan a PSBT using a laptop camera from my phone screen for 2 minutes, until I realised the screen brightness was the issue.  o.O