### PR TITLE
simplify QR scanner QML interface, remove properties, add results to signals

### DIFF
--- a/electrum/gui/qml/components/ImportAddressesKeysDialog.qml
+++ b/electrum/gui/qml/components/ImportAddressesKeysDialog.qml
@@ -91,11 +91,11 @@ ElDialog {
                                     ? qsTr('Scan another address')
                                     : qsTr('Scan another private key')
                             })
-                            dialog.onFound.connect(function() {
-                                if (verify(dialog.scanData)) {
+                            dialog.onFoundText.connect(function(data) {
+                                if (verify(data)) {
                                     if (import_ta.text != '')
                                         import_ta.text = import_ta.text + ',\n'
-                                    import_ta.text = import_ta.text + dialog.scanData
+                                    import_ta.text = import_ta.text + data
                                 }
                                 dialog.close()
                             })

--- a/electrum/gui/qml/components/ImportChannelBackupDialog.qml
+++ b/electrum/gui/qml/components/ImportChannelBackupDialog.qml
@@ -62,8 +62,8 @@ ElDialog {
                         var dialog = app.scanDialog.createObject(app, {
                             hint:  qsTr('Scan a channel backup')
                         })
-                        dialog.onFound.connect(function() {
-                            channelbackup_ta.text = dialog.scanData
+                        dialog.onFoundText.connect(function(data) {
+                            channelbackup_ta.text = data
                             dialog.close()
                         })
                         dialog.open()

--- a/electrum/gui/qml/components/OpenChannelDialog.qml
+++ b/electrum/gui/qml/components/OpenChannelDialog.qml
@@ -124,9 +124,9 @@ ElDialog {
                             var dialog = app.scanDialog.createObject(app, {
                                 hint: qsTr('Scan a node-id or a connect string')
                             })
-                            dialog.onFound.connect(function() {
-                                if (channelopener.validateConnectString(dialog.scanData)) {
-                                    channelopener.connectStr = dialog.scanData
+                            dialog.onFoundText.connect(function(data) {
+                                if (channelopener.validateConnectString(data)) {
+                                    channelopener.connectStr = data
                                     node.text = channelopener.connectStr
                                 } else {
                                     var errdialog = app.messageDialog.createObject(app, {

--- a/electrum/gui/qml/components/ScanDialog.qml
+++ b/electrum/gui/qml/components/ScanDialog.qml
@@ -2,17 +2,19 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import org.electrum
+
 import "controls"
 
 // currently not used on android, kept for future use when qt6 camera stops crashing
 ElDialog {
     id: scanDialog
 
-    property string scanData
     property string error
     property string hint
 
-    signal found
+    signal foundText(data: string)
+    signal foundBinary(data: Bytes)
 
     width: parent.width
     height: parent.height
@@ -35,9 +37,8 @@ ElDialog {
             Layout.fillWidth: true
             Layout.fillHeight: true
             hint: scanDialog.hint
-            onFound: {
-                scanDialog.scanData = scanData
-                scanDialog.found()
+            onFoundText: (data) => {
+                scanDialog.foundText(data)
             }
         }
 

--- a/electrum/gui/qml/components/SendDialog.qml
+++ b/electrum/gui/qml/components/SendDialog.qml
@@ -59,7 +59,10 @@ ElDialog {
             hint: Daemon.currentWallet.isLightning
                 ? qsTr('Scan an Invoice, an Address, an LNURL-pay, a PSBT or a Channel Backup')
                 : qsTr('Scan an Invoice, an Address, an LNURL-pay or a PSBT')
-            onFound: dialog.dispatch(scanData)
+
+            onFoundText: (data) => {
+                dialog.dispatch(data)
+            }
         }
 
         ButtonContainer {

--- a/electrum/gui/qml/components/SweepDialog.qml
+++ b/electrum/gui/qml/components/SweepDialog.qml
@@ -117,9 +117,9 @@ ElDialog {
                                 var dialog = app.scanDialog.createObject(app, {
                                     hint: qsTr('Scan a private key')
                                 })
-                                dialog.onFound.connect(function() {
-                                    if (verifyPrivateKey(dialog.scanData))
-                                        addPrivateKey(dialog.scanData)
+                                dialog.onFoundText.connect(function(data) {
+                                    if (verifyPrivateKey(data))
+                                        addPrivateKey(data)
                                     dialog.close()
                                 })
                                 dialog.open()

--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -47,8 +47,7 @@ Item {
                 ? qsTr('Scan an Invoice, an Address, an LNURL-pay, a PSBT or a Channel Backup')
                 : qsTr('Scan an Invoice, an Address, an LNURL-pay or a PSBT')
         })
-        scanner.onFound.connect(function() {
-            var data = scanner.scanData
+        scanner.onFoundText.connect(function(data) {
             data = data.trim()
             if (bitcoin.isRawTx(data)) {
                 app.stack.push(Qt.resolvedUrl('TxDetails.qml'), { rawtx: data })

--- a/electrum/gui/qml/components/controls/QRScan.qml
+++ b/electrum/gui/qml/components/controls/QRScan.qml
@@ -10,14 +10,12 @@ Item {
 
     property bool active: false
     property string url
-    property string scanData
     property string hint
 
-    signal found
+    signal foundText(data: string)
 
     function restart() {
         console.log('qrscan.restart')
-        scanData = ''
         qr.reset()
         start()
     }
@@ -153,8 +151,7 @@ Item {
         function onDataChanged() {
             console.log('QR DATA: ' + qr.data)
             scanner.active = false
-            scanner.scanData = qr.data
-            scanner.found()
+            scanner.foundText(qr.data)
         }
     }
 

--- a/electrum/gui/qml/components/wizard/WCHaveMasterKey.qml
+++ b/electrum/gui/qml/components/wizard/WCHaveMasterKey.qml
@@ -166,9 +166,9 @@ WizardComponent {
                                 ? qsTr('Scan a cosigner master public key')
                                 : qsTr('Scan a master key')
                         })
-                        dialog.onFound.connect(function() {
-                            if (verifyMasterKey(dialog.scanData))
-                                masterkey_ta.text = dialog.scanData
+                        dialog.onFoundText.connect(function(data) {
+                            if (verifyMasterKey(data))
+                                masterkey_ta.text = data
                             else
                                 masterkey_ta.text = ''
                             dialog.close()

--- a/electrum/gui/qml/components/wizard/WCImport.qml
+++ b/electrum/gui/qml/components/wizard/WCImport.qml
@@ -76,11 +76,11 @@ WizardComponent {
                                     ? qsTr('Scan another private key')
                                     : qsTr('Scan a private key or an address')
                         })
-                        dialog.onFound.connect(function() {
-                            if (verify(dialog.scanData)) {
+                        dialog.onFoundText.connect(function(data) {
+                            if (verify(data)) {
                                 if (import_ta.text != '')
                                     import_ta.text = import_ta.text + '\n'
-                                import_ta.text = import_ta.text + dialog.scanData
+                                import_ta.text = import_ta.text + data
                             }
                             dialog.close()
                         })

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -34,7 +34,7 @@ from .qefx import QEFX
 from .qetxfinalizer import QETxFinalizer, QETxRbfFeeBumper, QETxCpfpFeeBumper, QETxCanceller, QETxSweepFinalizer, FeeSlider
 from .qeinvoice import QEInvoice, QEInvoiceParser
 from .qerequestdetails import QERequestDetails
-from .qetypes import QEAmount
+from .qetypes import QEAmount, QEBytes
 from .qeaddressdetails import QEAddressDetails
 from .qetxdetails import QETxDetails
 from .qechannelopener import QEChannelOpener
@@ -426,6 +426,7 @@ class ElectrumQmlApplication(QGuiApplication):
 
         # TODO QT6 order of declaration is important now?
         qmlRegisterType(QEAmount, 'org.electrum', 1, 0, 'Amount')
+        qmlRegisterType(QEBytes, 'org.electrum', 1, 0, 'Bytes')
         qmlRegisterType(QENewWalletWizard, 'org.electrum', 1, 0, 'QNewWalletWizard')
         qmlRegisterType(QETermsOfUseWizard, 'org.electrum', 1, 0, 'QTermsOfUseWizard')
         qmlRegisterType(QEServerConnectWizard, 'org.electrum', 1, 0, 'QServerConnectWizard')

--- a/electrum/gui/qml/qetypes.py
+++ b/electrum/gui/qml/qetypes.py
@@ -116,3 +116,27 @@ class QEAmount(QObject):
 
     def __repr__(self):
         return f"<QEAmount max={self._is_max} sats={self._amount_sat} msats={self._amount_msat} empty={self.isEmpty}>"
+
+
+class QEBytes(QObject):
+    def __init__(self, data: bytes = None, *, parent=None):
+        super().__init__(parent)
+        self.data = data
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, _data):
+        self._data = _data
+
+    @pyqtProperty(bool)
+    def isEmpty(self):
+        return self._data is None or self._data == bytes()
+
+    def __str__(self):
+        return f'{self._data}'
+
+    def __repr__(self):
+        return f"<QEBytes data={'None' if self._data is None else self._data.hex()}>"


### PR DESCRIPTION
android: pass on QR binary scan result data as well
qml: add signals for QEQRScanner and fallbacks, add QEBytes container type so we can pass along byte arrays between QML and python, port qr scan occurrences to new signals.