### PR TITLE
qt: handle shutil.copyfail exc in add_plugin_dialog

### DIFF
--- a/electrum/gui/qt/plugins_dialog.py
+++ b/electrum/gui/qt/plugins_dialog.py
@@ -281,7 +281,15 @@ class PluginsDialog(WindowModalDialog, MessageBoxMixin):
         if os.path.exists(path):
             self.show_warning(_('Plugin already installed.'))
             return
-        shutil.copyfile(filename, path)
+        try:
+            shutil.copyfile(filename, path)
+        except OSError as e:
+            self.show_error(_("Could not copy plugin file {} into directory {}:\n\n{}").format(
+                filename,
+                path,
+                str(e)
+            ))
+            return
         self._try_add_external_plugin_from_path(path)
 
     def _try_add_external_plugin_from_path(self, path: str):


### PR DESCRIPTION
Handles exceptions thrown by `shutil.copyfile()` in the `add_plugin_dialog`.
E.g. in issue #10101 the user tried to access an onedrive vault directory which made shutil fail to copy the file with:
```
OSError: [Errno 22] Invalid argument: 'odopen://unlockvault/?accounttype=personal'
```