### PR TITLE
plugin ConfigVars: define vars less dynamically

### DIFF
--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -290,11 +290,7 @@ class Plugins(DaemonThread):
             else:
                 zipfile = zipimport.zipimporter(metadata['path'])
                 init_spec = zipfile.find_spec(name)
-            module = self.exec_module_from_spec(init_spec, base_name)
-            # import config vars
-            if hasattr(module, 'config_vars'):
-                for cv in module.config_vars:
-                    setattr(SimpleConfig, cv.key().upper(), cv)
+            self.exec_module_from_spec(init_spec, base_name)
             if name == "trustedcoin":
                 # removes trustedcoin after loading to not show it in the list of plugins
                 del self.internal_plugin_metadata[name]

--- a/electrum/plugins/payserver/__init__.py
+++ b/electrum/plugins/payserver/__init__.py
@@ -1,6 +1,5 @@
-from electrum.simple_config import ConfigVar
-config_vars = [
-    ConfigVar('payserver_port', default=8080, type_=int),
-    ConfigVar('payserver_root', default='/r', type_=str),
-    ConfigVar('payserver_allow_create_invoice', default=False, type_=bool),
-]
+from electrum.simple_config import ConfigVar, SimpleConfig
+
+SimpleConfig.PAYSERVER_PORT = ConfigVar('payserver_port', default=8080, type_=int)
+SimpleConfig.PAYSERVER_ROOT = ConfigVar('payserver_root', default='/r', type_=str)
+SimpleConfig.PAYSERVER_ALLOW_CREATE_INVOICE = ConfigVar('payserver_allow_create_invoice', default=False, type_=bool)

--- a/electrum/plugins/payserver/__init__.py
+++ b/electrum/plugins/payserver/__init__.py
@@ -1,5 +1,5 @@
 from electrum.simple_config import ConfigVar, SimpleConfig
 
-SimpleConfig.PAYSERVER_PORT = ConfigVar('payserver_port', default=8080, type_=int)
-SimpleConfig.PAYSERVER_ROOT = ConfigVar('payserver_root', default='/r', type_=str)
-SimpleConfig.PAYSERVER_ALLOW_CREATE_INVOICE = ConfigVar('payserver_allow_create_invoice', default=False, type_=bool)
+SimpleConfig.PAYSERVER_PORT = ConfigVar('payserver_port', default=8080, type_=int, plugin=__name__)
+SimpleConfig.PAYSERVER_ROOT = ConfigVar('payserver_root', default='/r', type_=str, plugin=__name__)
+SimpleConfig.PAYSERVER_ALLOW_CREATE_INVOICE = ConfigVar('payserver_allow_create_invoice', default=False, type_=bool, plugin=__name__)

--- a/electrum/plugins/swapserver/__init__.py
+++ b/electrum/plugins/swapserver/__init__.py
@@ -1,6 +1,5 @@
-from electrum.simple_config import ConfigVar
-config_vars = [
-    ConfigVar('swapserver_port', default=None, type_=int),
-    ConfigVar('swapserver_fee_millionths', default=5000, type_=int),
-    ConfigVar('swapserver_ann_pow_nonce', default=0, type_=int),
-]
+from electrum.simple_config import ConfigVar, SimpleConfig
+
+SimpleConfig.SWAPSERVER_PORT = ConfigVar('swapserver_port', default=None, type_=int)
+SimpleConfig.SWAPSERVER_FEE_MILLIONTHS = ConfigVar('swapserver_fee_millionths', default=5000, type_=int)
+SimpleConfig.SWAPSERVER_ANN_POW_NONCE = ConfigVar('swapserver_ann_pow_nonce', default=0, type_=int)

--- a/electrum/plugins/swapserver/__init__.py
+++ b/electrum/plugins/swapserver/__init__.py
@@ -1,5 +1,5 @@
 from electrum.simple_config import ConfigVar, SimpleConfig
 
