### PR TITLE
qml: do not display success if swap failed..

### DIFF
--- a/electrum/gui/qml/qeswaphelper.py
+++ b/electrum/gui/qml/qeswaphelper.py
@@ -386,11 +386,15 @@ class QESwapHelper(AuthMixin, QObject, QtEventListener):
                 self.canCancel = True
                 txid = fut.result()
                 try:  # swaphelper might be destroyed at this point
-                    self.userinfo = ' '.join([
-                        _('Success!'),
-                        messages.MSG_FORWARD_SWAP_FUNDING_MEMPOOL,
-                    ])
-                    self.state = QESwapHelper.State.Success
+                    if txid:
+                        self.userinfo = ' '.join([
+                            _('Success!'),
+                            messages.MSG_FORWARD_SWAP_FUNDING_MEMPOOL,
+                        ])
+                        self.state = QESwapHelper.State.Success
+                    else:
+                        self.userinfo = _('Swap failed!')
+                        self.state = QESwapHelper.State.Failed
                 except RuntimeError:
                     pass
             except concurrent.futures.CancelledError:


### PR DESCRIPTION
I am not able to test this commit because the qml gui is broken for me on master:
```
  1.82 | W | gui.qml.qeapp | file:///opt/electrum/electrum/gui/qml/components/WalletMainView.qml:332:9: Unable to assign QEWallet to QEWallet
  1.82 | W | gui.qml.qeapp | file:///opt/electrum/electrum/gui/qml/components/WalletMainView.qml:327:9: Unable to assign QEWallet to QEWallet

```
not sure what causes that issue.