### PR TITLE
android: rm APK_VERSION, and change versionCode calculation

### DIFF
--- a/contrib/add_cosigner
+++ b/contrib/add_cosigner
@@ -37,13 +37,12 @@ version_module = importlib.util.module_from_spec(version_spec)
 version_spec.loader.exec_module(version_module)
 
 ELECTRUM_VERSION = version_module.ELECTRUM_VERSION
-APK_VERSION = version_module.APK_VERSION
 print("version", ELECTRUM_VERSION)
 
 # GPG name of cosigner
 cosigner = sys.argv[1]
 
-version = version_win = version_mac = ELECTRUM_VERSION
+version = version_win = version_mac = version_android = ELECTRUM_VERSION
 
 files = {
     "tgz": f"Electrum-{version}.tar.gz",
@@ -53,9 +52,9 @@ files = {
     "win": f"electrum-{version_win}.exe",
     "win_setup": f"electrum-{version_win}-setup.exe",
     "win_portable": f"electrum-{version_win}-portable.exe",
-    "apk_arm64": f"Electrum-{APK_VERSION}-arm64-v8a-release.apk",
-    "apk_armeabi": f"Electrum-{APK_VERSION}-armeabi-v7a-release.apk",
-    "apk_x86_64": f"Electrum-{APK_VERSION}-x86_64-release.apk",
+    "apk_arm64": f"Electrum-{version_android}-arm64-v8a-release.apk",
+    "apk_armeabi": f"Electrum-{version_android}-armeabi-v7a-release.apk",
+    "apk_x86_64": f"Electrum-{version_android}-x86_64-release.apk",
 }
 
 

--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -197,8 +197,8 @@ RUN cd /opt \
     && git remote add sombernight https://github.com/SomberNight/python-for-android \
     && git remote add accumulator https://github.com/accumulator/python-for-android \
     && git fetch --all \
-    # commit: from branch sombernight/qt6-wip (note: careful with force-pushing! see #8162) \
-    && git checkout "58d21ad89b6182c0d70289d647eb85eaa412412c^{commit}" \
+    # commit: from branch sombernight/electrum_20240930 (note: careful with force-pushing! see #8162) \
+    && git checkout "7197c1c28409fbeebd8494093349a2bfd770526a^{commit}" \
     && /opt/venv/bin/python3 -m pip install --no-build-isolation --no-dependencies -e .
 
 # build env vars

--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -40,7 +40,7 @@ source.exclude_patterns = Makefile,setup*,
     packages/frozenlist-*.dist-info/*
 
 # (str) Application versioning (method 1)
-version.regex = APK_VERSION = '(.*)'
+version.regex = ELECTRUM_VERSION = '(.*)'
 version.filename = %(source.dir)s/electrum/version.py
 
 # (str) Application versioning (method 2)

--- a/contrib/android/get_apk_versioncode.py
+++ b/contrib/android/get_apk_versioncode.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+import importlib.util
+import os
+import sys
+
+ARCH_DICT = {
+    "x86_64": "4",
+    "arm64-v8a": "3",
+    "armeabi-v7a": "2",
+    "x86": "1",
+}
+
+
+def get_electrum_version() -> str:
+    project_root = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    version_file_path = os.path.join(project_root, "electrum", "version.py")
+    # load version.py; needlessly complicated alternative to "imp.load_source":
+    version_spec = importlib.util.spec_from_file_location('version', version_file_path)
+    version_module = version = importlib.util.module_from_spec(version_spec)
+    version_spec.loader.exec_module(version_module)
+    return version.ELECTRUM_VERSION
+
+
+def get_android_versioncode(*, arch_name: str) -> int:
+    version_code = 0
+    # add ELECTRUM_VERSION
+    app_version = get_electrum_version()
+    app_version_components = app_version.split('.')
+    assert len(app_version_components) == 3, f"version str expected to have 3 components, but got {app_version!r}"
+    for i in app_version_components:
+        version_code *= 100
+        version_code += int(i)
+    # add arch
+    arch_code = ARCH_DICT[arch_name]
+    assert len(arch_code) == 1
+    version_code *= 10
+    version_code += int(arch_code)
+    # compensate for legacy scheme
+    # note: up until version 4.5.5, we used a different scheme for version_code.
+    #       4_______________4_05_05_00
+    #       ^ android arch, ^ app_version (4.5.5.0)
+    # This offset ensures that all new-scheme version codes are larger than the old-scheme version codes.
+    offset_due_to_legacy_scheme = 45_000_000
+    version_code += offset_due_to_legacy_scheme
+    return version_code
+
+
+if __name__ == '__main__':
+    try:
+        android_arch = sys.argv[1]
+    except Exception:
+        print(f"usage: {os.path.basename(__file__)} <android_arch>", file=sys.stderr)
+        sys.exit(1)
+    if android_arch not in ARCH_DICT:
+        print(f"usage: {os.path.basename(__file__)} <android_arch>", file=sys.stderr)
+        print(f"error: unknown {android_arch=}", file=sys.stderr)
+        print(f"       should be one of: {list(ARCH_DICT.keys())}", file=sys.stderr)
+        sys.exit(1)
+    version_code = get_android_versioncode(arch_name=android_arch)
+    print(version_code, file=sys.stdout)

--- a/contrib/android/make_apk.sh
+++ b/contrib/android/make_apk.sh
@@ -91,15 +91,17 @@ if [[ "$2" == "all" ]] ; then
     # build all apks
     # FIXME failures are not propagated out: we should fail the script if any arch build fails
     export APP_ANDROID_ARCHS=armeabi-v7a
+    export APP_ANDROID_NUMERIC_VERSION=$("$CONTRIB_ANDROID"/get_apk_versioncode.py "$APP_ANDROID_ARCHS")
     make $TARGET
     export APP_ANDROID_ARCHS=arm64-v8a
+    export APP_ANDROID_NUMERIC_VERSION=$("$CONTRIB_ANDROID"/get_apk_versioncode.py "$APP_ANDROID_ARCHS")
     make $TARGET
-    #export APP_ANDROID_ARCHS=x86
-    #make $TARGET
     export APP_ANDROID_ARCHS=x86_64
+    export APP_ANDROID_NUMERIC_VERSION=$("$CONTRIB_ANDROID"/get_apk_versioncode.py "$APP_ANDROID_ARCHS")
     make $TARGET
 else
     export APP_ANDROID_ARCHS=$2
+    export APP_ANDROID_NUMERIC_VERSION=$("$CONTRIB_ANDROID"/get_apk_versioncode.py "$APP_ANDROID_ARCHS")
     make $TARGET
 fi
 

--- a/contrib/make_download
+++ b/contrib/make_download
@@ -19,7 +19,6 @@ version_module = importlib.util.module_from_spec(version_spec)
 version_spec.loader.exec_module(version_module)
 
 ELECTRUM_VERSION = version_module.ELECTRUM_VERSION
-APK_VERSION = version_module.APK_VERSION
 print(f"version: {ELECTRUM_VERSION}", file=sys.stderr)
 
 dirname = sys.argv[1]
@@ -37,7 +36,7 @@ download_page_str = download_page_str.replace("##VERSION##", version)
 download_page_str = download_page_str.replace("##VERSION_WIN##", version_win)
 download_page_str = download_page_str.replace("##VERSION_MAC##", version_mac)
 download_page_str = download_page_str.replace("##VERSION_ANDROID##", version_android)
-download_page_str = download_page_str.replace("##VERSION_APK##", APK_VERSION)
+download_page_str = download_page_str.replace("##VERSION_APK##", version_android)
 
 # note: all dist files need to be listed here that we expect sigs for,
 #       even if they are not linked to from the website
@@ -49,9 +48,9 @@ files = {
     "win": f"electrum-{version_win}.exe",
     "win_setup": f"electrum-{version_win}-setup.exe",
     "win_portable": f"electrum-{version_win}-portable.exe",
-    "apk_arm64": f"Electrum-{APK_VERSION}-arm64-v8a-release.apk",
-    "apk_armeabi": f"Electrum-{APK_VERSION}-armeabi-v7a-release.apk",
-    "apk_x86_64": f"Electrum-{APK_VERSION}-x86_64-release.apk",
+    "apk_arm64": f"Electrum-{version_android}-arm64-v8a-release.apk",
+    "apk_armeabi": f"Electrum-{version_android}-armeabi-v7a-release.apk",
+    "apk_x86_64": f"Electrum-{version_android}-x86_64-release.apk",
 }
 
 # default signers

--- a/contrib/print_electrum_version.py
+++ b/contrib/print_electrum_version.py
@@ -4,10 +4,8 @@
 #
 # For example:
 # $ VERSION=$("$CONTRIB"/print_electrum_version.py)
-# $ VERSION=$("$CONTRIB"/print_electrum_version.py APK_VERSION)
 # instead of
 # $ VERSION=$(python3 -c "import electrum; print(electrum.version.ELECTRUM_VERSION)")
-# $ VERSION=$(python3 -c "import electrum; print(electrum.version.APK_VERSION)")
 
 import importlib.util
 import os

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -82,9 +82,7 @@ fi
 
 
 VERSION=$("$CONTRIB"/print_electrum_version.py)
-APK_VERSION=$("$CONTRIB"/print_electrum_version.py APK_VERSION)
 info "VERSION: $VERSION"
-info "APK_VERSION: $APK_VERSION"
 REV=$(git describe --tags)
 info "REV: $REV"
 COMMIT=$(git rev-parse HEAD)
@@ -149,13 +147,13 @@ else
 fi
 
 # android
-apk1="Electrum-$APK_VERSION-armeabi-v7a-release.apk"
-apk2="Electrum-$APK_VERSION-arm64-v8a-release.apk"
-apk3="Electrum-$APK_VERSION-x86_64-release.apk"
+apk1="Electrum-$VERSION-armeabi-v7a-release.apk"
+apk2="Electrum-$VERSION-arm64-v8a-release.apk"
+apk3="Electrum-$VERSION-x86_64-release.apk"
 for arch in armeabi-v7a arm64-v8a x86_64
 do
-    apk="Electrum-$APK_VERSION-$arch-release.apk"
-    apk_unsigned="Electrum-$APK_VERSION-$arch-release-unsigned.apk"
+    apk="Electrum-$VERSION-$arch-release.apk"
+    apk_unsigned="Electrum-$VERSION-$arch-release-unsigned.apk"
     if test -f "dist/$apk"; then
         info "file exists: $apk"
     else

--- a/electrum/version.py
+++ b/electrum/version.py
@@ -1,5 +1,4 @@
 ELECTRUM_VERSION = '4.5.5'       # version of the client package
-APK_VERSION = '4.5.5.0'          # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4'     # protocol version requested
 


### PR DESCRIPTION
This drops the trailing .0 from the version number of android apks. It is a historical thing that we don't need/utilise anymore. (Some years ago, prior to reproducible builds at least, sometimes we had .1 and .2 releases just for android-specific bugs.)
Related https://github.com/spesmilo/electrum/issues/9210#issuecomment-2376572832

Also, the android `versionCode` calculation is changed to accommodate the changed version string, but also to have the architecture part in the least significant digits, as requested in https://github.com/spesmilo/electrum/issues/9210#issuecomment-2380559324

@thecockatiel Could you check if this looks good to you? (re version string and int version code construction)