### PR TITLE
plugins: keepkey: vendor our fork of keepkeylib (as git submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "electrum/www"]
 	path = electrum/plugins/payserver/www
 	url = https://github.com/spesmilo/electrum-http.git
+[submodule "electrum/plugins/keepkey/keepkeylib"]
+	path = electrum/plugins/keepkey/keepkeylib
+	url = https://github.com/spesmilo/electrum-keepkeylib.git

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -42,7 +42,6 @@ datas += collect_data_files(f"{PYPKG}.plugins")
 datas += collect_data_files('trezorlib')  # TODO is this needed? and same question for other hww libs
 datas += collect_data_files('safetlib')
 datas += collect_data_files('btchip')
-datas += collect_data_files('keepkeylib')
 datas += collect_data_files('ckcc')
 datas += collect_data_files('bitbox02')
 

--- a/contrib/deterministic-build/requirements-hw.txt
+++ b/contrib/deterministic-build/requirements-hw.txt
@@ -279,10 +279,6 @@ hidapi==0.14.0 \
 idna==3.6 \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-keepkey==6.3.1 \
-    --hash=sha256:88e2b5291c85c8e8567732f675697b88241082884aa1aba32257f35ee722fc09 \
-    --hash=sha256:cef1e862e195ece3e42640a0f57d15a63086fd1dedc8b5ddfcbc9c2657f0bb1e \
-    --hash=sha256:f369d640c65fec7fd8e72546304cdc768c04224a6b9b00a19dc2cd06fa9d2a6b
 ledger-bitcoin==0.3.0 \
     --hash=sha256:ad9cdeaf33a45562bbd5bae6751025b869a2f81d6eb0267dd062a01f5925a4d5 \
     --hash=sha256:e7c33404d02044c3810b294a510f7ad97bc65ab12dbdd180d873f2b4ebc0711a

--- a/contrib/osx/osx.spec
+++ b/contrib/osx/osx.spec
@@ -45,7 +45,6 @@ datas += collect_data_files(f"{PYPKG}.plugins")
 datas += collect_data_files('trezorlib')  # TODO is this needed? and same question for other hww libs
 datas += collect_data_files('safetlib')
 datas += collect_data_files('btchip')
-datas += collect_data_files('keepkeylib')
 datas += collect_data_files('ckcc')
 datas += collect_data_files('bitbox02')
 

--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -8,7 +8,7 @@ safet>=0.1.5
 
 # device plugin: keepkey
 ecdsa>=0.9
-protobuf>=3.0.0
+protobuf>=3.20
 mnemonic>=0.8
 hidapi>=0.7.99.post15
 libusb1>=1.6
@@ -28,10 +28,6 @@ bitbox02>=6.2.0
 # device plugin: jade
 cbor2>=5.4.6,<6.0.0
 pyserial>=3.5.0,<4.0.0
-
-# prefer older protobuf (see #7922)
-# (pulled in via e.g. keepkey and bitbox02)
-protobuf>=3.20,<4
 
 # prefer older colorama to avoid needing hatchling
 # (pulled in via trezor -> click -> colorama)

--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -7,7 +7,11 @@ trezor[hidapi]>=0.13.0,<0.14
 safet>=0.1.5
 
 # device plugin: keepkey
-keepkey>=6.3.1
+ecdsa>=0.9
+protobuf>=3.0.0
+mnemonic>=0.8
+hidapi>=0.7.99.post15
+libusb1>=1.6
 
 # device plugin: ledger
 # note: btchip-python only needed for "legacy" protocol and HW.1 support

--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -1,5 +1,5 @@
 qrcode
-protobuf>=3.20,<4
+protobuf>=3.20
 qdarkstyle>=3.2
 aiorpcx>=0.22.0,<0.25
 aiohttp>=3.3.0,<4.0.0

--- a/electrum/plugins/keepkey/client.py
+++ b/electrum/plugins/keepkey/client.py
@@ -1,4 +1,4 @@
-from keepkeylib.client import proto, BaseClient, ProtocolMixin
+from .keepkeylib.keepkeylib.client import proto, BaseClient, ProtocolMixin
 from .clientbase import KeepKeyClientBase
 
 class KeepKeyClient(KeepKeyClientBase, ProtocolMixin, BaseClient):

