### PR TITLE
wallet_db: add configvar for partial_writes, disable by default

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -515,7 +515,7 @@ class Daemon(Logger):
                 raise InvalidPassword('No password given')
             storage.decrypt(password)
         # read data, pass it to db
-        db = WalletDB(storage.read(), storage=storage, upgrade=upgrade)
+        db = WalletDB(storage.read(), storage=storage, upgrade=upgrade, config=config)
         if db.get_action():
             raise WalletUnfinished(db)
         wallet = Wallet(db, config=config)

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -194,7 +194,7 @@ class QENewWalletWizard(NewWalletWizard, QEAbstractWizard, MessageBoxMixin):
             "The wallet '{}' contains multiple accounts, which are no longer supported since Electrum 2.7.\n\n"
             "Do you want to split your wallet into multiple files?").format(wallet_path)
         if self.question(msg):
-            file_list = WalletDB.split_accounts(wallet_path, split_data)
+            file_list = WalletDB.split_accounts(wallet_path, split_data, config=self.config)
             msg = _('Your accounts have been moved to') + ':\n' + '\n'.join(file_list) + '\n\n' + _(
                 'Do you want to delete the old file') + ':\n' + wallet_path
             if self.question(msg):

--- a/electrum/plugins/watchtower/watchtower.py
+++ b/electrum/plugins/watchtower/watchtower.py
@@ -67,7 +67,7 @@ class WatchTower(Logger, EventListener):
     def __init__(self, network: 'Network'):
         Logger.__init__(self)
         self.config = network.config
-        wallet_db = WalletDB('', storage=None, upgrade=True)
+        wallet_db = WalletDB('', storage=None, upgrade=True, config=self.config)
         self.adb = AddressSynchronizer(wallet_db, self.config, name=self.diagnostic_name())
         self.adb.start_network(network)
         self.callbacks = {}  # address -> lambda function

--- a/electrum/scripts/bruteforce_pw.py
+++ b/electrum/scripts/bruteforce_pw.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         test_password = partial(test_password_for_storage_encryption, storage)
         print(f"wallet found: with storage encryption.")
     else:
