### PR TITLE
Remove query_short_channel_ids zlib compression

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -605,16 +605,17 @@ class Peer(Logger, EventListener):
         await self.querying.wait()
         self.querying.clear()
 
-    def query_short_channel_ids(self, ids, compressed=True):
+    def query_short_channel_ids(self, ids):
+        # compression MUST NOT be used according to updated bolt
+        # (https://github.com/lightning/bolts/pull/981)
         ids = sorted(ids)
         s = b''.join(ids)
-        encoded = zlib.compress(s) if compressed else s
-        prefix = b'\x01' if compressed else b'\x00'
+        prefix = b'\x00'  # uncompressed
         self.send_message(
             'query_short_channel_ids',
             chain_hash=constants.net.rev_genesis_bytes(),
-            len=1+len(encoded),
-            encoded_short_ids=prefix+encoded)
+            len=1+len(s),
+            encoded_short_ids=prefix+s)
 
     async def _message_loop(self):
         try:


### PR DESCRIPTION
We send the query_short_channel_ids gossip message with zlib compression encoding enabled by default. However this was removed/forbidden in the bolt spec in this PR https://github.com/lightning/bolts/pull/981 and must not be done anymore, see https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#query-messages. I removed the compression part completely as i see no case where it could be used anymore.