### PR TITLE
qt: remove colon in "Payment received:" notification

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1357,10 +1357,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             return
         if status == PR_PAID:
             # FIXME notification should only be shown if request was not PAID before
-            msg = _('Payment received:')
+            msg = _('Payment received')
             amount = req.get_amount_sat()
             if amount:
-                msg += ' ' + self.format_amount_and_units(amount)
+                msg += ': ' + self.format_amount_and_units(amount)
             msg += '\n' + req.get_message()
             self.notify(msg)
             self.receive_tab.request_list.delete_item(key)


### PR DESCRIPTION
If there is no amount in the payment request the notification would look weird as it would just show `Payment received:` indicating something might be missing. Now it just says `Payment received` instead (without the colon).

Before:
![Screenshot_20250627_125116](https://github.com/user-attachments/assets/5e4f7ed8-39dc-4925-a7f1-dc48564af184)

After:
![Screenshot_20250627_125420](https://github.com/user-attachments/assets/7bbcb78f-59fb-4464-9128-e6392ad05cba)
