### PR TITLE
fix: suggest_splits exclude single channel splits

### DIFF
--- a/electrum/mpp_split.py
+++ b/electrum/mpp_split.py
@@ -82,14 +82,10 @@ def remove_single_part_configs(configs: List[SplitConfig]) -> List[SplitConfig]:
 
 
 def remove_single_channel_splits(configs: List[SplitConfig]) -> List[SplitConfig]:
-    filtered = []
-    for config in configs:
-        for v in config.values():
-            if len(v) > 1:
-                continue
-            filtered.append(config)
-    return filtered
-
+    return [
+        config for config in configs
+        if all(len(channel_splits) <= 1 for channel_splits in config.values())
+    ]
 
 def rate_config(
         config: SplitConfig,

--- a/tests/test_mpp_split.py
+++ b/tests/test_mpp_split.py
@@ -87,6 +87,12 @@ class TestMppSplit(ElectrumTestCase):
                 # check that the whole amount has been split on this channel
                 self.assertEqual(sum(split.config[(b"0", b"0")]), 1_000_000_000)
 
+        with self.subTest(msg="test exclude single channel splits"):
+            splits = mpp_split.suggest_splits(1_000_000_000, self.channels_with_funds, exclude_single_channel_splits=True)
+            for split in splits:
+                for channel_split in split.config.values():
+                    assert len(channel_split) <= 1, split
+
     def test_send_to_single_node(self):
         splits = mpp_split.suggest_splits(1_000_000_000, self.channels_with_funds, exclude_single_part_payments=False, exclude_multinode_payments=True)
         for split in splits:


### PR DESCRIPTION
passing `exclude_single_channel_splits` to `suggest_splits` did not reliably remove single channel splits from configurations if the same configuration also contained a valid split on another channel

This [comment](https://github.com/spesmilo/electrum/blob/f908a34b0b100a9b81ed9a5c76e128eb73776bdc/electrum/lnworker.py#L1942C47-L1942C51) explains `exclude_single_channel_splits` as:

> we don't split within a channel when sending to a trampoline node, 
the trampoline node will split for us