### PR TITLE
invoices: only skip generating BIP21 URI for payment request if both …

### DIFF
--- a/electrum/gui/qml/qerequestdetails.py
+++ b/electrum/gui/qml/qerequestdetails.py
@@ -4,8 +4,9 @@ from typing import Optional
 from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject, QTimer, pyqtEnum
 
 from electrum.logging import get_logger
-from electrum.invoices import (PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID, PR_INFLIGHT,
-                               PR_FAILED, PR_ROUTING, PR_UNCONFIRMED, LN_EXPIRY_NEVER)
+from electrum.invoices import (
+    PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID, PR_INFLIGHT, PR_FAILED, PR_ROUTING, PR_UNCONFIRMED, LN_EXPIRY_NEVER
+)
 from electrum.lnutil import MIN_FUNDING_SAT
 
 from .qewallet import QEWallet

--- a/electrum/invoices.py
+++ b/electrum/invoices.py
@@ -344,10 +344,11 @@ class Request(BaseInvoice):
     ) -> Optional[str]:
         addr = self.get_address()
         amount = self.get_amount_sat()
-        if amount is None:
-            return
-        amount = int(amount)
         message = self.message
+        if amount is None and not message:
+            return
+        if amount:
+            amount = int(amount)
         extra = {}
         if self.time and self.exp:
             extra['time'] = str(int(self.time))


### PR DESCRIPTION
…amount and message are empty.

This will result in only showing a bare address QR in the GUIs iff both amount and message are left empty.