### PR TITLE
Allow plugins to register CLI commands 

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1594,18 +1594,6 @@ def plugin_command(s, plugin_name = None):
         return func_wrapper
     return decorator
 
-def remove_disabled_plugin_commands(config: SimpleConfig, plugins_with_commands: set[str]):
-    """Removes registered commands of plugins that are not enabled in the config."""
-    global known_commands
-    global plugin_commands
-    assert len(known_commands) > 0, "known_commands should not be empty, called too early?"
-    for plugin_name in plugins_with_commands:
-        if not config.get(f'enable_plugin_{plugin_name}'):
-            registered_commands: set[str] = plugin_commands[plugin_name]
-            assert len(registered_commands) > 0, "plugin command registered with the invalid plugin name"
-            for command_name in registered_commands:
-                del known_commands[command_name]
-                delattr(Commands, command_name)
 
 def eval_bool(x: str) -> bool:
     if x == 'false': return False
@@ -1890,5 +1878,6 @@ def get_parser():
                 group.add_argument(k, nargs='?', help=v)
 
     # 'gui' is the default command
+    # note: set_default_subparser modifies sys.argv
     parser.set_default_subparser('gui')
     return parser

--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -349,7 +349,9 @@ class CommandsServer(AuthenticatedServer):
 
     async def run_cmdline(self, config_options):
         cmdname = config_options['cmd']
-        cmd = known_commands[cmdname]
+        cmd = known_commands.get(cmdname)
+        if not cmd:
+            return f"unknown command: {cmdname}"
         # arguments passed to function
         args = [config_options.get(x) for x in cmd.params]
         # decode json arguments

--- a/electrum/plugins/labels/commands.py
+++ b/electrum/plugins/labels/commands.py
@@ -1,0 +1,22 @@
+from electrum.commands import plugin_command
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .labels import LabelsPlugin
+    from electrum.commands import Commands
+
+plugin_name = "labels"
+
+@plugin_command('w', plugin_name)
+async def push(self: 'Commands', wallet=None) -> int:
+    """ push labels to server """
+    plugin: 'LabelsPlugin' = self.daemon._plugins.get_plugin(plugin_name)
+    return await plugin.push_thread(wallet)
+
+
+@plugin_command('w', plugin_name)
+async def pull(self: 'Commands', wallet=None) -> int:
+    """ pull labels from server """
+    assert wallet is not None
+    plugin: 'LabelsPlugin' = self.daemon._plugins.get_plugin(plugin_name)
+    return await plugin.pull_thread(wallet, force=False)

--- a/electrum/plugins/labels/labels.py
+++ b/electrum/plugins/labels/labels.py
@@ -108,7 +108,7 @@ class LabelsPlugin(BasePlugin):
                 except Exception as e:
                     raise Exception('Could not decode: ' + await result.text()) from e
 
-    async def push_thread(self, wallet: 'Abstract_Wallet'):
+    async def push_thread(self, wallet: 'Abstract_Wallet') -> int:
         wallet_data = self.wallets.get(wallet, None)
         if not wallet_data:
             raise Exception('Wallet {} not loaded'.format(wallet))
@@ -126,8 +126,9 @@ class LabelsPlugin(BasePlugin):
             bundle["labels"].append({'encryptedLabel': encoded_value,
                                      'externalId': encoded_key})
         await self.do_post("/labels", bundle)
+        return len(bundle['labels'])
 
-    async def pull_thread(self, wallet: 'Abstract_Wallet', force: bool):
+    async def pull_thread(self, wallet: 'Abstract_Wallet', force: bool) -> int:
         wallet_data = self.wallets.get(wallet, None)
         if not wallet_data:
             raise Exception('Wallet {} not loaded'.format(wallet))
@@ -140,7 +141,7 @@ class LabelsPlugin(BasePlugin):
             raise ErrorConnectingServer(e) from e
         if response["labels"] is None or len(response["labels"]) == 0:
             self.logger.info('no new labels')
