### PR TITLE
qml: don't confuse second payment to same address with previous uncon…

### DIFF
--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -167,6 +167,9 @@ class QEInvoice(QObject, QtEventListener):
     def status(self):
         if not self._effectiveInvoice:
             return PR_UNKNOWN
+        if self.invoiceType == QEInvoice.Type.OnchainInvoice and self._effectiveInvoice.get_amount_sat() == 0:
+            # no amount set, not a final invoice, get_invoice_status would be wrong
+            return PR_UNPAID
         return self._wallet.wallet.get_invoice_status(self._effectiveInvoice)
 
     @pyqtProperty(str, notify=statusChanged)


### PR DESCRIPTION
…firmed payment to that address

QEInvoiceParser creates a zero amount output invoice when pasting an address, which would return the wrong status when calling wallet.get_invoice_status() (there is some address heuristic in wallet._is_onchain_invoice_paid which is associating with a previous unconfirmed payment to the same address)