### PR TITLE
Show flat fee in qml swap provider selection

### DIFF
--- a/electrum/gui/qml/components/NostrSwapServersDialog.qml
+++ b/electrum/gui/qml/components/NostrSwapServersDialog.qml
@@ -96,7 +96,7 @@ ElDialog {
                             }
                             Label {
                                 Layout.fillWidth: true
-                                text: model.percentage_fee + '%'
+                                text: model.percentage_fee + '% + ' + model.mining_fee + ' sat'
                             }
                             Label {
                                 text: qsTr('last seen')


### PR DESCRIPTION
Shows flat mining fee of the swap provider in the qml gui. See `+ 150 sat` below:

![Screenshot From 2025-02-21 08-58-19](https://github.com/user-attachments/assets/da7d2c5c-7bcb-402a-aa90-a58c36ae2901)
