### PR TITLE
qml: apply TxInput/TxOutput coloring for swap and billing addresses.

### DIFF
--- a/electrum/gui/qml/components/Constants.qml
+++ b/electrum/gui/qml/components/Constants.qml
@@ -68,6 +68,7 @@ Item {
     property color colorAddressUsedWithBalance: Qt.rgba(0.75,0.75,0.75,1)
     property color colorAddressFrozen: Qt.rgba(0.5,0.5,1,1)
     property color colorAddressBilling: "#8cb3f2"
+    property color colorAddressSwap: colorAddressBilling
 
     function colorAlpha(baseColor, alpha) {
         return Qt.rgba(baseColor.r, baseColor.g, baseColor.b, alpha)

--- a/electrum/gui/qml/components/controls/TxInput.qml
+++ b/electrum/gui/qml/components/controls/TxInput.qml
@@ -11,6 +11,12 @@ TextHighlightPane {
     property variant model
     property int idx: -1
 
+    property string _suffix: model.is_mine || model.is_change
+            ? qsTr('mine')
+            : model.is_swap
+                ? qsTr('swap')
+                : ""
+
     ColumnLayout {
         width: parent.width
 
@@ -55,16 +61,21 @@ TextHighlightPane {
             Label {
                 Layout.fillWidth: true
                 text: model.address
-                    ? model.address
+                    ? model.address + (_suffix
+                        ? ' <span style="font-size:' + constants.fontSizeXSmall + 'px">(' + _suffix + ')</span>'
+                        : "")
                     : '&lt;' + qsTr('address unknown') + '&gt;'
                 font.family: FixedFont
                 font.pixelSize: constants.fontSizeMedium
+                textFormat: Text.RichText
                 color: model.is_mine
                     ? model.is_change
                         ? constants.colorAddressInternal
                         : constants.colorAddressExternal
-                    : Material.foreground
-                elide: Text.ElideMiddle
+                    : model.is_swap
+                        ? constants.colorAddressSwap
+                        : Material.foreground
+                wrapMode: Text.WrapAnywhere
             }
         }
 

--- a/electrum/gui/qml/components/controls/TxOutput.qml
+++ b/electrum/gui/qml/components/controls/TxOutput.qml
@@ -13,6 +13,14 @@ TextHighlightPane {
     property bool allowClickAddress: true
     property int idx: -1
 
+    property string _suffix: model.is_mine || model.is_change
+            ? qsTr('mine')
+            : model.is_swap
+                ? qsTr('swap')
+                : model.is_billing
+                    ? qsTr('billing')
+                    : ""
+
     RowLayout {
         width: parent.width
 
@@ -57,18 +65,23 @@ TextHighlightPane {
             RowLayout {
                 Layout.fillWidth: true
                 Label {
-                    text: model.address
+                    text: model.address + (_suffix
+                        ? ' <span style="font-size:' + constants.fontSizeXSmall + 'px">(' + _suffix + ')</span>'
+                        : "")
                     Layout.fillWidth: true
                     wrapMode: Text.Wrap
                     font.pixelSize: constants.fontSizeMedium
                     font.family: FixedFont
+                    textFormat: Text.RichText
                     color: model.is_mine
                         ? model.is_change
                             ? constants.colorAddressInternal
                             : constants.colorAddressExternal
                         : model.is_billing
                             ? constants.colorAddressBilling
-                            : Material.foreground
+                            : model.is_swap
+                                ? constants.colorAddressSwap
+                                : Material.foreground
                     TapHandler {
                         enabled: allowClickAddress && model.is_mine
                         onTapped: {


### PR DESCRIPTION
Instead of a legend for the colors, I suffixed the inputs/outputs with a short description. Feedback welcome if legend is preferred over suffixed approach