### PR TITLE
swaps: Announce available liquidity instead of static maximum value

### DIFF
--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -177,7 +177,7 @@ class SwapDialog(WindowModalDialog, QtEventListener):
             self.max_button.setChecked(False)
 
     def _spend_max_reverse_swap(self) -> None:
-        amount = min(self.lnworker.num_sats_can_send(), self.swap_manager.get_max_amount())
+        amount = min(self.lnworker.num_sats_can_send(), self.swap_manager.get_provider_max_forward_amount())
         amount = int(amount)  # round down msats
         self.send_amount_e.setAmount(amount)
 
@@ -295,9 +295,9 @@ class SwapDialog(WindowModalDialog, QtEventListener):
         coins = self.window.get_coins()
         if onchain_amount == '!':
             max_amount = sum(c.value_sats() for c in coins)
-            max_swap_amount = self.swap_manager.max_amount_forward_swap()
+            max_swap_amount = self.swap_manager.client_max_amount_forward_swap()
             if max_swap_amount is None:
-                raise InvalidSwapParameters("swap_manager.max_amount_forward_swap() is None")
+                raise InvalidSwapParameters("swap_manager.client_max_amount_forward_swap() is None")
             if max_amount > max_swap_amount:
                 onchain_amount = max_swap_amount
         outputs = [PartialTxOutput.from_address_and_value(DummyAddress.SWAP, onchain_amount)]

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -242,7 +242,7 @@ class UTXOList(MyTreeView):
             return False
         value = sum(x.value_sats() for x in coins)
         min_amount = self.wallet.lnworker.swap_manager.get_min_amount()
-        max_amount = self.wallet.lnworker.swap_manager.max_amount_forward_swap()
+        max_amount = self.wallet.lnworker.swap_manager.client_max_amount_forward_swap()
         if min_amount is None or max_amount is None:
             # we need to fetch data from swap server
             return True

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -912,6 +912,11 @@ class LNWallet(LNWorker):
         return (self.can_have_recoverable_channels()
                 and self.config.LIGHTNING_USE_RECOVERABLE_CHANNELS)
 
+    def has_anchor_channels(self) -> bool:
+        """Returns True if any active channel is an anchor channel."""
+        return any(chan.has_anchors() and not chan.is_redeemed()
+                    for chan in self.channels.values())
+
     @property
     def channels(self) -> Mapping[bytes, Channel]:
         """Returns a read-only copy of channels."""

--- a/electrum/plugins/swapserver/server.py
+++ b/electrum/plugins/swapserver/server.py
@@ -66,7 +66,9 @@ class HttpSwapServer(Logger, EventListener):
                 "BTC/BTC": {
                     "rate": 1,
                     "limits": {
-                        "maximal": sm._max_amount,
+                        "maximal": min(sm._max_forward, sm._max_reverse),  # legacy
+                        "max_forward_amount": sm._max_forward,  # new version, uses 2 separate limits
+                        "max_reverse_amount": sm._max_reverse,
                         "minimal": sm._min_amount,
                     },
                     "fees": {

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -926,12 +926,8 @@ class SwapManager(Logger):
         """ for server """
         self.percentage = float(self.config.SWAPSERVER_FEE_MILLIONTHS) / 10000  # type: ignore
         self._min_amount = 20000
-        anchor_reserve = self.config.LN_UTXO_RESERVE \
-                                if (any(chan.has_anchors() and not chan.is_redeemed()
-                                for chan in self.lnworker.channels.values())) else 0
-        oc_balance = max(sum([coin.value_sats() for coin in self.wallet.get_spendable_coins()])
-                                - anchor_reserve, 0)
-        max_forward: int = min(int(self.lnworker.num_sats_can_receive()), oc_balance, 10000000)
+        oc_balance_sat: int = self.wallet.get_spendable_balance_sat()
+        max_forward: int = min(int(self.lnworker.num_sats_can_receive()), oc_balance_sat, 10000000)
         max_reverse: int = min(int(self.lnworker.num_sats_can_send()), 10000000)
         self._max_forward: int = self._keep_leading_digits(max_forward, 2)
         self._max_reverse: int = self._keep_leading_digits(max_reverse, 2)


### PR DESCRIPTION
Makes swap provider announce the actual available liquidity for forward and reverse swaps instead of a static hardcoded max value. This should increase reliability of swaps as clients will know upfront if the provider even has enough liquidity to fulfill their request.

Depends on https://github.com/spesmilo/electrum/pull/9647