### PR TITLE
fix: type error when loading psbt with lnworker enabled

### DIFF
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -822,7 +822,7 @@ class TxDialog(QDialog, MessageBoxMixin):
             tx_item_fiat = self.wallet.get_tx_item_fiat(
                 tx_hash=txid, amount_sat=abs(amount), fx=fx, tx_fee=fee)
 
-        if self.wallet.lnworker:
+        if self.wallet.lnworker and txid:
             # if it is a group, collect ln amount
             full_history = self.wallet.get_full_history()
             item = full_history.get('group:' + txid)


### PR DESCRIPTION
Fixes the following exception:
```
 26.46 | E | gui.qt.exception_window.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 2300, in do_process_from_text
    self.show_transaction(tx)
    ~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 1127, in show_transaction
    show_transaction(
    ~~~~~~~~~~~~~~~~^
        tx,
        ^^^
    ...<4 lines>...
        show_broadcast_button=show_broadcast_button,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/code/electrum-fork/electrum/gui/qt/transaction_dialog.py", line 418, in show_transaction
    d = TxDialog(
        tx,
    ...<4 lines>...
        on_closed=on_closed,
    )
  File "/home/user/code/electrum-fork/electrum/gui/qt/transaction_dialog.py", line 570, in __init__
    self.update()
    ~~~~~~~~~~~^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/transaction_dialog.py", line 828, in update
    item = full_history.get('group:' + txid)
                            ~~~~~~~~~^~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```

Can be reproduced by loading the PSBT in 'Additional Information' of https://github.com/spesmilo/electrum/issues/9282 from clipboard