### PR TITLE
qt: pass Invoice object to transaction dialog when appropriate.

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1165,7 +1165,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         tx: Transaction,
         *,
         external_keypairs: Mapping[bytes, bytes] = None,
-        payment_identifier: PaymentIdentifier = None,
+        invoice: Invoice = None,
         show_sign_button: bool = True,
         show_broadcast_button: bool = True,
     ):
@@ -1173,7 +1173,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             tx,
             parent=self,
             external_keypairs=external_keypairs,
-            payment_identifier=payment_identifier,
+            invoice=invoice,
             show_sign_button=show_sign_button,
             show_broadcast_button=show_broadcast_button,
         )
@@ -1409,18 +1409,18 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         """
         return self.utxo_list.get_spend_list()
 
-    def broadcast_or_show(self, tx: Transaction, *, payment_identifier: PaymentIdentifier = None):
+    def broadcast_or_show(self, tx: Transaction, *, invoice: 'Invoice' = None):
         if not tx.is_complete():
-            self.show_transaction(tx, payment_identifier=payment_identifier)
+            self.show_transaction(tx, invoice=invoice)
             return
         if not self.network:
             self.show_error(_("You can't broadcast a transaction without a live network connection."))
-            self.show_transaction(tx, payment_identifier=payment_identifier)
+            self.show_transaction(tx, invoice=invoice)
             return
-        self.broadcast_transaction(tx, payment_identifier=payment_identifier)
+        self.broadcast_transaction(tx, invoice=invoice)
 
-    def broadcast_transaction(self, tx: Transaction, *, payment_identifier: PaymentIdentifier = None):
-        self.send_tab.broadcast_transaction(tx, payment_identifier=payment_identifier)
+    def broadcast_transaction(self, tx: Transaction, *, invoice: Invoice = None):
+        self.send_tab.broadcast_transaction(tx, invoice=invoice)
 
     @protected
     def sign_tx(

--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -64,7 +64,7 @@ from .my_treeview import create_toolbar_with_menu, QMenuWithConfig
 if TYPE_CHECKING:
     from .main_window import ElectrumWindow
     from electrum.wallet import Abstract_Wallet
-    from electrum.payment_identifier import PaymentIdentifier
+    from electrum.invoices import Invoice
 
 
 _logger = get_logger(__name__)
@@ -409,7 +409,7 @@ def show_transaction(
     parent: 'ElectrumWindow',
     prompt_if_unsaved: bool = False,
     external_keypairs: Mapping[bytes, bytes] = None,
-    payment_identifier: 'PaymentIdentifier' = None,
+    invoice: 'Invoice' = None,
     on_closed: Callable[[], None] = None,
     show_sign_button: bool = True,
     show_broadcast_button: bool = True,
@@ -420,7 +420,7 @@ def show_transaction(
             parent=parent,
             prompt_if_unsaved=prompt_if_unsaved,
             external_keypairs=external_keypairs,
-            payment_identifier=payment_identifier,
+            invoice=invoice,
             on_closed=on_closed,
         )
         if not show_sign_button:
@@ -445,7 +445,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         parent: 'ElectrumWindow',
         prompt_if_unsaved: bool,
         external_keypairs: Mapping[bytes, bytes] = None,
-        payment_identifier: 'PaymentIdentifier' = None,
+        invoice: 'Invoice' = None,
         on_closed: Callable[[], None] = None,
     ):
         '''Transactions in the wallet will show their description.
@@ -458,13 +458,15 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.main_window = parent
         self.config = parent.config
         self.wallet = parent.wallet
-        self.payment_identifier = payment_identifier
+        self.invoice = invoice
         self.prompt_if_unsaved = prompt_if_unsaved
         self.on_closed = on_closed
         self.saved = False
         self.desc = None
         if txid := tx.txid():
             self.desc = self.wallet.get_label_for_txid(txid) or None
+        if not self.desc and self.invoice:
+            self.desc = self.invoice.get_message()
         self.setMinimumWidth(640)
 
         self.psbt_only_widgets = []  # type: List[Union[QWidget, QAction]]
@@ -483,13 +485,8 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.tx_desc_label = QLabel(_("Description:"))
         vbox.addWidget(self.tx_desc_label)
         self.tx_desc = ButtonsLineEdit('')
-        def on_edited():
-            text = self.tx_desc.text()
-            if self.wallet.set_label(txid, text):
-                self.main_window.history_list.update()
-                self.main_window.utxo_list.update()
-                self.main_window.labels_changed_signal.emit()
-        self.tx_desc.editingFinished.connect(on_edited)
+
+        self.tx_desc.editingFinished.connect(self.store_tx_label)
         self.tx_desc.addCopyButton()
         vbox.addWidget(self.tx_desc)
 
@@ -570,6 +567,13 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.update()
         self.set_title()
 
+    def store_tx_label(self):
+        text = self.tx_desc.text()
+        if self.wallet.set_label(self.tx.txid(), text):
+            self.main_window.history_list.update()
+            self.main_window.utxo_list.update()
+            self.main_window.labels_changed_signal.emit()
+
     def set_tx(self, tx: 'Transaction'):
         # Take a copy; it might get updated in the main window by
         # e.g. the FX plugin.  If this happens during or after a long
@@ -598,7 +602,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         self.main_window.push_top_level_window(self)
         self.main_window.send_tab.save_pending_invoice()
         try:
-            self.main_window.broadcast_transaction(self.tx, payment_identifier=self.payment_identifier)
+            self.main_window.broadcast_transaction(self.tx, invoice=self.invoice)
         finally:
             self.main_window.pop_top_level_window(self)
         self.saved = True
@@ -713,6 +717,7 @@ class TxDialog(QDialog, MessageBoxMixin):
     def save(self):
         self.main_window.push_top_level_window(self)
         if self.main_window.save_transaction_into_wallet(self.tx):
+            self.store_tx_label()
             self.save_button.setDisabled(True)
             self.saved = True
         self.main_window.pop_top_level_window(self)
@@ -842,7 +847,8 @@ class TxDialog(QDialog, MessageBoxMixin):
             # note: when not finalized, RBF and locktime changes do not trigger
             #       a make_tx, so the txid is unreliable, hence:
             self.tx_hash_e.setText(_('Unknown'))
-        if not self.wallet.adb.get_transaction(txid):
+        tx_in_db = bool(self.wallet.adb.get_transaction(txid))
+        if not desc and not tx_in_db:
             self.tx_desc.hide()
             self.tx_desc_label.hide()
         else:


### PR DESCRIPTION
This is purely informational and optional, with the main immediate use to provide the invoice description/message/label to the transaction dialog, so it can be stored when saving the tx in history, or passed along with PSBTs sent to cosigners.

Before, the tx description was not saved in history when an invoice was not saved before signing and saving the tx for sending later.