### PR TITLE
Add/remove plugins from GUI

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -165,6 +165,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     def __init__(self, gui_object: 'ElectrumGui', wallet: Abstract_Wallet):
         QMainWindow.__init__(self)
         self.gui_object = gui_object
+        self.should_stop_wallet_on_close = True
         self.config = config = gui_object.config  # type: SimpleConfig
         self.gui_thread = gui_object.gui_thread
         assert wallet, "no wallet"
@@ -759,7 +760,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             tools_menu.addAction(_("Electrum preferences"), self.settings_dialog)
 
         tools_menu.addAction(_("&Network"), self.gui_object.show_network_dialog).setEnabled(bool(self.network))
-        tools_menu.addAction(_("&Plugins"), partial(self.gui_object.show_plugins_dialog, self.wallet))
+        tools_menu.addAction(_("&Plugins"), self.gui_object.show_plugins_dialog)
         tools_menu.addSeparator()
         tools_menu.addAction(_("&Sign/verify message"), self.sign_verify_message)
         tools_menu.addAction(_("&Encrypt/decrypt message"), self.encrypt_message)
@@ -2633,8 +2634,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.save_notes_text()
         if not self.isMaximized():
             g = self.geometry()
-            self.wallet.db.put("winpos-qt", [g.left(),g.top(),
-                                                  g.width(),g.height()])
+            self.wallet.db.put(
+                "winpos-qt", [g.left(),g.top(), g.width(),g.height()])
         if self.qr_window:
             self.qr_window.close()
         self.close_wallet()

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -30,6 +30,7 @@ from electrum.gui.qt.password_dialog import PasswordLayout, PW_NEW, MSG_ENTER_PA
 from electrum.gui.qt.seed_dialog import SeedWidget, MSG_PASSPHRASE_WARN_ISSUE4566, KeysWidget
 from electrum.gui.qt.util import (PasswordLineEdit, char_width_in_lineedit, WWLabel, InfoButton, font_height,
                                   ChoiceWidget, MessageBoxMixin, icon_path, IconLabel, read_QIcon)
+from electrum.gui.qt.plugins_dialog import PluginsDialog
 
 if TYPE_CHECKING:
     from electrum.simple_config import SimpleConfig
@@ -1081,6 +1082,7 @@ class WCChooseHWDevice(WalletWizardComponent, Logger):
         self.scanFailed.connect(self.on_scan_failed)
         self.scanComplete.connect(self.on_scan_complete)
         self.plugins = wizard.plugins
+        self.config = wizard.config
 
         self.error_l = WWLabel()
         self.error_l.setVisible(False)
@@ -1093,9 +1095,13 @@ class WCChooseHWDevice(WalletWizardComponent, Logger):
         self.rescan_button = QPushButton(_('Rescan devices'))
         self.rescan_button.clicked.connect(self.on_rescan)
 
+        self.add_plugin_button = QPushButton(_('Add plugin'))
+        self.add_plugin_button.clicked.connect(self.on_add_plugin)
+
         hbox = QHBoxLayout()
         hbox.addStretch(1)
         hbox.addWidget(self.rescan_button)
+        hbox.addWidget(self.add_plugin_button)
         hbox.addStretch(1)
 
         self.layout().addWidget(self.error_l)
@@ -1108,6 +1114,11 @@ class WCChooseHWDevice(WalletWizardComponent, Logger):
         self.scan_devices()
 
     def on_rescan(self):
+        self.scan_devices()
+
+    def on_add_plugin(self):
+        d = PluginsDialog(self.config, self.plugins)
+        d.exec()
         self.scan_devices()
 
     def on_scan_failed(self, code, message):

--- a/electrum/plugins/jade/manifest.json
+++ b/electrum/plugins/jade/manifest.json
@@ -3,5 +3,6 @@
   "fullname": "Blockstream Jade Wallet",
   "description": "Provides support for the Blockstream Jade hardware wallet",
   "registers_keystore": ["hardware", "jade", "Jade wallet"],
+  "icon":"jade.png",
   "available_for": ["qt", "cmdline"]
 }

--- a/electrum/plugins/labels/qt.py
+++ b/electrum/plugins/labels/qt.py
@@ -68,16 +68,6 @@ class Plugin(LabelsPlugin):
         dialog.show_error(_("Error synchronising labels") + f':\n{repr(exc_info[1])}')
 
     @hook
-    def init_qt(self, gui: 'ElectrumGui'):
-        if self._init_qt_received:  # only need/want the first signal
-            return
-        self._init_qt_received = True
-        # If the user just enabled the plugin, the 'load_wallet' hook would not
-        # get called for already loaded wallets, hence we call it manually for those:
-        for window in gui.windows:
-            self.load_wallet(window.wallet, window)
-
-    @hook
     def load_wallet(self, wallet: 'Abstract_Wallet', window: 'ElectrumWindow'):
         self.obj.labels_changed_signal.connect(window.update_tabs)
         self.start_wallet(wallet)

