### PR TITLE
plugin: nwc: improve filtering of expired requests

### DIFF
--- a/electrum/plugins/nwc/nwcserver.py
+++ b/electrum/plugins/nwc/nwcserver.py
@@ -269,7 +269,7 @@ class NWCServer(Logger, EventListener):
         query = {
             "authors": list(self.connections.keys()),  # the pubkeys of the client connections
             "kinds": [self.REQUEST_EVENT_KIND],
-            "limit": 0,
+            "limit": 0,  # requests only new events after creating this subscription
             "since": int(time.time())
         }
         async for event in self.manager.get_events(query, single_event=False, only_stored=False):
@@ -290,8 +290,16 @@ class NWCServer(Logger, EventListener):
                 await self.send_error(event, "NOT_IMPLEMENTED")
                 continue
 
-            if event.created_at < int(time.time()) - 15:
+            # if the request has an explicitly set expiration tag, ignore it if it is expired
+            # otherwise ignore requests older than 30 sec to not handle requests the user may
+            # already expect to have timed out
+            if event.expires_at() is not None:
+                if event.is_expired():
+                    self.logger.debug(f"expired nwc request event: {event.content}")
+                    continue
+            elif event.created_at < int(time.time()) - 30:
                 self.logger.debug(f"old nwc request event: {event.content}")
+                await self.send_error(event, "OTHER", f"not handling too old request")
                 continue
 
             # decrypt the requests content


### PR DESCRIPTION
improve the filtering of incoming requests by checking if they have explicitly set an expiration tag. If so, they will only be ignored if this timestamp is exceeded. Otherwise requests older than 30 secons will get ignored and an error will get sent to the client so the client is aware it's request arrived too late.
This is done to prevent handling requests the user may already expects to have failed.

This depends on an aionostr version containing pr https://github.com/spesmilo/electrum-aionostr/pull/12. (Version > 0.0.10)