### PR TITLE
Do gossip timestamp request so we get sent gossip by peers

### DIFF
--- a/electrum/channel_db.py
+++ b/electrum/channel_db.py
@@ -699,6 +699,15 @@ class ChannelDB(SqlDB):
         self.logger.debug("on_node_announcement: %d/%d"%(len(new_nodes), len(msg_payloads)))
         self.update_counts()
 
+    def get_youngest_policy_timestamp(self) -> int:
+        timestamp = 0
+        with self.lock:
+            _policies = self._policies.copy()
+        for policy in _policies.values():
+            if policy.timestamp > timestamp:
+                timestamp = policy.timestamp
+        return timestamp
+
     def get_old_policies(self, delta) -> Sequence[Tuple[bytes, ShortChannelID]]:
         with self.lock:
             _policies = self._policies.copy()


### PR DESCRIPTION
Bolt 7 says in [Rebroadcasting](https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#rebroadcasting) 

> MUST not send gossip it did not generate itself, until it receives gossip_timestamp_filter.

We already had the function ```request_gossip()``` which was never called, so we only pulled the gossip by requesting channel ids in ```query_gossip()``` but never told the peer to forward gossip to us (by sending ```gossip_timestamp_filter```). 
With this PR we also first check if the peer supports gossip queries (has ```gossip_queries``` feature bit) and limit the gossip fetching a bit by not requesting the full gossip every time we connect.