### PR TITLE
qt: use system theme as default theme and add 'System' theme option

### DIFF
--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -75,7 +75,8 @@ from electrum.bip32 import is_xprv
 
 from electrum.gui.common_qt.i18n import ElectrumTranslator
 
-from .util import read_QIcon, ColorScheme, custom_message_box, MessageBoxMixin, WWLabel
+from .util import (read_QIcon, ColorScheme, custom_message_box, MessageBoxMixin, WWLabel,
+                   is_system_dark_mode)
 from .main_window import ElectrumWindow
 from .network_dialog import NetworkDialog
 from .stylesheet_patcher import patch_qt_stylesheet
@@ -180,7 +181,8 @@ class ElectrumGui(BaseElectrumGui, Logger):
              - in Coins tab, the color for "frozen" UTXOs, or
              - in TxDialog, the receiving/change address colors
         """
-        use_dark_theme = self.config.GUI_QT_COLOR_THEME == 'dark'
+        use_dark_theme = self.config.GUI_QT_COLOR_THEME == 'dark' \
+                            or self.config.GUI_QT_COLOR_THEME == 'default' and is_system_dark_mode()
         if use_dark_theme:
             try:
                 import qdarkstyle

--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -36,7 +36,7 @@ from electrum.util import base_units_list, event_listener
 
 from electrum.gui import messages
 
-from .util import ColorScheme, HelpLabel, Buttons, CloseButton, QtEventListener
+from .util import ColorScheme, HelpLabel, Buttons, CloseButton, QtEventListener, is_system_dark_mode
 
 
 if TYPE_CHECKING:
@@ -252,15 +252,26 @@ class SettingsDialog(QDialog, QtEventListener):
         qr_combo.currentIndexChanged.connect(on_video_device)
 
         colortheme_combo = QComboBox()
-        colortheme_combo.addItem(_('Light'), 'default')
+        colortheme_combo.addItem(_('Light'), 'light')
         colortheme_combo.addItem(_('Dark'), 'dark')
+        colortheme_combo.addItem(_('System'), 'default')
         index = colortheme_combo.findData(self.config.GUI_QT_COLOR_THEME)
         colortheme_combo.setCurrentIndex(index)
         colortheme_label = QLabel(self.config.cv.GUI_QT_COLOR_THEME.get_short_desc() + ':')
 
+        def theme_transition_requires_restart(prev_theme: str, new_theme: str) -> bool:
+            system = 'dark' if is_system_dark_mode() else 'light'
+            effective_prev = system if prev_theme == 'default' else prev_theme
+            effective_new = system if new_theme == 'default' else new_theme
+            return effective_prev != effective_new
+
         def on_colortheme(x):
+            prev_color = self.config.GUI_QT_COLOR_THEME
             self.config.GUI_QT_COLOR_THEME = colortheme_combo.itemData(x)
-            self.need_restart = True
+            self.need_restart = theme_transition_requires_restart(
+                prev_color,
+                self.config.GUI_QT_COLOR_THEME
+            )
         colortheme_combo.currentIndexChanged.connect(on_colortheme)
 
         updatecheck_cb = checkbox_from_configvar(self.config.cv.AUTOMATIC_CENTRALIZED_UPDATE_CHECKS)

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -1328,6 +1328,17 @@ def font_height(widget: QWidget = None) -> int:
     return QFontMetrics(widget.font()).height()
 
 
+def is_system_dark_mode() -> bool:
+    """Returns True if the system theme is in dark mode, False otherwise."""
+    qapp: Optional[QApplication] = QApplication.instance()
+    if not qapp:
+        return False
+    palette: QPalette = qapp.palette()
+    window_color: QColor = palette.color(QPalette.ColorRole.Window)
+    text_color: QColor = palette.color(QPalette.ColorRole.WindowText)
+    return text_color.lightness() > window_color.lightness()
+
+
 def webopen(url: str):
     if sys.platform == 'linux' and os.environ.get('APPIMAGE'):
         # When on Linux webbrowser.open can fail in AppImage because it can't find the correct libdbus.


### PR DESCRIPTION
Adds a theme setting to qt gui to use the system theme color instead of a fixed theme, also uses it as default config.

Edit: see https://github.com/spesmilo/electrum/issues/9690, will wait for the qt function to handle this properly