### PR TITLE
fix Coldcard msg signing for segwit v0 address types

### DIFF
--- a/electrum/plugins/coldcard/coldcard.py
+++ b/electrum/plugins/coldcard/coldcard.py
@@ -212,9 +212,9 @@ class CKCCClient(HardwareClientBase):
         return self.dev.send_recv(CCProtocolPacker.version(), timeout=1000).split('\n')
 
     @runs_in_hwd_thread
-    def sign_message_start(self, path, msg):
+    def sign_message_start(self, path, msg, addr_fmt):
         # this starts the UX experience.
-        self.dev.send_recv(CCProtocolPacker.sign_message(msg, path), timeout=None)
+        self.dev.send_recv(CCProtocolPacker.sign_message(msg, path, addr_fmt), timeout=None)
 
     @runs_in_hwd_thread
     def sign_message_poll(self):
@@ -328,12 +328,18 @@ class Coldcard_KeyStore(Hardware_KeyStore):
             return b''
 
         path = self.get_derivation_prefix() + ("/%d/%d" % sequence)
+
+        if script_type:
+            addr_fmt = self._encode_txin_type(script_type)
+        else:
+            addr_fmt = AF_CLASSIC
+
         try:
             cl = self.get_client()
             try:
                 self.handler.show_message("Signing message (using %s)..." % path)
 
-                cl.sign_message_start(path, msg)
+                cl.sign_message_start(path, msg, addr_fmt)
 
                 while 1:
                     # How to kill some time, without locking UI?


### PR DESCRIPTION
* this is bug where electrum showed correct address (i.e `p2wpkh` or `p2sh-p2wpkh`) but Coldcard was always showing `p2pkh` address. Msg verifies OK (sig correct) as all the address types for specific path have same public key, but address verification on device is not possible