### PR TITLE
qt: windows: protect against screenshots and screen recordings

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -24,6 +24,7 @@
 # SOFTWARE.
 
 import ast
+import sys
 from typing import TYPE_CHECKING, Dict
 
 from PyQt6.QtCore import Qt
@@ -262,6 +263,20 @@ class SettingsDialog(QDialog, QtEventListener):
             self.need_restart = True
         filelogging_cb.stateChanged.connect(on_set_filelogging)
 
+        screenshot_protection_cb = checkbox_from_configvar(
+            self.config.cv.GUI_QT_SCREENSHOT_PROTECTION
+        )
+        screenshot_protection_cb.setChecked(self.config.GUI_QT_SCREENSHOT_PROTECTION)
+        if sys.platform not in ['windows', 'win32']:
+            screenshot_protection_cb.setChecked(False)
+            screenshot_protection_cb.setDisabled(True)
+            screenshot_protection_cb.setToolTip(_("This option is only available on Windows"))
+
+        def on_set_screenshot_protection(_x):
+            self.config.GUI_QT_SCREENSHOT_PROTECTION = screenshot_protection_cb.isChecked()
+            self.need_restart = True
+        screenshot_protection_cb.stateChanged.connect(on_set_screenshot_protection)
+
         block_explorers = sorted(util.block_explorer_info().keys())
         BLOCK_EX_CUSTOM_ITEM = _("Custom URL")
         if BLOCK_EX_CUSTOM_ITEM in block_explorers:  # malicious translation?
@@ -386,6 +401,7 @@ class SettingsDialog(QDialog, QtEventListener):
         misc_widgets = []
         misc_widgets.append((updatecheck_cb, None))
         misc_widgets.append((filelogging_cb, None))
+        misc_widgets.append((screenshot_protection_cb, None))
         misc_widgets.append((alias_label, self.alias_e))
         misc_widgets.append((qr_label, qr_combo))
 

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -6,6 +6,7 @@ import platform
 import queue
 import os
 import webbrowser
+import ctypes
 from functools import partial, lru_cache, wraps
 from typing import (NamedTuple, Callable, Optional, TYPE_CHECKING, List, Any, Sequence, Tuple, Union)
 
@@ -1530,6 +1531,21 @@ def insert_spaces(text: str, every_chars: int) -> str:
     '''Insert spaces at every Nth character to allow for WordWrap'''
     return ' '.join(text[i:i+every_chars] for i in range(0, len(text), every_chars))
 
+
+def set_windows_os_screenshot_protection_drm_flag(window: QWidget) -> None:
+    """
+    sets the windows WDA_MONITOR flag on the window so windows prevents capturing
+    screenshots and microsoft recall will not be able to record the window
+    https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity
+    """
+    if sys.platform not in ('win32', 'windows'):
+        return
+    try:
+        window_id = int(window.winId())
+        WDA_MONITOR = 0x01
+        ctypes.windll.user32.SetWindowDisplayAffinity(window_id, WDA_MONITOR)
+    except Exception:
+        _logger.exception(f"failed to set windows screenshot protection flag")
 
 class _ABCQObjectMeta(type(QObject), ABCMeta): pass
 class _ABCQWidgetMeta(type(QWidget), ABCMeta): pass

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -800,6 +800,14 @@ Warning: setting this to too low will result in lots of payment failures."""),
     GUI_QT_SHOW_TAB_CONTACTS = ConfigVar('show_contacts_tab', default=False, type_=bool)
     GUI_QT_SHOW_TAB_CONSOLE = ConfigVar('show_console_tab', default=False, type_=bool)
     GUI_QT_SHOW_TAB_NOTES = ConfigVar('show_notes_tab', default=False, type_=bool)
+    GUI_QT_SCREENSHOT_PROTECTION = ConfigVar(
+        'screenshot_protection', default=True, type_=bool,
+        short_desc=lambda: _("Prevent screenshots"),
+        # currently this option is Windows only, so the description can be specific to Windows
+        long_desc=lambda: _(
+            'Signals Windows to disallow recordings and screenshots of the application window. '
+            'There is no guarantee Windows will respect this signal.'),
+    )
 
     GUI_QML_PREFERRED_REQUEST_TYPE = ConfigVar('preferred_request_type', default='bolt11', type_=str)
     GUI_QML_USER_KNOWS_PRESS_AND_HOLD = ConfigVar('user_knows_press_and_hold', default=False, type_=bool)


### PR DESCRIPTION
fixes #9858 
Protects the main window, wallet wizard and `WindowModalDialog` instances from screenshots and screen recordings on Windows OS (including windows recall) by setting the `WDA_EXCLUDEFROMCAPTURE` flag on the windows (see https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity). 
This should cover all critical windows like the seed dialog and balances.
Introduces a config variable `GUI_QT_SCREENSHOT_PROTECTION` which is enabled by default and can (only on windows) be set from the 'Misc' tab of `SettingsDialog`.