### PR TITLE
config vars for plugins

### DIFF
--- a/electrum/plugins/payserver/__init__.py
+++ b/electrum/plugins/payserver/__init__.py
@@ -1,0 +1,6 @@
+from electrum.simple_config import ConfigVar
+config_vars = [
+    ConfigVar('payserver_port', default=8080, type_=int),
+    ConfigVar('payserver_root', default='/r', type_=str),
+    ConfigVar('payserver_allow_create_invoice', default=False, type_=bool),
+]

--- a/electrum/plugins/swapserver/__init__.py
+++ b/electrum/plugins/swapserver/__init__.py
@@ -1,0 +1,6 @@
+from electrum.simple_config import ConfigVar
+config_vars = [
+    ConfigVar('swapserver_port', default=None, type_=int),
+    ConfigVar('swapserver_fee_millionths', default=5000, type_=int),
+    ConfigVar('swapserver_ann_pow_nonce', default=0, type_=int),
+]

--- a/electrum/plugins/watchtower/__init__.py
+++ b/electrum/plugins/watchtower/__init__.py
@@ -1,0 +1,6 @@
+from electrum.simple_config import ConfigVar
+config_vars = [
+    ConfigVar('watchtower_server_port', default=None, type_=int),
+    ConfigVar('watchtower_server_user', default=None, type_=str),
+    ConfigVar('watchtower_server_password', default=None, type_=str),
+]

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -814,12 +814,8 @@ Warning: setting this to too low will result in lots of payment failures."""),
 
     # connect to remote submarine swap server
     SWAPSERVER_URL = ConfigVar('swapserver_url', default='', type_=str)
-    # run submarine swap server locally
-    SWAPSERVER_PORT = ConfigVar('swapserver_port', default=None, type_=int)
-    SWAPSERVER_FEE_MILLIONTHS = ConfigVar('swapserver_fee_millionths', default=5000, type_=int)
     TEST_SWAPSERVER_REFUND = ConfigVar('test_swapserver_refund', default=False, type_=bool)
     SWAPSERVER_NPUB = ConfigVar('swapserver_npub', default=None, type_=str)
-    SWAPSERVER_ANN_POW_NONCE = ConfigVar('swapserver_ann_pow_nonce', default=0, type_=int)
     SWAPSERVER_POW_TARGET = ConfigVar('swapserver_pow_target', default=30, type_=int)
 
     # nostr
@@ -845,16 +841,6 @@ Warning: setting this to too low will result in lots of payment failures."""),
 
     # connect to remote WT
     WATCHTOWER_CLIENT_URL = ConfigVar('watchtower_url', default=None, type_=str)
-
-    # run WT locally
-    WATCHTOWER_SERVER_ENABLED = ConfigVar('run_watchtower', default=False, type_=bool)
-    WATCHTOWER_SERVER_PORT = ConfigVar('watchtower_port', default=None, type_=int)
-    WATCHTOWER_SERVER_USER = ConfigVar('watchtower_user', default=None, type_=str)
-    WATCHTOWER_SERVER_PASSWORD = ConfigVar('watchtower_password', default=None, type_=str)
-
-    PAYSERVER_PORT = ConfigVar('payserver_port', default=8080, type_=int)
-    PAYSERVER_ROOT = ConfigVar('payserver_root', default='/r', type_=str)
-    PAYSERVER_ALLOW_CREATE_INVOICE = ConfigVar('payserver_allow_create_invoice', default=False, type_=bool)
 
     PLUGIN_TRUSTEDCOIN_NUM_PREPAY = ConfigVar('trustedcoin_prepay', default=20, type_=int)
 

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -116,9 +116,9 @@ class TestLightningWatchtower(TestLightning):
         },
         'carol': {
             'enable_plugin_watchtower': 'true',
-            'watchtower_user': 'wtuser',
-            'watchtower_password': 'wtpassword',
-            'watchtower_port': '12345',
+            'watchtower_server_user': 'wtuser',
+            'watchtower_server_password': 'wtpassword',
+            'watchtower_server_port': '12345',
         }
     }
 


### PR DESCRIPTION
 - probably needs a better way to pass default value and type
 - needs to set `SimpleConfig._init_done`:  we are currently passing the config object to the constructor of Plugins(). That might be easier if we passed Plugins to the constructor of SimpleConfig