### PR TITLE
dns: use async dnspython interface 

### DIFF
--- a/electrum/dns_hacks.py
+++ b/electrum/dns_hacks.py
@@ -7,17 +7,15 @@ import socket
 import concurrent
 from concurrent import futures
 import ipaddress
-from typing import Optional
+import asyncio
 
 import dns
-import dns.resolver
+import dns.asyncresolver
 
 from .logging import get_logger
-
+from .util import get_asyncio_loop
 
 _logger = get_logger(__name__)
-
-_dns_threads_executor = None  # type: Optional[concurrent.futures.Executor]
 
 
 def configure_dns_resolver() -> None:
@@ -38,16 +36,11 @@ def configure_dns_resolver() -> None:
 
 def _prepare_windows_dns_hack():
     # enable dns cache
-    resolver = dns.resolver.get_default_resolver()
+    resolver = dns.asyncresolver.get_default_resolver()
     if resolver.cache is None:
         resolver.cache = dns.resolver.Cache()
     # ensure overall timeout for requests is long enough
     resolver.lifetime = max(resolver.lifetime or 1, 30.0)
-    # prepare threads
-    global _dns_threads_executor
-    if _dns_threads_executor is None:
-        _dns_threads_executor = concurrent.futures.ThreadPoolExecutor(max_workers=20,
-                                                                      thread_name_prefix='dns_resolver')
 
 
 def _is_force_system_dns_for_host(host: str) -> bool:
@@ -69,8 +62,15 @@ def _fast_getaddrinfo(host, *args, **kwargs):
         addrs = []
         expected_errors = (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer,
                            concurrent.futures.CancelledError, concurrent.futures.TimeoutError)
-        ipv6_fut = _dns_threads_executor.submit(dns.resolver.resolve, host, dns.rdatatype.AAAA)
-        ipv4_fut = _dns_threads_executor.submit(dns.resolver.resolve, host, dns.rdatatype.A)
+        loop = get_asyncio_loop()
+        ipv6_fut = asyncio.run_coroutine_threadsafe(
+            dns.asyncresolver.resolve(host, dns.rdatatype.AAAA),
+            loop,
+        )
+        ipv4_fut = asyncio.run_coroutine_threadsafe(
+            dns.asyncresolver.resolve(host, dns.rdatatype.A),
+            loop,
+        )
         # try IPv6
         try:
             answers = ipv6_fut.result()

--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -17,6 +17,7 @@ from electrum.lnutil import format_short_channel_id
 from electrum.bitcoin import COIN, address_to_script
 from electrum.paymentrequest import PaymentRequest
 from electrum.payment_identifier import PaymentIdentifier, PaymentIdentifierState, PaymentIdentifierType
+from electrum.network import Network
 
 from .qetypes import QEAmount
 from .qewallet import QEWallet
@@ -523,7 +524,7 @@ class QEInvoiceParser(QEInvoice):
 
     def _bip70_payment_request_resolved(self, pr: 'PaymentRequest'):
         self._logger.debug('resolved payment request')
-        if pr.verify():
+        if Network.run_from_another_thread(pr.verify()):
             invoice = Invoice.from_bip70_payreq(pr, height=0)
             if self._wallet.wallet.get_invoice_status(invoice) == PR_PAID:
                 self.validationError.emit('unknown', _('Invoice already paid'))

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1658,7 +1658,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             grid.addWidget(QLabel(format_time(invoice.exp + invoice.time)), 4, 1)
         if invoice.bip70:
             pr = paymentrequest.PaymentRequest(bytes.fromhex(invoice.bip70))
-            pr.verify()
+            Network.run_from_another_thread(pr.verify())
             grid.addWidget(QLabel(_("Requestor") + ':'), 5, 0)
             grid.addWidget(QLabel(pr.get_requestor()), 5, 1)
             grid.addWidget(QLabel(_("Signature") + ':'), 6, 0)

--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -349,7 +349,7 @@ class PaymentIdentifier(Logger):
                     self.set_state(PaymentIdentifierState.NOT_FOUND)
             elif self.bip70:
                 pr = await paymentrequest.get_payment_request(self.bip70)
-                if pr.verify():
+                if await pr.verify():
                     self.bip70_data = pr
                     self.set_state(PaymentIdentifierState.MERCHANT_NOTIFY)
                 else:
