### PR TITLE
constants.py: add datadir_subdir, cli_flag, config_key methods

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -2090,21 +2090,10 @@ def add_global_options(parser, suppress=False):
     group.add_argument(
         "-P", "--portable", action="store_true", dest="portable", default=False,
         help=argparse.SUPPRESS if suppress else "Use local 'electrum_data' directory")
-    group.add_argument(
-        "--testnet", action="store_true", dest="testnet", default=False,
-        help=argparse.SUPPRESS if suppress else "Use Testnet")
-    group.add_argument(
-        "--testnet4", action="store_true", dest="testnet4", default=False,
-        help=argparse.SUPPRESS if suppress else "Use Testnet4")
-    group.add_argument(
-        "--regtest", action="store_true", dest="regtest", default=False,
-        help=argparse.SUPPRESS if suppress else "Use Regtest")
-    group.add_argument(
-        "--simnet", action="store_true", dest="simnet", default=False,
-        help=argparse.SUPPRESS if suppress else "Use Simnet")
-    group.add_argument(
-        "--signet", action="store_true", dest="signet", default=False,
-        help=argparse.SUPPRESS if suppress else "Use Signet")
+    for chain in constants.NETS_LIST:
+        group.add_argument(
+            f"--{chain.cli_flag()}", action="store_true", dest=chain.config_key(), default=False,
+            help=argparse.SUPPRESS if suppress else f"Use {chain.NET_NAME} chain")
     group.add_argument(
         "-o", "--offline", action="store_true", dest=SimpleConfig.NETWORK_OFFLINE.key(), default=None,
         help=argparse.SUPPRESS if suppress else "Run offline")
@@ -2134,11 +2123,8 @@ def get_simple_parser():
     parser = PassThroughOptionParser()
     parser.add_option("-D", "--dir", dest="electrum_path", help="electrum directory")
     parser.add_option("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electrum_data' directory")
-    parser.add_option("--testnet", action="store_true", dest="testnet", default=False, help="Use Testnet")
-    parser.add_option("--testnet4", action="store_true", dest="testnet4", default=False, help="Use Testnet4")
-    parser.add_option("--regtest", action="store_true", dest="regtest", default=False, help="Use Regtest")
-    parser.add_option("--simnet", action="store_true", dest="simnet", default=False, help="Use Simnet")
-    parser.add_option("--signet", action="store_true", dest="signet", default=False, help="Use Signet")
+    for chain in constants.NETS_LIST:
+        parser.add_option(f"--{chain.cli_flag()}", action="store_true", dest=chain.config_key(), default=False, help=f"Use {chain.NET_NAME} chain")
     return parser
 
 

--- a/run_electrum
+++ b/run_electrum
@@ -420,16 +420,8 @@ def main():
                 _logger.info(f"get_default_language: failed. got exc={e!r}")
         set_language(lang)
 
-    if config.get('testnet'):
-        constants.BitcoinTestnet.set_as_network()
-    elif config.get('testnet4'):
-        constants.BitcoinTestnet4.set_as_network()
-    elif config.get('regtest'):
-        constants.BitcoinRegtest.set_as_network()
-    elif config.get('simnet'):
-        constants.BitcoinSimnet.set_as_network()
-    elif config.get('signet'):
-        constants.BitcoinSignet.set_as_network()
+    chain = config.get_selected_chain()
+    chain.set_as_network()
 
     # check if we received a valid payment identifier
     uri = config_options.get('url')


### PR DESCRIPTION
- constants.py: add `datadir_subdir`, `cli_flag`, `config_key` methods
- use these to generalise recurring "switch-like" ifs
- this effectively also adds a `--mainnet` CLI option
    - closes https://github.com/spesmilo/electrum/issues/9790