### PR TITLE
logging: add config.LOGS_MAX_TOTAL_SIZE_BYTES: to limit size on disk

### DIFF
--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -892,7 +892,18 @@ Warning: setting this to too low will result in lots of payment failures."""),
         short_desc=lambda: _("Write logs to file"),
         long_desc=lambda: _('Debug logs can be persisted to disk. These are useful for troubleshooting.'),
     )
-    LOGS_NUM_FILES_KEEP = ConfigVar('logs_num_files_keep', default=30, type_=int)
+    LOGS_NUM_FILES_KEEP = ConfigVar(
+        'logs_num_files_keep', default=30, type_=int,
+        long_desc=lambda: _("Old log files get deleted on startup, with only the newest few being kept."),
+    )
+    LOGS_MAX_TOTAL_SIZE_BYTES = ConfigVar(
+        'logs_max_total_size', default=200_000_000, type_=int,
+        long_desc=lambda: _(
+            "Old log files get deleted on startup. "
+            "This value limits the max total size of the old log files kept, "
+            "and also separately the max size of the current log file. "
+            "Hence, the max disk usage will be twice this value."),
+    )
     GUI_ENABLE_DEBUG_LOGS = ConfigVar('gui_enable_debug_logs', default=False, type_=bool)
     LOCALIZATION_LANGUAGE = ConfigVar(
         'language', default="", type_=str,


### PR DESCRIPTION
This is about logging to disk, which happens if `config.WRITE_LOGS_TO_DISK` is enabled - which is not the default.

Currently on master:
- on every startup, a new logfile is created
  - the size of this logfile is unbounded
- old log files get deleted on startup, with only the newest few being kept
  - the number of files kept is configured via `config.LOGS_NUM_FILES_KEEP=30`

New:
- a new configvar is added: `config.LOGS_MAX_TOTAL_SIZE_BYTES=200_000_000`
- the logfile during a single process lifecycle is limited to `config.LOGS_MAX_TOTAL_SIZE_BYTES`
- old log files get deleted on startup, and the total size of those that are kept is limited to `config.LOGS_MAX_TOTAL_SIZE_BYTES`
- hence the max disk usage of log files is capped at `2 * config.LOGS_MAX_TOTAL_SIZE_BYTES`
  - however due to `config.LOGS_NUM_FILES_KEEP`, disk usage is typically not expected to get near this
- the log file is created using `logging.handlers.RotatingFileHandler(backupCount=4)`, which will result in multiple log files, each suffixed with `.1`, `.2`, etc. Each of these log files can grow up to `config.LOGS_MAX_TOTAL_SIZE_BYTES/(backupCount+1)`, and only the latest `backupCount+1` of them are kept.
  - so by default, each log file chunk created will be at most 40 MB, and only the last 5 for the current session is kept. The logger keeps deleting the oldest chunk whenever it creates a new one.
  - typical usage is expected to not result in any log rotation. So I expect approx 1 log file to be created per process launch.