-SimpleConfig.SWAPSERVER_PORT = ConfigVar('swapserver_port', default=None, type_=int)
-SimpleConfig.SWAPSERVER_FEE_MILLIONTHS = ConfigVar('swapserver_fee_millionths', default=5000, type_=int)
-SimpleConfig.SWAPSERVER_ANN_POW_NONCE = ConfigVar('swapserver_ann_pow_nonce', default=0, type_=int)
+SimpleConfig.SWAPSERVER_PORT = ConfigVar('swapserver_port', default=None, type_=int, plugin=__name__)
+SimpleConfig.SWAPSERVER_FEE_MILLIONTHS = ConfigVar('swapserver_fee_millionths', default=5000, type_=int, plugin=__name__)
+SimpleConfig.SWAPSERVER_ANN_POW_NONCE = ConfigVar('swapserver_ann_pow_nonce', default=0, type_=int, plugin=__name__)

--- a/electrum/plugins/watchtower/__init__.py
+++ b/electrum/plugins/watchtower/__init__.py
@@ -1,6 +1,5 @@
-from electrum.simple_config import ConfigVar
-config_vars = [
-    ConfigVar('watchtower_server_port', default=None, type_=int),
-    ConfigVar('watchtower_server_user', default=None, type_=str),
-    ConfigVar('watchtower_server_password', default=None, type_=str),
-]
+from electrum.simple_config import ConfigVar, SimpleConfig
+
+SimpleConfig.WATCHTOWER_SERVER_PORT = ConfigVar('watchtower_server_port', default=None, type_=int)
+SimpleConfig.WATCHTOWER_SERVER_USER = ConfigVar('watchtower_server_user', default=None, type_=str)
+SimpleConfig.WATCHTOWER_SERVER_PASSWORD = ConfigVar('watchtower_server_password', default=None, type_=str)

--- a/electrum/plugins/watchtower/__init__.py
+++ b/electrum/plugins/watchtower/__init__.py
@@ -1,5 +1,5 @@
 from electrum.simple_config import ConfigVar, SimpleConfig
 
-SimpleConfig.WATCHTOWER_SERVER_PORT = ConfigVar('watchtower_server_port', default=None, type_=int)
-SimpleConfig.WATCHTOWER_SERVER_USER = ConfigVar('watchtower_server_user', default=None, type_=str)
-SimpleConfig.WATCHTOWER_SERVER_PASSWORD = ConfigVar('watchtower_server_password', default=None, type_=str)
+SimpleConfig.WATCHTOWER_SERVER_PORT = ConfigVar('watchtower_server_port', default=None, type_=int, plugin=__name__)
+SimpleConfig.WATCHTOWER_SERVER_USER = ConfigVar('watchtower_server_user', default=None, type_=str, plugin=__name__)
+SimpleConfig.WATCHTOWER_SERVER_PASSWORD = ConfigVar('watchtower_server_password', default=None, type_=str, plugin=__name__)

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -45,6 +45,7 @@ class ConfigVar(property):
         convert_getter: Callable[[Any], Any] = None,
         short_desc: Callable[[], str] = None,
         long_desc: Callable[[], str] = None,
+        plugin: Optional[str] = None,
     ):
         self._key = key
         self._default = default
@@ -56,6 +57,13 @@ class ConfigVar(property):
         assert long_desc is None or callable(long_desc)
         self._short_desc = short_desc
         self._long_desc = long_desc
+        if plugin:  # enforce "key" starts with name of plugin
+            pkg_prefix = "electrum.plugins."  # for internal plugins
+            if plugin.startswith(pkg_prefix):
+                plugin = plugin[len(pkg_prefix):]
+            assert "." not in plugin, plugin
+            key_prefix = plugin + "_"
+            assert key.startswith(key_prefix), f"ConfigVar {key=} must be prefixed with the plugin name ({key_prefix})"
         property.__init__(self, self._get_config_value, self._set_config_value)
         assert key not in _config_var_from_key, f"duplicate config key str: {key!r}"
         _config_var_from_key[key] = self


### PR DESCRIPTION
- define vars less dynamically
- enforce "key" starts with name of plugin
    - this depends on https://github.com/spesmilo/electrum/pull/9655 to work properly