### PR TITLE
lightning: trigger payment_failed only once in LNWallet.htlc_failed().

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2601,8 +2601,9 @@ class LNWallet(LNWorker):
             else:
                 self.logger.info(f"received unknown htlc_failed, probably from previous session (phash={payment_hash.hex()})")
                 key = payment_hash.hex()
-                self.set_invoice_status(key, PR_UNPAID)
-                util.trigger_callback('payment_failed', self.wallet, key, '')
+                if self.get_payment_status(payment_hash) != PR_UNPAID:
+                    self.set_invoice_status(key, PR_UNPAID)
+                    util.trigger_callback('payment_failed', self.wallet, key, '')
 
         if fw_key:
             fw_htlcs = self.active_forwardings[fw_key]


### PR DESCRIPTION
When a channel with outgoing htlc is force closed and there is no preimage released by the recipient `LNWallet.htlc_failed()` will indirectly get called on each startup and new block until the channel is not being watched anymore. 
This triggers the `payment_failed` callback every time which will trigger a UI reaction in qt and qml, which is annoying and misleading.
This PR adds a check `if self.get_payment_status(payment_hash) != PR_UNPAID` so that the callback will get triggered only once (when the payment status hasn't already been set to `PR_UNPAID`).