### PR TITLE
qml: fix updating network settings

### DIFF
--- a/electrum/gui/qml/components/ServerConfigDialog.qml
+++ b/electrum/gui/qml/components/ServerConfigDialog.qml
@@ -34,7 +34,6 @@ ElDialog {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
             }
-
         }
 
         FlatButton {
@@ -42,9 +41,10 @@ ElDialog {
             text: qsTr('Ok')
             icon.source: '../../icons/confirmed.png'
             onClicked: {
-                Network.oneServer = serverconfig.serverConnectMode == ServerConnectModeComboBox.Mode.Single
-                Config.autoConnect = serverconfig.serverConnectMode == ServerConnectModeComboBox.Mode.Autoconnect
-                Network.server = serverconfig.address
+                let auto_connect = serverconfig.serverConnectMode == ServerConnectModeComboBox.Mode.Autoconnect
+                let server = serverconfig.address
+                let one_server = serverconfig.serverConnectMode == ServerConnectModeComboBox.Mode.Single
+                Network.setServerParameters(server, auto_connect, one_server)
                 rootItem.close()
             }
         }

--- a/electrum/gui/qml/components/ServerConnectWizard.qml
+++ b/electrum/gui/qml/components/ServerConnectWizard.qml
@@ -21,10 +21,7 @@ Wizard {
         } else {
             Network.proxy = {'enabled': false}
         }
-        Config.autoConnect = wizard_data['autoconnect']
-        if (!wizard_data['autoconnect']) {
-            Network.server = wizard_data['server']
-        }
+        Network.setServerParameters(wizard_data['server'], wizard_data['autoconnect'], wizard_data['one_server'])
     }
 
     Component.onCompleted: {

--- a/electrum/gui/qml/components/controls/ServerConnectModeComboBox.qml
+++ b/electrum/gui/qml/components/controls/ServerConnectModeComboBox.qml
@@ -22,12 +22,12 @@ ElComboBox {
     ]
 
     Component.onCompleted: {
-        if (!Config.autoConnectDefined) { // initial setup
+        if (!Network.autoConnectDefined) { // initial setup
             server_connect_mode_cb.currentIndex = server_connect_mode_cb.indexOfValue(
                 ServerConnectModeComboBox.Mode.Manual)
         } else {
             server_connect_mode_cb.currentIndex = server_connect_mode_cb.indexOfValue(
-                Config.autoConnect
+                Network.autoConnect
                     ? ServerConnectModeComboBox.Mode.Autoconnect
                     : Network.oneServer
                         ? ServerConnectModeComboBox.Mode.Single

--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -526,7 +526,7 @@ ApplicationWindow
         }
 
         function continueWithServerConnection() {
-            if (!Config.autoConnectDefined) {
+            if (!Network.autoConnectDefined) {
                 var dialog = serverConnectWizard.createObject(app)
                 // without completed serverConnectWizard we can't start
                 dialog.rejected.connect(function() {

--- a/electrum/gui/qml/qeconfig.py
+++ b/electrum/gui/qml/qeconfig.py
@@ -82,21 +82,6 @@ class QEConfig(AuthMixin, QObject):
             self.config.TERMS_OF_USE_ACCEPTED = 0
         self.termsOfUseChanged.emit()
 
-    autoConnectChanged = pyqtSignal()
-    @pyqtProperty(bool, notify=autoConnectChanged)
-    def autoConnect(self):
-        return self.config.NETWORK_AUTO_CONNECT
-
-    @autoConnect.setter
-    def autoConnect(self, auto_connect):
-        self.config.NETWORK_AUTO_CONNECT = auto_connect
-        self.autoConnectChanged.emit()
-
-    # auto_connect is actually a tri-state, expose the undefined case
-    @pyqtProperty(bool, notify=autoConnectChanged)
-    def autoConnectDefined(self):
-        return self.config.cv.NETWORK_AUTO_CONNECT.is_set()
-
     baseUnitChanged = pyqtSignal()
     @pyqtProperty(str, notify=baseUnitChanged)
     def baseUnit(self):


### PR DESCRIPTION
Previously the server parameters were each handled differently, e.g. auto-connect was only applied when updating Network.server and not when Config.autoConnect was updated. Similarly, updating Network.server did not restart the network, leading to >1 connection when Network.oneServer was set to True before updating Network.server.

Consolidate server parameter updates into a single call, remove the individual setters, and move Config.autoConnect and Config.autoConnectDefined to Network.