### PR TITLE
qt: SeedWidget: for xpubs, show copy button next to QR button.

### DIFF
--- a/electrum/gui/qt/seed_dialog.py
+++ b/electrum/gui/qt/seed_dialog.py
@@ -119,6 +119,7 @@ class SeedWidget(QWidget):
                 self.seed_e = ButtonsTextEdit()
             else:  # e.g. xpub
                 self.seed_e = ShowQRTextEdit(config=self.config)
+                self.seed_e.addCopyButton()
             self.seed_e.setReadOnly(True)
             self.seed_e.setText(seed)
         else:  # we expect user to enter text


### PR DESCRIPTION
This is only used when displaying wallet xpub in wizard for multisig setup.