### PR TITLE
gui: "Choose Swap Provider" screen: show hex pubkey, and longer prefix

### DIFF
--- a/electrum/gui/qml/components/NostrSwapServersDialog.qml
+++ b/electrum/gui/qml/components/NostrSwapServersDialog.qml
@@ -93,12 +93,14 @@ ElDialog {
                                 source: Qt.resolvedUrl('../../icons/network.png')
                             }
                             Label {
-                                text: qsTr('Npub')
+                                text: qsTr('Pubkey')
                                 color: Material.accentColor
                             }
                             Label {
                                 Layout.fillWidth: true
-                                text: model.npub.substring(0,10)
+                                // only show the prefix of the pubkey for readability, but
+                                // keep it long enough so that collisions are hard to brute-force:
+                                text: model.server_pubkey.substring(0,32)
                                 wrapMode: Text.Wrap
                             }
                             Label {

--- a/electrum/gui/qml/qeswaphelper.py
+++ b/electrum/gui/qml/qeswaphelper.py
@@ -32,7 +32,8 @@ class QESwapServerNPubListModel(QAbstractListModel):
     _logger = get_logger(__name__)
 
     # define listmodel rolemap
-    _ROLE_NAMES= ('npub', 'timestamp', 'percentage_fee', 'mining_fee', 'min_amount', 'max_forward_amount', 'max_reverse_amount')
+    _ROLE_NAMES= ('npub', 'server_pubkey', 'timestamp', 'percentage_fee', 'mining_fee',
+                  'min_amount', 'max_forward_amount', 'max_reverse_amount')
     _ROLE_KEYS = range(Qt.ItemDataRole.UserRole, Qt.ItemDataRole.UserRole + len(_ROLE_NAMES))
     _ROLE_MAP  = dict(zip(_ROLE_KEYS, [bytearray(x.encode()) for x in _ROLE_NAMES]))
 
@@ -69,6 +70,7 @@ class QESwapServerNPubListModel(QAbstractListModel):
     def offer_to_model(self, x: 'SwapOffer'):
         return {
             'npub': x.server_npub,
+            'server_pubkey': x.server_pubkey,
             'percentage_fee': x.pairs.percentage,
             'mining_fee': x.pairs.mining_fee,
             'min_amount': x.pairs.min_amount,

--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -443,7 +443,7 @@ class SwapServerDialog(WindowModalDialog, QtEventListener):
             fee = f"{x.pairs.percentage}% + {x.pairs.mining_fee} sats"
             max_forward = self.window.format_amount(x.pairs.max_forward) + ' ' + self.window.base_unit()
             max_reverse = self.window.format_amount(x.pairs.max_reverse) + ' ' + self.window.base_unit()
-            item = QTreeWidgetItem([x.server_pubkey[0:10], fee, max_forward, max_reverse, last_seen])
+            item = QTreeWidgetItem([x.server_pubkey, fee, max_forward, max_reverse, last_seen])
             item.setData(0, ROLE_NPUB, x.server_npub)
             items.append(item)
         self.servers_list.insertTopLevelItems(0, items)


### PR DESCRIPTION
- makes it consistent between the qml and qt guis that now both show the hex pubkey
  - previously qml was showing npub
- don't truncate to first 10 chars, as that's still easy to bruteforce
  - the qt gui has space to display the full pubkey (64 hex chars) and can use the TreeWidget's columns to truncate as needed
  - qml has less space, truncate to 32 hex chars there (128 bits should be enough against bruteforce)