### PR TITLE
fix: remove .desktop from setDesktopFileName argument

### DIFF
--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -152,7 +152,7 @@ class ElectrumGui(BaseElectrumGui, Logger):
         if hasattr(QtCore.Qt, "AA_ShareOpenGLContexts"):
             QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
         if hasattr(QGuiApplication, 'setDesktopFileName'):
-            QGuiApplication.setDesktopFileName('electrum.desktop')
+            QGuiApplication.setDesktopFileName('electrum')
         QGuiApplication.setApplicationName("Electrum")
         self.gui_thread = threading.current_thread()
         self.windows = []  # type: List[ElectrumWindow]


### PR DESCRIPTION
Removes the '.desktop' suffix from the
`QGuiApplication.setDesktopFileName` argument to prevent the following warning on startup of Electrum:
```
QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop.
For compatibility reasons, the .desktop suffix will be removed.
Please specify a desktop file name without .desktop suffix
```

The [qt docs](https://doc.qt.io/qtforpython-6/PySide6/QtGui/QGuiApplication.html#PySide6.QtGui.QGuiApplication.desktopFileName) say that `desktopFileName` is "... is the file name, without the full path or the trailing “.desktop” extension of the desktop entry that represents this application according to the freedesktop desktop entry specification."

In QML we do the same:
https://github.com/spesmilo/electrum/blob/da18c975a2f2ac690276c3201e387e15f10ee056/electrum/gui/qml/__init__.py#L68