### PR TITLE
fix: wizard: qml: call checkIfLast in WCHaveSeed

### DIFF
--- a/electrum/gui/qml/components/wizard/WCHaveSeed.qml
+++ b/electrum/gui/qml/components/wizard/WCHaveSeed.qml
@@ -224,7 +224,11 @@ WizardComponent {
         id: validationTimer
         interval: 500
         repeat: false
-        onTriggered: checkValid()
+        onTriggered: {
+            checkValid()
+            // checkIsLast depends on 'seed_extend'(_canPassphrase) getting set in apply()
+            checkIsLast()
+        }
     }
 
     Component.onCompleted: {


### PR DESCRIPTION
When the user has already loaded a wallet in QML and tries to restore a
new wallet `WCHaveSeed.qml` incorrectly shows a `Finish` button instead
of a `Next` button and raises a KeyError if the user clicks on Finish
instead of resolving the passphrase input view (regression from
https://github.com/spesmilo/electrum/pull/10016).

This happens because `last` of `have_seed` depends on
`NewWalletWizard.is_single_password()` and `NewWalletWizard.wants_ext(wizard_data)`.
`is_single_password()` is true if a wallet is already loaded,
while `wants_ext(wizard_data)` is false as `wants_ext()` depends on `seed_extend: True` being present in
`wizard_data` which only gets set after `apply()` of `WCHaveSeed` gets
called, however the evaluation of `WCHaveSeed` being the last view
happens before the view is shown and modified by the user.
By calling `checkIsLast()` in the validation timer of `WCHaveSeed` the
`last` property gets set again after `apply()` has been called, so
the view is guaranteed to correctly show either the `Finish` or `Next` button
after a seed has been entered.

Fixes https://github.com/spesmilo/electrum/issues/10117