### PR TITLE
qml: call QEChannelOpener.validate() on updateMaxAmount

### DIFF
--- a/electrum/gui/qml/qechannelopener.py
+++ b/electrum/gui/qml/qechannelopener.py
@@ -261,5 +261,6 @@ class QEChannelOpener(QObject, AuthMixin):
                     self.maxAmountMessage.emit(message)
             finally:
                 self._updating_max = False
+                self.validate()
 
         threading.Thread(target=calc_max, daemon=True).start()


### PR DESCRIPTION
Calls `QEChannelOpener.validate()` after setting the max amount slider in the channel open dialog so that the `Open Channel...` button gets activated when max amount was set. 
Right now if max amount gets set and no other value gets changed the `Open Channel...` button stays deactivated.

![image](https://github.com/user-attachments/assets/5985c1ea-41a8-4dce-816b-9db5075d154f)
