### PR TITLE
qml: fix storing override amount too soon, while user is allowed to set a new override amount which was silently ignored.

### DIFF
--- a/electrum/gui/qml/components/InvoiceDialog.qml
+++ b/electrum/gui/qml/components/InvoiceDialog.qml
@@ -487,10 +487,6 @@ ElDialog {
                         if (amountMax.checked)
                             invoice.amountOverride.isMax = true
                     }
-                    if (!invoice.isSaved) {
-                        // save invoice if newly parsed
-                        invoice.saveInvoice()
-                    }
                     doPay() // only signal here
                 }
             }
@@ -506,9 +502,6 @@ ElDialog {
         }
         if (payImmediately) {
             if (invoice.canPay) {
-                if (!invoice.isSaved) {
-                    invoice.saveInvoice()
-                }
                 doPay()
             }
         }

--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -113,6 +113,7 @@ Item {
         })
         var canComplete = !Daemon.currentWallet.isWatchOnly && Daemon.currentWallet.canSignWithoutCosigner
         dialog.accepted.connect(function() {
+            invoice.saveInvoice()
             if (!canComplete) {
                 if (Daemon.currentWallet.isWatchOnly) {
                     dialog.finalizer.saveOrShow()

--- a/electrum/gui/qml/qeinvoicelistmodel.py
+++ b/electrum/gui/qml/qeinvoicelistmodel.py
@@ -132,7 +132,7 @@ class QEAbstractInvoiceListModel(QAbstractListModel):
             item['address'] = ''
         item['date'] = format_time(item['timestamp'])
         item['amount'] = QEAmount(from_invoice=invoice)
-        item['onchain_fallback'] = invoice.is_lightning() and invoice.get_address()
+        item['onchain_fallback'] = invoice.is_lightning() and bool(invoice.get_address())
 
         return item
 


### PR DESCRIPTION
- lightning: implicit save of lightning invoice with override amount deferred until actual payment is done. 
- on-chain: for now, invoice is implicitly saved when override amount is passed to `ConfirmTxDialog`. (this is sooner than current desktop client, which saves when `OK` is clicked from `ConfirmTxDialog`, or `Broadcast` is clicked from `Preview`)