### PR TITLE
fix: qml: update tx label on detailsChanged signal

### DIFF
--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -642,11 +642,21 @@ Item {
 
             onRequestPaid: {
                 close()
+                var capturedHistoryModel = Daemon.currentWallet.historyModel
                 if (isLightning) {
-                    app.stack.push(Qt.resolvedUrl('LightningPaymentDetails.qml'), {'key': key})
+                    var page = app.stack.push(Qt.resolvedUrl('LightningPaymentDetails.qml'), {'key': key})
+                    var capturedKey = key
+                    page.detailsChanged.connect(function() {
+                            capturedHistoryModel.updateTxLabel(capturedKey, page.label)
+                        }
+                    )
                 } else {
                     let paidTxid = getPaidTxid()
-                    app.stack.push(Qt.resolvedUrl('TxDetails.qml'), {'txid': paidTxid})
+                    var page = app.stack.push(Qt.resolvedUrl('TxDetails.qml'), {'txid': paidTxid})
+                    page.detailsChanged.connect(function() {
+                            capturedHistoryModel.updateTxLabel(paidTxid, page.label)
+                        }
+                    )
                 }
             }
             onClosed: destroy()


### PR DESCRIPTION
when setting a transaction label in the qml `LightningPaymentDetails` or `TxDetails` dialogs which get opened directly by the `ReceiveDialog` (through the `onRequestPaid` callback) the label is not shown in the main transaction list as no callback for `detailsChanged` is registered which gets called when the label changes. As a result the label is only visible after the main list gets reloaded (e.g. restart). This commit adds callbacks for `detailsChanged` so the labels are shown directly when changing them after receiving the payment.

Can be tested by: Creating a lightning invoice -> paying it while keeping the QR code dialog open -> setting a label when it switches to the payment details after the payment arrived -> going back to the main menu -> label is not visible.