### PR TITLE
qml: add seed passphrase property to QEWallet, show in WalletDetails

### DIFF
--- a/electrum/gui/qml/components/WalletDetails.qml
+++ b/electrum/gui/qml/components/WalletDetails.qml
@@ -176,6 +176,28 @@ Pane {
                         }
 
                         Label {
+                            id: seed_extension_label
+                            Layout.columnSpan: 2
+                            Layout.topMargin: constants.paddingSmall
+                            visible: seedText.visible && Daemon.currentWallet.seedPassphrase
+                            text: qsTr('Seed Extension')
+                            color: Material.accentColor
+                        }
+
+                        TextHighlightPane {
+                            Layout.columnSpan: 2
+                            Layout.fillWidth: true
+                            visible: seed_extension_label.visible
+                            Label {
+                                Layout.fillWidth: true
+                                text: Daemon.currentWallet.seedPassphrase
+                                wrapMode: Text.Wrap
+                                font.family: FixedFont
+                                font.pixelSize: constants.fontSizeMedium
+                            }
+                        }
+
+                        Label {
                             Layout.columnSpan: 2
                             Layout.topMargin: constants.paddingSmall
                             visible: Daemon.currentWallet.isLightning

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -105,6 +105,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         self._lightningbalancefrozen = QEAmount()
 
         self._seed = ''
+        self._seed_passphrase = ''
 
         self.tx_notification_queue = queue.Queue()
         self.tx_notification_last_time = 0
@@ -373,6 +374,10 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     @pyqtProperty(str, notify=dataChanged)
     def seed(self):
         return self._seed
+
+    @pyqtProperty(str, notify=dataChanged)
+    def seedPassphrase(self):
+        return self._seed_passphrase
 
     @pyqtProperty(str, notify=dataChanged)
     def txinType(self):
@@ -770,9 +775,11 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     def retrieve_seed(self):
         try:
             self._seed = self.wallet.get_seed(self.password)
+            self._seed_passphrase = self.wallet.keystore.get_passphrase(self.password)
             self.seedRetrieved.emit()
         except Exception:
             self._seed = ''
+            self._seed_passphrase = ''
 
         self.dataChanged.emit()
 


### PR DESCRIPTION
fix for #9204