### PR TITLE
qt: fix: ToU 'I Accept' button not getting enabled

### DIFF
--- a/electrum/gui/qt/wizard/terms_of_use.py
+++ b/electrum/gui/qt/wizard/terms_of_use.py
@@ -52,32 +52,7 @@ class WCTermsOfUseScreen(WizardComponent):
         self.tos_label = WWLabel()
         self.tos_label.setText(messages.MSG_TERMS_OF_USE)
         self.layout().addWidget(self.tos_label)
-        self._valid = False
-
-        # Find the scroll area and connect to its scrollbar
-        QTimer.singleShot(100, self.check_scroll_position)
-        self.window().installEventFilter(self)
-
-    def eventFilter(self, obj, event):
-        if obj == self.window() and event.type() == QEvent.Type.Resize:
-            # catch window resize events to check if the scrollbar is visible
-            QTimer.singleShot(100, self.check_scroll_position)
-        return super().eventFilter(obj, event)
-
-    def check_scroll_position(self):
-        scroll_area = self.window().findChild(QScrollArea)
-        if scroll_area and scroll_area.verticalScrollBar() \
-                and scroll_area.verticalScrollBar().isVisible():
-            scrollbar = scroll_area.verticalScrollBar()
-            def on_scroll_change(value):
-                if value >= scrollbar.maximum() - 5:  # Allow 5 pixel margin
-                    self._valid = True
-                    self.on_updated()
-            scrollbar.valueChanged.connect(on_scroll_change)
-        else:
-            # scrollbar is not visible or not found
-            self._valid = True
-            self.on_updated()
+        self._valid = True
 
     def apply(self):
         pass


### PR DESCRIPTION
The 'I Accept' button might not get enabled for some users where startup is very slow.
The first check if the 'I Agree' button should be enabled gets fired 100ms after constructing the Dialog, which might not be enough and return False incorrectly. 
So we can either remove the logic completely (as done here) to prevent this issue, or alternatively increase the initial timer to some large timout after which the window should be assembled fully (e.g. 2 seconds). As the user is not able to read the whole terms in few seconds this would be a viable option too.