### PR TITLE
fix: prevent KeyError if _fail_swap gets called multiple times

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -361,7 +361,8 @@ class SwapManager(Logger):
         self.lnwatcher.remove_callback(swap.lockup_address)
         if not swap.is_funded():
             with self.swaps_lock:
-                self._swaps.pop(swap.payment_hash.hex())
+                if self._swaps.pop(swap.payment_hash.hex(), None) is None:
+                    self.logger.debug(f"swap {swap.payment_hash.hex()} has already been deleted.")
                 # TODO clean-up other swaps dicts, i.e. undo _add_or_reindex_swap()
 
     @classmethod


### PR DESCRIPTION
If `_fail_swap()` gets called multiple times (e.g. from callbacks) it raises a `KeyError` as the swap got already popped from `self._swaps`.
In theory `_fail_swap` unregisters itself from the lnwatcher callback but the callback may is scheduled multiple times before it has the chance to unregister itself.
Lost the traceback, but `LNWatcher.on_event_adb_added_tx()` called `_claim_swap()` multiple times on a swap after startup which caused this to show up in my logs.