### PR TITLE
gui: oneserver option: make text more verbose

### DIFF
--- a/electrum/gui/qml/components/controls/ServerConfig.qml
+++ b/electrum/gui/qml/components/controls/ServerConfig.qml
@@ -26,7 +26,7 @@ Item {
         CheckBox {
             id: auto_server_cb
             visible: showAutoselectServer
-            text: qsTr('Select server automatically')
+            text: Config.shortDescFor('NETWORK_AUTO_CONNECT')
             checked: !showAutoselectServer
             enabled: !one_server_cb.checked
         }
@@ -54,11 +54,11 @@ Item {
             CheckBox {
                 id: one_server_cb
                 Layout.fillWidth: true
-                text: qsTr('One server')
+                text: Config.shortDescFor('NETWORK_ONESERVER')
             }
 
             HelpButton {
-                heading: qsTr('One server')
+                heading: Config.shortDescFor('NETWORK_ONESERVER')
                 helptext: Config.longDescFor('NETWORK_ONESERVER')
             }
         }

--- a/electrum/gui/qml/qeconfig.py
+++ b/electrum/gui/qml/qeconfig.py
@@ -36,7 +36,10 @@ class QEConfig(AuthMixin, QObject):
     @pyqtSlot(str, result=str)
     def longDescFor(self, key) -> str:
         cv = getattr(self.config.cv, key)
-        return cv.get_long_desc() if cv else ''
+        if not cv:
+            return ""
+        desc = cv.get_long_desc()
+        return messages.to_rtf(desc)
 
     @pyqtSlot(str, result=str)
     def getTranslatedMessage(self, key) -> str:

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -384,17 +384,13 @@ class ServerWidget(QWidget, QtEventListener):
         grid.addWidget(self.status_label, 0, 1, 1, 3)
         grid.addWidget(self.status_label_helpbutton, 0, 4)
 
-        self.autoconnect_cb = QCheckBox(_('Select server automatically'))
+        self.autoconnect_cb = QCheckBox(self.config.cv.NETWORK_AUTO_CONNECT.get_short_desc())
         self.autoconnect_cb.stateChanged.connect(self.on_server_settings_changed)
 
-        msg = ' '.join([
-            _("If auto-connect is enabled, Electrum will always use a server that is on the longest blockchain."),
-            _("If it is disabled, you have to choose a server you want to use. Electrum will warn you if your server is lagging.")
-        ])
         grid.addWidget(self.autoconnect_cb, 1, 0, 1, 3)
-        grid.addWidget(HelpButton(msg), 1, 4)
+        grid.addWidget(HelpButton(self.config.cv.NETWORK_AUTO_CONNECT.get_long_desc()), 1, 4)
 
-        self.one_server_cb = QCheckBox(_('One server'))
+        self.one_server_cb = QCheckBox(self.config.cv.NETWORK_ONESERVER.get_short_desc())
         self.one_server_cb.setEnabled(self.config.cv.NETWORK_ONESERVER.is_modifiable())
         self.one_server_cb.stateChanged.connect(self.on_server_settings_changed)
         grid.addWidget(self.one_server_cb, 2, 0, 1, 3)

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -615,12 +615,26 @@ class SimpleConfig(Logger):
         return CVLookupHelper()
 
     # config variables ----->
-    NETWORK_AUTO_CONNECT = ConfigVar('auto_connect', default=True, type_=bool)
+    NETWORK_AUTO_CONNECT = ConfigVar(
+        'auto_connect', default=True, type_=bool,
+        short_desc=lambda: _('Select server automatically'),
+        long_desc=lambda: _("If auto-connect is enabled, Electrum will always use a server that is on the longest blockchain. "
+                            "If it is disabled, you have to choose a server you want to use. Electrum will warn you if your server is lagging."),
+    )
     NETWORK_ONESERVER = ConfigVar(
         'oneserver', default=False, type_=bool,
-        short_desc=lambda: _('Connect only to a single Electrum Server'),
-        long_desc=lambda: _('This is only intended for connecting to your own node. '
-                            'Using this option on a public server is a security risk and is discouraged.')
+        short_desc=lambda: _('Only connect to one server (full trust)'),
+        long_desc=lambda: _(
+            "This is only intended for connecting to your own fully trusted server. "
+            "Using this option on a public server is a security risk and is discouraged."
+            "\n\n"
+            "By default, Electrum tries to maintain connections to ~10 servers. "
+            "One of these nodes gets selected to be the history server and will learn the wallet addresses. "
+            "All the other nodes are *only* used for block header notifications. "
+            "\n\n"
+            "Getting block headers from multiple sources is useful to detect lagging servers, chain splits, and forks. "
+            "Chain split detection is security-critical for determining number of confirmations."
+        )
     )
     NETWORK_PROXY = ConfigVar('proxy', default=None, type_=str, convert_getter=lambda v: "none" if v is None else v)
     NETWORK_PROXY_USER = ConfigVar('proxy_user', default=None, type_=str)


### PR DESCRIPTION
some cosmetic followups to https://github.com/spesmilo/electrum/pull/9243

I think the checkbox text needs to be more descriptive.
I also added a longer explanation for the option.  However TBH to properly explain the tradeoffs it would need an even longer explanation, which would also touch on auto-connect. 

-----

In general I think the auto-connect and oneserver options are inherently intertwined (already showcased by the fact that the `auto_connect and oneserver` combination is disallowed).  Maybe we could have a slider instead of two checkboxes. The slider of "trust" :D
```
(A1. auto_connect) --> (A2. no auto_connect) --> (A3. oneserver)
```

Also consider https://github.com/spesmilo/electrum/issues/9528, which also kind of fits into the slider.  Then we could have:
```
(B1. auto_connect to random) --> (B2. history_server must be bookmarked, other_nodes can be any) --> (B3. all nodes must be bookmarked before we connect) --> (B4. oneserver)
```
yep... it gets kind of complicated. and not easy to explain :(
My thinking with the slider approach is that if we implemented https://github.com/spesmilo/electrum/issues/9528, `A2` would turn into `B2`, and `B3` would be an entirely new state.
So that option, instead of adding another checkbox and increasing the state space from 2x2 to 2x2x2, would increase it from 3 to 4.