### PR TITLE
qt: invoice_list: only show invoice if it is not None

### DIFF
--- a/electrum/gui/qt/invoice_list.py
+++ b/electrum/gui/qt/invoice_list.py
@@ -143,6 +143,9 @@ class InvoiceList(MyTreeView):
 
     def show_invoice(self, key):
         invoice = self.wallet.get_invoice(key)
+        if not invoice:
+            self.update()
+            return
         if invoice.is_lightning():
             self.main_window.show_lightning_invoice(invoice)
         else:


### PR DESCRIPTION
Check if the invoice is not None when the user tries to open the invoice details to prevent an Exception, update the list instead if the invoice hasn't been found.
It can happen that the user deletes the invoice through the CLI and then tries to open the details in the gui, which hasn't been updated, leading to the exception in #10144 
Fixes #10144