### PR TITLE
fix: handle UserCancelled in show_transaction

### DIFF
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -47,7 +47,8 @@ from electrum.i18n import _
 from electrum.plugin import run_hook
 from electrum.transaction import SerializationError, Transaction, PartialTransaction, TxOutpoint, TxinDataFetchProgress
 from electrum.logging import get_logger
-from electrum.util import ShortID, get_asyncio_loop, UI_UNIT_NAME_TXSIZE_VBYTES, delta_time_str
+from electrum.util import (ShortID, get_asyncio_loop, UI_UNIT_NAME_TXSIZE_VBYTES, delta_time_str,
+                           UserCancelled)
 from electrum.network import Network
 from electrum.wallet import TxSighashRiskLevel, TxSighashDanger
 
@@ -449,6 +450,8 @@ def show_transaction(
     except SerializationError as e:
         _logger.exception('unable to deserialize the transaction')
         parent.show_critical(_("Electrum was unable to deserialize the transaction:") + "\n" + str(e))
+    except UserCancelled:
+        return
     else:
         d.show()
 


### PR DESCRIPTION
`TxDialog` may has to fetch tx information from the network on construction (`self.set_tx()`) and is showing a `RunCoroutineDialog`. If the user cancels this dialog the `UserCancelled` exception is not caught in `show_transaction()` and can even lead to Electrum crashing. 

Fixes #10041

Can be tested with this diff:
```diff
diff --git a/electrum/gui/qt/transaction_dialog.py b/electrum/gui/qt/transaction_dialog.py
index d8e708a95..3fa6bd36a 100644
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -614,7 +614,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         tx.add_info_from_wallet(self.wallet)
         # FIXME for PSBTs, we do a blocking fetch, as the missing data might be needed for e.g. signing
         # - otherwise, the missing data is for display-completeness only, e.g. fee, input addresses (we do it async)
-        if not tx.is_complete() and tx.is_missing_info_from_network():
+        if True:  # not tx.is_complete() and tx.is_missing_info_from_network():
             self.main_window.run_coroutine_dialog(
                 tx.add_info_from_network(self.wallet.network, timeout=10),
                 _("Adding info to tx, from network..."),
diff --git a/electrum/transaction.py b/electrum/transaction.py
index 8bbae09bf..e62c9d9a2 100644
--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1264,6 +1264,7 @@ class Transaction:
         timeout=None,
     ) -> None:
         """note: it is recommended to call add_info_from_wallet first, as this can save some network requests"""
+        import asyncio; await asyncio.sleep(10)
         if not self.is_missing_info_from_network():
             return
         if progress_cb is None:
```