### PR TITLE
Fix trampoline onion construction by selecting correct last hop

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1605,7 +1605,7 @@ class Peer(Logger, EventListener):
         # if we are forwarding a trampoline payment, add trampoline onion
         if trampoline_onion:
             self.logger.info(f'adding trampoline onion to final payload')
-            trampoline_payload = hops_data[num_hops-2].payload
+            trampoline_payload = hops_data[-1].payload
             trampoline_payload["trampoline_onion_packet"] = {
                 "version": trampoline_onion.version,
                 "public_key": trampoline_onion.public_key,


### PR DESCRIPTION
The trampoline onion construction in ```create_onion_for_route()``` was not including the trampoline payload to the last hop which caused forwarding to fail. By changing the index accessing hops_data to the last element (-1) it now works.