### PR TITLE
swaps: don't limit attempts when paying swap invoice

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -293,7 +293,7 @@ class SwapManager(Logger):
         self.invoices_to_pay[key] = 1000000000000 # lock
         try:
             invoice = self.wallet.get_invoice(key)
-            success, log = await self.lnworker.pay_invoice(invoice, attempts=10)
+            success, log = await self.lnworker.pay_invoice(invoice)
         except Exception as e:
             self.logger.info(f'exception paying {key}, will not retry')
             self.invoices_to_pay.pop(key, None)


### PR DESCRIPTION
In `SwapManager.pay_invoice()` we pass attempts=10 to `lnworker.pay_invoice()`.
The comment says it's only supposed for unit tests:
```
    async def pay_invoice(
            self, invoice: Invoice, *,
            amount_msat: int = None,
            attempts: int = None,  # used only in unit tests
```
Without attempts it will be limited to 30 if the payer uses trampoline, otherwise it uses a timeout of 120 sec.