### PR TITLE
fix: make ToU scrollbar detection more reliable

### DIFF
--- a/electrum/gui/qt/wizard/terms_of_use.py
+++ b/electrum/gui/qt/wizard/terms_of_use.py
@@ -55,7 +55,7 @@ class WCTermsOfUseScreen(WizardComponent):
         self._valid = False
 
         # Find the scroll area and connect to its scrollbar
-        QTimer.singleShot(0, self.check_scroll_position)
+        QTimer.singleShot(100, self.check_scroll_position)
         self.window().installEventFilter(self)
 
     def eventFilter(self, obj, event):


### PR DESCRIPTION
adds some delay before detecting the scrollbar in the terms of use dialog. This prevents it from falsely detecting a scrollbar and disabling the "I Agree" button even if there is no scrollbar. I noticed this issue on windows, the order in which the window is created seems to be slightly different from linux/wayland there.