--- a/electrum/plugins/keepkey/keepkey.py
+++ b/electrum/plugins/keepkey/keepkey.py
@@ -75,10 +75,8 @@ class KeepKeyPlugin(HW_PluginBase):
 
         try:
             from . import client
-            import keepkeylib
-            import keepkeylib.ckd_public
-            import keepkeylib.transport_hid
-            import keepkeylib.transport_webusb
+            from .keepkeylib import keepkeylib
+            from .keepkeylib.keepkeylib import ckd_public, transport_hid, transport_webusb
             self.client_class = client.KeepKeyClient
             self.ckd_public = keepkeylib.ckd_public
             self.types = keepkeylib.client.types
@@ -90,11 +88,12 @@ class KeepKeyPlugin(HW_PluginBase):
             self.device_manager().register_enumerate_func(self.enumerate)
             self.libraries_available = True
         except ImportError:
+            self.logger.debug("error importing keepkeylib", exc_info=True)
             self.libraries_available = False
 
     @runs_in_hwd_thread
     def enumerate(self):
-        from keepkeylib.transport_webusb import WebUsbTransport
+        from .keepkeylib.keepkeylib.transport_webusb import WebUsbTransport
         results = []
         for dev in WebUsbTransport.enumerate():
             path = self._dev_to_str(dev)
@@ -112,12 +111,12 @@ class KeepKeyPlugin(HW_PluginBase):
 
     @runs_in_hwd_thread
     def hid_transport(self, pair):
-        from keepkeylib.transport_hid import HidTransport
+        from .keepkeylib.keepkeylib.transport_hid import HidTransport
         return HidTransport(pair)
 
     @runs_in_hwd_thread
     def webusb_transport(self, device):
-        from keepkeylib.transport_webusb import WebUsbTransport
+        from .keepkeylib.keepkeylib.transport_webusb import WebUsbTransport
         for dev in WebUsbTransport.enumerate():
             if device.path == self._dev_to_str(dev):
                 return WebUsbTransport(dev)


### PR DESCRIPTION
replaces https://github.com/spesmilo/electrum/pull/9581

The difference is that this PR adds our fork of keepkeylib as a git submodule, instead of including it directly into the git tree. This avoids polluting the tree.

[Our fork of keepkeylib](https://github.com/spesmilo/electrum-keepkeylib) has the protobuf-generated code regenerated with more modern protoc, and a lot of altcoin stuff is removed.

Also see description of prev PR:

> This adds keepkeylib into our git tree. We will vendor it that way from now, instead of declaring it as an external dependency.
> 
> Upstream keepkeylib is effectively unmaintained -- but the only problem with it is that it requires an old version of `protobuf`. (see https://github.com/keepkey/python-keepkey/issues/146)
> By vendoring it, we can fix that ourselves.
> 
> keepkeylib is [taken from PyPI](https://files.pythonhosted.org/packages/30/38/558d9a2dd1fd74f50ff4587b4054496ffb69e21ab1138eb448f3e8e2f4a7/keepkey-6.3.1.tar.gz), at keepkey==6.3.1, which is the version we have [sha256 pinned](https://github.com/spesmilo/electrum/blob/30901212d0e4cb503bf0f76f6a5a3c1b0473de2c/contrib/deterministic-build/requirements-hw.txt#L284) for 5 years.
> 
> This also vendors the corresponding source protobuf files, which were not part of the keepkeylib sdist. Those are taken from the git repo, at the [corresponding commit](https://github.com/keepkey/python-keepkey/commit/2170fc4479bf5a4b63d2067801ecf041430db769) (for v6.3.1).
> 
> Subsequent commits
> - strip out some of the shitcoin crap from keepkeylib, though only the parts that were easy to remove
> - regenerate the pb2 files using `protoc-21.12` (which is the version currently in debian stable, already much newer than what was previously used)
> 
> closes https://github.com/spesmilo/electrum/issues/7922

