### PR TITLE
allow testnet4 and signet in crash reporter

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -74,7 +74,12 @@ class BaseCrashReporter(Logger):
 
     def send_report(self, asyncio_loop, proxy: 'ProxySettings', *, timeout=None) -> CrashReportResponse:
         # FIXME the caller needs to catch generic "Exception", as this method does not have a well-defined API...
-        if constants.net.GENESIS[-4:] not in ["4943", "e26f"] and ".electrum.org" in BaseCrashReporter.report_server:
+        if (constants.net.GENESIS[-4:] not in [
+            "e26f",  # mainnet
+            "4943",  # testnet 3
+            "f043",  # testnet 4
+            "1ef6",  # signet
+        ] and ".electrum.org" in BaseCrashReporter.report_server):
             # Gah! Some kind of altcoin wants to send us crash reports.
             raise Exception(_("Missing report URL."))
         report = self.get_traceback_info()


### PR DESCRIPTION
allows to submit crash reports from testnet 4 and signet too in addition to testnet3 and mainnet.