### PR TITLE
qml: ExceptionDialog: put user_text inside Flickable

### DIFF
--- a/electrum/gui/qml/components/ExceptionDialog.qml
+++ b/electrum/gui/qml/components/ExceptionDialog.qml
@@ -61,12 +61,21 @@ ElDialog
             Layout.fillWidth: true
             text: qsTr('Please briefly describe what led to the error (optional):')
         }
-        TextArea {
-            id: user_text
-            Layout.fillWidth: true
+        Flickable {
+            width: parent.width
             Layout.fillHeight: true
-            background: Rectangle {
-                color: Qt.darker(Material.background, 1.25)
+            contentHeight: user_text.height
+            interactive: height < contentHeight
+            clip: true
+
+            TextArea {
+                id: user_text
+                width: parent.width
+                height: Math.max(implicitHeight, 100)
+                wrapMode: TextInput.WordWrap
+                background: Rectangle {
+                    color: Qt.darker(Material.background, 1.25)
+                }
             }
         }
         Label {


### PR DESCRIPTION
This tries to make the dialog better behave if the user types a lot of text.

note: I have not tested on Android.