### PR TITLE
Handle reverse swap exception more gracefully

### DIFF
--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -270,8 +270,12 @@ class SwapDialog(WindowModalDialog, QtEventListener):
                 expected_onchain_amount_sat=onchain_amount + self.swap_manager.get_claim_fee(),
                 zeroconf=self.zeroconf,
             )
-            # we must not leave the context, so we use run_couroutine_dialog
-            funding_txid = self.window.run_coroutine_dialog(coro, _('Initiating swap...'))
+            try:
+                # we must not leave the context, so we use run_couroutine_dialog
+                funding_txid = self.window.run_coroutine_dialog(coro, _('Initiating swap...'))
+            except Exception as e:
+                self.window.show_error(f"Reverse swap failed: {str(e)}")
+                return
             self.window.on_swap_result(funding_txid, is_reverse=True)
             return True
         else:


### PR DESCRIPTION
Currently when we raise an exception on creation of a reverse swap it pops up to the GUI. This PR handles exceptions as we do in ```do_normal_swap()```., it shows the user an error dialog with the exception. 

Example exception now caught:
```
3602.51 | E | gui.qt.exception_window.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
  File "/home/user/code/electrum-fork/electrum/gui/qt/channels_list.py", line 366, in <lambda>
    menu.addAction(read_QIcon('update.png'), _('Submarine swap'), lambda: self.main_window.run_swap_dialog())
                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 1190, in run_swap_dialog
    return d.run(transport)
           ~~~~~^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/swap_dialog.py", line 274, in run
    funding_txid = self.window.run_coroutine_dialog(coro, _('Initiating swap...'))
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 309, in run_coroutine_dialog
    return d.run()
           ~~~~~^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/util.py", line 397, in run
    raise self._exception
  File "/home/user/code/electrum-fork/electrum/gui/qt/util.py", line 387, in task
    self._result = self._future.result()
                   ~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.13/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/user/code/electrum-fork/electrum/submarine_swaps.py", line 878, in reverse_swap
    raise Exception(f"rswap check failed: onchain_amount is less than what we expected: "
                    f"{onchain_amount} < {expected_onchain_amount_sat}")
Exception: rswap check failed: onchain_amount is less than what we expected: 18178 < 18260
```