### PR TITLE
asyncio: hold our own strong refs for tasks and futures

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -755,7 +755,6 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
 
         proxy = self.proxy
         if proxy and proxy.enabled and proxy.mode == 'socks5':
-            # FIXME GC issues? do we need to store the Future?
             asyncio.run_coroutine_threadsafe(tor_probe_task(proxy), self.asyncio_loop)
 
     @log_exceptions


### PR DESCRIPTION
see https://docs.python.org/3.13/library/asyncio-task.html#asyncio.create_task :

> Important
> Save a reference to the result of this function, to avoid a task
> disappearing mid-execution. The event loop only keeps weak references
> to tasks. A task that isn’t referenced elsewhere may get garbage
> collected at any time, even before it’s done. For reliable
> “fire-and-forget” background tasks, gather them in a collection

ref https://github.com/python/cpython/issues/91887
