### PR TITLE
Add filehash of external plugins to PluginDialog 

### DIFF
--- a/electrum/gui/qt/plugins_dialog.py
+++ b/electrum/gui/qt/plugins_dialog.py
@@ -8,7 +8,7 @@ from electrum.gui import messages
 from electrum.plugin import run_hook, BasePlugin
 
 from . import util
-from .util import WindowModalDialog, Buttons, CloseButton, HelpButton, WWLabel
+from .util import WindowModalDialog, Buttons, CloseButton, HelpButton, WWLabel, insert_spaces
 
 
 if TYPE_CHECKING:
@@ -23,6 +23,7 @@ class PluginDialog(WindowModalDialog):
         description = metadata.get('description', '')
         requires = metadata.get('requires')
         version = metadata.get('version', 'n/a')
+        zip_hash = metadata.get('zip_hash_sha256', None)
 
         WindowModalDialog.__init__(self, window, 'Plugin')
         self.setMinimumSize(400,250)
@@ -39,6 +40,8 @@ class PluginDialog(WindowModalDialog):
         form.addRow(QLabel(_('Author') + ':'), QLabel(author))
         form.addRow(QLabel(_('Description') + ':'), WWLabel(description))
         form.addRow(QLabel(_('Version') + ':'), QLabel(version))
+        if zip_hash:
+            form.addRow(QLabel('Hash [sha256]:'), WWLabel(insert_spaces(zip_hash, 8)))
         if requires:
             msg = '\n'.join(map(lambda x: x[1], requires))
             form.addRow(QLabel(_('Requires') + ':'), WWLabel(msg))

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -1473,6 +1473,9 @@ def qt_event_listener(func):
         self.qt_callback_signal.emit( (func,) + args)
     return decorator
 
+def insert_spaces(text: str, every_chars: int) -> str:
+    '''Insert spaces at every Nth character to allow for WordWrap'''
+    return ' '.join(text[i:i+every_chars] for i in range(0, len(text), every_chars))
 
 class _ABCQObjectMeta(type(QObject), ABCMeta): pass
 class _ABCQWidgetMeta(type(QWidget), ABCMeta): pass

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -45,6 +45,7 @@ from . import bip32
 from . import plugins
 from .simple_config import SimpleConfig
 from .logging import get_logger, Logger
+from .crypto import sha256
 
 if TYPE_CHECKING:
     from .plugins.hw_wallet import HW_PluginBase, HardwareClientBase, HardwareHandlerBase
@@ -222,6 +223,7 @@ class Plugins(DaemonThread):
                 if 'fullname' not in d:
                     continue
                 d['display_name'] = d['fullname']
+                d['zip_hash_sha256'] = get_file_hash256(path)
                 self.external_plugin_metadata[name] = d
 
     def load_external_plugins(self):
@@ -359,6 +361,10 @@ class Plugins(DaemonThread):
             self.run_jobs()
         self.on_stop()
 
+def get_file_hash256(path: str) -> str:
+    '''Get the sha256 hash of a file in hex, similar to `sha256sum`.'''
+    with open(path, 'rb') as f:
+        return sha256(f.read()).hex()
 
 def hook(func):
     hook_names.add(func.__name__)


### PR DESCRIPTION
This PR adds the sha256 hash of the zipfile of external plugins to the PluginDialog so users can see it when enabling a plugin. 

![Screenshot From 2025-01-09 18-07-20](https://github.com/user-attachments/assets/8eac748f-5e59-4ca7-9d3a-3ca430935133)

The hash is calculated when searching for plugins and split with a whitespace every 16 chars to allow for line wrapping and easier readability. 