### PR TITLE
swaps: Reduce logging verbosity of aionostr.Manager in swap transport

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -1412,10 +1412,12 @@ class NostrTransport(SwapServerTransport):
                 proxy = make_aiohttp_proxy_connector(self.network.proxy, self.ssl_context)
             else:
                 proxy: Optional['ProxyConnector'] = None
+            nostr_logger = self.logger.getChild('aionostr')
+            nostr_logger.setLevel('INFO')  # DEBUG is very verbose with aionostr
             return aionostr.Manager(
                 self.relays,
                 private_key=self.nostr_private_key,
-                log=self.logger,
+                log=nostr_logger,
                 ssl_context=self.ssl_context,
                 proxy=proxy,
                 connect_timeout=self.connect_timeout


### PR DESCRIPTION
Set log level of the logger passed into the aionostr.Manager to INFO because the debug log output of Manager is very verbose (showing single websocket messages etc.). This still provides enough useful information for debugging purposes.