### PR TITLE
lightning: fix exception if LIGHTNING_LISTEN is not set on public node

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1734,11 +1734,18 @@ class Peer(Logger, EventListener):
         rgb_color = bytes.fromhex('000000')
         alias = bytes(alias, 'utf8')
         alias += bytes(32 - len(alias))
-        addr = self.lnworker.config.LIGHTNING_LISTEN
-        hostname, port = addr.split(':')
-        if port is None:  # use default port if not specified
-            port = 9735
-        addresses = NodeInfo.to_addresses_field(hostname, int(port))
+        if self.lnworker.config.LIGHTNING_LISTEN is not None:
+            addr = self.lnworker.config.LIGHTNING_LISTEN
+            try:
+                hostname, port = addr.split(':')
+                if port is None:  # use default port if not specified
+                    port = 9735
+                addresses = NodeInfo.to_addresses_field(hostname, int(port))
+            except Exception:
+                self.logger.exception(f"Invalid lightning_listen address: {addr}")
+                return
+        else:
+            addresses = b''
         raw_msg = encode_msg(
             "node_announcement",
             flen=flen,


### PR DESCRIPTION
If public channels are opened without setting `LIGHTNING_LISTEN` to some listening address `LNPeer.send_node_announcement()` will raise an exception as the default value of `LIGHTNING_LISTEN` is `None`. However it should be possible to have public channels without announcing a listening address.
Exception:
```
  File "/home/user/code/electrum-fork/electrum/lnpeer.py", line 553, in _send_own_gossip
    self.send_node_announcement(alias)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/user/code/electrum-fork/electrum/lnpeer.py", line 1738, in send_node_announcement
    hostname, port = addr.split(':')
                     ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```