### PR TITLE
Additional regtest tests for just in time channels

### DIFF
--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -135,8 +135,17 @@ class TestLightningJIT(TestLightning):
         }
     }
 
-    def test_just_in_time(self):
-        self.run_shell(['just_in_time'])
+    def test_just_in_time_no_channel(self):
+        # jit payment to node without existing channels
+        self.run_shell(['just_in_time_no_channel'])
+
+    def test_just_in_time_existing_channels(self):
+        # payment should not open additional channels as there is already a sufficient channel
+        self.run_shell(['just_in_time_existing_channels'])
+
+    def test_just_in_time_failed_htlc(self):
+        # jit client fails htlc, LSP doesn't get preimage. No channel should be opened.
+        self.run_shell(['just_in_time_failed_htlc'])
 
 
 class TestLightningJITTrampoline(TestLightningJIT):


### PR DESCRIPTION
Depends on https://github.com/spesmilo/electrum/pull/9584, to be evaluated after 9584 is merged.

Adds 2 additional regtest test for just in time opening, one for unwinding a failed opening procedure, the other one for a payment with exiting channels to test if the client correctly determines if it should request a jit channel or not. The existing test now does two payments which should open two channels to see if multiple jit openings to the same client work.