### PR TITLE
Catch UserCancelled exception in main window on user swap cancellation

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1174,6 +1174,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             except InvalidSwapParameters as e:
                 self.show_error(str(e))
                 return
+            except UserCancelled:
+                return
 
     def create_sm_transport(self):
         sm = self.wallet.lnworker.swap_manager


### PR DESCRIPTION
Fixes the following traceback in case a user cancels a reverse swap before the coordinator answered:
```bash
Traceback (most recent call last):
  File "/home/user/code/electrum/electrum/gui/qt/channels_list.py", line 366, in <lambda>
    menu.addAction(read_QIcon('update.png'), _('Submarine swap'), lambda: self.main_window.run_swap_dialog())
                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/user/code/electrum/electrum/gui/qt/main_window.py", line 1189, in run_swap_dialog
    return d.run(transport)
           ~~~~~^^^^^^^^^^^
  File "/home/user/code/electrum/electrum/gui/qt/swap_dialog.py", line 263, in run
    funding_txid = self.window.run_coroutine_dialog(coro, _('Initiating swap...'))
  File "/home/user/code/electrum/electrum/gui/qt/main_window.py", line 308, in run_coroutine_dialog
    return d.run()
           ~~~~~^^
  File "/home/user/code/electrum/electrum/gui/qt/util.py", line 397, in run
    raise self._exception
electrum.util.UserCancelled
```