### PR TITLE
lightning: remove LIGHTNING_LEGACY_ADD_TRAMPOLINE config option

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -130,19 +130,10 @@ class SettingsDialog(QDialog, QtEventListener):
             else:
                 self.network.run_from_another_thread(
                     self.network.stop_gossip())
-            legacy_add_trampoline_cb.setEnabled(use_trampoline)
             util.trigger_callback('ln_gossip_sync_progress')
             # FIXME: update all wallet windows
             util.trigger_callback('channels_updated', self.wallet)
         trampoline_cb.stateChanged.connect(on_trampoline_checked)
-
-        legacy_add_trampoline_cb = checkbox_from_configvar(self.config.cv.LIGHTNING_LEGACY_ADD_TRAMPOLINE)
-        legacy_add_trampoline_cb.setChecked(self.config.LIGHTNING_LEGACY_ADD_TRAMPOLINE)
-        legacy_add_trampoline_cb.setEnabled(trampoline_cb.isChecked())
-
-        def on_legacy_add_trampoline_checked(_x):
-            self.config.LIGHTNING_LEGACY_ADD_TRAMPOLINE = legacy_add_trampoline_cb.isChecked()
-        legacy_add_trampoline_cb.stateChanged.connect(on_legacy_add_trampoline_checked)
 
         lnfee_hlabel = HelpLabel.from_configvar(self.config.cv.LIGHTNING_PAYMENT_FEE_MAX_MILLIONTHS)
         lnfee_map = [500, 1_000, 3_000, 5_000, 10_000, 20_000, 30_000, 50_000]
@@ -394,7 +385,6 @@ class SettingsDialog(QDialog, QtEventListener):
         units_widgets.append((thousandsep_cb, None))
         lightning_widgets = []
         lightning_widgets.append((trampoline_cb, None))
-        lightning_widgets.append((legacy_add_trampoline_cb, None))
         lightning_widgets.append((lnfee_hlabel, lnfee_hbox_w))
         fiat_widgets = []
         fiat_widgets.append((QLabel(_('Fiat currency')), ccy_combo))

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1608,7 +1608,12 @@ class LNWallet(LNWorker):
             amount_to_pay=amount_to_pay,
             invoice_pubkey=node_pubkey,
             uses_trampoline=self.uses_trampoline(),
-            use_two_trampolines=self.config.LIGHTNING_LEGACY_ADD_TRAMPOLINE,
+            # the config option to use two trampoline hops for legacy payments has been removed as
+            # the trampoline onion is too small (400 bytes) to accommodate two trampoline hops and
+            # routing hints, making the functionality unusable for payments that require routing hints.
+            # TODO: if you read this, the year is 2027 and there is no use for the second trampoline
+            # hop code anymore remove the code completely.
+            use_two_trampolines=False,
         )
         self.logs[payment_hash.hex()] = log = []  # TODO incl payment_secret in key (re trampoline forwarding)
 

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -678,13 +678,6 @@ If this is enabled, other nodes cannot open a channel to you. Channel recovery d
     )
     LIGHTNING_TO_SELF_DELAY_CSV = ConfigVar('lightning_to_self_delay', default=7 * 144, type_=int)
     LIGHTNING_MAX_FUNDING_SAT = ConfigVar('lightning_max_funding_sat', default=LN_MAX_FUNDING_SAT_LEGACY, type_=int)
-    LIGHTNING_LEGACY_ADD_TRAMPOLINE = ConfigVar(
-        'lightning_legacy_add_trampoline', default=False, type_=bool,
-        short_desc=lambda: _("Add extra trampoline to legacy payments"),
-        long_desc=lambda: _("""When paying a non-trampoline invoice, add an extra trampoline to the route, in order to improve your privacy.
-
-This will result in longer routes; it might increase your fees and decrease the success rate of your payments."""),
-    )
     INITIAL_TRAMPOLINE_FEE_LEVEL = ConfigVar('initial_trampoline_fee_level', default=1, type_=int)
     LIGHTNING_PAYMENT_FEE_MAX_MILLIONTHS = ConfigVar(
         'lightning_payment_fee_max_millionths', default=10_000,  # 1%


### PR DESCRIPTION
The config option (`LIGHTNING_LEGACY_ADD_TRAMPOLINE`) to add a 2nd trampoline hop to legacy trampoline payments requires too much space in the trampoline onion. Because the trampoline onion has only limited space of 400b and the payload with 2nd t hop and no r_tags already requires 392b it is practically unusable for payments that require routing hints to be included in the onion (e.g. because the receiver has no direct channel to the 2nd trampoline node) as there is no space left to include even a single routing hint (1r_tag == ~52b).

As discussed, this pr removes the config option from SimpleConfig and the GUI, however it keeps the logic of use_second_trampoline so we could in theory enable it again if the conditions (available space?) change. I also added a TODO to completely remove the code in 2027 if it is not useful for anything else again until then.