### PR TITLE
Add .desktop file keywords entry.

### DIFF
--- a/electrum.desktop
+++ b/electrum.desktop
@@ -17,6 +17,7 @@ Terminal=false
 Type=Application
 MimeType=x-scheme-handler/bitcoin;x-scheme-handler/lightning;
 Actions=Testnet;
+Keywords=crypto;currency;BTC
 
 [Desktop Action Testnet]
 Exec=electrum --testnet %u


### PR DESCRIPTION
The `Keywords` field in .desktop files provides additional key words beyond those in the `Name` and `GenericName` fields that can be used to search for a program.  Debian likes to have this field populated.  This patch adds a few words, but there are probably others that I haven't thought of.