### PR TITLE
crash reporter: rm `Never`, add confirm to `Send`, and only show window once per exc group

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -33,6 +33,7 @@ from . import constants
 from .i18n import _
 from .util import make_aiohttp_session, error_text_str_to_safe_str
 from .logging import describe_os_version, Logger, get_git_version
+from .crypto import sha256
 
 if TYPE_CHECKING:
     from .network import ProxySettings
@@ -139,6 +140,17 @@ class BaseCrashReporter(Logger):
             "stack": readable_trace,
             "id": _id,
         }
+
+    @classmethod
+    def get_traceback_groupid_hash(
+        cls,
+        exctype: type[BaseException],
+        excvalue: BaseException,
+        tb: TracebackType | None,
+    ) -> bytes:
+        tb_info = cls.get_traceback_info(exctype, excvalue, tb)
+        _id = tb_info["id"]
+        return sha256(str(_id))
 
     def get_additional_info(self):
         args = {

--- a/electrum/gui/qml/components/ExceptionDialog.qml
+++ b/electrum/gui/qml/components/ExceptionDialog.qml
@@ -92,15 +92,6 @@ ElDialog
             Button {
                 Layout.fillWidth: true
                 Layout.preferredWidth: 2
-                text: qsTr('Never')
-                onClicked: {
-                    AppController.showNever()
-                    close()
-                }
-            }
-            Button {
-                Layout.fillWidth: true
-                Layout.preferredWidth: 2
                 text: qsTr('Not Now')
                 onClicked: close()
             }

--- a/electrum/gui/qml/components/ExceptionDialog.qml
+++ b/electrum/gui/qml/components/ExceptionDialog.qml
@@ -77,7 +77,17 @@ ElDialog
                 Layout.fillWidth: true
                 Layout.preferredWidth: 3
                 text: qsTr('Send Bug Report')
-                onClicked: AppController.sendReport(user_text.text)
+                onClicked: {
+                    var dialog = app.messageDialog.createObject(app, {
+                        text: qsTr('Confirm to send bugreport?'),
+                        yesno: true,
+                        z: 1001  // assure topmost of all other dialogs
+                    })
+                    dialog.accepted.connect(function() {
+                        AppController.sendReport(user_text.text)
+                    })
+                    dialog.open()
+                }
             }
             Button {
                 Layout.fillWidth: true

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -379,10 +379,6 @@ class QEAppController(BaseCrashReporter, QObject):
         self.sendingBugreport.emit()
         threading.Thread(target=report_task, daemon=True).start()
 
-    @pyqtSlot()
-    def showNever(self):
-        self.config.SHOW_CRASH_REPORTER = False
-
     def _get_traceback_str_to_display(self) -> str:
         # The msg_box that shows the report uses rich_text=True, so
         # if traceback contains special HTML characters, e.g. '<',
@@ -551,9 +547,6 @@ class Exception_Hook(QObject, Logger):
 
     @classmethod
     def maybe_setup(cls, *, wallet: 'Abstract_Wallet' = None, slot=None) -> None:
-        if not QEConfig.instance.config.SHOW_CRASH_REPORTER:
-            EarlyExceptionsQueue.set_hook_as_ready()  # flush already queued exceptions
-            return
         if not cls._INSTANCE:
             cls._INSTANCE = Exception_Hook(slot=slot)
         if wallet:

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -344,7 +344,7 @@ class QEAppController(BaseCrashReporter, QObject):
     @pyqtSlot(result='QVariantMap')
     def crashData(self):
         return {
-            'traceback': self.get_traceback_info(),
+            'traceback': self.get_traceback_info(*self.exc_args),
             'extra': self.get_additional_info(),
             'reportstring': self.get_report_string()
         }

--- a/electrum/gui/qt/exception_window.py
+++ b/electrum/gui/qt/exception_window.py
@@ -83,7 +83,7 @@ class Exception_Window(BaseCrashReporter, QWidget, MessageBoxMixin, Logger):
         buttons = QHBoxLayout()
 
         report_button = QPushButton(_('Send Bug Report'))
-        report_button.clicked.connect(lambda _checked: self.send_report())
+        report_button.clicked.connect(lambda _checked: self._ask_for_confirm_to_send_report())
         report_button.setIcon(read_QIcon("tab_send.png"))
         buttons.addWidget(report_button)
 
@@ -102,6 +102,10 @@ class Exception_Window(BaseCrashReporter, QWidget, MessageBoxMixin, Logger):
 
         self.setLayout(main_box)
         self.show()
+
+    def _ask_for_confirm_to_send_report(self):
+        if self.question("Confirm to send bugreport?"):
+            self.send_report()
 
     def send_report(self):
         def on_success(response: CrashReportResponse):

--- a/electrum/gui/qt/exception_window.py
+++ b/electrum/gui/qt/exception_window.py
@@ -87,10 +87,6 @@ class Exception_Window(BaseCrashReporter, QWidget, MessageBoxMixin, Logger):
         report_button.setIcon(read_QIcon("tab_send.png"))
         buttons.addWidget(report_button)
 
-        never_button = QPushButton(_('Never'))
-        never_button.clicked.connect(lambda _checked: self.show_never())
-        buttons.addWidget(never_button)
-
         close_button = QPushButton(_('Not Now'))
         close_button.clicked.connect(lambda _checked: self.close())
         buttons.addWidget(close_button)
@@ -135,10 +131,6 @@ class Exception_Window(BaseCrashReporter, QWidget, MessageBoxMixin, Logger):
 
     def on_close(self):
         Exception_Window._active_window = None
-        self.close()
-
-    def show_never(self):
-        self.config.SHOW_CRASH_REPORTER = False
         self.close()
 
     def closeEvent(self, event):
@@ -192,9 +184,6 @@ class Exception_Hook(QObject, Logger):
 
     @classmethod
     def maybe_setup(cls, *, config: 'SimpleConfig', wallet: 'Abstract_Wallet' = None) -> None:
-        if not config.SHOW_CRASH_REPORTER:
-            EarlyExceptionsQueue.set_hook_as_ready()  # flush already queued exceptions
-            return
         if not cls._INSTANCE:
             cls._INSTANCE = Exception_Hook(config=config)
         if wallet:

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -886,7 +886,6 @@ Warning: setting this to too low will result in lots of payment failures."""),
         long_desc=lambda: _("Select which language is used in the GUI (after restart)."),
     )
     BLOCKCHAIN_PREFERRED_BLOCK = ConfigVar('blockchain_preferred_block', default=None)
-    SHOW_CRASH_REPORTER = ConfigVar('show_crash_reporter', default=True, type_=bool)
     DONT_SHOW_TESTNET_WARNING = ConfigVar('dont_show_testnet_warning', default=False, type_=bool)
     RECENTLY_OPEN_WALLET_FILES = ConfigVar('recently_open', default=None)
     IO_DIRECTORY = ConfigVar('io_dir', default=os.path.expanduser('~'), type_=str)


### PR DESCRIPTION
This changes the crash reporter in the Qt/QML guis a bit.

- on clicking "Send", there is now an additional small confirmation popup
  - this makes it harder to accidentally send a report
- the "Never" button and the corresponding `config.SHOW_CRASH_REPORTER` option is removed
  -  we now always hook into `sys.excepthook` to show the crash reporter
- don't show crash reporter multiple times for the "same" exception
  - at least until the user restarts the program (there is no persistence)
  - exceptions are grouped the same way the crash reporter server is grouping them (I think)
  - in case there's e.g. a thread with timer spamming an exception erroneously,
    we won't spam the user with the crash reporter window

The motivation is https://github.com/spesmilo/electrum/pull/10049#issuecomment-3089278083 :
- it turns out @f321x accidentally clicked "Never" and set `config.SHOW_CRASH_REPORTER=False` some time in the past without realising it
- the GUI does not expose `config.SHOW_CRASH_REPORTER` any further, there is no way to reenable it after "Never" was clicked
- in that particular crash example, the whole Qt program was aborting (if `config.SHOW_CRASH_REPORTER is False`), as without hooking into sys.excepthook, a Qt thread died
  - by always hooking into `sys.excepthook`, the testing matrix becomes smaller
- I see two usecases for the (now-removed) "Never" option: 
  - (1) user never wants to send reports to us
    - this PR does not properly handle this, however at least it makes it harder to accidentally send a report
  - (2) an exception is getting spammed, e.g. from a thread on a timer, but for non-critical functionality, so that the program would be operational with the exception silenced
    - has happened in the past
    - this is now handled differently, by grouping the exceptions and only showing one reporter window for any given groupid