### PR TITLE
fix: add extra check to script_GetOp

### DIFF
--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -620,7 +620,7 @@ def script_GetOp(_bytes : bytes):
                 i += 4
                             
             if nSize > _bytes_len - i:
-                raise MalformedBitcoinScript(f"Push of data element that is larger than remaining data: {nSize} vs {_bytes_len - i}")    
+                raise MalformedBitcoinScript(f"Push of data element that is larger than remaining data: {nSize} vs {_bytes_len - i}")
             
             vch = _bytes[i:i + nSize]
             i += nSize

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -618,10 +618,10 @@ def script_GetOp(_bytes : bytes):
                 try: (nSize,) = struct.unpack_from('<I', _bytes, i)
                 except struct.error: raise MalformedBitcoinScript()
                 i += 4
-                            
+
             if nSize > _bytes_len - i:
                 raise MalformedBitcoinScript(f"Push of data element that is larger than remaining data: {nSize} vs {_bytes_len - i}")
-            
+
             vch = _bytes[i:i + nSize]
             i += nSize
 

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -597,6 +597,7 @@ class BCDataStream(object):
 
 
 def script_GetOp(_bytes : bytes):
+    _bytes_len = len(_bytes)
     i = 0
     while i < len(_bytes):
         vch = None
@@ -617,6 +618,10 @@ def script_GetOp(_bytes : bytes):
                 try: (nSize,) = struct.unpack_from('<I', _bytes, i)
                 except struct.error: raise MalformedBitcoinScript()
                 i += 4
+                            
+            if nSize > _bytes_len - i:
+                raise MalformedBitcoinScript(f"Push of data element that is larger than remaining data: {nSize} vs {_bytes_len - i}")    
+            
             vch = _bytes[i:i + nSize]
             i += nSize
 


### PR DESCRIPTION
Hi
This check is done by bitcoinj when parsing chunks and there was a test case for it in that lib, so you can consider this a thought

test cases from bitcoinj for context:
```
  ["0x4c01","0x01 NOP", "P2SH,STRICTENC","BAD_OPCODE", "PUSHDATA1 with not enough bytes"],
  ["0x4d0200ff","0x01 NOP", "P2SH,STRICTENC","BAD_OPCODE", "PUSHDATA2 with not enough bytes"],
  ["0x4e03000000ffff","0x01 NOP", "P2SH,STRICTENC","BAD_OPCODE", "PUSHDATA4 with not enough bytes"],
```

feel free to close this if you think this is unnecessary, I would certainly be happy to know your opinion on this