### PR TITLE
qml: reduce tx history timestamp precision

### DIFF
--- a/electrum/gui/qml/qetransactionlistmodel.py
+++ b/electrum/gui/qml/qetransactionlistmodel.py
@@ -162,7 +162,8 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
 
         return item
 
-    def get_section_by_timestamp(self, timestamp):
+    @staticmethod
+    def get_section_by_timestamp(timestamp):
         txts = datetime.fromtimestamp(timestamp)
         today = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
 
@@ -177,14 +178,15 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
         else:
             return 'older'
 
-    def format_date_by_section(self, section, date):
+    @staticmethod
+    def format_date_by_section(section: str, date: datetime):
         # TODO: l10n
         dfmt = {
-            'today': '%H:%M:%S',
-            'yesterday': '%H:%M:%S',
-            'lastweek': '%a, %H:%M:%S',
-            'lastmonth': '%a %d, %H:%M:%S',
-            'older': '%Y-%m-%d %H:%M:%S'
+            'today': '%H:%M',
+            'yesterday': '%H:%M',
+            'lastweek': '%a, %H:%M',
+            'lastmonth': '%a %d, %H:%M',
+            'older': '%Y-%m-%d %H:%M'
         }
         if section not in dfmt:
             section = 'older'

--- a/tests/test_qml_qetransactionlistmodel.py
+++ b/tests/test_qml_qetransactionlistmodel.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from electrum.gui.qml.qetransactionlistmodel import QETransactionListModel
+
+from . import ElectrumTestCase
+
+
+class TestQETransactionListModel(ElectrumTestCase):
+
+    def test_get_section_by_timestamp(self):
+        f = QETransactionListModel.get_section_by_timestamp
+
+        mock_today = datetime(2023, 6, 15, 0, 0, 0, 0)
+        with patch('electrum.gui.qml.qetransactionlistmodel.datetime') as mock_dt:
+            mock_dt.today.return_value = mock_today
+            mock_dt.fromtimestamp = datetime.fromtimestamp
+
+            today_ts = datetime(2023, 6, 15, 10, 30, 0).timestamp()
+            self.assertEqual(f(today_ts), 'today')
+
+            today_edge_ts = datetime(2023, 6, 15, 0, 0, 1).timestamp()
+            self.assertEqual(f(today_edge_ts), 'today')
+
+            yesterday_ts = datetime(2023, 6, 14, 15, 0, 0).timestamp()
+            self.assertEqual(f(yesterday_ts), 'yesterday')
+
+            yesterday_edge_ts = datetime(2023, 6, 13, 23, 59, 59).timestamp()
+            self.assertEqual(f(yesterday_edge_ts), 'lastweek')
+
+            lastweek_ts = datetime(2023, 6, 12, 12, 0, 0).timestamp()
+            self.assertEqual(f(lastweek_ts), 'lastweek')
+
+            lastweek_boundary_ts = datetime(2023, 6, 8, 12, 0, 0).timestamp()
+            self.assertEqual(f(lastweek_boundary_ts), 'lastweek')
+
+            lastmonth_ts = datetime(2023, 6, 5, 9, 0, 0).timestamp()
+            self.assertEqual(f(lastmonth_ts), 'lastmonth')
+
+            lastmonth_boundary_ts = datetime(2023, 5, 15, 8, 0, 0).timestamp()
+            self.assertEqual(f(lastmonth_boundary_ts), 'lastmonth')
+
+            older_ts = datetime(2023, 5, 14, 10, 0, 0).timestamp()
+            self.assertEqual(f(older_ts), 'older')
+
+            much_older_ts = datetime(2022, 1, 1, 0, 0, 0).timestamp()
+            self.assertEqual(f(much_older_ts), 'older')
+
+    def test_format_date_by_section(self):
+        f = QETransactionListModel.format_date_by_section
+
+        test_date = datetime(2023, 6, 15, 14, 30, 45)
+
+        result = f('today', test_date)
+        self.assertEqual(result, '14:30')
+
+        result = f('yesterday', test_date)
+        self.assertEqual(result, '14:30')
+
+        result = f('lastweek', test_date)
+        self.assertEqual(result, 'Thu, 14:30')
+
+        result = f('lastmonth', test_date)
+        self.assertEqual(result, 'Thu 15, 14:30')
+
+        result = f('older', test_date)
+        self.assertEqual(result, '2023-06-15 14:30')
+
+        result = f('unknown_section', test_date)
+        self.assertEqual(result, '2023-06-15 14:30')
+


### PR DESCRIPTION
Reduces the precision of the date field in the qml transaction history
list to minutes. Seconds don't seem very useful in practice and add
clutter to the UI. This adapts the behavior to the Qt GUI.