### PR TITLE
remove btchip

### DIFF
--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -41,11 +41,6 @@ try:
     # legacy imports
     # note: we could replace "btchip" with "ledger_bitcoin.btchip" but the latter does not support HW.1
     import hid
-    from btchip.btchipComm import HIDDongleHIDAPI
-    from btchip.btchip import btchip
-    from btchip.btchipUtils import compress_public_key
-    from btchip.bitcoinTransaction import bitcoinTransaction
-    from btchip.btchipException import BTChipException
 
     LEDGER_BITCOIN = True
 except ImportError as e:


### PR DESCRIPTION
Addresses issue  #[9370](https://github.com/spesmilo/electrum/issues/9370).

`ledger_bitcoin` already ships with a copy of the `btchip` module and `btchip-python` is unmaintained and [archived as of Oct 14, 2024](https://github.com/LedgerHQ/btchip-python). 

Despite `btchip-python` no longer being used in electrum ([except for only HW.1](https://github.com/spesmilo/electrum/issues/9370#issuecomment-2572626499)), as of the upgrade to Ubuntu 24.04 [with a newer `setuptools`](https://github.com/spesmilo/electrum/issues/9370#issuecomment-2586757615) it causes an error that disables access with a Ledger to Electrum. 

