### PR TITLE
reintroduce separate request types for lightning and onchain

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1074,17 +1074,20 @@ class Commands(Logger):
         return wallet.get_unused_address()
 
     @command('w')
-    async def add_request(self, amount, memo='', expiry=3600, force=False, wallet: Abstract_Wallet = None):
+    async def add_request(self, amount, memo='', expiry=3600, lightning=False, force=False, wallet: Abstract_Wallet = None):
         """Create a payment request, using the first unused address of the wallet.
         The address will be considered as used after this operation.
         If no payment is received, the address will be considered as unused if the payment request is deleted from the wallet."""
-        addr = wallet.get_unused_address()
-        if addr is None:
-            if force:
-                addr = wallet.create_new_address(False)
-            else:
-                return False
         amount = satoshis(amount)
+        if not lightning:
+            addr = wallet.get_unused_address()
+            if addr is None:
+                if force:
+                    addr = wallet.create_new_address(False)
+                else:
+                    return False
+        else:
+            addr = None
         expiry = int(expiry) if expiry else None
         key = wallet.create_request(amount, memo, expiry, addr)
         req = wallet.get_request(key)
@@ -1586,6 +1589,8 @@ command_options = {
     'addtransaction': (None,'Whether transaction is to be used for broadcasting afterwards. Adds transaction to the wallet'),
     'domain':      ("-D", "List of addresses"),
     'memo':        ("-m", "Description of the request"),
+    'amount':      (None, "Requested amount (in btc)"),
+    'lightning':   (None, "Create lightning request"),
     'expiry':      (None, "Time in seconds"),
     'timeout':     (None, "Timeout in seconds"),
     'force':       (None, "Create new address beyond gap limit, if no more addresses are available."),

--- a/electrum/gui/qml/components/ReceiveDetailsDialog.qml
+++ b/electrum/gui/qml/components/ReceiveDetailsDialog.qml
@@ -106,6 +106,7 @@ ElDialog {
             }
             FlatButton {
                 Layout.fillWidth: true
+                enabled: Daemon.currentWallet.isLightning && Daemon.currentWallet.lightningCanReceive.satsInt > amountBtc.textAsSats.satsInt
                 text: qsTr('Lightning')
                 icon.source: '../../icons/lightning.png'
                 onClicked: { dialog.isLightning = true; doAccept() }

--- a/electrum/gui/qml/components/ReceiveDetailsDialog.qml
+++ b/electrum/gui/qml/components/ReceiveDetailsDialog.qml
@@ -11,12 +11,13 @@ import "controls"
 ElDialog {
     id: dialog
 
-    title: qsTr('Receive payment')
+    title: qsTr('Create Invoice')
     iconSource: Qt.resolvedUrl('../../icons/tab_receive.png')
 
     property alias amount: amountBtc.text
     property alias description: message.text
     property alias expiry: expires.currentValue
+    property bool isLightning: false
 
     padding: 0
 
@@ -93,11 +94,22 @@ ElDialog {
             }
         }
 
-        FlatButton {
-            Layout.fillWidth: true
-            text: qsTr('Create request')
-            icon.source: '../../icons/confirmed.png'
-            onClicked: doAccept()
+        GridLayout {
+            width: parent.width
+	    columns: 2
+
+            FlatButton {
+                Layout.fillWidth: true
+                text: qsTr('Onchain')
+                icon.source: '../../icons/bitcoin.png'
+                onClicked: { dialog.isLightning = false; doAccept() }
+            }
+            FlatButton {
+                Layout.fillWidth: true
+                text: qsTr('Lightning')
+                icon.source: '../../icons/lightning.png'
+                onClicked: { dialog.isLightning = true; doAccept() }
+            }
         }
     }
 

--- a/electrum/gui/qml/components/ReceiveDialog.qml
+++ b/electrum/gui/qml/components/ReceiveDialog.qml
@@ -48,21 +48,6 @@ ElDialog {
                 width: parent.width
                 spacing: constants.paddingMedium
 
-                states: [
-                    State {
-                        name: 'bolt11'
-                        PropertyChanges { target: qrloader; sourceComponent: qri_bolt11 }
-                    },
-                    State {
-                        name: 'bip21uri'
-                        PropertyChanges { target: qrloader; sourceComponent: qri_bip21uri }
-                    },
-                    State {
-                        name: 'address'
-                        PropertyChanges { target: qrloader; sourceComponent: qri_address }
-                    }
-                ]
-
                 TextHighlightPane {
                     Layout.alignment: Qt.AlignHCenter
                     Layout.fillWidth: true
@@ -80,33 +65,15 @@ ElDialog {
 
                             color: 'white'
 
-                            Loader {
-                                id: qrloader
+                            QRImage {
                                 anchors.centerIn: parent
-                                Component {
-                                    id: qri_bolt11
-                                    QRImage {
-                                        qrdata: _bolt11
-                                        render: _render_qr
-                                        enableToggleText: true
-                                    }
-                                }
-                                Component {
-                                    id: qri_bip21uri
-                                    QRImage {
-                                        qrdata: _bip21uri
-                                        render: _render_qr
-                                        enableToggleText: true
-                                    }
-                                }
-                                Component {
-                                    id: qri_address
-                                    QRImage {
-                                        qrdata: _address
-                                        render: _render_qr
-                                        enableToggleText: true
-                                    }
-                                }
+                                qrdata: _bolt11
+                                    ? _bolt11
+                                    : _bip21uri
+                                        ? _bip21uri
+                                        : _address
+                                render: _render_qr
+                                enableToggleText: true
                             }
                         }
                     }
@@ -250,22 +217,6 @@ ElDialog {
     RequestDetails {
         id: request
         wallet: Daemon.currentWallet
-        onDetailsChanged: {
-            var req_type = Config.preferredRequestType
-            if (bolt11 && req_type == 'bolt11') {
-                rootLayout.state = 'bolt11'
-            } else if (bip21 && req_type == 'bip21uri') {
-                rootLayout.state = 'bip21uri'
-            } else if (req_type == 'address') {
-                rootLayout.state = 'address'
-            } else if (bolt11) {
-                rootLayout.state = 'bolt11'
-            } else if (bip21) {
-                rootLayout.state = 'bip21uri'
-            } else {
-                rootLayout.state = 'address'
-            }
-        }
         onStatusChanged: {
             if (status == RequestDetails.Paid || status == RequestDetails.Unconfirmed) {
                 _ispaid = true

--- a/electrum/gui/qml/components/ReceiveDialog.qml
+++ b/electrum/gui/qml/components/ReceiveDialog.qml
@@ -109,63 +109,6 @@ ElDialog {
                                 }
                             }
                         }
-
-                        ButtonContainer {
-                            Layout.fillWidth: true
-                            showSeparator: false
-                            Component {
-                                id: _ind
-                                Rectangle {
-                                    color: Material.dialogColor
-                                    opacity: parent.checked ? 1 : 0
-                                    radius: 5
-                                    width: parent.width
-                                    height: parent.height
-
-                                    Behavior on opacity {
-                                        NumberAnimation { duration: 200 }
-                                    }
-                                }
-                            }
-                            TabButton {
-                                id: bolt11Button
-                                Layout.fillWidth: true
-                                Layout.preferredWidth: 1
-                                text: qsTr('Lightning')
-                                enabled: _bolt11
-                                checked: rootLayout.state == 'bolt11'
-                                indicator: _ind.createObject()
-                                onClicked: {
-                                    rootLayout.state = 'bolt11'
-                                    Config.preferredRequestType = 'bolt11'
-                                }
-                            }
-                            TabButton {
-                                id: bip21Button
-                                Layout.fillWidth: true
-                                Layout.preferredWidth: 1
-                                text: qsTr('URI')
-                                enabled: _bip21uri
-                                checked: rootLayout.state == 'bip21uri'
-                                indicator: _ind.createObject()
-                                onClicked: {
-                                    rootLayout.state = 'bip21uri'
-                                    Config.preferredRequestType = 'bip21uri'
-                                }
-                            }
-                            TabButton {
-                                id: addressButton
-                                Layout.fillWidth: true
-                                Layout.preferredWidth: 1
-                                text: qsTr('Address')
-                                checked: rootLayout.state == 'address'
-                                indicator: _ind.createObject()
-                                onClicked: {
-                                    rootLayout.state = 'address'
-                                    Config.preferredRequestType = 'address'
-                                }
-                            }
-                        }
                     }
                 }
 

--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -126,9 +126,9 @@ Item {
         dialog.open()
     }
 
-    function createRequest(lightning_only, reuse_address) {
+    function createRequest(lightning, reuse_address) {
         var qamt = Config.unitsToSats(_request_amount)
-        Daemon.currentWallet.createRequest(qamt, _request_description, _request_expiry, lightning_only, reuse_address)
+        Daemon.currentWallet.createRequest(qamt, _request_description, _request_expiry, lightning, reuse_address)
     }
 
     function startSweep() {
@@ -596,7 +596,7 @@ Item {
                 _request_amount = _receiveDetailsDialog.amount
                 _request_description = _receiveDetailsDialog.description
                 _request_expiry = _receiveDetailsDialog.expiry
-                createRequest(false, false)
+                createRequest(_receiveDetailsDialog.isLightning, false)
             }
             onRejected: {
                 console.log('rejected')

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -664,24 +664,25 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     @pyqtSlot(QEAmount, str, int, bool)
     @pyqtSlot(QEAmount, str, int, bool, bool)
     @pyqtSlot(QEAmount, str, int, bool, bool, bool)
-    def createRequest(self, amount: QEAmount, message: str, expiration: int, lightning_only: bool = False, reuse_address: bool = False):
+    def createRequest(self, amount: QEAmount, message: str, expiration: int, lightning: bool = False, reuse_address: bool = False):
         self.deleteExpiredRequests()
         try:
             amount = amount.satsInt
-            addr = self.wallet.get_unused_address()
-            if addr is None:
-                if reuse_address:
-                    addr = self.wallet.get_receiving_address()
-                elif lightning_only:
-                    addr = None
-                else:
-                    msg = [
-                        _('No address available.'),
-                        _('All your addresses are used in pending requests.'),
-                        _('To see the list, press and hold the Receive button.'),
-                    ]
-                    self.requestCreateError.emit(' '.join(msg))
-                    return
+            if not lightning:
+                addr = self.wallet.get_unused_address()
+                if addr is None:
+                    if reuse_address:
+                        addr = self.wallet.get_receiving_address()
+                    else:
+                        msg = [
+                            _('No address available.'),
+                            _('All your addresses are used in pending requests.'),
+                            _('To see the list, press and hold the Receive button.'),
+                        ]
+                        self.requestCreateError.emit(' '.join(msg))
+                        return
+            else:
+                addr = None
 
             key = self.wallet.create_request(amount, message, expiration, addr)
         except InvoiceError as e:

--- a/electrum/gui/qt/request_list.py
+++ b/electrum/gui/qt/request_list.py
@@ -157,6 +157,7 @@ class RequestList(MyTreeView):
             #items[self.Columns.DATE].setData(request_type, ROLE_REQUEST_TYPE)
             items[self.Columns.DATE].setData(key, ROLE_KEY)
             items[self.Columns.DATE].setData(timestamp, ROLE_SORT_ORDER)
+            items[self.Columns.DATE].setIcon(read_QIcon("lightning" if req.is_lightning() else "bitcoin"))
             items[self.Columns.AMOUNT].setData(amount_str_nots.strip(), self.ROLE_CLIPBOARD_DATA)
             items[self.Columns.STATUS].setIcon(read_QIcon(pr_icons.get(status)))
             self.std_model.insertRow(self.std_model.rowCount(), items)

--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -109,12 +109,14 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
                + _('Keyboard shortcut: type "!" to send all your coins.'))
         amount_label = HelpLabel(_('Amount'), msg)
         grid.addWidget(amount_label, 3, 0)
-        grid.addWidget(self.amount_e, 3, 1)
+
+        amount_widgets = QHBoxLayout()
+        amount_widgets.addWidget(self.amount_e)
 
         self.fiat_send_e = AmountEdit(self.fx.get_currency if self.fx else '')
         if not self.fx or not self.fx.is_enabled():
             self.fiat_send_e.setVisible(False)
-        grid.addWidget(self.fiat_send_e, 3, 2)
+        amount_widgets.addWidget(self.fiat_send_e)
         self.amount_e.frozen.connect(
             lambda: self.fiat_send_e.setFrozen(self.amount_e.isReadOnly()))
 
@@ -125,20 +127,20 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
         self.max_button.setFixedWidth(btn_width)
         self.max_button.setCheckable(True)
         self.max_button.setEnabled(False)
-        grid.addWidget(self.max_button, 3, 3)
+        amount_widgets.addWidget(self.max_button)
+        amount_widgets.addStretch(1)
+        grid.addLayout(amount_widgets, 3, 1, 1, -1)
 
         invoice_error_icon = read_QIcon("warning.png")
         self.invoice_error = IconLabel(reverse=True, hide_if_empty=True)
         self.invoice_error.setIcon(invoice_error_icon)
         grid.addWidget(self.invoice_error, 3, 4, Qt.AlignmentFlag.AlignRight)
 
-        self.paste_button = QPushButton()
+        self.paste_button = QPushButton(_('Paste'))
         self.paste_button.clicked.connect(self.do_paste)
         self.paste_button.setIcon(read_QIcon('copy.png'))
         self.paste_button.setToolTip(_('Paste invoice from clipboard'))
-        self.paste_button.setMaximumWidth(35)
         self.paste_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        grid.addWidget(self.paste_button, 0, 5)
 
         self.spinner = QMovie(icon_path('spinner.gif'))
         self.spinner.setScaledSize(QSize(24, 24))
@@ -155,10 +157,16 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
         self.send_button.setEnabled(False)
         self.clear_button = EnterButton(_("Clear"), self.do_clear)
 
-        buttons = QHBoxLayout()
-        buttons.addStretch(1)
+        #buttons1 = QHBoxLayout()
+        #buttons1.addWidget(self.paste_button)
+        #buttons1.addWidget(self.clear_button)
+        #buttons1.addStretch(1)
+        #grid.addLayout(buttons1, 0, 1, 1, 4)
 
+        buttons = QHBoxLayout()
+        buttons.addWidget(self.paste_button)
         buttons.addWidget(self.clear_button)
+        buttons.addStretch(1)
         buttons.addWidget(self.save_button)
         buttons.addWidget(self.send_button)
         grid.addLayout(buttons, 6, 1, 1, 4)

--- a/electrum/invoices.py
+++ b/electrum/invoices.py
@@ -344,8 +344,9 @@ class Request(BaseInvoice):
     ) -> Optional[str]:
         addr = self.get_address()
         amount = self.get_amount_sat()
-        if amount is not None:
-            amount = int(amount)
+        if amount is None:
+            return
+        amount = int(amount)
         message = self.message
         extra = {}
         if self.time and self.exp:

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -1097,7 +1097,6 @@ Warning: setting this to too low will result in lots of payment failures."""),
         'gui_qt_tx_dialog_export_include_global_xpubs', default=False, type_=bool,
         short_desc=lambda: _('For hardware device; include xpubs'),
     )
-    GUI_QT_RECEIVE_TABS_INDEX = ConfigVar('receive_tabs_index', default=0, type_=int)
     GUI_QT_RECEIVE_TAB_QR_VISIBLE = ConfigVar('receive_qr_visible', default=False, type_=bool)
     GUI_QT_TX_EDITOR_SHOW_IO = ConfigVar(
         'show_tx_io', default=False, type_=bool,

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2833,6 +2833,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         return invoice
 
     def create_request(self, amount_sat: Optional[int], message: Optional[str], exp_delay: Optional[int], address: Optional[str]):
+        """ will create a lightning request if address is None """
         # for receiving
         amount_sat = amount_sat or 0
         assert isinstance(amount_sat, int), f"{amount_sat!r}"
@@ -2841,9 +2842,11 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         address = address or None  # converts "" to None
         exp_delay = exp_delay or 0
         timestamp = int(Request._get_cur_time())
-        payment_hash = None  # type: Optional[bytes]
-        if self.has_lightning():
+        if address is None:
+            assert self.has_lightning()
             payment_hash = self.lnworker.create_payment_info(amount_msat=amount_msat, write_to_disk=False)
+        else:
+            payment_hash = None
         outputs = [PartialTxOutput.from_address_and_value(address, amount_sat)] if address else []
         height = self.adb.get_local_height()
         req = Request(

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -133,12 +133,12 @@ if [[ $1 == "breach" ]]; then
     channel=$($alice open_channel $bob_node 0.15 --password='')
     new_blocks 3
     wait_until_channel_open alice
-    request=$($bob add_request 0.01 -m "blah" | jq -r ".lightning_invoice")
+    request=$($bob add_request 0.01 --lightning -m "blah" | jq -r ".lightning_invoice")
     echo "alice pays"
     $alice lnpay $request
     sleep 2
     ctx=$($alice get_channel_ctx $channel --iknowwhatimdoing)
-    request=$($bob add_request 0.01 -m "blah2" | jq -r ".lightning_invoice")
+    request=$($bob add_request 0.01 --lightning -m "blah2" | jq -r ".lightning_invoice")
     echo "alice pays again"
     $alice lnpay $request
     echo "alice broadcasts old ctx"
@@ -289,7 +289,7 @@ if [[ $1 == "extract_preimage" ]]; then
     wait_until_channel_open alice
     chan_id=$($alice list_channels | jq -r ".[0].channel_point")
     # alice pays bob
-    invoice=$($bob add_request 0.04 -m "test" | jq -r ".lightning_invoice")
+    invoice=$($bob add_request 0.04 --lightning -m "test" | jq -r ".lightning_invoice")
     screen -S alice_payment -dm -L -Logfile /tmp/alice/screen.log $alice lnpay $invoice --timeout=600
     sleep 1
     unsettled=$($alice list_channels | jq '.[] | .local_unsettled_sent')
@@ -319,7 +319,7 @@ if [[ $1 == "redeem_htlcs" ]]; then
     new_blocks 3
     wait_until_channel_open alice
     # alice pays bob
-    invoice=$($bob add_request 0.04 -m "test" | jq -r ".lightning_invoice")
+    invoice=$($bob add_request 0.04 --lightning -m "test" | jq -r ".lightning_invoice")
     $alice lnpay $invoice --timeout=1 || true
     unsettled=$($alice list_channels | jq '.[] | .local_unsettled_sent')
     if [[ "$unsettled" == "0" ]]; then
@@ -361,7 +361,7 @@ if [[ $1 == "breach_with_unspent_htlc" ]]; then
     new_blocks 3
     wait_until_channel_open alice
     echo "alice pays bob"
-    invoice=$($bob add_request 0.04 -m "test" | jq -r ".lightning_invoice")
+    invoice=$($bob add_request 0.04 --lightning -m "test" | jq -r ".lightning_invoice")
     $alice lnpay $invoice --timeout=1 || true
     unsettled=$($alice list_channels | jq '.[] | .local_unsettled_sent')
     if [[ "$unsettled" == "0" ]]; then
@@ -390,7 +390,7 @@ if [[ $1 == "breach_with_spent_htlc" ]]; then
     new_blocks 3
     wait_until_channel_open alice
     echo "alice pays bob"
-    invoice=$($bob add_request 0.04 -m "test" | jq -r ".lightning_invoice")
+    invoice=$($bob add_request 0.04 --lightning -m "test" | jq -r ".lightning_invoice")
     $alice lnpay $invoice --timeout=1 || true
     ctx=$($alice get_channel_ctx $channel --iknowwhatimdoing)
     unsettled=$($alice list_channels | jq '.[] | .local_unsettled_sent')
@@ -453,11 +453,11 @@ if [[ $1 == "watchtower" ]]; then
     new_blocks 3
     wait_until_channel_open alice
     echo "alice pays bob"
-    invoice1=$($bob add_request 0.01 -m "invoice1" | jq -r ".lightning_invoice")
+    invoice1=$($bob add_request 0.01 --lightning -m "invoice1" | jq -r ".lightning_invoice")
     $alice lnpay $invoice1
     ctx=$($alice get_channel_ctx $channel --iknowwhatimdoing)
     echo "alice pays bob again"
-    invoice2=$($bob add_request 0.01 -m "invoice2" | jq -r ".lightning_invoice")
+    invoice2=$($bob add_request 0.01 --lightning -m "invoice2" | jq -r ".lightning_invoice")
     $alice lnpay $invoice2
     bob_ctn=$($bob list_channels | jq '.[0].local_ctn')
     msg="waiting until watchtower is synchronized"
@@ -492,7 +492,7 @@ if [[ $1 == "just_in_time" ]]; then
     wait_until_channel_open carol
     echo "carol pays alice"
     # note: set amount to 0.001 to test failure: 'payment too low'
-    invoice=$($alice add_request 0.01 -m "invoice" | jq -r ".lightning_invoice")
+    invoice=$($alice add_request 0.01 --lightning -m "invoice" | jq -r ".lightning_invoice")
     $carol lnpay $invoice
 fi
 


### PR DESCRIPTION
This PR removes on-chain fallback addresses in bolt11 invoices, and removes gap limit restrictions on the number of lightning invoices that can be created. In the GUI, it reintroduces the previous design with two buttons in the receive tab, which is simpler.

The QML component `ReceiveDialog.qml` needs further simplification.
The payserver plugin needs to be adapted too.