### PR TITLE
Fail incoming htlcs if we forwarded and chan was force-closed (fix #8547)

### DIFF
--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -124,6 +124,22 @@ class TestLightningWatchtower(TestLightning):
         self.run_shell(['watchtower'])
 
 
+class TestLightningABC(TestLightning):
+    agents = {
+        'alice': {
+        },
+        'bob': {
+            'lightning_listen': 'localhost:9735',
+            'lightning_forward_payments': 'true',
+        },
+        'carol': {
+        }
+    }
+
+    def test_fw_fail_htlc(self):
+        self.run_shell(['fw_fail_htlc'])
+
+
 class TestLightningJIT(TestLightning):
     agents = {
         'alice': {


### PR DESCRIPTION
call lnworker.htlc_failed once the htlc_tx is deeply mined.

In the case of a forwarding, this will fail incoming htlcs. (fixes #8547)