### PR TITLE
Handle unfunded zeroconf channels in update_unfunded_state

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -963,6 +963,7 @@ class Peer(Logger, EventListener):
         )
         chan.storage['funding_inputs'] = [txin.prevout.to_json() for txin in funding_tx.inputs()]
         chan.storage['has_onchain_backup'] = has_onchain_backup
+        chan.storage['init_timestamp'] = int(time.time())
         if isinstance(self.transport, LNTransport):
             chan.add_or_update_peer_addr(self.transport.peer_addr)
         sig_64, _ = chan.sign_next_commitment()

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -501,6 +501,9 @@ NBLOCK_CLTV_DELTA_TOO_FAR_INTO_FUTURE = 28 * 144
 
 MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED = 2016
 
+# timeout after which we consider a zeroconf channel without funding tx to be failed
+ZEROCONF_TIMEOUT = 60 * 10
+
 class RevocationStore:
     # closely based on code in lightningnetwork/lnd
 

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -615,7 +615,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     def on_event_adb_removed_tx(self, adb, txid: str, tx: Transaction):
         if self.adb != adb:
             return
-        if not self.tx_is_related(tx):
+        if not tx or not self.tx_is_related(tx):
             return
         self.clear_tx_parents_cache()
         util.trigger_callback('removed_transaction', self, tx)


### PR DESCRIPTION
This adds handling of zeroconf channels with funding tx height `TX_HEIGHT_LOCAL`. This way the client removes channels if the LSP fails to broadcast the funding transaction instead of trying to continue using it. It also allows the LSP to remove the channel on client side by sending shutdown instead of broadcasting the funding tx, the client will then remove the channel as it is in `CLOSING` state, this is useful if the LSP wants to abort the opening procedure, e.g. if the client fails to provide the preimage.
Required for https://github.com/spesmilo/electrum/pull/9584