### PR TITLE
contrib/release_www.sh: put android versionCode in "version" file

### DIFF
--- a/contrib/android/get_apk_versioncode.py
+++ b/contrib/android/get_apk_versioncode.py
@@ -9,6 +9,7 @@ ARCH_DICT = {
     "arm64-v8a": "3",
     "armeabi-v7a": "2",
     "x86": "1",
+    "null": "0",
 }
 
 
@@ -58,4 +59,5 @@ if __name__ == '__main__':
         print(f"       should be one of: {list(ARCH_DICT.keys())}", file=sys.stderr)
         sys.exit(1)
     version_code = get_android_versioncode(arch_name=android_arch)
+    assert isinstance(version_code, int), f"{version_code=!r} must be an int."
     print(version_code, file=sys.stdout)

--- a/contrib/release_www.sh
+++ b/contrib/release_www.sh
@@ -37,16 +37,26 @@ fi
 VERSION=$("$CONTRIB"/print_electrum_version.py)
 info "VERSION: $VERSION"
 
+ANDROID_VERSIONCODE_NULLARCH=$("$CONTRIB"/android/get_apk_versioncode.py "null")
+# ^ note: should parse as an integer in the final json
+info "ANDROID_VERSIONCODE_NULLARCH: $ANDROID_VERSIONCODE_NULLARCH"
+
 set -x
 
 info "updating www repo"
 ./contrib/make_download "$WWW_DIR"
 info "signing the version announcement file"
 sig=$(./run_electrum -o signmessage $ELECTRUM_SIGNING_ADDRESS $VERSION -w $ELECTRUM_SIGNING_WALLET)
+# note: the contents of "extradata" are currently not signed. We could add another field, extradata_sigs,
+#       containing signature(s) for "extradata". extradata, being json, would have to be canonically
+#       serialized before signing.
 cat <<EOF > "$WWW_DIR"/version
 {
     "version": "$VERSION",
-    "signatures": {"$ELECTRUM_SIGNING_ADDRESS": "$sig"}
+    "signatures": {"$ELECTRUM_SIGNING_ADDRESS": "$sig"},
+    "extradata": {
+        "android_versioncode_nullarch": $ANDROID_VERSIONCODE_NULLARCH
+    }
 }
 EOF
 

--- a/contrib/release_www.sh
+++ b/contrib/release_www.sh
@@ -43,7 +43,12 @@ info "updating www repo"
 ./contrib/make_download "$WWW_DIR"
 info "signing the version announcement file"
 sig=$(./run_electrum -o signmessage $ELECTRUM_SIGNING_ADDRESS $VERSION -w $ELECTRUM_SIGNING_WALLET)
-echo "{ \"version\":\"$VERSION\", \"signatures\":{ \"$ELECTRUM_SIGNING_ADDRESS\":\"$sig\"}}" > "$WWW_DIR"/version
+cat <<EOF > "$WWW_DIR"/version
+{
+    "version": "$VERSION",
+    "signatures": {"$ELECTRUM_SIGNING_ADDRESS": "$sig"}
+}
+EOF
 
 # push changes to website repo
 pushd "$WWW_DIR"


### PR DESCRIPTION
This updates the `version` file hosted at `https://electrum.org/version` to also include the android `versionCode` (or rather, a closely related value, as that would depend on the target architecture).
This can be used by the F-Droid buildserver to detect new versions and release updates automatically.

ref:
https://github.com/spesmilo/electrum/pull/9221#issuecomment-2386549086
https://f-droid.org/en/docs/Build_Metadata_Reference/#UpdateCheckMode

@thecockatiel does this look good? AFAICT UpdateCheckMode/HTTP cannot parse json files, but I think a regex should be sufficient to extract the version number from this structure.

Example file:
```
{
    "version": "4.5.5",
    "signatures": {"13xjmVAB1EATPP8RshTE8S8sNwwSUM9p1P": "H29AgDpgA0jFGPq6AiL8DAZsyq0TSyzmbHGxT7dwimRTeF28qc93agiG+oR6K+81gNVqNxvDRO2rOC1BmsW3yhE="},
    "extradata": {
        "android_versioncode_nullarch": 45405050
    }
}
```