### PR TITLE
qt: SwapDialog: update on changes, don't translate f-str

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -32,7 +32,7 @@ from .transaction import (
 from .util import (
     log_exceptions, ignore_exceptions, BelowDustLimit, OldTaskGroup, ca_path, gen_nostr_ann_pow,
     get_nostr_ann_pow_amount, make_aiohttp_proxy_connector, get_running_loop, get_asyncio_loop, wait_for2,
-    run_sync_function_on_asyncio_thread
+    run_sync_function_on_asyncio_thread, trigger_callback
 )
 from . import lnutil
 from .lnutil import hex_to_bytes, REDEEM_AFTER_DOUBLE_SPENT_DELAY, Keypair
@@ -1648,6 +1648,7 @@ class NostrTransport(SwapServerTransport):
             if self.config.SWAPSERVER_NPUB == offer.server_npub:
                 self.sm.update_pairs(pairs)
             self._offers[offer.server_npub] = offer
+            trigger_callback('swap_offers_changed', self.get_recent_offers())
             # mirror event to other relays
             await self.taskgroup.spawn(self.rebroadcast_event(event, server_relays))
 


### PR DESCRIPTION
1. Updates the `SwapDialog` and `SwapServerDialog` when new offers come in by triggering a callback in the `NostrTransport`. As some Nostr events always come in later than others, but the text of the `providers` button got set on construction of `SwapDialog` the button text often doesn't show the correct number of swapservers.
2. Change button text to show "providers" if len(providers) != 1, else "provider", don't use f-string in `_()` anymore