### PR TITLE
qml: simplify QEConfig and QEDaemon use.

### DIFF
--- a/electrum/gui/qml/__init__.py
+++ b/electrum/gui/qml/__init__.py
@@ -82,7 +82,7 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.timer.timeout.connect(lambda: None)  # periodically enter python scope
 
         # hook for crash reporter
-        Exception_Hook.maybe_setup(config=config, slot=self.app.appController.crash)
+        Exception_Hook.maybe_setup(slot=self.app.appController.crash)
 
         # Initialize any QML plugins
         run_hook('init_qml', self.app)

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -121,6 +121,8 @@ class QEWalletListModel(QAbstractListModel):
 
 
 class QEDaemon(AuthMixin, QObject):
+    instance = None  # type: Optional[QEDaemon]
+
     _logger = get_logger(__name__)
 
     _available_wallets = None
@@ -149,6 +151,9 @@ class QEDaemon(AuthMixin, QObject):
 
     def __init__(self, daemon: 'Daemon', plugins: 'Plugins', parent=None):
         super().__init__(parent)
+        if QEDaemon.instance:
+            raise RuntimeError('There should only be one QEDaemon instance')
+        QEDaemon.instance = self
         self.daemon = daemon
         self.plugins = plugins
         self.qefx = QEFX(daemon.fx, daemon.config)

--- a/electrum/plugins/trustedcoin/qml.py
+++ b/electrum/plugins/trustedcoin/qml.py
@@ -5,8 +5,9 @@ from electrum.plugin import hook
 from electrum.util import UserFacingException
 
 from electrum.gui.qml.qewallet import QEWallet
-from .common_qt import TrustedcoinPluginQObject
+from electrum.gui.qml.qedaemon import QEDaemon
 
+from .common_qt import TrustedcoinPluginQObject
 from .trustedcoin import TrustedCoinPlugin, TrustedCoinException
 
 if TYPE_CHECKING:
@@ -44,7 +45,7 @@ class Plugin(TrustedCoinPlugin):
     def init_qml(self, app: 'ElectrumQmlApplication'):
         self.logger.debug(f'init_qml hook called, gui={str(type(app))}')
         self._app = app
-        wizard = self._app.daemon.newWalletWizard
+        wizard = QEDaemon.instance.newWalletWizard
         # important: TrustedcoinPluginQObject needs to be parented, as keeping a ref
         # in the plugin is not enough to avoid gc
         # Note: storing the trustedcoin qt helper in the plugin is different from the desktop client,


### PR DESCRIPTION
force QEDaemon singleton, and refer to QEDaemon.instance where possible In cases where we would run into circular dependencies, pass the instance

also refer to singleton QEConfig instead of passing instance in qeapp.py