### PR TITLE
txbatcher: pass fee policy names instead of fee descriptors

### DIFF
--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -196,7 +196,7 @@ class LNWatcher(Logger, EventListener):
     def maybe_redeem(self, sweep_info: 'SweepInfo') -> bool:
         """ returns False if it was dust """
         try:
-            self.lnworker.wallet.txbatcher.add_sweep_input('lnwatcher', sweep_info, self.config.FEE_POLICY_LIGHTNING)
+            self.lnworker.wallet.txbatcher.add_sweep_input('lnwatcher', sweep_info)
         except BelowDustLimit:
             return False
         return True

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -734,9 +734,10 @@ Warning: setting this to too low will result in lots of payment failures."""),
     TEST_SHUTDOWN_FEE_RANGE = ConfigVar('test_shutdown_fee_range', default=None)
     TEST_SHUTDOWN_LEGACY = ConfigVar('test_shutdown_legacy', default=False, type_=bool)
 
-    FEE_POLICY = ConfigVar('fee_policy', default='eta:2', type_=str)  # exposed to GUI
-    FEE_POLICY_LIGHTNING = ConfigVar('fee_policy_lightning', default='eta:2', type_=str)  # for txbatcher (sweeping)
-    FEE_POLICY_SWAPS = ConfigVar('fee_policy_swaps', default='eta:2', type_=str)  # for txbatcher (sweeping and sending if we are a swapserver)
+    # fee_policy is a dict: fee_policy_name -> fee_policy_descriptor
+    FEE_POLICY = ConfigVar('fee_policy.default', default='eta:2', type_=str)  # exposed to GUI
+    FEE_POLICY_LIGHTNING = ConfigVar('fee_policy.lnwatcher', default='eta:2', type_=str)  # for txbatcher (sweeping)
+    FEE_POLICY_SWAPS = ConfigVar('fee_policy.swaps', default='eta:2', type_=str)  # for txbatcher (sweeping and sending if we are a swapserver)
 
     RPC_USERNAME = ConfigVar('rpcuser', default=None, type_=str)
     RPC_PASSWORD = ConfigVar('rpcpassword', default=None, type_=str)

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -461,7 +461,7 @@ class SwapManager(Logger):
                 can_be_batched=can_be_batched,
             )
             try:
-                self.wallet.txbatcher.add_sweep_input('swaps', sweep_info, self.config.FEE_POLICY_SWAPS)
+                self.wallet.txbatcher.add_sweep_input('swaps', sweep_info)
             except BelowDustLimit:
                 self.logger.info('utxo value below dust threshold')
                 return
@@ -496,7 +496,7 @@ class SwapManager(Logger):
             swap = self.swaps[key]
             if not swap.is_funded():
                 output = self.create_funding_output(swap)
-                self.wallet.txbatcher.add_payment_output('swaps', output, self.config.FEE_POLICY_SWAPS)
+                self.wallet.txbatcher.add_payment_output('swaps', output)
                 swap._payment_pending = True
         else:
             self.logger.info(f'key not in swaps {key}')


### PR DESCRIPTION
 - this allows to change the fee policy dynamically
 - the fee policy that applies is set in config
 - the fee policy name is stored in txbatch storage