### PR TITLE
qml: pass updated fee policy to make_tx function when opening channel

### DIFF
--- a/electrum/gui/qml/qechannelopener.py
+++ b/electrum/gui/qml/qechannelopener.py
@@ -170,9 +170,8 @@ class QEChannelOpener(QObject, AuthMixin):
         self._logger.debug('amount = %s' % str(amount))
 
         coins = self._wallet.wallet.get_spendable_coins(None, nonlocal_only=True)
-        fee_policy = FeePolicy(self._wallet.wallet.config.FEE_POLICY)
 
-        mktx = lambda amt: lnworker.mktx_for_open_channel(
+        mktx = lambda amt, fee_policy: lnworker.mktx_for_open_channel(
             coins=coins,
             funding_sat=amt,
             node_id=self._node_pubkey,

--- a/electrum/gui/qml/qetxfinalizer.py
+++ b/electrum/gui/qml/qetxfinalizer.py
@@ -380,7 +380,7 @@ class QETxFinalizer(TxFeeSlider):
         self._logger.debug(f'make_tx amount={amount}')
 
         if self.f_make_tx:
-            tx = self.f_make_tx(amount)
+            tx = self.f_make_tx(amount, self._fee_policy)
         else:
             # default impl
             coins = self._wallet.wallet.get_spendable_coins(None)


### PR DESCRIPTION
The fee slider in the qml lightning channel tx dialog didn't work because the fee policy passed to `mktx_for_open_channel` was not updated when the slider position changed.

![Untitled](https://github.com/user-attachments/assets/97def6e2-4c54-4982-b0a8-a8c545c4a92d)

