### PR TITLE
fix failing pip installs in regtest CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,7 +112,7 @@ task:
     - python3 -m pip install --user --upgrade pip
     # install electrum
     - export ELECTRUM_ECC_DONT_COMPILE=1  # we build manually to make caching it easier
-    - python3 -m pip install .[tests]
+    - python3 -m pip install .[tests] --ignore-installed  # ignore installed system installed attrs
     # install e-x some commits after 1.18.0 tag
     - python3 -m pip install git+https://github.com/spesmilo/electrumx.git@0b260d4345242cc41e316e97d7de10ae472fd172
     - "BITCOIND_VERSION=$(curl https://bitcoincore.org/en/download/ | grep -E -i --only-matching 'Latest version: [0-9\\.]+' | grep -E --only-matching '[0-9\\.]+')"
@@ -139,6 +139,7 @@ task:
   env:
     LD_LIBRARY_PATH: contrib/_saved_secp256k1_build/
     ELECTRUM_REQUIREMENTS: contrib/requirements/requirements.txt
+    PIP_BREAK_SYSTEM_PACKAGES: 1
     # ElectrumX exits with an error without this:
     ALLOW_ROOT: 1
   depends_on:


### PR DESCRIPTION
It seems like the OS version of the CI image has been bumped, the regtest of PR https://github.com/spesmilo/electrum/pull/10073 fails for me with this error:

```
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 111702 files and directories currently installed.)
Preparing to unpack .../jq_1.7.1-3ubuntu0.24.04.1_amd64.deb ...
Unpacking jq (1.7.1-3ubuntu0.24.04.1) over (1.7.1-3build1) ...
Preparing to unpack .../libjq1_1.7.1-3ubuntu0.24.04.1_amd64.deb ...
Unpacking libjq1:amd64 (1.7.1-3ubuntu0.24.04.1) over (1.7.1-3build1) ...
Setting up libjq1:amd64 (1.7.1-3ubuntu0.24.04.1) ...
Setting up jq (1.7.1-3ubuntu0.24.04.1) ...
Processing triggers for man-db (2.12.0-4build2) ...
Processing triggers for libc-bin (2.39-0ubuntu8.5) ...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
python3 -m pip install --user --upgrade pip
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
`--ignore-installed` is required too as `python3-attrs` is already installed on the image via apt.