--- a/electrum/plugins/nwc/qt.py
+++ b/electrum/plugins/nwc/qt.py
@@ -25,27 +25,23 @@ class Plugin(NWCServerPlugin):
 
     @hook
     def load_wallet(self, wallet: 'Abstract_Wallet', window: 'ElectrumWindow'):
-        self.start_plugin(wallet)
-
-    @hook
-    def init_qt(self, gui: 'ElectrumGui'):
-        if self._init_qt_received:
+        if not wallet.has_lightning():
             return
-        self._init_qt_received = True
-        for w in gui.windows:
-            self.start_plugin(w.wallet)
+        self.start_plugin(wallet)
 
     def requires_settings(self):
         return True
 
     def settings_dialog(self, window: WindowModalDialog, wallet: 'Abstract_Wallet'):
-        if not wallet.has_lightning():
-            window.show_error(_("{} plugin requires a lightning enabled wallet. Setup lightning first.")
-                           .format("NWC"))
+        if not self.initialized:
+            window.show_error(
+                _("{} plugin requires a lightning enabled wallet. Open a lightning-enabled wallet first.")
+                .format("NWC"))
             return
 
         d = WindowModalDialog(window, _("Nostr Wallet Connect"))
         main_layout = QVBoxLayout(d)
+        main_layout.addWidget(QLabel(_("Using wallet:") + ' ' + self.nwc_server.wallet.basename()))
 
         # Connections list
         main_layout.addWidget(QLabel(_("Existing Connections:")))

--- a/electrum/plugins/psbt_nostr/qt.py
+++ b/electrum/plugins/psbt_nostr/qt.py
@@ -71,14 +71,6 @@ class Plugin(BasePlugin):
 
 
     @hook
-    def init_qt(self, gui: 'ElectrumGui'):
-        if self._init_qt_received:  # only need/want the first signal
-            return
-        self._init_qt_received = True
-        for window in gui.windows:
-            self.load_wallet(window.wallet, window)
-
-    @hook
     def load_wallet(self, wallet: 'Abstract_Wallet', window: 'ElectrumWindow'):
         if type(wallet) != Multisig_Wallet:
             return

--- a/electrum/plugins/revealer/manifest.json
+++ b/electrum/plugins/revealer/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "revealer",
-  "fullname": "Revealer Backup Utility",
-  "description": "This plug-in allows you to create a visually encrypted backup of your wallet seeds, or of custom alphanumeric secrets.",
-  "available_for": ["qt"]
+    "name": "revealer",
+    "fullname": "Revealer Backup Utility",
+    "description": "This plug-in allows you to create a visually encrypted backup of your wallet seeds, or of custom alphanumeric secrets.",
+    "icon": "revealer.png",
+    "available_for": ["qt"]
 }

--- a/electrum/plugins/revealer/qt.py
+++ b/electrum/plugins/revealer/qt.py
@@ -73,7 +73,7 @@ class Plugin(RevealerPlugin):
         self.icon_bytes = self.read_file("revealer.png")
 
     @hook
-    def init_qt(self, gui: 'ElectrumGui'):
+    def load_wallet(self, wallet, window):
         if self._init_qt_received:  # only need/want the first signal
             return
         self._init_qt_received = True

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -346,6 +346,15 @@ class SimpleConfig(Logger):
         assert isinstance(key, str), key
         return self.get(key, default=...) is not ...
 
+    def is_plugin_enabled(self, name: str) -> bool:
+        return bool(self.get(f'plugins.{name}.enabled'))
+
+    def enable_plugin(self, name: str):
+        self.set_key(f'plugins.{name}.enabled', True, save=True)
+
+    def disable_plugin(self, name: str):
+        self.set_key(f'plugins.{name}.enabled', False, save=True)
+
     def _check_dependent_keys(self) -> None:
         if self.NETWORK_SERVERFINGERPRINT:
             if not self.NETWORK_SERVER:

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -272,6 +272,8 @@ class NewWalletWizard(AbstractWizard):
         }
         self._daemon = daemon
         self.plugins = plugins
+        # todo: load only if needed, like hw plugins
+        self.plugins.load_plugin_by_name('trustedcoin')
 
     def start(self, initial_data: dict = None) -> WizardViewState:
         if initial_data is None:


### PR DESCRIPTION
 - both internal and external plugins require GUI install (except internal HW plugins, which are 'auto-loaded' and hidden)
 - remove init_qt hook
 - in Qt, reload wallet windows if plugin enabled/disabled
 - add 'uninstall' button to PluginDialog
 - add 'add plugins' button to wizard hw screen
 - add icons to the plugin list