### PR TITLE
ci: fix windows build caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -186,7 +186,7 @@ task:
   container:
     dockerfile: contrib/build-wine/Dockerfile
     cpu: 1
-    memory: 2G
+    memory: 3G
   pip_cache:
     folders:
       - contrib/build-wine/.cache/win*/wine_pip_cache

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -189,16 +189,14 @@ task:
     memory: 2G
   pip_cache:
     folders:
-      - contrib/build-wine/.cache/win32/wine_pip_cache
-      - contrib/build-wine/.cache/win64/wine_pip_cache
+      - contrib/build-wine/.cache/win*/wine_pip_cache
     fingerprint_script:
       - echo $CIRRUS_TASK_NAME
       - git ls-files -s contrib/deterministic-build/*.txt
       - git ls-files -s contrib/build-wine/
   build2_cache:
     folders:
-      - contrib/build-wine/.cache/win32/build
-      - contrib/build-wine/.cache/win64/build
+      - contrib/build-wine/.cache/win*/build
     fingerprint_script:
       - echo $CIRRUS_TASK_NAME
       - cat contrib/make_libsecp256k1.sh | sha256sum


### PR DESCRIPTION
follow-up https://github.com/spesmilo/electrum/commit/fcc4e1d38773da0484910cacc80c16117b9c15c5

error msg was:
```
SHA for cache folders (/opt/wine64/drive_c/electrum/contrib/build-wine/.cache/win32/wine_pip_cache, /opt/wine64/drive_c/electrum/contrib/build-wine/.cache/win64/wine_pip_cache) is 'be33ad1b0598b1733992e36659bb71406f8fcfaa3a442166ecbe26e2db9a65c2'
Failed to tar caches for Upload 'pip' cache with error walking folder /opt/wine64/drive_c/electrum/contrib/build-wine/.cache/win32/wine_pip_cache: lstat /opt/wine64/drive_c/electrum/contrib/build-wine/.cache/win32/wine_pip_cache: no such file or directory!
```