-            return
+            return 0
 
         self.logger.info(f'received {len(response["labels"])} labels')
         result = {}
@@ -165,6 +166,7 @@ class LabelsPlugin(BasePlugin):
         self.set_nonce(wallet, response["nonce"] + 1)
         util.trigger_callback('labels_received', wallet, result)
         self.on_pulled(wallet)
+        return len(result)
 
     def on_pulled(self, wallet: 'Abstract_Wallet') -> None:
         pass

--- a/run_electrum
+++ b/run_electrum
@@ -103,7 +103,7 @@ from electrum.storage import WalletStorage
 from electrum.util import print_msg, print_stderr, json_encode, json_decode, UserCancelled
 from electrum.util import InvalidPassword
 from electrum.plugin import Plugins
-from electrum.commands import get_parser, known_commands, Commands, config_variables, remove_disabled_plugin_commands
+from electrum.commands import get_parser, known_commands, Commands, config_variables
 from electrum import daemon
 from electrum import keystore
 from electrum.util import create_and_start_event_loop, UserFacingException, JsonRPCError
@@ -340,8 +340,6 @@ def main():
             sys.argv[i] = input("Enter argument:")
         elif arg == ':':
             sys.argv[i] = prompt_password('Enter argument (will not echo):', confirm=False)
-    # load (only) the commands modules of plugins so their commands are registered
-    plugin_commands = Plugins(cmd_only=True)
 
     # config is an object passed to the various constructors (wallet, interface, gui)
     if is_android:
@@ -360,14 +358,22 @@ def main():
             # ~hack for easier regtest builds. pkgname subject to change.
             config_options['regtest'] = True
     else:
+        # save sys args for next parser
+        saved_sys_argv = sys.argv[:]
+        # disable help, the next parser will display it
+        if '-h' in sys.argv:
+            sys.argv.remove('-h')
+        # parse first without plugins
+        config_options = parse_command_line()
+        tmp_config = SimpleConfig(config_options)
+        # load (only) the commands modules of plugins so their commands are registered
+        plugin_commands = Plugins(tmp_config, cmd_only=True)
+        # re-parse command line
+        sys.argv = saved_sys_argv[:]
         config_options = parse_command_line()
 
     config = SimpleConfig(config_options)
     cmdname = config.get('cmd')
-
-    # now that we know which plugins are enabled we can remove commands of disabled plugins again
-    # enabled plugins depend on the datadir which is parsed by argparse, so they can only be unloaded afterwards
-    remove_disabled_plugin_commands(config, plugin_commands.loaded_command_modules)
 
     # set language as early as possible
     # Note: we are already too late for strings that are declared in the global scope
@@ -500,10 +506,7 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
     else:
         # command line
         configure_logging(config, log_to_file=False)  # don't spam logfiles for each client-side RPC, but support "-v"
-        cmd = known_commands.get(cmdname)
-        if not cmd:
-            print_stderr("unknown command:", cmdname)
-            sys_exit(1)
+        cmd = known_commands[cmdname]
         wallet_path = config.get_wallet_path()
         if not config.NETWORK_OFFLINE:
             init_cmdline(config_options, wallet_path, rpcserver=True, config=config)

--- a/run_electrum
+++ b/run_electrum
@@ -102,7 +102,8 @@ from electrum.wallet import Wallet
 from electrum.storage import WalletStorage
 from electrum.util import print_msg, print_stderr, json_encode, json_decode, UserCancelled
 from electrum.util import InvalidPassword
-from electrum.commands import get_parser, known_commands, Commands, config_variables
+from electrum.plugin import Plugins
+from electrum.commands import get_parser, known_commands, Commands, config_variables, remove_disabled_plugin_commands
 from electrum import daemon
 from electrum import keystore
 from electrum.util import create_and_start_event_loop, UserFacingException, JsonRPCError
@@ -110,8 +111,6 @@ from electrum.i18n import set_language
 
 if TYPE_CHECKING:
     import threading
