### PR TITLE
Use non_local coins only when creating max amount tx in qml gui

### DIFF
--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -415,7 +415,7 @@ class QEInvoice(QObject, QtEventListener):
             try:
                 outputs = [PartialTxOutput(scriptpubkey=address_to_script(address), value='!')]
                 make_tx = lambda fee_policy, *, confirmed_only=False: self._wallet.wallet.make_unsigned_transaction(
-                    coins=self._wallet.wallet.get_spendable_coins(None),
+                    coins=self._wallet.wallet.get_spendable_coins(nonlocal_only=True),
                     outputs=outputs,
                     fee_policy=fee_policy,
                     is_sweep=False)


### PR DESCRIPTION
Fixes the same issue as https://github.com/spesmilo/electrum/pull/9630 in qml too.

> When there is a local tx in the history and the user tries to do a Max spend from the qt gui get_coins will return local outputs that cannot be spend, causing a transaction broadcast error. This happens for example when there is a local lightning force close tx in the history waiting for the timeout, breaking the Max spend button for >1000 blocks.