### PR TITLE
lightning: enable anchor channels by default

### DIFF
--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -842,7 +842,7 @@ Warning: setting this to too low will result in lots of payment failures."""),
     )
 
     # anchor outputs channels
-    ENABLE_ANCHOR_CHANNELS = ConfigVar('enable_anchor_channels', default=False, type_=bool)
+    ENABLE_ANCHOR_CHANNELS = ConfigVar('enable_anchor_channels', default=True, type_=bool)
     # zeroconf channels
     ACCEPT_ZEROCONF_CHANNELS = ConfigVar('accept_zeroconf_channels', default=False, type_=bool)
     ZEROCONF_TRUSTED_NODE = ConfigVar('zeroconf_trusted_node', default='', type_=str)


### PR DESCRIPTION
Now that anchor channels are ready to use and sufficiently tested we could make them default.