### PR TITLE
cmd: fix password command eval type

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -339,7 +339,7 @@ class Commands(Logger):
         Change wallet password.
 
         arg:bool:encrypt_file:Whether the file on disk should be encrypted with the provided password (default=true)
-        arg:bool:new_password:New Password
+        arg:str:new_password:New Password
         """
         if wallet.storage.is_encrypted_with_hw_device() and new_password:
             raise UserFacingException("Can't change the password of a wallet encrypted with a hw device.")


### PR DESCRIPTION
The eval type of the `new_password` argument to the `password` command should be `str`, currently the command is not usable as it tries to eval `new_password` as bool.