### PR TITLE
Replace config GUI_LAST_WALLET with CURRENT_WALLET

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -246,7 +246,7 @@ class Commands(Logger):
             'connected': self.network.is_connected(),
             'auto_connect': net_params.auto_connect,
             'version': ELECTRUM_VERSION,
-            'default_wallet': self.config.get_wallet_path(),
+            'current_wallet': self.config.get_wallet_path(use_fallback=False),
             'fee_estimates': self.network.fee_estimates.get_data()
         }
         return response
@@ -278,6 +278,7 @@ class Commands(Logger):
         if wallet is None:
             raise UserFacingException('could not load wallet')
         run_hook('load_wallet', wallet, None)
+        return wallet_path
 
     @command('n')
     async def close_wallet(self, wallet_path=None):

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -178,7 +178,7 @@ class QEDaemon(AuthMixin, QObject):
         if path is None:
             self._path = self.daemon.config.get('wallet_path')  # command line -w option
             if self._path is None:
-                self._path = self.daemon.config.GUI_LAST_WALLET
+                self._path = self.daemon.config.CURRENT_WALLET
         else:
             self._path = path
         if self._path is None:

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -488,9 +488,6 @@ class ElectrumGui(BaseElectrumGui, Logger):
         if window in self.windows:
             self.windows.remove(window)
         self.build_tray_menu()
-        # save wallet path of last open window
-        if not self.windows:
-            self.config.save_last_wallet(window.wallet)
         run_hook('on_close_window', window)
         if window.should_stop_wallet_on_close:
             self.daemon.stop_wallet(window.wallet.storage.path)
@@ -555,7 +552,7 @@ class ElectrumGui(BaseElectrumGui, Logger):
             return
         # start wizard to select/create wallet
         self.timer.start()
-        path = self.config.get_wallet_path(use_gui_last_wallet=True)
+        path = self.config.get_wallet_path()
         try:
             if not self.start_new_window(path, self.config.get('url'), app_is_starting=True):
                 return

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -26,7 +26,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
     def __init__(self, *, config, daemon, plugins):
         BaseElectrumGui.__init__(self, config=config, daemon=daemon, plugins=plugins)
         self.network = daemon.network
-        storage = WalletStorage(config.get_wallet_path(use_gui_last_wallet=True))
+        storage = WalletStorage(config.get_wallet_path())
         if not storage.file_exists():
             print("Wallet not found. try 'electrum create'")
             exit()

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -62,7 +62,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
     def __init__(self, *, config: 'SimpleConfig', daemon: 'Daemon', plugins: 'Plugins'):
         BaseElectrumGui.__init__(self, config=config, daemon=daemon, plugins=plugins)
         self.network = daemon.network
-        storage = WalletStorage(config.get_wallet_path(use_gui_last_wallet=True))
+        storage = WalletStorage(config.get_wallet_path())
         password = None
         if not storage.file_exists():
             print("Wallet not found. try 'electrum create'")
@@ -70,7 +70,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         if storage.is_encrypted():
             password = getpass.getpass('Password:', stream=None)
         del storage
-        self.wallet = self.daemon.load_wallet(config.get_wallet_path(use_gui_last_wallet=True), password)
+        self.wallet = self.daemon.load_wallet(config.get_wallet_path(), password)
         self.contacts = self.wallet.contacts
 
         locale.setlocale(locale.LC_ALL, '')

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -458,27 +458,18 @@ class SimpleConfig(Logger):
         else:
             return self.WALLET_BACKUP_DIRECTORY
 
-    def get_wallet_path(self, *, use_gui_last_wallet=False):
-        """Set the path of the wallet."""
-
+    def get_wallet_path(self, *, use_fallback=True) -> Optional[str]:
+        """Returns the wallet path."""
         # command line -w option
         if self.get('wallet_path'):
             return os.path.join(self.get('cwd', ''), self.get('wallet_path'))
-
-        if use_gui_last_wallet:
-            path = self.GUI_LAST_WALLET
-            if path and os.path.exists(path):
-                return path
-
-        new_path = self.get_fallback_wallet_path()
-
-        # TODO: this can be removed by now
-        # default path in pre 1.9 versions
-        old_path = os.path.join(self.path, "electrum.dat")
-        if os.path.exists(old_path) and not os.path.exists(new_path):
-            os.rename(old_path, new_path)
-
-        return new_path
+        # current wallet
+        path = self.CURRENT_WALLET
+        if path and os.path.exists(path):
+            return path
+        if use_fallback:
+            return self.get_fallback_wallet_path()
+        return
 
     def get_datadir_wallet_path(self):
         util.assert_datadir_available(self.path)
@@ -495,11 +486,6 @@ class SimpleConfig(Logger):
 
     def get_session_timeout(self):
         return self.HWD_SESSION_TIMEOUT
