### PR TITLE
fix: SendTab not updating amount after text input change

### DIFF
--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -689,7 +689,7 @@ def invoice_from_payment_identifier(
         invoice = pi.bolt11
         if not invoice:
             return
-        if invoice.amount_msat is None:
+        if invoice._lnaddr.get_amount_msat() is None:
             invoice.set_amount_msat(int(amount_sat * 1000))
         return invoice
     else:


### PR DESCRIPTION
When paying a 0 amount invoice, after clicking pay the entered amount will get saved in
`PaymentIdentifier.boltPaymentIdentifier.bolt11.amount_msat`. However if the user clicks cancel instead of pay, and then changes the amount, amount_msat will not get updated, as it is not None anymore. If the user clicks pay again, it will pay the previously entered wrong amount. 
This change instead checks the `LnAddr` amount instead of the `Invoice` amount, which will always stay `None` for 0 amount invoices.