### PR TITLE
fee_policy: add fallback_feepolicy to FeePolicy

### DIFF
--- a/electrum/fee_policy.py
+++ b/electrum/fee_policy.py
@@ -80,7 +80,11 @@ class FeePolicy(Logger):
 
     def __init__(self, descriptor: str, *, fallback_feepolicy: 'FeePolicy' = None):
         Logger.__init__(self)
-        self._fallback_feepolicy = fallback_feepolicy
+        if len(chain := descriptor.split(',', 1)) > 1:
+            self._fallback_feepolicy = FeePolicy(chain[1], fallback_feepolicy=fallback_feepolicy)
+            descriptor = chain[0]
+        else:
+            self._fallback_feepolicy = fallback_feepolicy
         try:
             name, value = descriptor.split(':')
             self.method = FeeMethod[name.upper()]
@@ -94,7 +98,8 @@ class FeePolicy(Logger):
         return self.get_descriptor()
 
     def get_descriptor(self) -> str:
-        return self.method.name.lower() + ':' + str(self.value)
+        return self.method.name.lower() + ':' + str(self.value) + \
+            (f',{self._fallback_feepolicy.get_descriptor()}' if self._fallback_feepolicy else '')
 
     def set_method(self, method: FeeMethod):
         assert isinstance(method, FeeMethod)

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -37,7 +37,7 @@ from .json_db import StoredObject, stored_in
 from . import constants
 from .address_synchronizer import TX_HEIGHT_LOCAL, TX_HEIGHT_FUTURE
 from .i18n import _
-from .fee_policy import FeePolicy
+from .fee_policy import FeePolicy, FixedFeeRatePolicy, FEERATE_FALLBACK_STATIC_FEE
 
 from .bitcoin import construct_script
 from .crypto import ripemd
@@ -473,8 +473,8 @@ class SwapManager(Logger):
         return self._get_tx_fee(self.config.FEE_POLICY_SWAPS)
 
     def _get_tx_fee(self, policy_descriptor: str):
-        fee_policy = FeePolicy(policy_descriptor)
-        return fee_policy.estimate_fee(SWAP_TX_SIZE, network=self.network, allow_fallback_to_static_rates=True)
+        fee_policy = FeePolicy(policy_descriptor, fallback_feepolicy=FixedFeeRatePolicy(FEERATE_FALLBACK_STATIC_FEE))
+        return fee_policy.estimate_fee(SWAP_TX_SIZE, network=self.network)
 
     def get_swap(self, payment_hash: bytes) -> Optional[SwapData]:
         # for history

--- a/tests/test_coinchooser.py
+++ b/tests/test_coinchooser.py
@@ -1,7 +1,7 @@
 from electrum.coinchooser import CoinChooserPrivacy
 from electrum.util import NotEnoughFunds
 from electrum.transaction import PartialTxInput, TxOutpoint, Transaction, PartialTxOutput
-from electrum.fee_policy import FeePolicy, FixedFeePolicy
+from electrum.fee_policy import FeePolicy, FixedFeePolicy, FEERATE_FALLBACK_STATIC_FEE, FixedFeeRatePolicy
 from functools import partial
 from typing import Optional
 
@@ -48,7 +48,8 @@ class TestCoinChooser(ElectrumTestCase):
 
     def test_make_tx_no_outputs_adds_change(self):
         coin_chooser = CoinChooserPrivacy(enable_output_value_rounding=False)
-        fee_estimator = partial(FeePolicy('eta:2').estimate_fee, allow_fallback_to_static_rates=True)
+        static_rates_fallback_policy = FixedFeeRatePolicy(FEERATE_FALLBACK_STATIC_FEE)
+        fee_estimator = partial(FeePolicy('eta:2', fallback_feepolicy=static_rates_fallback_policy).estimate_fee)
 
         # dummy input with value of 330 sat
         prevout_txid = bytes.fromhex("81d0b29f08c6256dcfbaf02ff1f1e756461cb1df550672e049af7429331c643f")

--- a/tests/test_fee_policy.py
+++ b/tests/test_fee_policy.py
@@ -1,4 +1,4 @@
-from electrum.fee_policy import FeeHistogram
+from electrum.fee_policy import FeeHistogram, FeePolicy, FixedFeePolicy
 
 from . import ElectrumTestCase
 
@@ -52,4 +52,9 @@ class Test_FeeHistogram(ElectrumTestCase):
         self.assertEqual(495000, mempool_fees.fee_to_depth(5.5))
         self.assertEqual(36495000, mempool_fees.fee_to_depth(0.5))
 
-
+    def test_policy_chain(self):
+        policy = FeePolicy('eta:2,mempool:1000000,feerate:150000', fallback_feepolicy=FixedFeePolicy(100000))
+        self.assertTrue(policy.get_descriptor() == 'eta:2,mempool:1000000,feerate:150000,fixed:100000')
+        self.assertTrue(policy._fallback_feepolicy.get_descriptor() == 'mempool:1000000,feerate:150000,fixed:100000')
+        self.assertTrue(policy._fallback_feepolicy._fallback_feepolicy.get_descriptor() == 'feerate:150000,fixed:100000')
+        self.assertTrue(policy._fallback_feepolicy._fallback_feepolicy._fallback_feepolicy.get_descriptor() == 'fixed:100000')


### PR DESCRIPTION
fee_policy: add fallback_feepolicy to FeePolicy constructor and use the fallback
when estimate_fee() cannot determine the (dynamic) fee.

This generalizes static fee estimation fallback to a feepolicy estimator chain.

