### PR TITLE
fix: verify author pubkey of psbt nostr events

### DIFF
--- a/electrum/plugins/psbt_nostr/psbt_nostr.py
+++ b/electrum/plugins/psbt_nostr/psbt_nostr.py
@@ -193,6 +193,9 @@ class CosignerWallet(Logger):
                 if event.id in self.known_events:
                     self.logger.info(f'known event {event.id} {util.age(event.created_at)}')
                     continue
+                if not any(event.pubkey == pubkey for _, pubkey in self.cosigner_list):
+                    self.logger.warning(f"got event from unknown author: {event.pubkey}")
+                    continue
                 if event.created_at > now() + self.KEEP_DELAY:
                     # might be malicious
                     continue


### PR DESCRIPTION
Checks if the pubkey of the author sending the psbt cosigning request is in our list of cosigner pubkeys to prevent accepting "fake" requests from other pubkeys. 

I don't (additionally) request the cosigner pubkeys in the relay query filter, as this would let the relays know the cosigner pubkeys without obvious benefit.