@@ -653,7 +653,7 @@ class PaymentIdentifier(Logger):
         if parts and len(parts) > 0 and bitcoin.is_address(parts[0]):
             return None
         try:
-            data = self.contacts.resolve(key)  # TODO: don't use contacts as delegate to resolve openalias, separate.
+            data = await self.contacts.resolve(key)  # TODO: don't use contacts as delegate to resolve openalias, separate.
             return data
         except AliasNotFoundException as e:
             self.logger.info(f'OpenAlias not found: {repr(e)}')

--- a/electrum/paymentrequest.py
+++ b/electrum/paymentrequest.py
@@ -40,7 +40,8 @@ except ImportError:
     sys.exit("Error: could not find paymentrequest_pb2.py. Create it with 'contrib/generate_payreqpb2.sh'")
 
 from . import bitcoin, constants, util, transaction, x509, rsakey
-from .util import bfh, make_aiohttp_session, error_text_bytes_to_safe_str, get_running_loop
+from .util import (bfh, make_aiohttp_session, error_text_bytes_to_safe_str, get_running_loop,
+                   get_asyncio_loop)
 from .invoices import Invoice, get_id_from_onchain_outputs
 from .bitcoin import address_to_script
 from .transaction import PartialTxOutput
@@ -104,10 +105,8 @@ async def get_payment_request(url: str) -> 'PaymentRequest':
         data = None
         error = f"Unknown scheme for payment request. URL: {url}"
     pr = PaymentRequest(data, error=error)
-    loop = get_running_loop()
-    # do x509/dnssec verification now (in separate thread, to avoid blocking event loop).
-    # we still expect the caller to at least check pr.error!
-    await loop.run_in_executor(None, pr.verify)
+    # do x509/dnssec verification now. we still expect the caller to at least check pr.error!
+    await pr.verify()
     return pr
 
 
@@ -153,7 +152,7 @@ class PaymentRequest:
         self.memo = self.details.memo
         self.payment_url = self.details.payment_url
 
-    def verify(self) -> bool:
+    async def verify(self) -> bool:
         # FIXME: we should enforce that this method was called before we attempt payment
         # note: this method might do network requests (at least for verify_dnssec)
         if self._verified_success is True:
@@ -176,7 +175,7 @@ class PaymentRequest:
         if pr.pki_type in ["x509+sha256", "x509+sha1"]:
             return self.verify_x509(pr)
         elif pr.pki_type in ["dnssec+btc", "dnssec+ecdsa"]:
-            return self.verify_dnssec(pr)
+            return await self.verify_dnssec(pr)
         else:
             self.error = "ERROR: Unsupported PKI Type for Message Signature"
             return False
@@ -222,10 +221,10 @@ class PaymentRequest:
         self._verified_success = True
         return True
 
-    def verify_dnssec(self, pr):
+    async def verify_dnssec(self, pr):
         sig = pr.signature
         alias = pr.pki_data
-        info = Contacts.resolve_openalias(alias)
+        info: dict = await Contacts.resolve_openalias(alias)
         if info.get('validated') is not True:
             self.error = "Alias verification failed (DNSSEC)"
             return False

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -60,7 +60,7 @@ import aiohttp
 from aiohttp_socks import ProxyConnector, ProxyType
 import aiorpcx
 import certifi
-import dns.resolver
+import dns.asyncresolver
 
 from .i18n import _
 from .logging import get_logger, Logger
@@ -1851,9 +1851,9 @@ def list_enabled_bits(x: int) -> Sequence[int]:
     return tuple(i for i, b in enumerate(rev_bin) if b == '1')
 
 
-def resolve_dns_srv(host: str):
+async def resolve_dns_srv(host: str):
     # FIXME this method is not using the network proxy. (although the proxy might not support UDP?)
-    srv_records = dns.resolver.resolve(host, 'SRV')
+    srv_records = await dns.asyncresolver.resolve(host, 'SRV')
     # priority: prefer lower
     # weight: tie breaker; prefer higher
     srv_records = sorted(srv_records, key=lambda x: (x.priority, -x.weight))


### PR DESCRIPTION
dnspython has [added](https://github.com/rthalley/dnspython/commit/7f197681162b420c8b3fd5b5339628378cf80d62) an async interface in version 2.0 which we already require in our requirements. 
The api is the same as the sync version and is stable between 2.0 and the current 2.7. 
So i switched the dnspython calls in dnssec (used for openalias resolving) and the lightning dns seed fetching to use the async interface instead of threads.