### PR TITLE
lnworker: pass PaySession to route building methods.

### DIFF
--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -22,7 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 import queue
 from collections import defaultdict
 from typing import Sequence, Tuple, Optional, Dict, TYPE_CHECKING, Set, Callable


### PR DESCRIPTION
Simplifies method signatures and groups quite a large set of parameters that are mostly passed down along the call stack but functionally belong together. Also removes bolt11 specific parameters in method signatures, e.g. r_tags, which are not relevant in e.g. a bolt12 context.