### PR TITLE
Txbatcher without password in memory

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -470,8 +470,6 @@ class Daemon(Logger):
         if wallet := self._wallets.get(wallet_key):
             return wallet
         wallet = self._load_wallet(path, password, upgrade=upgrade, config=self.config)
-        if wallet.requires_unlock() and password is not None:
-            wallet.unlock(password)
         wallet.start_network(self.network)
         self.add_wallet(wallet)
         self.update_recently_opened_wallets(path)

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -308,7 +308,6 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.build_tray_menu()
         w.warn_if_testnet()
         w.warn_if_watching_only()
-        w.require_full_encryption()
         return w
 
     def count_wizards_in_progress(func):

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -425,6 +425,8 @@ class AbstractChannel(Logger, ABC):
             conf = closing_height.conf
             if conf > 0:
                 self.set_state(ChannelState.CLOSED)
+                if self.lnworker:
+                    self.lnworker.wallet.txbatcher.set_password_future(None)
             else:
                 # we must not trust the server with unconfirmed transactions,
                 # because the state transition is irreversible. if the remote

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -2120,6 +2120,13 @@ class PartialTransaction(Transaction):
 
         return tx
 
+    def requires_keystore(self):
+        """
+        Returns True if signing will require private keys from the keystore
+        Called by txbatcher in order to know if a password is needed
+        """
+        return not all(hasattr(txin, 'make_witness') for txin in self.inputs())
+
     @classmethod
     def from_io(
             cls,


### PR DESCRIPTION
This makes it possible to use `txbatcher` without unlocking the wallet.
 - if a password is required, send a signal to the GUI, unless the wallet is unlocked.
 - if a transaction is verified, cancel the password future; the next iteration might not require a password anymore (for example, after a commitment tx has been mined we do not need to sweep anchor outputs anymore)
