### PR TITLE
swaps: make swap transport use shared timeout value

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1225,8 +1225,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         sm = self.wallet.lnworker.swap_manager
         if not sm.is_initialized.is_set():
             async def wait_until_initialized():
+                timeout = transport.connect_timeout + 1
                 try:
-                    await asyncio.wait_for(sm.is_initialized.wait(), timeout=5)
+                    await asyncio.wait_for(sm.is_initialized.wait(), timeout=timeout)
                 except asyncio.TimeoutError:
                     return
             try:


### PR DESCRIPTION
Swap provider discovery using nostr was sometimes unreliable (in the sense of showing that no providers could be found, even though the logs showed successful connections) because the timeout in `initialize_swap_manager()` was independent of the connection timeout used for the relay manager. So the relay manager tried to connect to (unreachable) relays longer than the timeout in `initialize_swap_manager()` causing  `initialize_swap_manager()` to close the NostrTransport again before the connect call even returned. The solution is to just use a shared timeout value (+ some buffer in `initialize_swap_manager()`)