### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/electrum/paymentrequest.proto
+++ b/electrum/paymentrequest.proto
@@ -3,7 +3,7 @@
 //
 // Use fields 1000+ for extensions;
 // to avoid conflicts, register extensions via pull-req at
-// https://github.com/bitcoin/bips/bip-0070/extensions.mediawiki
+// https://github.com/bitcoin/bips/blob/master/bip-0070/extensions.mediawiki
 //
 
 syntax = "proto2";


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.