### PR TITLE
interface: disable ssl.VERIFY_X509_STRICT for self-signed certs

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -513,6 +513,9 @@ class Interface(Logger):
         else:
             # pinned self-signed cert
             sslc = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=self.cert_path)
+            # note: Flag "ssl.VERIFY_X509_STRICT" is enabled by default in python 3.13+ (disabled in older versions).
+            #       We explicitly disable it as it breaks lots of servers.
+            sslc.verify_flags &= ~ssl.VERIFY_X509_STRICT
             sslc.check_hostname = False
         return sslc
 


### PR DESCRIPTION
The `ssl.VERIFY_X509_STRICT` flag for openssl verification has been enabled by default in python 3.13+ (it was disabled before that). see https://github.com/python/cpython/issues/107361 and https://discuss.python.org/t/ssl-changing-the-default-sslcontext-verify-flags/30230/16

We explicitly disable it for self-signed certs, thereby restoring the pre-3.13 defaults, as it seems to break lots of servers.

For example, using python 3.13 (or setting `sslc.verify_flags |= ssl.VERIFY_X509_STRICT`),
- I can connect to `btc.electroncash.dk:60002:s`
- but not to `electrum.emzy.de:50002:s`

despite both using self-signed certs.

We should investigate more why exactly "strict" verification fails for some self-signed certs and not for others, and make sure that at least newly generated certs adhere to the stricter requirements (e.g. update guide in e-x?).