### PR TITLE
qml: detect transaction removed (e.g. replace-by-fee) for qetxdetails…

### DIFF
--- a/electrum/gui/qml/components/CpfpBumpFeeDialog.qml
+++ b/electrum/gui/qml/components/CpfpBumpFeeDialog.qml
@@ -222,11 +222,4 @@ ElDialog {
             onClicked: doAccept()
         }
     }
-
-    Connections {
-        target: cpfpfeebumper
-        function onTxMined() {
-            dialog.doReject()
-        }
-    }
 }

--- a/electrum/gui/qml/components/RbfBumpFeeDialog.qml
+++ b/electrum/gui/qml/components/RbfBumpFeeDialog.qml
@@ -231,11 +231,4 @@ ElDialog {
             onClicked: doAccept()
         }
     }
-
-    Connections {
-        target: rbffeebumper
-        function onTxMined() {
-            dialog.doReject()
-        }
-    }
 }

--- a/electrum/gui/qml/components/RbfCancelDialog.qml
+++ b/electrum/gui/qml/components/RbfCancelDialog.qml
@@ -163,11 +163,4 @@ ElDialog {
             onClicked: doAccept()
         }
     }
-
-    Connections {
-        target: txcanceller
-        function onTxMined() {
-            dialog.doReject()
-        }
-    }
 }


### PR DESCRIPTION
… and qetxfinalizer,

show broadcast-failed status in TxDetails.

This also avoids stacking order confusion leading to unclosable dialogs if e.g. TxDetails is closed while a dialog is shown on top (Note: this _avoids_ the issue. There's still a window stack issue in certain cases when a non-topmost pane is closed while a dialog is on top)