### PR TITLE
wizard: enable_keystore: fix for multisig

### DIFF
--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -440,10 +440,6 @@ class WCExtendKeystore(WalletWizardComponent):
 
     def apply(self):
         self.wizard_data['keystore_type'] = self.choice_w.selected_key
-        if multisig_type(self.wizard_data['wallet_type']):
-            self.wizard_data['multisig_participants'] = 2
-            self.wizard_data['multisig_signatures'] = 2
-            self.wizard_data['multisig_cosigner_data'] = {}
 
 
 class WCCreateSeed(WalletWizardComponent):

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -57,7 +57,7 @@ class QEKeystoreWizard(KeystoreWizard, QEAbstractWizard, MessageBoxMixin):
             config: 'SimpleConfig',
             app: 'QElectrumApplication',
             plugins: 'Plugins',
-            start_viewstate: WizardViewState = None
+            start_viewstate: WizardViewState = None,
     ):
         assert 'wallet_type' in start_viewstate.wizard_data, 'wallet_type required'
 

--- a/electrum/gui/qt/wizard/wizard.py
+++ b/electrum/gui/qt/wizard/wizard.py
@@ -124,10 +124,7 @@ class QEAbstractWizard(QDialog, MessageBoxMixin):
 
     @pyqtSlot()
     def strt(self):
-        if self.start_viewstate is not None:
-            viewstate = self._current = self.start_viewstate
-        else:
-            viewstate = self.start_wizard()
+        viewstate = self.start_wizard(start_viewstate=self.start_viewstate)
         self.load_next_component(viewstate.view, viewstate.wizard_data, viewstate.params)
         self.set_default_focus()
 
@@ -236,8 +233,8 @@ class QEAbstractWizard(QDialog, MessageBoxMixin):
                 self.prev()  # rollback the submit above
                 raise e
 
-    def start_wizard(self) -> 'WizardViewState':
-        self.start()
+    def start_wizard(self, *, start_viewstate: Optional['WizardViewState'] = None) -> 'WizardViewState':
+        self.start(start_viewstate=start_viewstate)
         return self._current
 
     def view_to_component(self, view) -> QWidget:

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -257,7 +257,7 @@ class KeystoreWizard(AbstractWizard):
         # one at a time
         return True
 
-    def start(self, initial_data: dict = None) -> WizardViewState:
+    def start(self, *, initial_data: dict = None) -> WizardViewState:
         if initial_data is None:
             initial_data = {}
         self.reset()
@@ -487,7 +487,7 @@ class NewWalletWizard(KeystoreWizard):
         # todo: load only if needed, like hw plugins
         self.plugins.load_plugin_by_name('trustedcoin')
 
-    def start(self, initial_data: dict = None) -> WizardViewState:
+    def start(self, *, initial_data: dict = None) -> WizardViewState:
         if initial_data is None:
             initial_data = {}
         self.reset()
@@ -861,7 +861,7 @@ class ServerConnectWizard(AbstractWizard):
             if wizard_data.get('autoconnect') is not None:
                 self._daemon.config.NETWORK_AUTO_CONNECT = wizard_data.get('autoconnect')
 
-    def start(self, initial_data: dict = None) -> WizardViewState:
+    def start(self, *, initial_data: dict = None) -> WizardViewState:
         if initial_data is None:
             initial_data = {}
         self.reset()
@@ -888,7 +888,7 @@ class TermsOfUseWizard(AbstractWizard):
     def accept_terms_of_use(self, _):
         self._config.TERMS_OF_USE_ACCEPTED = TERMS_OF_USE_LATEST_VERSION
 
-    def start(self, initial_data: dict = None) -> WizardViewState:
+    def start(self, *, initial_data: dict = None) -> WizardViewState:
         if initial_data is None:
             initial_data = {}
         self.reset()

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -257,13 +257,14 @@ class KeystoreWizard(AbstractWizard):
         # one at a time
         return True
 
-    def start(self, *, initial_data: dict = None) -> WizardViewState:
-        if initial_data is None:
-            initial_data = {}
+    def start(self, *, start_viewstate: WizardViewState = None) -> WizardViewState:
         self.reset()
-        start_view = 'keystore_type'
-        params = self.navmap[start_view].get('params', {})
-        self._current = WizardViewState(start_view, initial_data, params)
+        if start_viewstate is None:
+            start_view = 'keystore_type'
+            params = self.navmap[start_view].get('params', {})
+            self._current = WizardViewState(start_view, {}, params)
+        else:
+            self._current = start_viewstate
         return self._current
 
     # returns (sub)dict of current cosigner (or root if first)
