### PR TITLE
Use getlocale() instead of getdefaultlocale() in crash reporter

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -124,7 +124,7 @@ class BaseCrashReporter(Logger):
             "python_version": sys.version,
             "os": describe_os_version(),
             "wallet_type": "unknown",
-            "locale": locale.getdefaultlocale()[0] or "?",
+            "locale": locale.getlocale()[0] or "?",
             "description": self.get_user_description()
         }
         try:


### PR DESCRIPTION
Changes usage of the depreciated [```locale.getdefaultlocale()```](https://docs.python.org/3/library/locale.html#locale.getdefaultlocale) to the new [```locale.getlocale()```](https://docs.python.org/3/library/locale.html#locale.getlocale) to fix the following depreciation warning:
```
../electrum/base_crash_reporter.py:127: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
  "locale": locale.getdefaultlocale()[0] or "?",
```