### PR TITLE
constants: NETS_LIST to have deterministic ordering

### DIFF
--- a/electrum/constants.py
+++ b/electrum/constants.py
@@ -251,6 +251,7 @@ class BitcoinSignet(BitcoinTestnet):
 
 
 NETS_LIST = tuple(all_subclasses(AbstractNet))  # type: Sequence[Type[AbstractNet]]
+NETS_LIST = tuple(sorted(NETS_LIST, key=lambda x: x.NET_NAME))
 
 assert len(NETS_LIST) == len(set([chain.NET_NAME for chain in NETS_LIST])), "NET_NAME must be unique for each concrete AbstractNet"
 assert len(NETS_LIST) == len(set([chain.datadir_subdir() for chain in NETS_LIST])), "datadir must be unique for each concrete AbstractNet"


### PR DESCRIPTION
Currently running the help command lists the supported chains in random order. This patch changes the ordering to be lexicographical.

```
$ ./run_electrum --help
usage: run_electrum [-h] [--version] [-v VERBOSITY] [-D ELECTRUM_PATH] [-w WALLET_PATH] [-P]
                    [--testnet] [--signet] [--mainnet] [--simnet] [--regtest] [--testnet4] [-o]
                    [--rpcuser RPCUSER] [--rpcpassword RPCPASSWORD] [--forgetconfig]
                    <command> ...

[...]

global options:
  -v VERBOSITY          Set verbosity (log levels)
  -D ELECTRUM_PATH, --dir ELECTRUM_PATH
                        electrum directory
  -w WALLET_PATH, --wallet WALLET_PATH
                        wallet path
  -P, --portable        Use local 'electrum_data' directory
  --testnet             Use testnet chain
  --signet              Use signet chain
  --mainnet             Use mainnet chain
  --simnet              Use simnet chain
  --regtest             Use regtest chain
  --testnet4            Use testnet4 chain
  -o, --offline         Run offline
  --rpcuser RPCUSER     RPC user
  --rpcpassword RPCPASSWORD
                        RPC password
  --forgetconfig        Forget config on exit

Run 'electrum help <command>' to see the help for a command
```

```
$ python3 -c "import electrum.constants as k; print(k.NETS_LIST)"
(<class 'electrum.constants.BitcoinTestnet'>, <class 'electrum.constants.BitcoinSignet'>, <class 'electrum.constants.BitcoinSimnet'>, <class 'electrum.constants.BitcoinMainnet'>, <class 'electrum.constants.BitcoinRegtest'>, <class 'electrum.constants.BitcoinTestnet4'>)

$ python3 -c "import electrum.constants as k; print(k.NETS_LIST)"
(<class 'electrum.constants.BitcoinTestnet4'>, <class 'electrum.constants.BitcoinSimnet'>, <class 'electrum.constants.BitcoinTestnet'>, <class 'electrum.constants.BitcoinSignet'>, <class 'electrum.constants.BitcoinMainnet'>, <class 'electrum.constants.BitcoinRegtest'>)
```