### PR TITLE
lightning: change derivation of funding_pubkey

### DIFF
--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -132,7 +132,7 @@ class LNWatcher(Logger, EventListener):
         if not keep_watching:
             await self.unwatch_channel(address, funding_outpoint)
 
-    async def sweep_commitment_transaction(self, funding_outpoint, closing_tx) -> bool:
+    async def sweep_commitment_transaction(self, funding_outpoint: str, closing_tx: Transaction) -> bool:
         raise NotImplementedError()  # implemented by subclasses
 
     async def update_channel_state(self, *, funding_outpoint: str, funding_txid: str,

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -206,7 +206,11 @@ async def sweep(
     return tx
 
 
-def get_locktime_for_new_transaction(network: 'Network') -> int:
+def get_locktime_for_new_transaction(
+    network: 'Network',
+    *,
+    include_random_component: bool = True,
+) -> int:
     # if no network or not up to date, just set locktime to zero
     if not network:
         return 0
@@ -225,8 +229,9 @@ def get_locktime_for_new_transaction(network: 'Network') -> int:
     locktime = min(chain_height, server_height)
     # sometimes pick locktime a bit further back, to help privacy
     # of setups that need more time (offline/multisig/coinjoin/...)
-    if random.randint(0, 9) == 0:
-        locktime = max(0, locktime - random.randint(0, 99))
+    if include_random_component:
+        if random.randint(0, 9) == 0:
+            locktime = max(0, locktime - random.randint(0, 99))
     locktime = max(0, locktime)
     return locktime
 

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -72,7 +72,7 @@ class WalletUnfinished(WalletFileException):
 # seed_version is now used for the version of the wallet file
 OLD_SEED_VERSION = 4        # electrum versions < 2.0
 NEW_SEED_VERSION = 11       # electrum versions >= 2.0
-FINAL_SEED_VERSION = 59     # electrum >= 2.7 will set this to prevent
+FINAL_SEED_VERSION = 60     # electrum >= 2.7 will set this to prevent
                             # old versions from overwriting new format
 
 
@@ -234,6 +234,7 @@ class WalletDBUpgrader(Logger):
         self._convert_version_57()
         self._convert_version_58()
         self._convert_version_59()
+        self._convert_version_60()
         self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
 
     def _convert_wallet_type(self):
@@ -1145,6 +1146,15 @@ class WalletDBUpgrader(Logger):
             chan['unfulfilled_htlcs'] = unfulfilled_htlcs
         self.data['channels'] = channels
         self.data['seed_version'] = 59
+
+    def _convert_version_60(self):
+        if not self._is_upgrade_method_needed(59, 59):
+            return
+        cbs = self.data.get('imported_channel_backups', {})
+        for channel_id, cb in list(cbs.items()):
+            if 'multisig_funding_privkey' not in cb:
+                cb['multisig_funding_privkey'] = None
+        self.data['seed_version'] = 60
 
     def _convert_imported(self):
         if not self._is_upgrade_method_needed(0, 13):

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -156,6 +156,7 @@ if [[ $1 == "backup" ]]; then
     echo "alice opens channel"
     bob_node=$($bob nodeid)
     channel1=$($alice open_channel $bob_node 0.15 --password='')
+    new_blocks 1  # cannot open multiple chans with same node in same block
     $alice setconfig use_recoverable_channels False
     channel2=$($alice open_channel $bob_node 0.15 --password='')
     new_blocks 3

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -1086,6 +1086,7 @@ class TestLNUtil(ElectrumTestCase):
                 remote_payment_pubkey=bfh('02a1bbc818e2e88847016a93c223eb4adef7bb8becb3709c75c556b6beb3afe7bd'),
                 remote_revocation_pubkey=bfh('022f28b7d8d1f05768ada3df1b0966083b8058e1e7197c57393e302ec118d7f0ae'),
                 local_payment_pubkey=None,
+                multisig_funding_privkey=None,
             ),
             decoded_cb,
         )
@@ -1113,6 +1114,7 @@ class TestLNUtil(ElectrumTestCase):
                 remote_payment_pubkey=bfh('02a1bbc818e2e88847016a93c223eb4adef7bb8becb3709c75c556b6beb3afe7bd'),
                 remote_revocation_pubkey=bfh('022f28b7d8d1f05768ada3df1b0966083b8058e1e7197c57393e302ec118d7f0ae'),
                 local_payment_pubkey=bfh('0308d686712782a44b0cef220485ad83dae77853a5bf8501a92bb79056c9dcb25a'),
+                multisig_funding_privkey=None,
             ),
             decoded_cb,
         )


### PR DESCRIPTION
Ideally, given an on-chain backup, after the remote force-closes, we should be able to spend our anchor output, to CPFP the remote commitment tx (assuming the channel used OPTION_ANCHORS). To spend the anchor output, we need to be able to sign with the local funding_privkey.

Previously we derived the funding_key from the channel_seed (which comes from os.urandom). Prior to anchors, there was no use case for signing with the funding_key given a channel backup. Now with anchors, we should make its derivation deterministic somehow, in a way so that it can be derived given just an on-chain backup.
- one way would be to put some more data into the existing OP_RETURN
  - uses block space
  - the OP_RETURNs can be disabled via "use_recoverable_channels"
  - only the initiator can use OP_RETURNs (so what if channel is in incoming dir?)
- instead, new scheme for our funding_key:
  - we derive the funding_privkey from the lnworker root secret (derived from our bip32 seed)
  - for outgoing channels:
    - lnworker_root_secret + remote_node_id + funding_tx_nlocktime
  - for incoming channels:
    - lnworker_root_secret + remote_node_id + remote_funding_pubkey
  - a check is added to avoid reusing the same key between channels: not letting to user open more than one channel with the same peer in a single block
  - only the first 16 bytes of the remote_node_id are used, as the onchain backup OP_RETURNs only contain that
  - note: we could even derive channel_seed deterministically this way
	- that would make avoiding reuse really security-critical
		(e.g. rev_acks across different chans reusing ~same revocation secrets)
	- for the funding_key in isolation, a potential key reuse is only a privacy risk.
- as the funding_privkey cannot be derived from the channel_seed anymore, it is included in the imported channel backups, which in turn need a new version defined
  - a **wallet db upgrade** is used to update already stored imported cbs
  - alternatively we could keep the imported cbs as-is, so no new version, no new funding_privkey field, as it is clearly somewhat redundant given on-chain backups can reconstruct it
    - however adding the field seems easier
      - otherwise the existing code would try to derive the funding_privkey from the channel_seed
      - also note: atm there is no field in the imported backups to distinguish anchor channels vs static-remotekey channels
