### PR TITLE
qt: replace BlockingWaitingDialog with RunCoroutineDialog

### DIFF
--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -532,7 +532,7 @@ class TxEditor(WindowModalDialog):
             if self.not_enough_funds:
                 self.io_widget.update(None)
             self.set_feerounding_visibility(False)
-            self.messages = []
+            self.messages = [_('Preparing transaction...')]
         else:
             self.messages = self.get_messages()
             self.update_fee_fields()
@@ -619,7 +619,7 @@ class ConfirmTxDialog(TxEditor):
             title=_("New Transaction"), # todo: adapt title for channel funding tx, swaps
             allow_preview=allow_preview)
 
-        self.update()
+        self.trigger_update()
 
     def _update_amount_label(self):
         tx = self.tx

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -42,7 +42,7 @@ from electrum.simple_config import SimpleConfig
 from electrum.bitcoin import DummyAddress
 
 from .util import (WindowModalDialog, ColorScheme, HelpLabel, Buttons, CancelButton,
-                   BlockingWaitingDialog, PasswordLineEdit, WWLabel, read_QIcon)
+                   PasswordLineEdit, WWLabel, read_QIcon)
 
 from .fee_slider import FeeSlider, FeeComboBox
 
@@ -619,7 +619,7 @@ class ConfirmTxDialog(TxEditor):
             title=_("New Transaction"), # todo: adapt title for channel funding tx, swaps
             allow_preview=allow_preview)
 
-        BlockingWaitingDialog(window, _("Preparing transaction..."), self.update)
+        self.update()
 
     def _update_amount_label(self):
         tx = self.tx

--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -62,7 +62,7 @@ from .util import (MessageBoxMixin, read_QIcon, Buttons, icon_path,
                    char_width_in_lineedit, TRANSACTION_FILE_EXTENSION_FILTER_SEPARATE,
                    TRANSACTION_FILE_EXTENSION_FILTER_ONLY_COMPLETE_TX,
                    TRANSACTION_FILE_EXTENSION_FILTER_ONLY_PARTIAL_TX,
-                   BlockingWaitingDialog, getSaveFileName, ColorSchemeItem,
+                   getSaveFileName, ColorSchemeItem,
                    get_iconname_qrcode, VLine, WaitingDialog)
 from .rate_limiter import rate_limited
 from .my_treeview import create_toolbar_with_menu, QMenuWithConfig
@@ -582,11 +582,9 @@ class TxDialog(QDialog, MessageBoxMixin):
         # FIXME for PSBTs, we do a blocking fetch, as the missing data might be needed for e.g. signing
         # - otherwise, the missing data is for display-completeness only, e.g. fee, input addresses (we do it async)
         if not tx.is_complete() and tx.is_missing_info_from_network():
-            BlockingWaitingDialog(
-                self,
+            self.main_window.run_coroutine_dialog(
+                tx.add_info_from_network(self.wallet.network, timeout=10),
                 _("Adding info to tx, from network..."),
-                lambda: Network.run_from_another_thread(
-                    tx.add_info_from_network(self.wallet.network, timeout=10)),
             )
         else:
             self.maybe_fetch_txin_data()


### PR DESCRIPTION
RunCoroutineDialog has a run() method that blocks the thread without blocking the GUI (using exec), and a Cancel button that cancels the coroutine.

main_window.run_coroutine_dialog() is a wrapper that returns the coroutine result and may raise exceptions.

BlockingWaitingDialog was removed is transaction_dialog, where it was not particularly useful.