### PR TITLE
Bump allowed aiorpcx version to 0.24

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -1,7 +1,7 @@
 qrcode
 protobuf>=3.20,<4
 qdarkstyle>=3.2
-aiorpcx>=0.22.0,<0.24
+aiorpcx>=0.22.0,<0.25
 aiohttp>=3.3.0,<4.0.0
 aiohttp_socks>=0.8.4
 certifi

--- a/run_electrum
+++ b/run_electrum
@@ -75,8 +75,8 @@ def check_imports():
         import aiorpcx
     except ImportError as e:
         sys.exit(f"Error: {str(e)}. Try 'sudo python3 -m pip install <module-name>'")
-    if not ((0, 22, 0) <= aiorpcx._version < (0, 24)):
-        raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.24')
+    if not ((0, 22, 0) <= aiorpcx._version < (0, 25)):
+        raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.25')
     # the following imports are for pyinstaller
     from google.protobuf import descriptor
     from google.protobuf import message


### PR DESCRIPTION
Increase the allowed version of [aiorpcx](https://github.com/kyuupichan/aiorpcX) to the new 0.24 version, which uses the new websockets version, so it's possible to get rid of the websockets deprecation warning when starting electrum.
Changelog of aiorpcX 0.24: [Changelog](https://github.com/kyuupichan/aiorpcX/blob/master/docs/changelog.rst#version-024-16-jan-2024)