### PR TITLE
fix: qml: wizard: delete seed_type from wizard_data if not set explicitly

### DIFF
--- a/electrum/gui/qml/components/wizard/WCWalletType.qml
+++ b/electrum/gui/qml/components/wizard/WCWalletType.qml
@@ -8,12 +8,16 @@ WizardComponent {
     valid: wallettypegroup.checkedButton !== null
 
     function apply() {
+        // apply gets called when the page is rendered and implicitly
+        // sets the first radio button or the last selected one when going back
         wizard_data['wallet_type'] = wallettypegroup.checkedButton.wallettype
+        delete wizard_data['seed_type']
         if (wizard_data['wallet_type'] == 'standard')
             wizard_data['seed_type'] = 'segwit'
         else if (wizard_data['wallet_type'] == '2fa')
             wizard_data['seed_type'] = '2fa_segwit'
-        // TODO: multisig
+        else if (wizard_data['wallet_type'] == 'multisig')
+            wizard_data['seed_type'] = 'segwit'
     }
 
     ButtonGroup {


### PR DESCRIPTION
Deletes the `seed_type` key from `wizard_data` in `WCWalletType` if it is not explicitly set to prevent a stale value from a previous wizard flow if the user goes back in the wizard and selects a different wallet type instead of completing the wizard with the previously selected wallet type.
This happens as the `apply()` function gets called with the previously set radio button, e.g. 2fa, if the user goes back. If he then selects multisig the `2fa_segwit` `seed_type` won't get cleared and cause the exception later.
Example exception when first selecting 2fa, then going back and creating a multisig wallet:
```
32.77 | E | gui.qml.qeapp.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
  File "/home/vagrant/electrum/electrum/gui/qml/qewizard.py", line 40, in submit
    view = self.resolve_next(self._current.view, wdata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/electrum/electrum/wizard.py", line 78, in resolve_next
    view_accept(wizard_data)
  File "/home/vagrant/electrum/electrum/wizard.py", line 501, in maybe_master_pubkey
    wizard_data['multisig_master_pubkey'] = self.keystore_from_data(wizard_data['wallet_type'], wizard_data).get_master_public_key()
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/electrum/electrum/wizard.py", line 339, in keystore_from_data
    return keystore.from_seed(data['seed'], passphrase=seed_extension, for_multisig=for_multisig)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/electrum/electrum/keystore.py", line 1197, in from_seed
    raise BitcoinException('Unexpected seed type {}'.format(repr(t)))
electrum.util.BitcoinException: Unexpected seed type '2fa_segwit'
```

Triggered by the following wizard stack:
```
 30.94 | D | wizard | view=create_seed
 30.94 | D | wizard | resolve_next view is confirm_seed
 30.94 | D | wizard | wizard stack:
0: 0x7fdc6804ae80 - {}

1: 0x7fdc6ac61400 - {'wallet_name': 'wallet_1'}

2: 0x7fdc680d8a80 - {'seed_type': '2fa_segwit', 'wallet_name': 'wallet_1', 'wallet_type': 'multisig'}

3: 0x7fdc6804ab00 - {'multisig_cosigner_data': {}, 'multisig_participants': 2, 'multisig_signatures': 2, 'seed_type': '2fa_segwit', 'wallet_name': 'wallet_1', 'wallet_type': 'multisig'}

4: 0x7fdc6807f0c0 - {'keystore_type': 'createseed', 'multisig_cosigner_data': {}, 'multisig_participants': 2, 'multisig_signatures': 2, 'seed_type': '2fa_segwit', 'wallet_name': 'wallet_1', 'wallet_type': 'multisig'}

c: 0x7fdc6807c380 - {'keystore_type': 'createseed', 'multisig_cosigner_data': {}, 'multisig_participants': 2, 'multisig_signatures': 2, 'seed': '<redacted>', 'seed_extend': False, 'seed_extra_words': '<redacted>', 'seed_type': '2fa_segwit', 'seed_variant': 'electrum', 'wallet_name': 'wallet_1', 'wallet_type': 'multisig'}
 30.94 | W | gui.qml.qeapp | next view: confirm_seed
```