### PR TITLE
fix: remove negative fee assert from get_tx_fee_warning

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3322,7 +3322,6 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             txid: Optional[str]) -> Optional[Tuple[bool, str, str]]:
 
         assert invoice_amt >= 0, f"{invoice_amt=!r} must be non-negative satoshis"
-        assert fee >= 0, f"{fee=!r} must be non-negative satoshis"
         is_future_tx = txid is not None and txid in self.adb.future_tx
         feerate = Decimal(fee) / tx_size  # sat/byte
         fee_ratio = Decimal(fee) / invoice_amt if invoice_amt else 0


### PR DESCRIPTION
Removes the `assert fee >= 0, f"{fee=!r} must be non-negative satoshis"` from `Abstract_Wallet.get_tx_fee_warning()` to prevent an exception when users load a psbt with negative tx fee. Is there any reason this would be strictly required? `get_tx_fee_warning()` handles the negative fee by showing an error that the fee is below the relay fee, which is technically correct. Maybe the user wants to add inputs with a second psbt.

```
$ bitcoin-cli --signet createpsbt "[{\"txid\": \"174269dcd6cdcac419aa0ee60dd1e25c18ef81d709969927ff42f9c07994d3f5\", \"vout\": 0}]" "[{\"$(bitcoin-cli --signet getnewaddress)\":3000}]"

> cHNidP8BAFICAAAAAfXTlHnA+UL/J5mWCdeB7xhc4tEN5g6qGcTKzdbcaUIXAAAAAAD9////AQC4ZNlFAAAAFgAUZqzq/pWbsc7mTDvYiP6m+VW/zeIAAAAAAAAA
```

Fixes #10065 