### PR TITLE
Jade native psbt

### DIFF
--- a/electrum/plugins/jade/jade.py
+++ b/electrum/plugins/jade/jade.py
@@ -26,14 +26,15 @@ _logger = get_logger(__name__)
 #import logging
 #LOGGING = logging.INFO
 #if LOGGING:
-#    logger = logging.getLogger('jade')
+#    logger = logging.getLogger('electrum.plugins.jade.jadepy.jade')
 #    logger.setLevel(LOGGING)
-#    device_logger = logging.getLogger('jade-device')
+#    device_logger = logging.getLogger('electrum.plugins.jade.jadepy.jade-device')
 #    device_logger.setLevel(LOGGING)
 
 try:
     # Do imports
     from .jadepy.jade import JadeAPI
+    from .jadepy.jade_serial import JadeSerialImpl
     from serial.tools import list_ports
 except ImportError as e:
     _logger.exception('error importing Jade plugin deps')
@@ -353,12 +354,9 @@ class Jade_KeyStore(Hardware_KeyStore):
 class JadePlugin(HW_PluginBase):
     keystore_class = Jade_KeyStore
     minimum_library = (0, 0, 1)
-    DEVICE_IDS = [(0x10c4, 0xea60), # Development Jade device
-                  (0x1a86, 0x55d4), # Retail Blockstream Jade (And some DIY devices)
-                  (0x0403, 0x6001), # DIY FTDI Based Devices (Eg: M5StickC-Plus)
-                  (0x1a86, 0x7523)] # DIY CH340 Based devices (Eg: ESP32-Wrover)
+    DEVICE_IDS = JadeSerialImpl.JADE_DEVICE_IDS
     SUPPORTED_XTYPES = ('standard', 'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')
-    MIN_SUPPORTED_FW_VERSION = (0, 1, 32)
+    MIN_SUPPORTED_FW_VERSION = (0, 1, 47)
 
     # For testing with qemu simulator (experimental)
     SIMULATOR_PATH = None  # 'tcp:127.0.0.1:2222'

--- a/electrum/plugins/jade/jadepy/README.md
+++ b/electrum/plugins/jade/jadepy/README.md
@@ -2,10 +2,9 @@
 
 This is a slightly modified version of the official [Jade](https://github.com/Blockstream/Jade) python library.
 
-This modified version was made from tag [1.0.29](https://github.com/Blockstream/Jade/releases/tag/1.0.29).
-
-Intention is to fold these modifications back into Jade repo, for future api release.
+This modified version was made from tag [1.0.31](https://github.com/Blockstream/Jade/releases/tag/1.0.31).
 
 ## Changes
+
 - Removed BLE module, reducing transitive dependencies
 - _http_request() function removed, so cannot be used as unintentional fallback

--- a/electrum/plugins/jade/jadepy/__init__.py
+++ b/electrum/plugins/jade/jadepy/__init__.py
@@ -1,4 +1,4 @@
 from .jade import JadeAPI
 from .jade_error import JadeError
 
-__version__ = "0.2.0"
+__version__ = "1.0.31"

--- a/electrum/plugins/jade/jadepy/jade_serial.py
+++ b/electrum/plugins/jade/jadepy/jade_serial.py
@@ -2,6 +2,7 @@ import serial
 import logging
 
 from serial.tools import list_ports
+from .jade_error import JadeError
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,10 @@ class JadeSerialImpl:
         assert self.ser is not None
 
         if not self.ser.is_open:
-            self.ser.open()
+            try:
+                self.ser.open()
+            except serial.serialutil.SerialException:
+                raise JadeError(1, "Unable to open port", self.device)
 
         # Ensure RTS and DTR are not set (as this can cause the hw to reboot)
         self.ser.setRTS(False)


### PR DESCRIPTION
1.  latest jade api to recognise more recently added hw
2.  remove code which walked psbt/tx data and mapped it into Jade's legacy 'sign_tx' json format - instead pass PSBT directly to Jade for signing, since this has been supported in fw now for well over a year and seems to be working well.

