### PR TITLE
qml: set BtcField.textAsSats initial value to match its text

### DIFF
--- a/electrum/gui/qml/components/controls/BtcField.qml
+++ b/electrum/gui/qml/components/controls/BtcField.qml
@@ -32,5 +32,5 @@ TextField {
         }
     }
 
-    Component.onCompleted: textAsSats = Config.unitsToSats('')
+    Component.onCompleted: amount.textChanged()
 }

--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -155,7 +155,7 @@ class QEInvoice(QObject, QtEventListener):
         return self._amountOverride
 
     @amountOverride.setter
-    def amountOverride(self, new_amount):
+    def amountOverride(self, new_amount: QEAmount):
         self._logger.debug(f'set new override amount {repr(new_amount)}')
         self._amountOverride.copyFrom(new_amount)
         self.amountOverrideChanged.emit()


### PR DESCRIPTION
textAsSats was being set to 0 initially, regardless of actual text, only healing after onTextChanged.

fixes https://github.com/spesmilo/electrum/issues/9974

-----

@accumulator could you review if this looks ok?

- not sure exactly what https://github.com/spesmilo/electrum/commit/376d88115445c918935d43ae92e0a52bfe3da42b was fixing
- e.g. do we need to explicitly initialise the `text` field to `""` or similar?