-
-    from electrum.plugin import Plugins
 
 _logger = get_logger(__name__)
 
@@ -261,11 +260,6 @@ async def run_offline_command(config, config_options, plugins: 'Plugins'):
     return result
 
 
-def init_plugins(config, gui_name):
-    from electrum.plugin import Plugins
-    return Plugins(config, gui_name)
-
-
 loop = None  # type: Optional[asyncio.AbstractEventLoop]
 stop_loop = None  # type: Optional[asyncio.Future]
 loop_thread = None  # type: Optional[threading.Thread]
@@ -313,7 +307,8 @@ def main():
             sys.argv[i] = input("Enter argument:")
         elif arg == ':':
             sys.argv[i] = prompt_password('Enter argument (will not echo):', confirm=False)
-
+    # load (only) the commands modules of plugins so their commands are registered
+    plugin_commands = Plugins(cmd_only=True)
     # parse command line
     parser = get_parser()
     args = parser.parse_args()
@@ -363,9 +358,12 @@ def main():
 
     if not config_options.get('verbosity'):
         warnings.simplefilter('ignore', DeprecationWarning)
-
     config = SimpleConfig(config_options)
     cmdname = config.get('cmd')
+
+    # now that we know which plugins are enabled we can remove commands of disabled plugins again
+    # enabled plugins depend on the datadir which is parsed by argparse, so they can only be unloaded afterwards
+    remove_disabled_plugin_commands(config, plugin_commands.loaded_command_modules)
 
     # set language as early as possible
     # Note: we are already too late for strings that are declared in the global scope
@@ -498,7 +496,10 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
     else:
         # command line
         configure_logging(config, log_to_file=False)  # don't spam logfiles for each client-side RPC, but support "-v"
-        cmd = known_commands[cmdname]
+        cmd = known_commands.get(cmdname)
+        if not cmd:
+            print_stderr("unknown command:", cmdname)
+            sys_exit(1)
         wallet_path = config.get_wallet_path()
         if not config.NETWORK_OFFLINE:
             init_cmdline(config_options, wallet_path, rpcserver=True, config=config)
@@ -538,7 +539,7 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
                 print_stderr("Run this command without --offline to interact with the daemon")
                 sys_exit(1)
             init_cmdline(config_options, wallet_path, rpcserver=False, config=config)
-            plugins = init_plugins(config, 'cmdline')
+            plugins = Plugins(config, 'cmdline')
             coro = run_offline_command(config, config_options, plugins)
             fut = asyncio.run_coroutine_threadsafe(coro, loop)
             try:

--- a/run_electrum
+++ b/run_electrum
@@ -37,7 +37,7 @@ if sys.version_info[:3] < _min_python_version_tuple:
 
 import warnings
 import asyncio
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Dict
 
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
@@ -271,6 +271,39 @@ def sys_exit(i):
         loop_thread.join(timeout=1)
     sys.exit(i)
 
+def parse_command_line() -> Dict:
+    # parse command line from sys.argv
+    parser = get_parser()
+    args = parser.parse_args()
+    config_options = args.__dict__
+    f = lambda key: config_options[key] is not None and key not in config_variables.get(args.cmd, {}).keys()
+    config_options = {key: config_options[key] for key in filter(f, config_options.keys())}
+    if config_options.get(SimpleConfig.NETWORK_SERVER.key()):
+        config_options[SimpleConfig.NETWORK_AUTO_CONNECT.key()] = False
+
+    config_options['cwd'] = cwd = os.getcwd()
+
+    # fixme: this can probably be achieved with a runtime hook (pyinstaller)
+    if is_pyinstaller and os.path.exists(os.path.join(sys._MEIPASS, 'is_portable')):
+        config_options['portable'] = True
+
+    if config_options.get('portable'):
+        if is_local:
+            # running from git clone or local source: put datadir next to main script
+            datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum_data')
+        else:
+            # Running a binary or installed source. The most generic but still reasonable thing
+            # is to use the current working directory. (see #7732)
+            # note: The main script is often unpacked to a temporary directory from a bundled executable,
+            #       and we don't want to put the datadir inside a temp dir.
+            # note: Re the portable .exe on Windows, when the user double-clicks it, CWD gets set
+            #       to the parent dir, i.e. we will put the datadir next to the exe.
+            datadir = os.path.join(os.path.realpath(cwd), 'electrum_data')
+        config_options['electrum_path'] = datadir
+
+    if not config_options.get('verbosity'):
+        warnings.simplefilter('ignore', DeprecationWarning)
+    return config_options
 
 def main():
     global loop, stop_loop, loop_thread
