### PR TITLE
refactor lnworker.pay_invoice to accept Invoice object instead of bolt11 string

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1264,10 +1264,11 @@ class Commands(Logger):
     @command('wnpl')
     async def lnpay(self, invoice, timeout=120, password=None, wallet: Abstract_Wallet = None):
         lnworker = wallet.lnworker
-        lnaddr = lnworker._check_invoice(invoice)
+        lnaddr = lnworker._check_bolt11_invoice(invoice)
         payment_hash = lnaddr.paymenthash
-        wallet.save_invoice(Invoice.from_bech32(invoice))
-        success, log = await lnworker.pay_invoice(invoice)
+        invoice_obj = Invoice.from_bech32(invoice)
+        wallet.save_invoice(invoice_obj)
+        success, log = await lnworker.pay_invoice(invoice_obj)
         return {
             'payment_hash': payment_hash.hex(),
             'success': success,

--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -7,14 +7,15 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject, pyqtEnum, 
 
 from electrum.i18n import _
 from electrum.logging import get_logger
-from electrum.invoices import (Invoice, PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID, PR_INFLIGHT,
-                               PR_FAILED, PR_ROUTING, PR_UNCONFIRMED, PR_BROADCASTING, PR_BROADCAST, LN_EXPIRY_NEVER)
+from electrum.invoices import (
+    Invoice, PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID, PR_INFLIGHT, PR_FAILED, PR_ROUTING, PR_UNCONFIRMED,
+    PR_BROADCASTING, PR_BROADCAST, LN_EXPIRY_NEVER
+)
 from electrum.transaction import PartialTxOutput, TxOutput
-from electrum.util import NotEnoughFunds, NoDynamicFeeEstimates
 from electrum.lnutil import format_short_channel_id
 from electrum.bitcoin import COIN, address_to_script
 from electrum.paymentrequest import PaymentRequest
-from electrum.payment_identifier import (PaymentIdentifier, PaymentIdentifierState, PaymentIdentifierType)
+from electrum.payment_identifier import PaymentIdentifier, PaymentIdentifierState, PaymentIdentifierType
 
 from .qetypes import QEAmount
 from .qewallet import QEWallet
@@ -56,7 +57,7 @@ class QEInvoice(QObject, QtEventListener):
         self._canPay = False
         self._key = None
         self._invoiceType = QEInvoice.Type.Invalid
-        self._effectiveInvoice = None
+        self._effectiveInvoice = None  # type: Optional[Invoice]
         self._userinfo = ''
         self._lnprops = {}
         self._amount = QEAmount()

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -29,7 +29,7 @@ from .util import QtEventListener, qt_event_listener
 
 if TYPE_CHECKING:
     from electrum.wallet import Abstract_Wallet
-    from .qeinvoice import QEInvoice
+    from electrum.invoices import Invoice
 
 
 class QEWallet(AuthMixin, QObject, QtEventListener):
@@ -640,12 +640,12 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         self.paymentAuthRejected.emit()
 
     @auth_protect(message=_('Pay lightning invoice?'), reject='ln_auth_rejected')
-    def pay_lightning_invoice(self, invoice: 'QEInvoice'):
+    def pay_lightning_invoice(self, invoice: 'Invoice'):
         amount_msat = invoice.get_amount_msat()
 
         def pay_thread():
             try:
-                coro = self.wallet.lnworker.pay_invoice(invoice.lightning_invoice, amount_msat=amount_msat)
+                coro = self.wallet.lnworker.pay_invoice(invoice, amount_msat=amount_msat)
                 fut = asyncio.run_coroutine_threadsafe(coro, get_asyncio_loop())
                 fut.result()
             except Exception as e:

--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -719,7 +719,7 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
         if not self.question(msg):
             return
         self.save_pending_invoice()
-        coro = lnworker.pay_invoice(invoice.lightning_invoice, amount_msat=amount_msat)
+        coro = lnworker.pay_invoice(invoice, amount_msat=amount_msat)
         self.window.run_coroutine_from_thread(coro, _('Sending payment'))
 
     def broadcast_transaction(self, tx: Transaction, *, payment_identifier: PaymentIdentifier = None):

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -670,7 +670,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         if not self.question(msg):
             return
         self.save_pending_invoice(invoice)
-        coro = self.wallet.lnworker.pay_invoice(invoice.lightning_invoice, amount_msat=amount_msat)
+        coro = self.wallet.lnworker.pay_invoice(invoice, amount_msat=amount_msat)
 
         #self.window.run_coroutine_from_thread(coro, _('Sending payment'))
         self.show_message(_("Please wait..."), getchar=False)

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1491,14 +1491,14 @@ class LNWallet(LNWorker):
 
     @log_exceptions
     async def pay_invoice(
-            self, invoice: str, *,
+            self, invoice: Invoice, *,
             amount_msat: int = None,
             attempts: int = None,  # used only in unit tests
             full_path: LNPaymentPath = None,
             channels: Optional[Sequence[Channel]] = None,
     ) -> Tuple[bool, List[HtlcLog]]:
-
-        lnaddr = self._check_invoice(invoice, amount_msat=amount_msat)
+        bolt11 = invoice.lightning_invoice
+        lnaddr = self._check_bolt11_invoice(bolt11, amount_msat=amount_msat)
         min_final_cltv_delta = lnaddr.get_min_final_cltv_delta()
         payment_hash = lnaddr.paymenthash
         key = payment_hash.hex()
@@ -1850,11 +1850,11 @@ class LNWallet(LNWorker):
             except Exception:
                 return None
 
-    def _check_invoice(self, invoice: str, *, amount_msat: int = None) -> LnAddr:
+    def _check_bolt11_invoice(self, bolt11_invoice: str, *, amount_msat: int = None) -> LnAddr:
         """Parses and validates a bolt11 invoice str into a LnAddr.
         Includes pre-payment checks external to the parser.
         """
-        addr = lndecode(invoice)
+        addr = lndecode(bolt11_invoice)
         if addr.is_expired():
             raise InvoiceError(_("This invoice has expired"))
         # check amount
@@ -2872,8 +2872,8 @@ class LNWallet(LNWorker):
             fallback_address=None,
             channels=[chan2],
         )
-        return await self.pay_invoice(
-            invoice, channels=[chan1])
+        invoice_obj = Invoice.from_bech32(invoice)
+        return await self.pay_invoice(invoice_obj, channels=[chan1])
 
     def can_receive_invoice(self, invoice: BaseInvoice) -> bool:
         assert invoice.is_lightning()


### PR DESCRIPTION
generalization needed in preparation for other invoice types, e.g. bolt12
