### PR TITLE
qt: allow lightning addresses in contacts

### DIFF
--- a/electrum/contacts.py
+++ b/electrum/contacts.py
@@ -29,7 +29,7 @@ from dns.exception import DNSException
 
 from . import bitcoin
 from . import dnssec
-from .util import read_json_file, write_json_file, to_string
+from .util import read_json_file, write_json_file, to_string, is_valid_email
 from .logging import Logger, get_logger
 from .util import trigger_callback
 
@@ -90,11 +90,12 @@ class Contacts(dict, Logger):
                 'address': k,
                 'type': 'address'
             }
-        if k in self.keys():
-            _type, addr = self[k]
-            if _type == 'address':
+        for address, (_type, label) in self.items():
+            if k.casefold() != label.casefold():
+                continue
+            if _type == 'address' or _type == 'lnaddress':
                 return {
-                    'address': addr,
+                    'address': address,
                     'type': 'contact'
                 }
         if openalias := self.resolve_openalias(k):
@@ -172,11 +173,11 @@ class Contacts(dict, Logger):
         for k, v in list(data.items()):
             if k == 'contacts':
                 return self._validate(v)
-            if not bitcoin.is_address(k):
+            if not (bitcoin.is_address(k) or is_valid_email(k)):
                 data.pop(k)
             else:
                 _type, _ = v
-                if _type != 'address':
+                if _type not in ('address', 'lnaddress'):
                     data.pop(k)
         return data
 

--- a/electrum/contacts.py
+++ b/electrum/contacts.py
@@ -83,6 +83,7 @@ class Contacts(dict, Logger):
             res = dict.pop(self, key)
             self.save()
             return res
+        return None
 
     def resolve(self, k):
         if bitcoin.is_address(k):
@@ -160,6 +161,8 @@ class Contacts(dict, Logger):
                 if not address:
                     continue
                 return address, name, validated
+            return None
+        return None
 
     @staticmethod
     def find_regex(haystack, needle):

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -54,8 +54,10 @@ from electrum.bitcoin import COIN, is_address, DummyAddress
 from electrum.plugin import run_hook
 from electrum.i18n import _
 from electrum.util import (format_time, UserCancelled, profiler, bfh, InvalidPassword,
-                           UserFacingException, get_new_wallet_name, send_exception_to_crash_reporter,
-                           AddTransactionException, os_chmod, UI_UNIT_NAME_TXSIZE_VBYTES)
+                           UserFacingException, get_new_wallet_name,
+                           send_exception_to_crash_reporter,
+                           AddTransactionException, os_chmod, UI_UNIT_NAME_TXSIZE_VBYTES,
+                           is_valid_email)
 from electrum.bip21 import BITCOIN_BIP21_URI_SCHEME
 from electrum.payment_identifier import PaymentIdentifier
 from electrum.invoices import PR_PAID, Invoice
@@ -1565,11 +1567,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.send_tab.payto_contacts(labels)
 
     def set_contact(self, label, address):
-        if not is_address(address):
+        if not (is_address(address) or is_valid_email(address)):  # email = lightning address
             self.show_error(_('Invalid Address'))
             self.contact_list.update()  # Displays original unchanged value
             return False
-        self.contacts[address] = ('address', label)
+        address_type = 'address' if is_address(address) else 'lnaddress'
+        self.contacts[address] = (address_type, label)
         self.contact_list.update()
         self.history_list.update()
         self.update_completions()
@@ -1949,7 +1952,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         line1.setFixedWidth(32 * char_width_in_lineedit())
         line2 = QLineEdit()
         line2.setFixedWidth(32 * char_width_in_lineedit())
-        grid.addWidget(QLabel(_("Address")), 1, 0)
+        address_label = QLabel(_("Address"))
+        address_label.setToolTip(_("Bitcoin- or Lightning address"))
+        grid.addWidget(address_label, 1, 0)
         grid.addWidget(line1, 1, 1)
         grid.addWidget(QLabel(_("Name")), 2, 0)
         grid.addWidget(line2, 2, 1)

--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -803,7 +803,7 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
     def payto_contacts(self, labels):
         paytos = [self.window.get_contact_payto(label) for label in labels]
         self.window.show_send_tab()
-        self.payto_e.do_clear()
+        self.do_clear()
         if len(paytos) == 1:
             self.logger.debug('payto_e setText 1')
             self.payto_e.setText(paytos[0])

--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -289,6 +289,10 @@ class PaymentIdentifier(Logger):
                 self._type = PaymentIdentifierType.EMAILLIKE
                 self.emaillike = contact['address']
                 self.set_state(PaymentIdentifierState.NEED_RESOLVE)
+            elif contact['type'] == 'lnaddress':
+                self._type = PaymentIdentifierType.LNADDR
+                self.lnurl = contact['address']
+                self.set_state(PaymentIdentifierState.NEED_RESOLVE)
         elif re.match(RE_EMAIL, text):
             self._type = PaymentIdentifierType.EMAILLIKE
             self.emaillike = text


### PR DESCRIPTION
Lightning addresses are used very widely so it should be possible to create contacts with a lightning address.
This would later allow us to import the contact list of a nostr npub and all the lightning addresses of these contacts.