### PR TITLE
followup 9e225d1: rm save_last_wallet call

### DIFF
--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -237,8 +237,6 @@ class QEDaemon(AuthMixin, QObject):
                 else:
                     self._logger.info('use single password disabled by config')
 
-                self.daemon.config.save_last_wallet(wallet)
-
                 run_hook('load_wallet', wallet)
 
                 success = True


### PR DESCRIPTION
fixes the following exception when starting the qml gui:
```
Traceback (most recent call last):
  File "/home/user/code/electrum-fork/electrum/util.py", line 1119, in run_with_except_hook
    run_original(*args2, **kwargs2)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qml/qedaemon.py", line 240, in load_wallet_task
    self.daemon.config.save_last_wallet(wallet)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SimpleConfig' object has no attribute 'save_last_wallet'
```