### PR TITLE
keystore.py: some clean-up

### DIFF
--- a/electrum/bip32.py
+++ b/electrum/bip32.py
@@ -290,12 +290,12 @@ class BIP32Node(NamedTuple):
         return hash_160(self.eckey.get_public_key_bytes(compressed=True))[0:4]
 
 
-def xpub_type(x: str):
+def xpub_type(x: str) -> str:
     assert x is not None
     return BIP32Node.from_xkey(x).xtype
 
 
-def is_xpub(text):
+def is_xpub(text: str) -> bool:
     try:
         node = BIP32Node.from_xkey(text)
         return not node.is_private()
@@ -303,7 +303,7 @@ def is_xpub(text):
         return False
 
 
-def is_xprv(text):
+def is_xprv(text: str) -> bool:
     try:
         node = BIP32Node.from_xkey(text)
         return node.is_private()
@@ -311,7 +311,7 @@ def is_xprv(text):
         return False
 
 
-def xpub_from_xprv(xprv):
+def xpub_from_xprv(xprv: str) -> str:
     return BIP32Node.from_xkey(xprv).to_xpub()
 
 

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -707,11 +707,6 @@ class BIP32_KeyStore(Xpub, Deterministic_KeyStore):
         pk = node.eckey.get_secret_bytes()
         return pk, True
 
-    def get_keypair(self, sequence, password):
-        k, _ = self.get_private_key(sequence, password)
-        cK = ecc.ECPrivkey(k).get_public_key_bytes()
-        return cK, k
-
     def can_have_deterministic_lightning_xprv(self):
         if (self.get_seed_type() == 'segwit'
                 and self.get_bip32_node_for_xpub().xtype == 'p2wpkh'):
@@ -916,16 +911,6 @@ class Hardware_KeyStore(Xpub, KeyStore):
             'label':self.label,
             'soft_device_id': self.soft_device_id,
         }
-
-    def unpaired(self):
-        '''A device paired with the wallet was disconnected.  This can be
-        called in any thread context.'''
-        self.logger.info("unpaired")
-
-    def paired(self):
-        '''A device paired with the wallet was (re-)connected.  This can be
-        called in any thread context.'''
-        self.logger.info("paired")
 
     def is_watching_only(self):
         '''The wallet is not watching-only; the user will be prompted for

--- a/electrum/old_mnemonic.py
+++ b/electrum/old_mnemonic.py
@@ -26,6 +26,7 @@
 from typing import Sequence, Union
 
 from .mnemonic import Wordlist
+from .util import is_hex_str
 
 
 # list of words from http://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/Contemporary_poetry
@@ -1668,11 +1669,10 @@ assert n == 1626
 # Note about US patent no 5892470: Here each word does not represent a given digit.
 # Instead, the digit represented by a word is variable, it depends on the previous word.
 
-def mn_encode(message: Union[str, bytes]) -> Sequence[str]:
-    # FIXME `message` is either bytes that can only contain hex chars, or is a hex str
+def mn_encode(message: str) -> Sequence[str]:
     # note: to generate an 'old'-type mnemonic for testing:
     #       " ".join(electrum.old_mnemonic.mn_encode(secrets.token_hex(16)))
-    #assert is_hex_str(message), f"expected hex, got {type(message)}"
+    assert is_hex_str(message), f"expected hex, got {type(message)}"
     assert len(message) % 8 == 0
     out = []
     for i in range(len(message)//8):

--- a/electrum/old_mnemonic.py
+++ b/electrum/old_mnemonic.py
@@ -23,6 +23,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Sequence, Union
+
 from .mnemonic import Wordlist
 
 
@@ -1666,7 +1668,11 @@ assert n == 1626
 # Note about US patent no 5892470: Here each word does not represent a given digit.
 # Instead, the digit represented by a word is variable, it depends on the previous word.
 
-def mn_encode(message):
+def mn_encode(message: Union[str, bytes]) -> Sequence[str]:
+    # FIXME `message` is either bytes that can only contain hex chars, or is a hex str
+    # note: to generate an 'old'-type mnemonic for testing:
+    #       " ".join(electrum.old_mnemonic.mn_encode(secrets.token_hex(16)))
+    #assert is_hex_str(message), f"expected hex, got {type(message)}"
     assert len(message) % 8 == 0
     out = []
     for i in range(len(message)//8):
@@ -1679,7 +1685,7 @@ def mn_encode(message):
     return out
 
 
-def mn_decode(wlist):
+def mn_decode(wlist: Sequence[str]) -> str:
     out = ''
     for i in range(len(wlist)//3):
         word1, word2, word3 = wlist[3*i:3*i+3]


### PR DESCRIPTION
The motivation is the surprise polymorphism that `old_mnemonic.mn_encode` was doing:
```
>>> electrum.old_mnemonic.mn_encode(b"deadbeef")
['off', 'such', 'ashamed']
>>> electrum.old_mnemonic.mn_encode("deadbeef")
['off', 'such', 'ashamed']
```
I am almost certain this was accidental (from python3 transition) and is clearly unwanted.
This PR intentionally breaks the first usage.

The test coverage is fairly decent for keystore.py, and despite the change to critical but rarely tested Old_KeyStore functionality, I am confident of this diff.