### PR TITLE
fix: don't suggest onion peers for channel opening

### DIFF
--- a/electrum/channel_db.py
+++ b/electrum/channel_db.py
@@ -217,6 +217,7 @@ class NodeInfo(NamedTuple):
                 return b'\x01' + ip_addr.packed + port_bytes
             elif ip_addr.version == 6:
                 return b'\x02' + ip_addr.packed + port_bytes
+            return b''
         elif hostname.endswith('.onion'):  # Tor onion v3
             onion_addr: bytes = base64.b32decode(hostname[:-6], casefold=True)
             return b'\x04' + onion_addr + port_bytes

--- a/electrum/lnrater.py
+++ b/electrum/lnrater.py
@@ -258,6 +258,12 @@ class LNRater(Logger):
             # don't want to connect to nodes we already have a channel with on another device
             if self.lnworker.has_conflicting_backup_with(pk):
                 continue
+            # node should be on clearnet and have an address saved
+            for (hostname, _, _) in self.lnworker.channel_db.get_node_addresses(node_id=pk):
+                if not hostname.endswith(".onion"):
+                    break
+            else:
+                continue
             break
 
         alias = node_info.alias if node_info else 'unknown node alias'


### PR DESCRIPTION
`suggest_node_channel_open()` did suggest peers with onion hostname, even if the caller has no proxy enabled. This causes channel openings in the gui to sometimes just not work and show a `CancelledError()` becaues it wasn't able to connect to the peer.
Now only clearnet peers will get recommended, as these will always work.

The change in channel_db.py is just a fixed linting error.