### PR TITLE
Make question dialog of trampoline checkbox child of SettingsDialog

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -121,7 +121,7 @@ class SettingsDialog(QDialog, QtEventListener):
                         _("Are you sure you want to disable trampoline?"),
                         _("Without this option, Electrum will need to sync with the Lightning network on every start."),
                         _("This may impact the reliability of your payments."),
-                ])):
+                ]), parent=self):
                     trampoline_cb.setCheckState(Qt.CheckState.Checked)
                     return
             self.config.LIGHTNING_USE_GOSSIP = not use_trampoline


### PR DESCRIPTION
Passes the SettingsDialog as parent to the question dialog shown when disabling the trampoline checkbox. This makes the question dialog show in front of the SettingsDialog and the SettingsDialog stay in focus. Before this the SettingsDialog would move behind the main window after answering the question dialog which is confusing.