### PR TITLE
Change OnionFailureCode returned when failing trampoline forwarding

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -2016,7 +2016,7 @@ class Peer(Logger, EventListener):
             self.logger.debug(
                 f"maybe_forward_trampoline. PaymentFailure for {payment_hash.hex()=}, {payment_secret.hex()=}: {e!r}")
             # FIXME: adapt the error code
-            raise OnionRoutingFailure(code=OnionFailureCode.UNKNOWN_NEXT_PEER, data=b'')
+            raise OnionRoutingFailure(code=OnionFailureCode.TRAMPOLINE_FEE_INSUFFICIENT, data=b'')
 
     def _maybe_refuse_to_forward_htlc_that_corresponds_to_payreq_we_created(self, payment_hash: bytes) -> bool:
         """Returns True if the HTLC should be failed.


### PR DESCRIPTION
This changes the OnionFailureCode returned from ```maybe_forward_trampoline()``` on ```PaymentFailure``` to ```TRAMPOLINE_FEE_INSUFFICIENT``` so the client will retry the payment with higher trampoline fee instead of giving up. 