@@ -309,9 +342,6 @@ def main():
             sys.argv[i] = prompt_password('Enter argument (will not echo):', confirm=False)
     # load (only) the commands modules of plugins so their commands are registered
     plugin_commands = Plugins(cmd_only=True)
-    # parse command line
-    parser = get_parser()
-    args = parser.parse_args()
 
     # config is an object passed to the various constructors (wallet, interface, gui)
     if is_android:
@@ -330,34 +360,8 @@ def main():
             # ~hack for easier regtest builds. pkgname subject to change.
             config_options['regtest'] = True
     else:
-        config_options = args.__dict__
-        f = lambda key: config_options[key] is not None and key not in config_variables.get(args.cmd, {}).keys()
-        config_options = {key: config_options[key] for key in filter(f, config_options.keys())}
-        if config_options.get(SimpleConfig.NETWORK_SERVER.key()):
-            config_options[SimpleConfig.NETWORK_AUTO_CONNECT.key()] = False
+        config_options = parse_command_line()
 
-    config_options['cwd'] = cwd = os.getcwd()
-
-    # fixme: this can probably be achieved with a runtime hook (pyinstaller)
-    if is_pyinstaller and os.path.exists(os.path.join(sys._MEIPASS, 'is_portable')):
-        config_options['portable'] = True
-
-    if config_options.get('portable'):
-        if is_local:
-            # running from git clone or local source: put datadir next to main script
-            datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum_data')
-        else:
-            # Running a binary or installed source. The most generic but still reasonable thing
-            # is to use the current working directory. (see #7732)
-            # note: The main script is often unpacked to a temporary directory from a bundled executable,
-            #       and we don't want to put the datadir inside a temp dir.
-            # note: Re the portable .exe on Windows, when the user double-clicks it, CWD gets set
-            #       to the parent dir, i.e. we will put the datadir next to the exe.
-            datadir = os.path.join(os.path.realpath(cwd), 'electrum_data')
-        config_options['electrum_path'] = datadir
-
-    if not config_options.get('verbosity'):
-        warnings.simplefilter('ignore', DeprecationWarning)
     config = SimpleConfig(config_options)
     cmdname = config.get('cmd')
 


### PR DESCRIPTION
This PR adds functionality which allows plugins to register cli commands. 
CLI commands can be registered from within a `commands.py` file at the plugins root by decorating them with the `@plugin_command(requirements, plugin_name)` decorator.

Example:
```python
file: plugins/demo_plugin/commands.py

from electrum.commands import plugin_command

plugin_name = "demo_plugin"

@plugin_command("", plugin_name=plugin_name)
async def plugin_demo_command(self: 'Commands'):
    plugin: 'DemoPlugin' = self.daemon._plugins.get_plugin(plugin_name)
    plugin.do_something()
    return "plugin did something (this is the cli output)"
```

This works for internal and external plugins. Plugin commands have to begin with `plugin_` and are not allowed to overwrite other commands. 

Here is a external demo plugin which registers 3 commands for testing: 
[nwc-0.0.1.zip](https://github.com/user-attachments/files/19228224/nwc-0.0.1.zip)
to be enabled with `setconfig enable_plugin_nwc true`. See the commands with `help | grep nwc`.

closes #1814