### PR TITLE
fix: exceptions when sending change to lightning

### DIFF
--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -338,7 +338,7 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
                     return
                 coro = sm.request_swap_for_amount(transport, swap_dummy_output.value)
                 try:
-                    swap, invoice = self.window.run_coroutine_dialog(coro, _('Requesting swap invoice...'))
+                    swap, swap_invoice = self.window.run_coroutine_dialog(coro, _('Requesting swap invoice...'))
                 except SwapServerError as e:
                     self.show_error(str(e))
                     return
@@ -346,7 +346,7 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
                     return
                 tx.replace_output_address(DummyAddress.SWAP, swap.lockup_address)
                 assert tx.get_dummy_output(DummyAddress.SWAP) is None
-                tx.swap_invoice = invoice
+                tx.swap_invoice = swap_invoice
                 tx.swap_payment_hash = swap.payment_hash
 
         if is_preview:

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -842,7 +842,7 @@ class SwapManager(Logger):
         if lightning_amount_sat is None:
             raise SwapServerError(_("Swap amount outside of providers limits") + ":\n"
                                   + _("min") + f": {self.get_min_amount()}\n"
-                                  + _("max") + f": {self.get_max_amount()}")
+                                  + _("max") + f": {self.get_provider_max_reverse_amount()}")
         swap, invoice = await self.request_normal_swap(
             transport,
             lightning_amount_sat=lightning_amount_sat,


### PR DESCRIPTION
Fixes these two exceptions when using the send change to lightning option:
```
Traceback (most recent call last):
  File "/home/user/code/electrum-fork/electrum/gui/qt/send_tab.py", line 572, in do_pay_or_get_invoice
    self.do_pay_invoice(self.pending_invoice)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/send_tab.py", line 599, in do_pay_invoice
    self.pay_onchain_dialog(invoice.outputs, invoice=invoice)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/send_tab.py", line 341, in pay_onchain_dialog
    swap, invoice = self.window.run_coroutine_dialog(coro, _('Requesting swap invoice...'))
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 316, in run_coroutine_dialog
    return d.run()
           ~~~~~^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/util.py", line 466, in run
    raise self._exception
  File "/home/user/code/electrum-fork/electrum/gui/qt/util.py", line 456, in task
    self._result = self._future.result()
                   ~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.13/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/user/code/electrum-fork/electrum/util.py", line 1206, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/submarine_swaps.py", line 845, in request_swap_for_amount
    + _("max") + f": {self.get_max_amount()}")
                      ^^^^^^^^^^^^^^^^^^^
AttributeError: 'SwapManager' object has no attribute 'get_max_amount'. Did you mean: 'get_min_amount'?
```

and this happened when clicking on the "Preview" button as the invoice object got replaced with the swap lightning invoice str due to the same variable name:

```
Traceback (most recent call last):
  File "/home/user/code/electrum-fork/electrum/gui/qt/send_tab.py", line 572, in do_pay_or_get_invoice
    self.do_pay_invoice(self.pending_invoice)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/send_tab.py", line 599, in do_pay_invoice
    self.pay_onchain_dialog(invoice.outputs, invoice=invoice)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/send_tab.py", line 353, in pay_onchain_dialog
    self.window.show_transaction(tx, external_keypairs=external_keypairs, invoice=invoice)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 1180, in show_transaction
    show_transaction(
    ~~~~~~~~~~~~~~~~^
        tx,
        ^^^
    ...<4 lines>...
        show_broadcast_button=show_broadcast_button,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/code/electrum-fork/electrum/gui/qt/transaction_dialog.py", line 427, in show_transaction
    d = TxDialog(
        tx,
    ...<4 lines>...
        on_closed=on_closed,
    )
  File "/home/user/code/electrum-fork/electrum/gui/qt/transaction_dialog.py", line 478, in __init__
    self.desc = self.invoice.get_message()
                ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get_message'
```