-
-    def save_last_wallet(self, wallet):
-        if self.get('wallet_path') is None:
-            path = wallet.storage.path
-            self.GUI_LAST_WALLET = path
 
     def get_video_device(self):
         device = self.VIDEO_DEVICE_PATH
@@ -762,7 +748,7 @@ Warning: setting this to too low will result in lots of payment failures."""),
     RPC_SOCKET_FILEPATH = ConfigVar('rpcsockpath', default=None, type_=str)
 
     GUI_NAME = ConfigVar('gui', default='qt', type_=str)
-    GUI_LAST_WALLET = ConfigVar('gui_last_wallet', default=None, type_=str)
+    CURRENT_WALLET = ConfigVar('current_wallet', default=None, type_=str)
 
     GUI_QT_COLOR_THEME = ConfigVar(
         'qt_gui_color_theme', default='default', type_=str,

--- a/run_electrum
+++ b/run_electrum
@@ -138,8 +138,12 @@ def init_cmdline(config_options, wallet_path, *, rpcserver: bool, config: 'Simpl
     if cmdname in ['payto', 'paytomany'] and config.get('broadcast'):
         cmd.requires_network = True
 
+    if cmd.requires_wallet and not wallet_path:
+        print_msg("wallet path not provided.")
+        sys_exit(1)
+
     # instantiate wallet for command-line
-    storage = WalletStorage(wallet_path)
+    storage = WalletStorage(wallet_path) if wallet_path else None
 
     if cmd.requires_wallet and not storage.file_exists():
         print_msg("Error: Wallet file not found.")
@@ -215,14 +219,14 @@ def get_password_for_hw_device_encrypted_storage(plugins: 'Plugins') -> str:
         sys.exit(0)
 
 
-async def run_offline_command(config, config_options, plugins: 'Plugins'):
+async def run_offline_command(config, config_options, wallet_path, plugins: 'Plugins'):
     cmdname = config.get('cmd')
     cmd = known_commands[cmdname]
     password = config_options.get('password')
     if 'wallet_path' in cmd.options and config_options.get('wallet_path') is None:
-        config_options['wallet_path'] = config.get_wallet_path()
+        config_options['wallet_path'] = wallet_path
     if cmd.requires_wallet:
-        storage = WalletStorage(config.get_wallet_path())
+        storage = WalletStorage(wallet_path)
         if storage.is_encrypted():
             if storage.is_encrypted_with_hw_device():
                 password = get_password_for_hw_device_encrypted_storage(plugins)
@@ -512,7 +516,6 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
                 sys_exit(1)
 
     elif cmdname == 'daemon':
-
         configure_logging(config)
         fd = daemon.get_file_descriptor(config)
         if fd is not None:
@@ -528,7 +531,11 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
         # command line
         configure_logging(config, log_to_file=False)  # don't spam logfiles for each client-side RPC, but support "-v"
         cmd = known_commands[cmdname]
-        wallet_path = config.get_wallet_path()
+        use_fallback = (cmdname in ['create', 'restore', 'load_wallet'])
+        wallet_path = config.get_wallet_path(use_fallback=use_fallback)
+        if cmd.requires_wallet and not wallet_path:
+            print_stderr('wallet path not provided')
+            sys_exit(1)
         if not config.NETWORK_OFFLINE:
             init_cmdline(config_options, wallet_path, rpcserver=True, config=config)
             timeout = config.CLI_TIMEOUT
@@ -568,7 +575,7 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
                 sys_exit(1)
             init_cmdline(config_options, wallet_path, rpcserver=False, config=config)
             plugins = Plugins(config, 'cmdline')
-            coro = run_offline_command(config, config_options, plugins)
+            coro = run_offline_command(config, config_options, wallet_path, plugins)
             fut = asyncio.run_coroutine_threadsafe(coro, loop)
             try:
                 try:

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -112,7 +112,7 @@ if [[ $1 == "init" ]]; then
     $agent setconfig --offline test_force_disable_mpp True
     echo "funding $2"
     # note: changing the funding amount affects all tests, as they rely on "wait_for_balance"
-    $bitcoin_cli sendtoaddress $($agent getunusedaddress -o) 1
+    $bitcoin_cli sendtoaddress $($agent getunusedaddress -o -w "/tmp/$2/regtest/wallets/default_wallet") 1
 fi
 
 if [[ $1 == "setconfig" ]]; then


### PR DESCRIPTION
 - CURRENT_WALLET is set when a single wallet is loaded in memory.
 - if several wallets are loaded, RPCs must specify which wallet they apply to, using the --wallet option.
 - the fallback to 'default_wallet' essentially only applies when creating a new wallet file