### PR TITLE
Reload existing peers into ChannelDB when enabling gossip

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -127,6 +127,9 @@ class SettingsDialog(QDialog, QtEventListener):
             self.config.LIGHTNING_USE_GOSSIP = not use_trampoline
             if not use_trampoline:
                 self.network.start_gossip()
+                if self.wallet.lnworker is not None:
+                    # add existing peers to ChannelDB
+                    self.wallet.lnworker.reload_peers_into_channeldb()
             else:
                 self.network.run_from_another_thread(
                     self.network.stop_gossip())

--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -127,9 +127,6 @@ class SettingsDialog(QDialog, QtEventListener):
             self.config.LIGHTNING_USE_GOSSIP = not use_trampoline
             if not use_trampoline:
                 self.network.start_gossip()
-                if self.wallet.lnworker is not None:
-                    # add existing peers to ChannelDB
-                    self.wallet.lnworker.reload_peers_into_channeldb()
             else:
                 self.network.run_from_another_thread(
                     self.network.stop_gossip())

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -436,6 +436,15 @@ class LNWorker(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
             for chan in peer.channels.values():
                 chan.add_or_update_peer_addr(peer_addr)
 
+    def reload_peers_into_channeldb(self) -> None:
+        '''Loads existing peers into the gossip ChannelDB'''
+        if self.uses_trampoline() or self.channel_db is None:
+            return
+        for peer in self.peers.values():
+            if not peer.is_initialized() or not isinstance(peer.transport, LNTransport):
+                continue
+            self.channel_db.add_recent_peer(peer.transport.peer_addr)
+
     async def _get_next_peers_to_try(self) -> Sequence[LNPeerAddr]:
         now = time.time()
         await self.channel_db.data_loaded.wait()


### PR DESCRIPTION
Currently when enabling gossip (disabling trampoline) in the qt settings dialog the ChannelDB will be created and doesn't contain peers. Peers get added to the ChannelDB by lnworker on connection, but not when enabling gossip. So the newly created gossip has to access fallback nodes because the ChannelDB is empty even though we already know about our channel peers. 
This PR will trigger a reload of the existing peers into the ChannelDB when disabling trampoline so we don't solely rely on the fallback nodes.