### PR TITLE
swaps: cleanup data after swap gets failed

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2318,6 +2318,13 @@ class LNWallet(LNWorker):
                 return key_list
         return []
 
+    def delete_payment_bundle(self, payment_hash: bytes) -> None:
+        payment_key = self._get_payment_key(payment_hash)
+        for key_list in self.payment_bundles:
+            if payment_key in key_list:
+                self.payment_bundles.remove(key_list)
+                return
+
     def save_preimage(self, payment_hash: bytes, preimage: bytes, *, write_to_disk: bool = True):
         if sha256(preimage) != payment_hash:
             raise Exception("tried to save incorrect preimage for payment_hash")

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -439,8 +439,12 @@ class SwapManager(Logger):
                 if spent_height > 0:
                     if current_height - spent_height > REDEEM_AFTER_DOUBLE_SPENT_DELAY:
                         self.logger.info(f'stop watching swap {swap.lockup_address}')
-                        self.lnwatcher.remove_callback(swap.lockup_address)
                         swap.is_redeemed = True
+                        # cleanup
+                        self.lnwatcher.remove_callback(swap.lockup_address)
+                        if not swap.is_reverse:
+                            self.lnworker.delete_payment_bundle(swap.payment_hash)
+                            self.lnworker.unregister_hold_invoice(swap.payment_hash)
 
             if not swap.is_reverse:
                 if swap.preimage is None and spent_height is not None:


### PR DESCRIPTION
Removes the persisted payment info from lnworker once a swap got failed. 
Stops persisting the OnionRoutingFailure as it is sufficient to delete the payment info to fail potential incoming htlcs. 
Deletes stored swap leftovers in lnworker and SwapManager