### PR TITLE
fix: blocked Exception_Window by setting modality

### DIFF
--- a/electrum/gui/qt/exception_window.py
+++ b/electrum/gui/qt/exception_window.py
@@ -99,6 +99,9 @@ class Exception_Window(BaseCrashReporter, QWidget, MessageBoxMixin, Logger):
 
         main_box.addLayout(buttons)
 
+        # prioritizes the window input over all other windows
+        self.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+
         self.setLayout(main_box)
         self.show()
 


### PR DESCRIPTION
If a dialog is open while an exception was raised in the dialog, the input of `Exception_Window` is blocked and the user cannot click the button to submit the issue report. Only if the other dialog is closed `Exception_Window` starts responding. By setting the modality of `Exception_Windows` to `ApplicationModal` the `Exception_Window` will get the 'highest priority' and accepts input even if other dialogs are open.

Can be tested by applying this diff and then checking the Trampoline checkbox in settings dialog:
```diff
diff --git a/electrum/gui/qt/settings_dialog.py b/electrum/gui/qt/settings_dialog.py
index aadd04b71..6f8218963 100644
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -115,6 +115,7 @@ class SettingsDialog(QDialog, QtEventListener):
         trampoline_cb.setChecked(not self.config.LIGHTNING_USE_GOSSIP)
 
         def on_trampoline_checked(_x):
+            raise Exception("test")
             use_trampoline = trampoline_cb.isChecked()
             if not use_trampoline:
                 if not window.question('\n'.join([

``` 