### PR TITLE
lnchannel: persist error sent by remote peer into db

### DIFF
--- a/electrum/gui/qt/channel_details.py
+++ b/electrum/gui/qt/channel_details.py
@@ -179,7 +179,7 @@ class ChannelDetailsDialog(QtWidgets.QDialog, MessageBoxMixin, QtEventListener):
             return
         self.window.show_transaction(tx)
 
-    def get_common_form(self, chan):
+    def get_common_form(self, chan: AbstractChannel):
         form = QtWidgets.QFormLayout(None)
         remote_id_e = ShowQRLineEdit(chan.node_id.hex(), self.window.config, title=_("Remote Node ID"))
         form.addRow(QLabel(_('Remote Node') + ':'), remote_id_e)
@@ -191,6 +191,10 @@ class ChannelDetailsDialog(QtWidgets.QDialog, MessageBoxMixin, QtEventListener):
         if remote_scid_alias := chan.get_remote_scid_alias():
             form.addRow(QLabel('Remote SCID Alias:'), SelectableLabel(str(ShortID(remote_scid_alias))))
         form.addRow(QLabel(_('State') + ':'), SelectableLabel(chan.get_state_for_GUI()))
+        if remote_peer_sent_error := chan.get_remote_peer_sent_error():
+            err_label = WWLabel(remote_peer_sent_error)  # note: text is already truncated to reasonable len
+            err_label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+            form.addRow(WWLabel(_('Remote peer sent error [DO NOT TRUST]') + ':'), err_label)
         self.capacity = self.format_sat(chan.get_capacity())
         form.addRow(QLabel(_('Capacity') + ':'), SelectableLabel(self.capacity))
         if not chan.is_backup():

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -282,9 +282,10 @@ class Peer(Logger, EventListener):
         self.logger.info(f"remote peer sent error [DO NOT TRUST THIS MESSAGE]: "
                          f"{error_text_bytes_to_safe_str(err_bytes, max_len=None)}. chan_id={chan_id.hex()}. "
                          f"{is_known_chan_id=}")
-        if chan_id in self.channels:
+        if chan := self.channels.get(chan_id):
             self.schedule_force_closing(chan_id)
             self.ordered_message_queues[chan_id].put_nowait((None, {'error': err_bytes}))
+            chan.save_remote_peer_sent_error(err_bytes)
         elif chan_id in self.temp_id_to_id:
             chan_id = self.temp_id_to_id[chan_id] or chan_id
             self.ordered_message_queues[chan_id].put_nowait((None, {'error': err_bytes}))


### PR DESCRIPTION
If a force-close happens due to e.g. a feerate disagreement or an invalid signature, etc, and the remote peer sends us an error, it can be useful if users can provide us with this error. If the user does not have logging enabled when the error is sent, without this persistence it will likely get lost.

![qt_chan_error](https://github.com/user-attachments/assets/ca473dc7-143f-4b9e-a09c-3b05f790214b)
