### PR TITLE
plugins: handle updating plugins from plugin manager

### DIFF
--- a/electrum/gui/qt/plugins_dialog.py
+++ b/electrum/gui/qt/plugins_dialog.py
@@ -67,6 +67,10 @@ class PluginDialog(WindowModalDialog):
             install_button = QPushButton(_('Install...'))
             install_button.clicked.connect(self.accept)
             buttons.insert(0, install_button)
+        elif self.plugins.get_metadata(name).get('zip_hash_sha256') != zip_hash:
+            update_button = QPushButton(_('Update...'))
+            update_button.clicked.connect(self.accept)
+            buttons.insert(0, update_button)
         else:
             remove_button = QPushButton(_('Uninstall'))
             remove_button.clicked.connect(self.do_remove)

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -401,6 +401,8 @@ class Plugins(DaemonThread):
         self.config.set_key(f'plugins.{name}.enabled', [])
 
     def install_external_plugin(self, name, path, privkey, manifest):
+        # uninstall old version first to get rid of old zip files when updating plugin
+        self.uninstall(name)
         self.external_plugin_metadata[name] = manifest
         self.authorize_plugin(name, path, privkey)
 


### PR DESCRIPTION
Currently there is no way to update a plugin with a new version in the plugin manager. The user first has to uninstall the old version, then install the new version. This PR adds an "Update..." button that will show if the user loads a plugin of the same (manifest) name but a different hash, allowing for updates/downgrades.