### PR TITLE
android: don't keep adding BarcodeScannerView instances to contentFrame when starting camera

### DIFF
--- a/electrum/gui/qml/java_classes/org/electrum/qr/SimpleScannerActivity.java
+++ b/electrum/gui/qml/java_classes/org/electrum/qr/SimpleScannerActivity.java
@@ -88,17 +88,19 @@ public class SimpleScannerActivity extends Activity {
     }
 
     private void startCamera() {
-        mScannerView = new BarcodeScannerView(this);
-        mScannerView.setCropRatio(0.75f); // Set crop ratio to 75% (this defines the square area shown in the scanner view)
-        // by default only Format.QR_CODE is set
-        ViewGroup contentFrame = (ViewGroup) findViewById(R.id.content_frame);
-        contentFrame.addView(mScannerView);
-        mScannerView.setOnBarcodeListener(result -> {
-            // Handle the scan result
-            this.setResultAndClose(result.getText());
-            // Return false to stop scanning after first result
-            return false;
-        });
+        if (mScannerView == null) {
+            mScannerView = new BarcodeScannerView(this);
+            mScannerView.setCropRatio(0.75f); // Set crop ratio to 75% (this defines the square area shown in the scanner view)
+            // by default only Format.QR_CODE is set
+            ViewGroup contentFrame = (ViewGroup) findViewById(R.id.content_frame);
+            contentFrame.addView(mScannerView);
+            mScannerView.setOnBarcodeListener(result -> {
+                // Handle the scan result
+                this.setResultAndClose(result.getText());
+                // Return false to stop scanning after first result
+                return false;
+            });
+        }
         mScannerView.openAsync();  // Start camera on resume
     }
 


### PR DESCRIPTION
When putting app to background with qr scanner active, then moved to foreground again, `SimpleScannerActivity` instance is not destroyed, but the local `mScannerView` was re-initialized with a new instance (through `startCamera()`) regardless of pre-existing instance, and added to the `contentFrame`. This leaves the previous `mScannerView` instance in limbo, potentially getting garbage collected at unpredictable times.