### PR TITLE
tx / gui: Disable output value rounding for 0 fee tx and don't show relay fee warning in gui

### DIFF
--- a/electrum/coinchooser.py
+++ b/electrum/coinchooser.py
@@ -201,7 +201,10 @@ class CoinChooserBase(Logger):
         # Last change output.  Round down to maximum precision but lose
         # no more than 10**max_dp_to_round_for_privacy
         # e.g. a max of 2 decimal places means losing 100 satoshis to fees
-        max_dp_to_round_for_privacy = 2 if self.enable_output_value_rounding else 0
+        # don't round if the fee estimator is set to 0 fixed fee, so a 0 fee tx remains a 0 fee tx
+        is_zero_fee_tx = True if fee_estimator_numchange(1) == 0 else False
+        output_value_rounding = self.enable_output_value_rounding and not is_zero_fee_tx
+        max_dp_to_round_for_privacy = 2 if output_value_rounding else 0
         N = int(pow(10, min(max_dp_to_round_for_privacy, zeroes[0])))
         amount = (remaining // N) * N
         amounts.append(amount)

--- a/electrum/gui/qml/qetxfinalizer.py
+++ b/electrum/gui/qml/qetxfinalizer.py
@@ -299,7 +299,7 @@ class TxFeeSlider(FeeSlider):
             if invoice_amt == 0:
                 invoice_amt = tx.output_value()
         fee_warning_tuple = self._wallet.wallet.get_tx_fee_warning(
-            invoice_amt=invoice_amt, tx_size=tx.estimated_size(), fee=tx.get_fee())
+            invoice_amt=invoice_amt, tx_size=tx.estimated_size(), fee=tx.get_fee(), txid=tx.txid())
         if fee_warning_tuple:
             allow_send, long_warning, short_warning = fee_warning_tuple
             self.warning = _('Warning') + ': ' + long_warning

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -517,7 +517,7 @@ class TxEditor(WindowModalDialog):
         amount = self.tx.output_value() if self.output_value == '!' else self.output_value
         tx_size = self.tx.estimated_size()
         fee_warning_tuple = self.wallet.get_tx_fee_warning(
-            invoice_amt=amount, tx_size=tx_size, fee=fee)
+            invoice_amt=amount, tx_size=tx_size, fee=fee, txid=self.tx.txid())
         if fee_warning_tuple:
             allow_send, long_warning, short_warning = fee_warning_tuple
             if not allow_send:

--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -905,7 +905,7 @@ class TxDialog(QDialog, MessageBoxMixin):
                 # 'amount' is zero for self-payments, so in that case we use sum-of-outputs
                 invoice_amt = abs(amount) if amount else self.tx.output_value()
                 fee_warning_tuple = self.wallet.get_tx_fee_warning(
-                    invoice_amt=invoice_amt, tx_size=size, fee=fee)
+                    invoice_amt=invoice_amt, tx_size=size, fee=fee, txid=self.tx.txid())
                 if fee_warning_tuple:
                     allow_send, long_warning, short_warning = fee_warning_tuple
                     fee_str += " - <font color={color}>{header}: {body}</font>".format(

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3276,16 +3276,18 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             self, *,
             invoice_amt: int,
             tx_size: int,
-            fee: int) -> Optional[Tuple[bool, str, str]]:
+            fee: int,
+            txid: Optional[str]) -> Optional[Tuple[bool, str, str]]:
 
         assert invoice_amt >= 0, f"{invoice_amt=!r} must be non-negative satoshis"
         assert fee >= 0, f"{fee=!r} must be non-negative satoshis"
+        is_future_tx = txid is not None and txid in self.adb.future_tx
         feerate = Decimal(fee) / tx_size  # sat/byte
         fee_ratio = Decimal(fee) / invoice_amt if invoice_amt else 0
         long_warning = None
         short_warning = None
         allow_send = True
-        if feerate < self.relayfee() / 1000:
+        if feerate < self.relayfee() / 1000 and not is_future_tx:
             long_warning = ' '.join([
                 _("This transaction requires a higher fee, or it will not be propagated by your current server."),
                 _("Try to raise your transaction fee, or use a server with a lower relay fee.")


### PR DESCRIPTION
Disable output value rounding for txs intended to have 0 fees (future txs) in `_change_amounts()` so it doesn't add a small fee due to rounding. 
Also stops showing the below relay fee warning in the gui if the tx is a future tx.


Before:
![Screenshot_20250407_114617](https://github.com/user-attachments/assets/0f945ff6-c7f8-4334-a7dd-62855dcd7102)
After:
![Screenshot_20250407_114724](https://github.com/user-attachments/assets/b40b94a7-5b73-4ea9-8a68-aec1ac6e2d97)