-        db = WalletDB(storage.read(), storage=storage, upgrade=False)
+        db = WalletDB(storage.read(), storage=storage, upgrade=False, config=config)
         wallet = Wallet(db, config=config)
         if not wallet.has_password():
             print("wallet found but it is not encrypted.")

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -687,6 +687,11 @@ class SimpleConfig(Logger):
 This can eliminate a serious privacy issue where a malicious user can track your spends by sending small payments
 to a previously-paid address of yours that would then be included with unrelated inputs in your future payments."""),
     )
+    WALLET_PARTIAL_WRITES = ConfigVar(
+        'wallet_partial_writes', default=False, type_=bool,
+        long_desc=lambda: _("""Allows partial updates to be written to disk for the wallet DB.
+If disabled, the full wallet file is written to disk for every change. Experimental."""),
+    )
 
     FX_USE_EXCHANGE_RATE = ConfigVar('use_exchange_rate', default=False, type_=bool)
     FX_CURRENCY = ConfigVar('currency', default='EUR', type_=str)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -498,7 +498,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         new_storage._encryption_version = self.storage._encryption_version
         new_storage.pubkey = self.storage.pubkey
 
-        new_db = WalletDB(self.db.dump(), storage=new_storage, upgrade=True)
+        new_db = WalletDB(self.db.dump(), storage=new_storage, upgrade=True, config=self.config)
         if self.lnworker:
             channel_backups = new_db.get_dict('imported_channel_backups')
             for chan_id, chan in self.lnworker.channels.items():
@@ -4192,7 +4192,7 @@ def create_new_wallet(
     storage = WalletStorage(path)
     if storage.file_exists():
         raise UserFacingException("Remove the existing wallet first!")
-    db = WalletDB('', storage=storage, upgrade=True)
+    db = WalletDB('', storage=storage, upgrade=True, config=config)
 
     seed = Mnemonic('en').make_seed(seed_type=seed_type)
     k = keystore.from_seed(seed, passphrase=passphrase)
@@ -4231,7 +4231,7 @@ def restore_wallet_from_text(
             raise UserFacingException("Remove the existing wallet first!")
     if encrypt_file is None:
         encrypt_file = True
-    db = WalletDB('', storage=storage, upgrade=True)
+    db = WalletDB('', storage=storage, upgrade=True, config=config)
     text = text.strip()
     if keystore.is_address_list(text):
         wallet = Imported_Wallet(db, config=config)

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -721,7 +721,7 @@ class NewWalletWizard(KeystoreWizard):
                 enc_version = StorageEncryptionVersion.USER_PASSWORD
             storage.set_password(data['password'], enc_version=enc_version)
 
-        db = WalletDB('', storage=storage, upgrade=True)
+        db = WalletDB('', storage=storage, upgrade=True, config=self._daemon.config)
         db.set_keystore_encryption(bool(data['password']))
 
         db.put('wallet_type', data['wallet_type'])

--- a/run_electrum
+++ b/run_electrum
@@ -240,7 +240,7 @@ async def run_offline_command(config: 'SimpleConfig', config_options: dict, wall
                 password = get_password_for_hw_device_encrypted_storage(plugins)
                 config_options['password'] = password
             storage.decrypt(password)
-        db = WalletDB(storage.read(), storage=storage, upgrade=True)
+        db = WalletDB(storage.read(), storage=storage, upgrade=True, config=config)
         wallet = Wallet(db, config=config)
         config_options['wallet'] = wallet
     else:

--- a/tests/test_storage_upgrade.py
+++ b/tests/test_storage_upgrade.py
@@ -342,24 +342,30 @@ class TestStorageUpgrade(WalletTestCase):
             try:
                 db = self._load_db_from_json_string(
                     wallet_json=wallet_json,
-                    upgrade=False)
+                    upgrade=False,
+                    config=self.config,
+                )
             except WalletRequiresUpgrade:
                 db = self._load_db_from_json_string(
                     wallet_json=wallet_json,
-                    upgrade=True)
+                    upgrade=True,
+                    config=self.config,
+                )
                 await self._sanity_check_upgraded_db(db)
             return db
         else:
             try:
                 db = self._load_db_from_json_string(
                     wallet_json=wallet_json,
-                    upgrade=False)
+                    upgrade=False,
+                    config=self.config,
+                )
             except WalletRequiresSplit as e:
                 split_data = e._split_data
                 self.assertEqual(accounts, len(split_data))
                 for item in split_data:
                     data = json.dumps(item)
-                    new_db = WalletDB(data, storage=None, upgrade=True)
+                    new_db = WalletDB(data, storage=None, upgrade=True, config=self.config)
                     await self._sanity_check_upgraded_db(new_db)
 
     async def _sanity_check_upgraded_db(self, db):
@@ -367,6 +373,6 @@ class TestStorageUpgrade(WalletTestCase):
         await wallet.stop()
 
     @staticmethod
-    def _load_db_from_json_string(*, wallet_json, upgrade):
-        db = WalletDB(wallet_json, storage=None, upgrade=upgrade)
+    def _load_db_from_json_string(*, wallet_json, upgrade, config: 'SimpleConfig'):
+        db = WalletDB(wallet_json, storage=None, upgrade=upgrade, config=config)
         return db

--- a/tests/test_timelock_recovery.py
+++ b/tests/test_timelock_recovery.py
@@ -35,7 +35,7 @@ class TestTimelockRecovery(ElectrumTestCase):
         with open(os.path.join(os.path.dirname(__file__), "test_timelock_recovery", "default_wallet"), "r") as f:
             wallet_str = f.read()
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        db = WalletDB(wallet_str, storage=storage, upgrade=True, config=self.config)
         wallet = Wallet(db, config=self.config)
         return wallet
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -166,10 +166,10 @@ class FakeADB:
         return TxMinedInfo(height=10, conf=10, timestamp=int(time.time()), header_hash='def')
 
 class FakeWallet:
-    def __init__(self, fiat_value):
+    def __init__(self, fiat_value, *, config: 'SimpleConfig'):
         super().__init__()
         self.fiat_value = fiat_value
-        self.db = WalletDB('', storage=None, upgrade=False)
+        self.db = WalletDB('', storage=None, upgrade=False, config=config)
         self.adb = FakeADB()
         self.db.transactions = self.db.verified_tx = {'abc':'Tx'}
 
@@ -184,9 +184,10 @@ ccy = 'TEST'
 class TestFiat(ElectrumTestCase):
     def setUp(self):
         super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
         self.value_sat = COIN
         self.fiat_value = {}
-        self.wallet = FakeWallet(fiat_value=self.fiat_value)
+        self.wallet = FakeWallet(fiat_value=self.fiat_value, config=self.config)
         self.fx = FakeFxThread(FakeExchange(Decimal('1000.001')))
         default_fiat = Abstract_Wallet.default_fiat_value(self.wallet, txid, self.fx, self.value_sat)
         self.assertEqual(Decimal('1000.001'), default_fiat)
@@ -316,7 +317,7 @@ class TestWalletPassword(WalletTestCase):
     async def test_update_password_of_imported_wallet(self):
         wallet_str = '{"addr_history":{"1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr":[],"15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA":[],"1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6":[]},"addresses":{"change":[],"receiving":["1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr","1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6","15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA"]},"keystore":{"keypairs":{"0344b1588589958b0bcab03435061539e9bcf54677c104904044e4f8901f4ebdf5":"L2sED74axVXC4H8szBJ4rQJrkfem7UMc6usLCPUoEWxDCFGUaGUM","0389508c13999d08ffae0f434a085f4185922d64765c0bff2f66e36ad7f745cc5f":"L3Gi6EQLvYw8gEEUckmqawkevfj9s8hxoQDFveQJGZHTfyWnbk1U","04575f52b82f159fa649d2a4c353eb7435f30206f0a6cb9674fbd659f45082c37d559ffd19bea9c0d3b7dcc07a7b79f4cffb76026d5d4dff35341efe99056e22d2":"5JyVyXU1LiRXATvRTQvR9Kp8Rx1X84j2x49iGkjSsXipydtByUq"},"type":"imported"},"pruned_txo":{},"seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[100,100,840,405]}'
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        db = WalletDB(wallet_str, storage=storage, upgrade=True, config=self.config)
         wallet = Wallet(db, config=self.config)
 
         wallet.check_password(None)
@@ -332,7 +333,7 @@ class TestWalletPassword(WalletTestCase):
     async def test_update_password_of_standard_wallet(self):
         wallet_str = '''{"addr_history":{"12ECgkzK6gHouKAZ7QiooYBuk1CgJLJxes":[],"12iR43FPb5M7sw4Mcrr5y1nHKepg9EtZP1":[],"13HT1pfWctsSXVFzF76uYuVdQvcAQ2MAgB":[],"13kG9WH9JqS7hyCcVL1ssLdNv4aXocQY9c":[],"14Tf3qiiHJXStSU4KmienAhHfHq7FHpBpz":[],"14gmBxYV97mzYwWdJSJ3MTLbTHVegaKrcA":[],"15FGuHvRssu1r8fCw98vrbpfc3M4xs5FAV":[],"17oJzweA2gn6SDjsKgA9vUD5ocT1sSnr2Z":[],"18hNcSjZzRcRP6J2bfFRxp9UfpMoC4hGTv":[],"18n9PFxBjmKCGhd4PCDEEqYsi2CsnEfn2B":[],"19a98ZfEezDNbCwidVigV5PAJwrR2kw4Jz":[],"19z3j2ELqbg2pR87byCCt3BCyKR7rc3q8G":[],"1A3XSmvLQvePmvm7yctsGkBMX9ZKKXLrVq":[],"1CmhFe2BN1h9jheFpJf4v39XNPj8F9U6d":[],"1DuphhHUayKzbkdvjVjf5dtjn2ACkz4zEs":[],"1E4ygSNJpWL2uPXZHBptmU2LqwZTqb1Ado":[],"1GTDSjkVc9vaaBBBGNVqTANHJBcoT5VW9z":[],"1GWqgpThAuSq3tDg6uCoLQxPXQNnU8jZ52":[],"1GhmpwqSF5cqNgdr9oJMZx8dKxPRo4pYPP":[],"1J5TTUQKhwehEACw6Jjte1E22FVrbeDmpv":[],"1JWySzjzJhsETUUcqVZHuvQLA7pfFfmesb":[],"1KQHxcy3QUHAWMHKUtJjqD9cMKXcY2RTwZ":[],"1KoxZfc2KsgovjGDxwqanbFEA76uxgYH4G":[],"1KqVEPXdpbYvEbwsZcEKkrA4A2jsgj9hYN":[],"1N16yDSYe76c5A3CoVoWAKxHeAUc8Jhf9J":[],"1Pm8JBhzUJDqeQQKrmnop1Frr4phe1jbTt":[]},"addresses":{"change":["1GhmpwqSF5cqNgdr9oJMZx8dKxPRo4pYPP","1GTDSjkVc9vaaBBBGNVqTANHJBcoT5VW9z","15FGuHvRssu1r8fCw98vrbpfc3M4xs5FAV","1A3XSmvLQvePmvm7yctsGkBMX9ZKKXLrVq","19z3j2ELqbg2pR87byCCt3BCyKR7rc3q8G","1JWySzjzJhsETUUcqVZHuvQLA7pfFfmesb"],"receiving":["14gmBxYV97mzYwWdJSJ3MTLbTHVegaKrcA","13HT1pfWctsSXVFzF76uYuVdQvcAQ2MAgB","19a98ZfEezDNbCwidVigV5PAJwrR2kw4Jz","1J5TTUQKhwehEACw6Jjte1E22FVrbeDmpv","1Pm8JBhzUJDqeQQKrmnop1Frr4phe1jbTt","13kG9WH9JqS7hyCcVL1ssLdNv4aXocQY9c","1KQHxcy3QUHAWMHKUtJjqD9cMKXcY2RTwZ","12ECgkzK6gHouKAZ7QiooYBuk1CgJLJxes","12iR43FPb5M7sw4Mcrr5y1nHKepg9EtZP1","14Tf3qiiHJXStSU4KmienAhHfHq7FHpBpz","1KqVEPXdpbYvEbwsZcEKkrA4A2jsgj9hYN","17oJzweA2gn6SDjsKgA9vUD5ocT1sSnr2Z","1E4ygSNJpWL2uPXZHBptmU2LqwZTqb1Ado","18hNcSjZzRcRP6J2bfFRxp9UfpMoC4hGTv","1KoxZfc2KsgovjGDxwqanbFEA76uxgYH4G","18n9PFxBjmKCGhd4PCDEEqYsi2CsnEfn2B","1CmhFe2BN1h9jheFpJf4v39XNPj8F9U6d","1DuphhHUayKzbkdvjVjf5dtjn2ACkz4zEs","1GWqgpThAuSq3tDg6uCoLQxPXQNnU8jZ52","1N16yDSYe76c5A3CoVoWAKxHeAUc8Jhf9J"]},"keystore":{"seed":"cereal wise two govern top pet frog nut rule sketch bundle logic","type":"bip32","xprv":"xprv9s21ZrQH143K29XjRjUs6MnDB9wXjXbJP2kG1fnRk8zjdDYWqVkQYUqaDtgZp5zPSrH5PZQJs8sU25HrUgT1WdgsPU8GbifKurtMYg37d4v","xpub":"xpub661MyMwAqRbcEdcCXm1sTViwjBn28zK9kFfrp4C3JUXiW1sfP34f6HA45B9yr7EH5XGzWuTfMTdqpt9XPrVQVUdgiYb5NW9m8ij1FSZgGBF"},"pruned_txo":{},"seed_type":"standard","seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[619,310,840,405]}'''
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        db = WalletDB(wallet_str, storage=storage, upgrade=True, config=self.config)
         wallet = Wallet(db, config=self.config)
 
         wallet.check_password(None)
@@ -347,14 +348,14 @@ class TestWalletPassword(WalletTestCase):
     async def test_update_password_with_app_restarts(self):
         wallet_str = '{"addr_history":{"1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr":[],"15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA":[],"1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6":[]},"addresses":{"change":[],"receiving":["1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr","1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6","15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA"]},"keystore":{"keypairs":{"0344b1588589958b0bcab03435061539e9bcf54677c104904044e4f8901f4ebdf5":"L2sED74axVXC4H8szBJ4rQJrkfem7UMc6usLCPUoEWxDCFGUaGUM","0389508c13999d08ffae0f434a085f4185922d64765c0bff2f66e36ad7f745cc5f":"L3Gi6EQLvYw8gEEUckmqawkevfj9s8hxoQDFveQJGZHTfyWnbk1U","04575f52b82f159fa649d2a4c353eb7435f30206f0a6cb9674fbd659f45082c37d559ffd19bea9c0d3b7dcc07a7b79f4cffb76026d5d4dff35341efe99056e22d2":"5JyVyXU1LiRXATvRTQvR9Kp8Rx1X84j2x49iGkjSsXipydtByUq"},"type":"imported"},"pruned_txo":{},"seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[100,100,840,405]}'
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        db = WalletDB(wallet_str, storage=storage, upgrade=True, config=self.config)
         wallet = Wallet(db, config=self.config)
         await wallet.stop()
 
         storage = WalletStorage(self.wallet_path)
         # if storage.is_encrypted():
         #     storage.decrypt(password)
-        db = WalletDB(storage.read(), storage=storage, upgrade=True)
+        db = WalletDB(storage.read(), storage=storage, upgrade=True, config=self.config)
         wallet = Wallet(db, config=self.config)
 
         wallet.check_password(None)

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -51,7 +51,7 @@ class WalletIntegrityHelper:
 
     @classmethod
     def create_standard_wallet(cls, ks, *, config: SimpleConfig, gap_limit=None):
-        db = storage.WalletDB('', storage=None, upgrade=True)
+        db = storage.WalletDB('', storage=None, upgrade=True, config=config)
         db.put('keystore', ks.dump())
         db.put('gap_limit', gap_limit or cls.gap_limit)
         w = Standard_Wallet(db, config=config)
@@ -60,7 +60,7 @@ class WalletIntegrityHelper:
 
     @classmethod
     def create_imported_wallet(cls, *, config: SimpleConfig, privkeys: bool):
-        db = storage.WalletDB('', storage=None, upgrade=True)
+        db = storage.WalletDB('', storage=None, upgrade=True, config=config)
         if privkeys:
             k = keystore.Imported_KeyStore({})
             db.put('keystore', k.dump())
@@ -71,7 +71,7 @@ class WalletIntegrityHelper:
     def create_multisig_wallet(cls, keystores: Sequence, multisig_type: str, *,
                                config: SimpleConfig, gap_limit=None):
         """Creates a multisig wallet."""
-        db = storage.WalletDB('', storage=None, upgrade=False)
+        db = storage.WalletDB('', storage=None, upgrade=False, config=config)
         for i, ks in enumerate(keystores):
             cosigner_index = i + 1
             db.put('x%d' % cosigner_index, ks.dump())


### PR DESCRIPTION
Adds a new configvar `WALLET_PARTIAL_WRITES` to enable/disable partial writes for the walletDB. This is a further restriction on top of the existing restrictions, e.g. wallet files still need to have file encryption disabled for partial writes. It defaults to off, so even for unencrypted wallets we disable partial writes for now.

This is used as a stopgap measure until we fix the issues found with the partial writes impl (see https://github.com/spesmilo/electrum/issues/10000).