### PR TITLE
fix: psbt_nostr: don't save tx without txid

### DIFF
--- a/electrum/plugins/psbt_nostr/psbt_nostr.py
+++ b/electrum/plugins/psbt_nostr/psbt_nostr.py
@@ -278,6 +278,7 @@ class CosignerWallet(Logger):
         on_failure: Callable = None,
         on_success: Callable = None
     ) -> None:
+        assert tx.txid(), "Shouldn't allow to save tx without txid"
         try:
             # TODO: adding tx should be handled more gracefully here:
             # 1) don't replace tx with same tx with less signatures

--- a/electrum/plugins/psbt_nostr/qml.py
+++ b/electrum/plugins/psbt_nostr/qml.py
@@ -48,7 +48,7 @@ class QReceiveSignalObject(QObject):
         QObject.__init__(self)
         self._plugin = plugin
 
-    cosignerReceivedPsbt = pyqtSignal(str, str, str, str)
+    cosignerReceivedPsbt = pyqtSignal(str, str, str, str, bool)
     sendPsbtFailed = pyqtSignal(str, arguments=['reason'])
     sendPsbtSuccess = pyqtSignal()
 
@@ -138,7 +138,8 @@ class QmlCosignerWallet(EventListener, CosignerWallet):
     def on_event_psbt_nostr_received(self, wallet, pubkey, event_id, tx: 'PartialTransaction', label: str):
         if self.wallet == wallet:
             self.tx = tx
-            self.plugin.so.cosignerReceivedPsbt.emit(pubkey, event_id, tx.serialize(), label)
+            can_be_saved = tx.txid() is not None
+            self.plugin.so.cosignerReceivedPsbt.emit(pubkey, event_id, tx.serialize(), label, can_be_saved)
 
     def close(self):
         super().close()
@@ -173,5 +174,5 @@ class QmlCosignerWallet(EventListener, CosignerWallet):
     def reject_psbt(self, event_id):
         self.mark_pending_event_rcvd(event_id)
 
-    def on_add_fail(self):
-        self.logger.error('failed to add tx to wallet')
+    def on_add_fail(self, error_msg: str):
+        self.logger.error(f'failed to add tx to wallet: {error_msg}')

--- a/electrum/plugins/psbt_nostr/qml/PsbtReceiveDialog.qml
+++ b/electrum/plugins/psbt_nostr/qml/PsbtReceiveDialog.qml
@@ -17,6 +17,7 @@ ElDialog {
     }
 
     property string tx_label
+    property bool can_be_saved
     property int choice: PsbtReceiveDialog.Choice.None
 
     // TODO: it might be better to defer popup until no dialogs are shown
@@ -81,6 +82,7 @@ ElDialog {
                 Layout.preferredWidth: 1
                 text: qsTr('Save to Wallet')
                 icon.source: Qt.resolvedUrl('../../../gui/icons/wallet.png')
+                visible: dialog.can_be_saved
                 onClicked: {
                     choice = PsbtReceiveDialog.Choice.Save
                     doAccept()

--- a/electrum/plugins/psbt_nostr/qml/main.qml
+++ b/electrum/plugins/psbt_nostr/qml/main.qml
@@ -7,9 +7,10 @@ import "../../../gui/qml/components/controls"
 Item {
     Connections {
         target: AppController ? AppController.plugin('psbt_nostr') : null
-        function onCosignerReceivedPsbt(pubkey, event, tx, label) {
+        function onCosignerReceivedPsbt(pubkey, event, tx, label, can_be_saved) {
             var dialog = psbtReceiveDialog.createObject(app, {
-                tx_label: label
+                tx_label: label,
+                can_be_saved: can_be_saved
             })
             dialog.accepted.connect(function () {
                 if (dialog.choice == PsbtReceiveDialog.Choice.Open) {


### PR DESCRIPTION
Stops the psbt nostr plugin from trying to save transactions without txid to the wallet history and doesn't give the user the option to do so if the txid is not available.