### PR TITLE
cli: set formatter_class for command descriptions

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -2337,6 +2337,7 @@ def get_parser():
             cmdname,
             description=cmd.description,
             help=cmd.short_description,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog="Run 'electrum -h to see the list of global options",
         )
         for optname, default in zip(cmd.options, cmd.defaults):


### PR DESCRIPTION
Sets the [`RawDescriptionHelpFormatter`](https://docs.python.org/3/library/argparse.html#argparse.RawDescriptionHelpFormatter) as `formatter_class` for the command parser. This makes argparse respect the newlines in the command descriptions and showing them in the cli with `-h` looks better by representing the same formatting as in source.

E.g. `serialize -h` before:
```
usage: run_electrum serialize [-h] jsontx

Create a signed raw transaction from a json tx template. Example value for "jsontx" arg: { "inputs": [ {"prevout_hash":
"9d221a69ca3997cbeaf5624d723e7dc5f829b1023078c177d37bdae95f37c539", "prevout_n": 1, "value_sats": 1000000, "privkey":
"p2wpkh:cVDXzzQg6RoCTfiKpe8MBvmm5d5cJc6JLuFApsFDKwWa6F5TVHpD"} ], "outputs": [ {"address": "tb1q4s8z6g5jqzllkgt8a4har94wl8tg0k9m8kv5zd", "value_sats":
990000} ] } :

positional arguments:
  jsontx      Transaction in json

options:
  -h, --help  show this help message and exit

Run 'electrum -h to see the list of global options
```

after this patch:
```
usage: run_electrum serialize [-h] jsontx

Create a signed raw transaction from a json tx template.

Example value for "jsontx" arg: {
    "inputs": [
        {"prevout_hash": "9d221a69ca3997cbeaf5624d723e7dc5f829b1023078c177d37bdae95f37c539", "prevout_n": 1,
         "value_sats": 1000000, "privkey": "p2wpkh:cVDXzzQg6RoCTfiKpe8MBvmm5d5cJc6JLuFApsFDKwWa6F5TVHpD"}
    ],
    "outputs": [
        {"address": "tb1q4s8z6g5jqzllkgt8a4har94wl8tg0k9m8kv5zd", "value_sats": 990000}
    ]
}
:

positional arguments:
  jsontx      Transaction in json

options:
  -h, --help  show this help message and exit

Run 'electrum -h to see the list of global options
```