### PR TITLE
fix: PluginsDialog bugs causing exceptions

### DIFF
--- a/electrum/gui/qt/plugins_dialog.py
+++ b/electrum/gui/qt/plugins_dialog.py
@@ -4,7 +4,7 @@ import shutil
 import os
 
 from PyQt6.QtWidgets import QLabel, QVBoxLayout, QGridLayout, QPushButton, QWidget, QScrollArea, QFormLayout, QFileDialog, QMenu, QApplication
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QTimer
 
 from electrum.i18n import _
 from electrum.logging import get_logger
@@ -365,8 +365,7 @@ class PluginsDialog(WindowModalDialog, MessageBoxMixin):
             status_button.update()
         if self.gui_object:
             self.gui_object.reload_windows()
-        self.setFocus()
-        self.activateWindow()
+        self.bring_to_front()
 
     def uninstall_plugin(self, name):
         if not self.question(_('Remove plugin \'{}\'?').format(name)):
@@ -375,3 +374,10 @@ class PluginsDialog(WindowModalDialog, MessageBoxMixin):
         if self.gui_object:
             self.gui_object.reload_windows()
         self.show_list()
+        self.bring_to_front()
+
+    def bring_to_front(self):
+        def _bring_self_to_front():
+            self.activateWindow()
+            self.setFocus()
+        QTimer.singleShot(100, _bring_self_to_front)

--- a/electrum/gui/qt/plugins_dialog.py
+++ b/electrum/gui/qt/plugins_dialog.py
@@ -9,8 +9,8 @@ from PyQt6.QtCore import Qt
 from electrum.i18n import _
 from electrum.logging import get_logger
 
-from .util import WindowModalDialog, Buttons, CloseButton, WWLabel, insert_spaces, MessageBoxMixin, EnterButton
-from .util import read_QIcon_from_bytes, IconLabel
+from .util import (WindowModalDialog, Buttons, CloseButton, WWLabel, insert_spaces, MessageBoxMixin,
+                   EnterButton, read_QIcon_from_bytes, IconLabel, RunCoroutineDialog)
 
 
 if TYPE_CHECKING:
@@ -254,7 +254,8 @@ class PluginsDialog(WindowModalDialog, MessageBoxMixin):
             return
         coro = self.plugins.download_external_plugin(url)
         try:
-            path = self.window.run_coroutine_dialog(coro, _("Downloading plugin..."))
+            d = RunCoroutineDialog(self, _("Downloading plugin..."), coro)
+            path = d.run()
         except UserCancelled:
             return
         except Exception as e:

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -246,10 +246,12 @@ class Plugins(DaemonThread):
             os.mkdir(pkg_path)
         return pkg_path
 
-    async def download_external_plugin(self, url):
+    async def download_external_plugin(self, url: str) -> str:
         filename = os.path.basename(urlparse(url).path)
         pkg_path = self.get_external_plugin_dir()
         path = os.path.join(pkg_path, filename)
+        if os.path.exists(path):
+            raise FileExistsError(f"Plugin {filename} already exists at {path}")
         async with aiohttp.ClientSession() as session:
             async with session.get(url) as resp:
                 if resp.status == 200:


### PR DESCRIPTION
Fixes 3 issues:
1.
If the plugin zip got already deleted while being in the `PluginDialog` of another installation of the same plugin, 
trying to delete it again will raise an exception, and closing the installing `PluginDialog` tries to delete the file if the user doesn't click on `Install...`.
This is fixed by catching the `FileNotFound` exception in `download_plugin_dialog()` and `add_plugin_dialog()` .
Related to this, if the user tries to install an external plugin that is already installed, and then closes the PluginDialog, the PluginsDialog will get into a bad state, throwing an exeption on future instantiations as `add_plugin_dialog()` will remove the required zipfile when cancelling the dialog, but the metadata will stay in `Plugins`.
This is fixed by checking if the plugin is already existing, instead of opening a new `PluginDialog` if the user tries to install a plugin that is already installed (checks if the zip at path already exists).

2.
`download_plugin_dialog()` tried to use `self.window.run_coroutine_dialog()`, however `PluginsDialog` has no access to this method as it's not a child of `ElectrumWindow` and has no access to window methods. So downloading couldn't work. This fixes it by creating a `RunCoroutineDialog` directly. 

3.
When reloading the windows, e.g. after enabling or disabling a plugin, the plugins dialog vanished behind the main window. By using a QT Timer its possible to bring the Dialog back in front after the windows have reloaded.