### PR TITLE
cli: add max_cltv, max_fee_msat parameters to lnpay

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1766,7 +1766,7 @@ class Commands(Logger):
             max_cltv_remaining = max_cltv - lnaddr.get_min_final_cltv_delta()
             assert max_cltv_remaining > 0, f"{max_cltv=} - {lnaddr.get_min_final_cltv_delta()=} < 1"
             max_cltv = max_cltv_remaining
-        budget = PaymentFeeBudget.custom(
+        budget = PaymentFeeBudget.from_invoice_amount(
             config=wallet.config,
             invoice_amount_msat=invoice_obj.amount_msat,
             max_cltv_delta=max_cltv,

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1947,25 +1947,14 @@ class PaymentFeeBudget(NamedTuple):
     #num_htlc: int
 
     @classmethod
-    def default(cls, *, invoice_amount_msat: int, config: 'SimpleConfig') -> 'PaymentFeeBudget':
-        fee_msat = PaymentFeeBudget._calculate_fee_msat(
-            invoice_amount_msat=invoice_amount_msat,
-            config=config,
-        )
-        return PaymentFeeBudget(
-            fee_msat=fee_msat,
-            cltv=NBLOCK_CLTV_DELTA_TOO_FAR_INTO_FUTURE,
-        )
-
-    @classmethod
-    def custom(
+    def from_invoice_amount(
         cls,
-        config: 'SimpleConfig',
         *,
         invoice_amount_msat: int,
+        config: 'SimpleConfig',
         max_cltv_delta: Optional[int] = None,
         max_fee_msat: Optional[int] = None,
-        ):
+    ) -> 'PaymentFeeBudget':
         if max_fee_msat is None:
             max_fee_msat = PaymentFeeBudget._calculate_fee_msat(
                 invoice_amount_msat=invoice_amount_msat,
@@ -1980,7 +1969,8 @@ class PaymentFeeBudget(NamedTuple):
         )
 
     @classmethod
-    def _calculate_fee_msat(cls,
+    def _calculate_fee_msat(
+        cls,
         *,
         invoice_amount_msat: int,
         config: 'SimpleConfig',

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1525,6 +1525,7 @@ class LNWallet(LNWorker):
             attempts: int = None,  # used only in unit tests
             full_path: LNPaymentPath = None,
             channels: Optional[Sequence[Channel]] = None,
+            budget: Optional[PaymentFeeBudget] = None,
     ) -> Tuple[bool, List[HtlcLog]]:
         bolt11 = invoice.lightning_invoice
         lnaddr = self._check_bolt11_invoice(bolt11, amount_msat=amount_msat)
@@ -1547,7 +1548,8 @@ class LNWallet(LNWorker):
         self.save_payment_info(info)
         self.wallet.set_label(key, lnaddr.get_description())
         self.set_invoice_status(key, PR_INFLIGHT)
-        budget = PaymentFeeBudget.default(invoice_amount_msat=amount_to_pay, config=self.config)
+        if budget is None:
+            budget = PaymentFeeBudget.default(invoice_amount_msat=amount_to_pay, config=self.config)
         if attempts is None and self.uses_trampoline():
             # we don't expect lots of failed htlcs with trampoline, so we can fail sooner
             attempts = 30

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1549,7 +1549,7 @@ class LNWallet(LNWorker):
         self.wallet.set_label(key, lnaddr.get_description())
         self.set_invoice_status(key, PR_INFLIGHT)
         if budget is None:
-            budget = PaymentFeeBudget.default(invoice_amount_msat=amount_to_pay, config=self.config)
+            budget = PaymentFeeBudget.from_invoice_amount(invoice_amount_msat=amount_to_pay, config=self.config)
         if attempts is None and self.uses_trampoline():
             # we don't expect lots of failed htlcs with trampoline, so we can fail sooner
             attempts = 30

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -288,7 +288,7 @@ class MockLNWallet(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
             amount_msat=amount_msat,
             paysession=paysession,
             full_path=full_path,
-            budget=PaymentFeeBudget.default(invoice_amount_msat=amount_msat, config=self.config),
+            budget=PaymentFeeBudget.from_invoice_amount(invoice_amount_msat=amount_msat, config=self.config),
         )]
 
     get_payments = LNWallet.get_payments


### PR DESCRIPTION
Adds `max_cltv`, `max_fee_millionths` and `fee_cutoff_msat` parameters to the `lnpay` cli command which allow to specify a custom `PaymentFeeBudget` for the lnpay payment. Allowing to specify a these parameters can be useful for usecases like https://github.com/spesmilo/electrum/issues/10056.

Closes #10056