### PR TITLE
Introducing Electrum Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Homepage: https://electrum.org/
 [![Build Status](https://api.cirrus-ci.com/github/spesmilo/electrum.svg?branch=master)](https://cirrus-ci.com/github/spesmilo/electrum)
 [![Test coverage statistics](https://coveralls.io/repos/github/spesmilo/electrum/badge.svg?branch=master)](https://coveralls.io/github/spesmilo/electrum?branch=master)
 [![Help translate Electrum online](https://d322cqt584bo4o.cloudfront.net/electrum/localized.svg)](https://crowdin.com/project/electrum)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Electrum%20Guru-006BFF)](https://gurubase.io/g/electrum)
 
 
 ## Getting started


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Electrum Guru](https://gurubase.io/g/electrum) to Gurubase. Electrum Guru uses the data from this repo and data from the [docs](https://electrum.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Electrum Guru" badge, which highlights that Electrum now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Electrum Guru in Gurubase, just let me know that's totally fine.