### PR TITLE
lnworker: reserve wallet addresses also for chan backups

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -487,6 +487,14 @@ class AbstractChannel(Logger, ABC):
     def can_be_deleted(self) -> bool:
         pass
 
+    @abstractmethod
+    def get_wallet_addresses_channel_might_want_reserved(self) -> Sequence[str]:
+        """Returns a list of addrs that the wallet should not use, to avoid address-reuse.
+        Typically, these addresses are wallet.is_mine, but that is not guaranteed,
+        in which case the wallet can just ignore those.
+        """
+        pass
+
 
 class ChannelBackup(AbstractChannel):
     """
@@ -637,6 +645,19 @@ class ChannelBackup(AbstractChannel):
         if self.get_state() == ChannelState.FUNDED:
             ret.append(ChanCloseOption.REQUEST_REMOTE_FCLOSE)
         return ret
+
+    def get_wallet_addresses_channel_might_want_reserved(self) -> Sequence[str]:
+        if self.is_imported:
+            # For v1 imported cbs, we have the local_payment_pubkey, which is
+            # directly used as p2wpkh() of static_remotekey channels.
+            # (for v0 imported cbs, the correct local_payment_pubkey is missing, and so
+            #  we might calculate a different address here, which might not be wallet.is_mine,
+            #  but that should be harmless)
+            our_payment_pubkey = self.config[LOCAL].payment_basepoint.pubkey
+            to_remote_address = make_commitment_output_to_remote_address(our_payment_pubkey)
+            return [to_remote_address]
+        else:  # on-chain backup
+            return []
 
 
 class Channel(AbstractChannel):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
     from .network import Network
     from .exchange_rate import FxThread
     from .submarine_swaps import SwapData
+    from .lnchannel import AbstractChannel
 
 
 _logger = get_logger(__name__)
@@ -2033,13 +2034,20 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def set_reserved_state_of_address(self, addr: str, *, reserved: bool) -> None:
         if not self.is_mine(addr):
+            # silently ignore non-ismine addresses
             return
         with self.lock:
+            has_changed = (addr in self._reserved_addresses) != reserved
             if reserved:
                 self._reserved_addresses.add(addr)
             else:
                 self._reserved_addresses.discard(addr)
-            self.db.put('reserved_addresses', list(self._reserved_addresses))
+            if has_changed:
+                self.db.put('reserved_addresses', list(self._reserved_addresses))
+
+    def set_reserved_addresses_for_chan(self, chan: 'AbstractChannel', *, reserved: bool) -> None:
+        for addr in chan.get_wallet_addresses_channel_might_want_reserved():
+            self.set_reserved_state_of_address(addr, reserved=reserved)
 
     def can_export(self):
         return not self.is_watching_only() and hasattr(self.keystore, 'get_private_key')


### PR DESCRIPTION
We were already reserving wallet addresses for full channels. Now we also do the same for imported channel backups. (but not for onchain, as we don't have enough info for that)

Without this, if the same seed is used on multiple devices (with each device having its own set of LN channels), the wallet instances will reuse keys (specifically the payment_basepoint, which for static_remotekey chans is used as the to_remote output so it is trivially visible onchain). Now with this change, at least if the wallet instances have imported channel backups of each other, this reuse is avoided.