### PR TITLE
qt: provide more detailed warning for plot feature, change matplotlib backend

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -671,13 +671,15 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
     def plot_history_dialog(self):
         try:
             from electrum.plot import plot_history, NothingToPlotException
-        except Exception as e:
+        except ImportError as e:
             _logger.error(f"could not import electrum.plot. This feature needs matplotlib to be installed. exc={e!r}")
-            self.main_window.show_message(
-                _("Can't plot history.") + '\n' +
-                _("Perhaps some dependencies are missing...") + " (matplotlib?)" + '\n' +
-                f"Error: {e!r}"
-            )
+            self.main_window.show_message("\n\n".join([
+                _("This feature requires the 'matplotlib' Python library which is not "
+                  "included in Electrum by default."),
+                _("If you run Electrum from source you can install matplotlib to use this feature."),
+                _("It is not possible to install matplotlib inside the binary executables "
+                  "(e.g. AppImage or Windows installation).")
+            ]))
             return
         try:
             plt = plot_history(list(self.hm.transactions.values()))

--- a/electrum/plot.py
+++ b/electrum/plot.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from collections import defaultdict
 
 import matplotlib
-matplotlib.use('Qt5Agg')
+matplotlib.use('QtAgg')
 import matplotlib.pyplot as plt
 import matplotlib.dates as md
 


### PR DESCRIPTION
This warning is more detailed and explains the user why the plotting
feature is not available to prevent confusion like in https://github.com/spesmilo/electrum/issues/6328.

Also changes the matplotlib backend from `qt5agg` to `QtAgg` as according to the [matplotlib docs](https://matplotlib.org/stable/api/backend_qt_api.html) the Qt version is now not specified explicitly anymore and the `qt5agg` config is deprecated.