### PR TITLE
qt: fix: set ApplicationAttribute.AA_DontShowIconsInMenus False

### DIFF
--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -157,6 +157,8 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.screenshot_protection_efilter = ScreenshotProtectionEventFilter()
         if sys.platform in ['win32', 'windows'] and self.config.GUI_QT_SCREENSHOT_PROTECTION:
             self.app.installEventFilter(self.screenshot_protection_efilter)
+        # explicitly set 'AA_DontShowIconsInMenus' False so menu icons are shown on MacOS
+        self.app.setAttribute(Qt.ApplicationAttribute.AA_DontShowIconsInMenus, on=False)
         self.app.setWindowIcon(read_QIcon("electrum.png"))
         self.translator = ElectrumTranslator()
         self.app.installTranslator(self.translator)


### PR DESCRIPTION
Explicitly sets the `AA_DontShowIconsInMenus` attribute to false as it defaults to true on some Qt versions / environments which causes icons to not show up in the menus (e.g. MacOS).
see https://forum.qt.io/post/813228
The attribute has to be set on `self.app` after the` QApplication` has been instantiated (https://doc.qt.io/qt-6/qt.html#ApplicationAttribute-enum)