### PR TITLE
Use non_local coins only when creating max amount tx in qt gui

### DIFF
--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -255,7 +255,7 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
             return
         make_tx = lambda fee_policy, *, confirmed_only=False: self.wallet.make_unsigned_transaction(
             fee_policy=fee_policy,
-            coins=self.window.get_coins(),
+            coins=self.window.get_coins(nonlocal_only=True),
             outputs=outputs,
             is_sweep=False)
         try:


### PR DESCRIPTION
When there is a local tx in the history and the user tries to do a Max spend from the qt gui get_coins will return local outputs that cannot be spend, causing a transaction broadcast error. This happens for example when there is a local lightning force close tx in the history waiting for the timeout, breaking the Max spend button for >1000 blocks.