@@ -487,13 +488,14 @@ class NewWalletWizard(KeystoreWizard):
         # todo: load only if needed, like hw plugins
         self.plugins.load_plugin_by_name('trustedcoin')
 
-    def start(self, *, initial_data: dict = None) -> WizardViewState:
-        if initial_data is None:
-            initial_data = {}
+    def start(self, *, start_viewstate: WizardViewState = None) -> WizardViewState:
         self.reset()
-        start_view = 'wallet_name'
-        params = self.navmap[start_view].get('params', {})
-        self._current = WizardViewState(start_view, initial_data, params)
+        if start_viewstate is None:
+            start_view = 'wallet_name'
+            params = self.navmap[start_view].get('params', {})
+            self._current = WizardViewState(start_view, {}, params)
+        else:
+            self._current = start_viewstate
         return self._current
 
     def is_single_password(self) -> bool:
@@ -861,13 +863,14 @@ class ServerConnectWizard(AbstractWizard):
             if wizard_data.get('autoconnect') is not None:
                 self._daemon.config.NETWORK_AUTO_CONNECT = wizard_data.get('autoconnect')
 
-    def start(self, *, initial_data: dict = None) -> WizardViewState:
-        if initial_data is None:
-            initial_data = {}
+    def start(self, *, start_viewstate: WizardViewState = None) -> WizardViewState:
         self.reset()
-        start_view = 'welcome'
-        params = self.navmap[start_view].get('params', {})
-        self._current = WizardViewState(start_view, initial_data, params)
+        if start_viewstate is None:
+            start_view = 'welcome'
+            params = self.navmap[start_view].get('params', {})
+            self._current = WizardViewState(start_view, {}, params)
+        else:
+            self._current = start_viewstate
         return self._current
 
 
@@ -888,11 +891,12 @@ class TermsOfUseWizard(AbstractWizard):
     def accept_terms_of_use(self, _):
         self._config.TERMS_OF_USE_ACCEPTED = TERMS_OF_USE_LATEST_VERSION
 
-    def start(self, *, initial_data: dict = None) -> WizardViewState:
-        if initial_data is None:
-            initial_data = {}
+    def start(self, *, start_viewstate: WizardViewState = None) -> WizardViewState:
         self.reset()
-        start_view = 'terms_of_use'
-        params = self.navmap[start_view].get('params', {})
-        self._current = WizardViewState(start_view, initial_data, params)
+        if start_viewstate is None:
+            start_view = 'terms_of_use'
+            params = self.navmap[start_view].get('params', {})
+            self._current = WizardViewState(start_view, {}, params)
+        else:
+            self._current = start_viewstate
         return self._current

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -140,7 +140,8 @@ class KeystoreWizardTestCase(WizardTestCase):
 
     def _wizard_for(self, *, wallet_type: str = 'standard', hww: bool = False) -> tuple[KeystoreWizard, WizardViewState]:
         w = KeystoreWizardTestCase.TKeystoreWizard(self.plugins)
-        v = w.start(initial_data={'wallet_type': wallet_type})
+        start_viewstate = WizardViewState('keystore_type', {'wallet_type': wallet_type}, {})
+        v = w.start(start_viewstate=start_viewstate)
         self.assertEqual('keystore_type', v.view)
         d = v.wizard_data
         if hww:

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -140,7 +140,7 @@ class KeystoreWizardTestCase(WizardTestCase):
 
     def _wizard_for(self, *, wallet_type: str = 'standard', hww: bool = False) -> tuple[KeystoreWizard, WizardViewState]:
         w = KeystoreWizardTestCase.TKeystoreWizard(self.plugins)
-        v = w.start({'wallet_type': wallet_type})
+        v = w.start(initial_data={'wallet_type': wallet_type})
         self.assertEqual('keystore_type', v.view)
         d = v.wizard_data
         if hww:


### PR DESCRIPTION
- fixes `enable_keystore()` in multisig wallet
  - regression from https://github.com/spesmilo/electrum/commit/66c0fec1eaa4ebf4b75ec70b5395320150a2801c
  - adds test case
- refactors the wizard "start" a bit
  - to merge `start_viewstate` and `initial_data`
  - to unify the flow in `QEAbstractWizard.strt`