### PR TITLE
run_electrum: relax aiorpcx version check

### DIFF
--- a/run_electrum
+++ b/run_electrum
@@ -74,8 +74,8 @@ def check_imports():
         import aiorpcx
     except ImportError as e:
         sys.exit(f"Error: {str(e)}. Try 'sudo python3 -m pip install <module-name>'")
-    if not ((0, 22, 0) <= aiorpcx._version <= (0, 24, 0)):
-        raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<=0.24.0')
+    if not ((0, 22, 0) <= aiorpcx._version < (0, 26, 0)):
+        raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.26.0')
     # the following imports are for pyinstaller
     from google.protobuf import descriptor
     from google.protobuf import message


### PR DESCRIPTION
Debian 13 (trixie) has aiorpcx 0.24, so this fix makes the Electrum 4.5.x branch compatible.