### PR TITLE
swaps: use eta:2 instead of config fee policy in qml, disable qt fee slider on reverse swaps

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1943,7 +1943,7 @@ class Commands(Logger):
                 funding_txid = None
             else:
                 lightning_amount_sat = satoshis(lightning_amount)
-                claim_fee = sm.get_swap_tx_fee()
+                claim_fee = sm.get_fee_for_txbatcher()
                 onchain_amount_sat = satoshis(onchain_amount) + claim_fee
                 funding_txid = await wallet.lnworker.swap_manager.reverse_swap(
                     transport,

--- a/electrum/gui/qml/qeswaphelper.py
+++ b/electrum/gui/qml/qeswaphelper.py
@@ -581,7 +581,7 @@ class QESwapHelper(AuthMixin, QObject, QtEventListener):
         server_miningfee = swap_manager.mining_fee
         self.serverMiningfee = QEAmount(amount_sat=server_miningfee)
         if self.isReverse:
-            self.miningfee = QEAmount(amount_sat=swap_manager.get_swap_tx_fee())
+            self.miningfee = QEAmount(amount_sat=swap_manager.get_fee_for_txbatcher())
             self.check_valid(self._send_amount, self._receive_amount)
         else:
             # update tx only if slider isn't moved for a while
@@ -703,7 +703,7 @@ class QESwapHelper(AuthMixin, QObject, QtEventListener):
                 txid = await swap_manager.reverse_swap(
                     self.swap_transport,
                     lightning_amount_sat=lightning_amount,
-                    expected_onchain_amount_sat=onchain_amount + swap_manager.get_swap_tx_fee(),
+                    expected_onchain_amount_sat=onchain_amount + swap_manager.get_fee_for_txbatcher(),
                 )
                 try:  # swaphelper might be destroyed at this point
                     if txid:

--- a/electrum/gui/qml/qeswaphelper.py
+++ b/electrum/gui/qml/qeswaphelper.py
@@ -543,7 +543,7 @@ class QESwapHelper(AuthMixin, QObject, QtEventListener):
             return
         outputs = [PartialTxOutput.from_address_and_value(DummyAddress.SWAP, onchain_amount)]
         coins = self._wallet.wallet.get_spendable_coins(None)
-        fee_policy = FeePolicy(self._wallet.wallet.config.FEE_POLICY)
+        fee_policy = FeePolicy('eta:2')
         try:
             self._tx = self._wallet.wallet.make_unsigned_transaction(
                 coins=coins,
@@ -677,7 +677,7 @@ class QESwapHelper(AuthMixin, QObject, QtEventListener):
             if max_amount > max_swap_amount:
                 onchain_amount = max_swap_amount
         outputs = [PartialTxOutput.from_address_and_value(DummyAddress.SWAP, onchain_amount)]
-        fee_policy = FeePolicy(self._wallet.wallet.config.FEE_POLICY)
+        fee_policy = FeePolicy('eta:2')
         try:
             tx = self._wallet.wallet.make_unsigned_transaction(
                 coins=coins,

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -476,9 +476,6 @@ class SwapManager(Logger):
                 self.logger.info('utxo value below dust threshold')
                 return
 
-    def get_swap_tx_fee(self):
-        return self._get_tx_fee(self.config.FEE_POLICY)
-
     def get_fee_for_txbatcher(self):
         return self._get_tx_fee(self.config.FEE_POLICY_SWAPS)
 
@@ -1094,13 +1091,13 @@ class SwapManager(Logger):
                                 f"send_amount={send_amount} -> recv_amount={recv_amount} -> inverted_send_amount={inverted_send_amount}")
         # second, add on-chain claim tx fee
         if is_reverse and recv_amount is not None:
-            recv_amount -= self.get_swap_tx_fee()
+            recv_amount -= self.get_fee_for_txbatcher()
         return recv_amount
 
     def get_send_amount(self, recv_amount: Optional[int], *, is_reverse: bool) -> Optional[int]:
         # first, add on-chain claim tx fee
         if is_reverse and recv_amount is not None:
-            recv_amount += self.get_swap_tx_fee()
+            recv_amount += self.get_fee_for_txbatcher()
         # second, add percentage fee
         send_amount = self._get_send_amount(recv_amount, is_reverse=is_reverse)
         # sanity check calculation can be inverted


### PR DESCRIPTION
QML:
now uses the `eta:2` fee policy for the funding tx of forward swaps as using the config fee policy could lead to issues (maybe too high or low), not configurable in the qml swap dialog.

Qt:
disables the `SwapDialog` fee slider on reverse swaps as the its value is not used anyways (txbatcher uses the swap fee policy for the claim transaction), and setting the claim tx fee could be dangerous (too low fee could allow server to refund itself after getting the preimage if the claim tx doesn't confirm in time).

Swaps:
remove `SwapManager.get_swap_tx_fee()` as it used the config fee policy and was used to calculate the claim tx fee amount, which is incorrect as the claim tx fee is not estimated with the user configurated fee policy in txbatcher, but the separate swap fee policy.
Replaced all calls with `SwapManager.get_fee_for_txbatcher()` which uses the correct `config.FEE_POLICY_SWAPS`.