### PR TITLE
run_electrum: improve check_imports()

### DIFF
--- a/run_electrum
+++ b/run_electrum
@@ -73,8 +73,13 @@ def check_imports():
         import qrcode
         import google.protobuf
         import aiorpcx
+        import aiohttp
+        import aiohttp_socks
+        import electrum_ecc
+        import jsonpatch
+        import electrum_aionostr
     except ImportError as e:
-        sys.exit(f"Error: {str(e)}. Try 'sudo python3 -m pip install <module-name>'")
+        sys.exit(f"Error: {str(e)}. Some dependencies are missing. Have you read the README? Or just try '$ python3 -m pip install -r contrib/requirements/requirements.txt'")
     if not ((0, 25, 0) <= aiorpcx._version < (0, 26)):
         raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.25.0<=ver<0.26')
     # the following imports are for pyinstaller


### PR DESCRIPTION
```
$ ./run_electrum
Error: No module named 'dns'. Try 'sudo python3 -m pip install <module-name>' $ pip install dns
ERROR: Could not find a version that satisfies the requirement dns (from versions: none) ERROR: No matching distribution found for dns
$ pip install dnspython
Collecting dnspython
  Downloading dnspython-2.7.0-py3-none-any.whl (313 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 313.6/313.6 kB 3.4 MB/s eta 0:00:00
Installing collected packages: dnspython
Successfully installed dnspython-2.7.0
$ ./run_electrum
Error: No module named 'certifi'. Try 'sudo python3 -m pip install <module-name>'

$ ./run_electrum
Error: No module named 'google'. Try 'sudo python3 -m pip install <module-name>' $ pip install google
Collecting google
  Downloading google-3.0.0-py2.py3-none-any.whl (45 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.3/45.3 kB 569.4 kB/s eta 0:00:00
Collecting beautifulsoup4
  Downloading beautifulsoup4-4.13.4-py3-none-any.whl (187 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 187.3/187.3 kB 3.4 MB/s eta 0:00:00
Collecting soupsieve>1.2
  Downloading soupsieve-2.7-py3-none-any.whl (36 kB)
Collecting typing-extensions>=4.0.0
  Using cached typing_extensions-4.14.0-py3-none-any.whl (43 kB)
Installing collected packages: typing-extensions, soupsieve, beautifulsoup4, google Successfully installed beautifulsoup4-4.13.4 google-3.0.0 soupsieve-2.7 typing-extensions-4.14.0 $ ./run_electrum
Error: No module named 'google'. Try 'sudo python3 -m pip install <module-name>' $ pip install protobuf
Collecting protobuf
  Downloading protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl (321 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 321.1/321.1 kB 3.6 MB/s eta 0:00:00
Installing collected packages: protobuf
Successfully installed protobuf-6.31.1
$ ./run_electrum
Error: No module named 'aiorpcx'. Try 'sudo python3 -m pip install <module-name>'

$ ./run_electrum
Traceback (most recent call last):
  File "/home/nabijaczleweli/uwu/electrum/./run_electrum", line 95, in <module>
    from electrum.logging import get_logger, configure_logging  # import logging submodule first
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nabijaczleweli/uwu/electrum/electrum/__init__.py", line 18, in <module>
    from .util import format_satoshis
  File "/home/nabijaczleweli/uwu/electrum/electrum/util.py", line 58, in <module>
    import aiohttp
ModuleNotFoundError: No module named 'aiohttp'
$ ./run_electrum
Traceback (most recent call last):
  File "/home/nabijaczleweli/uwu/electrum/./run_electrum", line 95, in <module>
    from electrum.logging import get_logger, configure_logging  # import logging submodule first
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nabijaczleweli/uwu/electrum/electrum/__init__.py", line 18, in <module>
    from .util import format_satoshis
  File "/home/nabijaczleweli/uwu/electrum/electrum/util.py", line 59, in <module>
    from aiohttp_socks import ProxyConnector, ProxyType
ModuleNotFoundError: No module named 'aiohttp_socks' $ pip install aiohttp aiohttp-socks
Requirement already satisfied: aiohttp in ./venv/lib/python3.11/site-packages (3.12.13) Collecting aiohttp-socks
  Downloading aiohttp_socks-0.10.1-py3-none-any.whl (10 kB)
Requirement already satisfied: aiohappyeyeballs>=2.5.0 in ./venv/lib/python3.11/site-packages (from aiohttp) (2.6.1) Requirement already satisfied: aiosignal>=1.1.2 in ./venv/lib/python3.11/site-packages (from aiohttp) (1.3.2) Requirement already satisfied: attrs>=17.3.0 in ./venv/lib/python3.11/site-packages (from aiohttp) (25.3.0) Requirement already satisfied: frozenlist>=1.1.1 in ./venv/lib/python3.11/site-packages (from aiohttp) (1.7.0) Requirement already satisfied: multidict<7.0,>=4.5 in ./venv/lib/python3.11/site-packages (from aiohttp) (6.4.4) Requirement already satisfied: propcache>=0.2.0 in ./venv/lib/python3.11/site-packages (from aiohttp) (0.3.2) Requirement already satisfied: yarl<2.0,>=1.17.0 in ./venv/lib/python3.11/site-packages (from aiohttp) (1.20.1) Collecting python-socks[asyncio]<3.0.0,>=2.4.3
  Downloading python_socks-2.7.1-py3-none-any.whl (54 kB)
$ ./run_electrum
Traceback (most recent call last):
  File "/home/nabijaczleweli/uwu/electrum/./run_electrum", line 95, in <module>
    from electrum.logging import get_logger, configure_logging  # import logging submodule first
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nabijaczleweli/uwu/electrum/electrum/__init__.py", line 19, in <module>
    from .wallet import Wallet
  File "/home/nabijaczleweli/uwu/electrum/electrum/wallet.py", line 44, in <module>
    import electrum_ecc as ecc
ModuleNotFoundError: No module named 'electrum_ecc' $ pip install electrum_ecc
Collecting electrum_ecc
  Downloading electrum_ecc-0.0.5.tar.gz (2.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 7.9 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: electrum_ecc
  Building wheel for electrum_ecc (pyproject.toml) ... done
  Created wheel for electrum_ecc: filename=electrum_ecc-0.0.5-py3-none-linux_x86_64.whl size=1285621 sha256=f2d27f7635ad82efa533055a4952e92f4db08ccab60d5dea0f3443e1ab57d5a7
  Stored in directory: /mnt/filling/store/nabijaczleweli/.cache/pip/wheels/ad/4d/86/1607d5642f3437553a45658305d979155f8007a7108f5e6d79
Successfully built electrum_ecc
Installing collected packages: electrum_ecc
Successfully installed electrum_ecc-0.0.5
$ ./run_electrum
Error: at least one of ('pycryptodomex', 'cryptography') needs to be installed. $ ./run_electrum
Traceback (most recent call last):
  File "/home/nabijaczleweli/uwu/electrum/./run_electrum", line 97, in <module>
    from electrum.logging import get_logger, configure_logging  # import logging submodule first
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nabijaczleweli/uwu/electrum/electrum/__init__.py", line 19, in <module>
    from .wallet import Wallet
  File "/home/nabijaczleweli/uwu/electrum/electrum/wallet.py", line 47, in <module>
    from . import util, keystore, transaction, bitcoin, coinchooser, bip32, descriptor
  File "/home/nabijaczleweli/uwu/electrum/electrum/keystore.py", line 53, in <module>
    from .plugin import run_hook
  File "/home/nabijaczleweli/uwu/electrum/electrum/plugin.py", line 53, in <module>
    from .simple_config import SimpleConfig
  File "/home/nabijaczleweli/uwu/electrum/electrum/simple_config.py", line 12, in <module>
    from . import invoices
  File "/home/nabijaczleweli/uwu/electrum/electrum/invoices.py", line 7, in <module>
    from .json_db import StoredObject, stored_in
  File "/home/nabijaczleweli/uwu/electrum/electrum/json_db.py", line 29, in <module>
    import jsonpatch
ModuleNotFoundError: No module named 'jsonpatch'

$ ./run_electrum
Traceback (most recent call last):
  File "/home/nabijaczleweli/uwu/electrum/./run_electrum", line 99, in <module>
    from electrum.logging import get_logger, configure_logging  # import logging submodule first
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nabijaczleweli/uwu/electrum/electrum/__init__.py", line 19, in <module>
    from .wallet import Wallet
  File "/home/nabijaczleweli/uwu/electrum/electrum/wallet.py", line 77, in <module>
    from .lnworker import LNWallet
  File "/home/nabijaczleweli/uwu/electrum/electrum/lnworker.py", line 78, in <module>
    from .submarine_swaps import SwapManager
  File "/home/nabijaczleweli/uwu/electrum/electrum/submarine_swaps.py", line 16, in <module>
    import electrum_aionostr as aionostr
ModuleNotFoundError: No module named 'electrum_aionostr'
```