### PR TITLE
qml: add config setting for max brightness on qr display

### DIFF
--- a/electrum/gui/qml/components/Preferences.qml
+++ b/electrum/gui/qml/components/Preferences.qml
@@ -422,11 +422,27 @@ Pane {
                             wrapMode: Text.Wrap
                         }
                     }
-                }
 
+                    RowLayout {
+                        Layout.columnSpan: 2
+                        Layout.fillWidth: true
+                        spacing: 0
+                        Switch {
+                            id: setMaxBrightnessOnQrDisplay
+                            onCheckedChanged: {
+                                if (activeFocus)
+                                    Config.setMaxBrightnessOnQrDisplay = checked
+                            }
+                        }
+                        Label {
+                            Layout.fillWidth: true
+                            text: qsTr('Set display to max brightness when displaying QR codes')
+                            wrapMode: Text.Wrap
+                        }
+                    }
+                }
             }
         }
-
     }
 
     Component {
@@ -447,6 +463,7 @@ Pane {
         useFallbackAddress.checked = Config.useFallbackAddress
         enableDebugLogs.checked = Config.enableDebugLogs
         alwaysAllowScreenshots.checked = Config.alwaysAllowScreenshots
+        setMaxBrightnessOnQrDisplay.checked = Config.setMaxBrightnessOnQrDisplay
         useRecoverableChannels.checked = Config.useRecoverableChannels
         syncLabels.checked = AppController.isPluginEnabled('labels')
     }

--- a/electrum/gui/qml/components/controls/QRImage.qml
+++ b/electrum/gui/qml/components/controls/QRImage.qml
@@ -78,10 +78,11 @@ Item {
     onVisibleChanged: {
         if (root.visible) {
             // set max brightness to make qr code easier to scan
-            AppController.setMaxScreenBrightness()
+            if (AppController.isMaxBrightnessOnQrDisplayEnabled()) {
+                AppController.setMaxScreenBrightness()
+            }
         } else {
             AppController.resetScreenBrightness()
         }
     }
-
 }

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -211,6 +211,10 @@ class QEAppController(BaseCrashReporter, QObject):
         jpythonActivity.startActivity(it)
 
     @pyqtSlot()
+    def isMaxBrightnessOnQrDisplayEnabled(self):
+        return self.config.GUI_QML_SET_MAX_BRIGHTNESS_ON_QR_DISPLAY
+
+    @pyqtSlot()
     def setMaxScreenBrightness(self):
         self._set_screen_brightness(1.0)
 

--- a/electrum/gui/qml/qeconfig.py
+++ b/electrum/gui/qml/qeconfig.py
@@ -189,6 +189,15 @@ class QEConfig(AuthMixin, QObject):
         self.config.GUI_QML_ALWAYS_ALLOW_SCREENSHOTS = enable
         self.alwaysAllowScreenshotsChanged.emit()
 
+    setMaxBrightnessOnQrDisplayChanged = pyqtSignal()
+    @pyqtProperty(bool, notify=setMaxBrightnessOnQrDisplayChanged)
+    def setMaxBrightnessOnQrDisplay(self):
+        return self.config.GUI_QML_SET_MAX_BRIGHTNESS_ON_QR_DISPLAY
+
+    @setMaxBrightnessOnQrDisplay.setter
+    def setMaxBrightnessOnQrDisplay(self, enable):
+        self.config.GUI_QML_SET_MAX_BRIGHTNESS_ON_QR_DISPLAY = enable
+
     useRecoverableChannelsChanged = pyqtSignal()
     @pyqtProperty(bool, notify=useRecoverableChannelsChanged)
     def useRecoverableChannels(self):

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -1125,6 +1125,7 @@ Warning: setting this to too low will result in lots of payment failures."""),
     GUI_QML_ADDRESS_LIST_SHOW_TYPE = ConfigVar('address_list_show_type', default=1, type_=int)
     GUI_QML_ADDRESS_LIST_SHOW_USED = ConfigVar('address_list_show_used', default=False, type_=bool)
     GUI_QML_ALWAYS_ALLOW_SCREENSHOTS = ConfigVar('android_always_allow_screenshots', default=False, type_=bool)
+    GUI_QML_SET_MAX_BRIGHTNESS_ON_QR_DISPLAY = ConfigVar('android_set_max_brightness_on_qr_display', default=True, type_=bool)
 
     BTC_AMOUNTS_DECIMAL_POINT = ConfigVar('decimal_point', default=DECIMAL_POINT_DEFAULT, type_=int)
     BTC_AMOUNTS_FORCE_NZEROS_AFTER_DECIMAL_POINT = ConfigVar(


### PR DESCRIPTION
In #9170 a feature was added that enables max screen brightness when displaying QR codes. I don't usually use the QR code and prefer to just copy the address from this screen. This puts the max brightness feature behind a config setting so I can stop accidentally blinding myself every time I open the request screen lol.  