### PR TITLE
Introduce incoming gossip query handling and forwarding

### DIFF
--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -9,6 +9,7 @@ from collections import namedtuple, defaultdict
 from typing import NamedTuple, List, Tuple, Mapping, Optional, TYPE_CHECKING, Union, Dict, Set, Sequence
 import re
 import sys
+import time
 
 import electrum_ecc as ecc
 from electrum_ecc import CURVE_ORDER, ecdsa_sig64_from_der_sig, ECPubkey, string_to_number
@@ -1509,6 +1510,10 @@ class LnFeatures(IntFlag):
                 features |= (1 << flag)
         return features
 
+    def min_len(self) -> int:
+        b = int.bit_length(self)
+        return b // 8 + int(bool(b % 8))
+
     def supports(self, feature: 'LnFeatures') -> bool:
         """Returns whether given feature is enabled.
 
@@ -1633,6 +1638,56 @@ def get_ln_flag_pair_of_bit(flag_bit: int) -> int:
     else:
         return flag_bit - 1
 
+
+class GossipTimestampFilter:
+    def __init__(self, first_timestamp: int, timestamp_range: int):
+        self.first_timestamp = first_timestamp
+        self.timestamp_range = timestamp_range
+        # True once we sent them the requested gossip and only forward
+        self.only_forwarding = False
+        if first_timestamp >= int(time.time()) - 20:
+            self.only_forwarding = True
+
+    def __str__(self):
+        return (f"GossipTimestampFilter | first_timestamp={self.first_timestamp} | "
+                f"timestamp_range={self.timestamp_range}")
+
+    def in_range(self, timestamp: int) -> bool:
+        return self.first_timestamp <= timestamp < self.first_timestamp + self.timestamp_range
+
+    @classmethod
+    def from_payload(cls, payload) -> Optional['GossipTimestampFilter']:
+        try:
+            first_timestamp = payload['first_timestamp']
+            timestamp_range = payload['timestamp_range']
+        except KeyError:
+            return None
+        if first_timestamp >= 0xFFFFFFFF:
+            return None
+        return cls(first_timestamp, timestamp_range)
+
+
+class GossipForwardingMessage:
+    def __init__(self,
+                 msg: bytes,
+                 scid: Optional[ShortChannelID] = None,
+                 timestamp: Optional[int] = None,
+                 sender_node_id: Optional[bytes] = None):
+        self.scid: Optional[ShortChannelID] = scid
+        self.sender_node_id: Optional[bytes] = sender_node_id
+        self.msg = msg
+        self.timestamp = timestamp
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> Optional['GossipForwardingMessage']:
+        try:
+            msg = payload['raw']
+            scid = ShortChannelID.normalize(payload.get('short_channel_id'))
+            sender_node_id = payload.get('sender_node_id')
+            timestamp = payload.get('timestamp')
+        except KeyError:
+            return None
+        return cls(msg, scid, timestamp, sender_node_id)
 
 def list_enabled_ln_feature_bits(features: int) -> tuple[int, ...]:
     """Returns a list of enabled feature bits. If both opt and req are set, only

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -1247,7 +1247,7 @@ class TestPeerDirect(TestPeer):
         async def action():
             await util.wait_for2(p1.initialized, 1)
             await util.wait_for2(p2.initialized, 1)
-            await p1.send_warning(alice_channel.channel_id, 'be warned!', close_connection=True)
+            p1.send_warning(alice_channel.channel_id, 'be warned!', close_connection=True)
         gath = asyncio.gather(action(), p1._message_loop(), p2._message_loop(), p1.htlc_switch(), p2.htlc_switch())
         with self.assertRaises(GracefulDisconnect):
             await gath
@@ -1259,7 +1259,7 @@ class TestPeerDirect(TestPeer):
         async def action():
             await util.wait_for2(p1.initialized, 1)
             await util.wait_for2(p2.initialized, 1)
-            await p1.send_error(alice_channel.channel_id, 'some error happened!', force_close_channel=True)
+            p1.send_error(alice_channel.channel_id, 'some error happened!', force_close_channel=True)
             assert alice_channel.is_closed()
             gath.cancel()
         gath = asyncio.gather(action(), p1._message_loop(), p2._message_loop(), p1.htlc_switch(), p2.htlc_switch())


### PR DESCRIPTION
This PR implements handling the [query messages](https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#query-messages) defined in BOLT-7.

Only `LNWallet` peers forward gossip messages and handle queries. This allows peers to find us (`LNWallet` publishes `node_announcement`), and prevents peers from querying both `LNGossip` and `LNWallet` for the same data. All this functionality will only be active if payment forwarding is enabled too.

### Queries
Queries are handled directly in the `Peer`, when receiving a query the Peer will fetch the requested messages from `ChannelDB` and forward them. Simultaneous queries are disallowed and dropped with warning.

### Forwarding
When receiving a `gossip_timestamp_filter` message it is stored as non-persisted variable of the `Peer`. 
When we receive gossip it is added to a separate queues in ChannelDB after validation. LNGossip requests these queues with the provided method in ChannelDB in an interval of 60 sec and provides a single list of all queued messages to be accessed by the single peers. Every `Peer` checks this list for changes (updated timestamp) occasionally and forwards it to the peer if it has been refreshed. 
In case our peer requested additional gossip (before the current timestamp), the `Peer` will query it directly from the `ChannelDB` and send it together with the gossip to be forwarded. 

### Additional changes
* made `send_warning` and `send_error` sync, because there is no reason for them to be `async`
* send `gossip_timestamp_filter` with time=now to `LNGossip` peers for them to forward new gossip messages to us.
* consider count of nodes we have in `ChannelDB` when calculating progress in `get_sync_progress_estimate()` to prevent us from jumping to 100% while not having received a single `node_announcement`, this can happen when peers send `node_announcements` last in order. This makes `is_synced()` more reliable.