### PR TITLE
reverse swaps: in the CLI, replace 'server_mining_fee' with

### DIFF
--- a/electrum/gui/qml/qeswaphelper.py
+++ b/electrum/gui/qml/qeswaphelper.py
@@ -719,7 +719,7 @@ class QESwapHelper(AuthMixin, QObject, QtEventListener):
                     transport=self.swap_transport,
                     lightning_amount_sat=lightning_amount,
                     expected_onchain_amount_sat=onchain_amount + swap_manager.get_fee_for_txbatcher(),
-                    server_mining_fee_sat=self.serverMiningfee.satsInt,
+                    prepayment_sat=2 * self.serverMiningfee.satsInt,
                 )
                 try:  # swaphelper might be destroyed at this point
                     if txid:

--- a/electrum/gui/qt/swap_dialog.py
+++ b/electrum/gui/qt/swap_dialog.py
@@ -338,7 +338,7 @@ class SwapDialog(WindowModalDialog, QtEventListener):
                 transport=transport,
                 lightning_amount_sat=lightning_amount,
                 expected_onchain_amount_sat=onchain_amount + self.swap_manager.get_fee_for_txbatcher(),
-                server_mining_fee_sat=self.last_server_mining_fee_sat,
+                prepayment_sat=2 * self.last_server_mining_fee_sat,
             )
             try:
                 # we must not leave the context, so we use run_couroutine_dialog

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -926,7 +926,7 @@ class SwapManager(Logger):
             transport: 'SwapServerTransport',
             lightning_amount_sat: int,
             expected_onchain_amount_sat: int,
-            server_mining_fee_sat: int,
+            prepayment_sat: int,
             channels: Optional[Sequence['Channel']] = None,
     ) -> Optional[str]:
         """send on Lightning, receive on-chain
@@ -943,9 +943,9 @@ class SwapManager(Logger):
         - Server fulfills HTLC using preimage.
 
         Note: expected_onchain_amount_sat is BEFORE deducting the on-chain claim tx fee.
-        Note: server_mining_fee_sat is passed as argument instead of accessing self.mining_fee to ensure
+        Note: prepayment_sat is passed as argument instead of accessing self.mining_fee to ensure
         the mining fees the user sees in the GUI are also the values used for the checks performed here.
-        We commit to server_mining_fee_sat as it limits the max fee pre-payment amt, which the server is trusted with.
+        We commit to prepayment_sat as it limits the max fee pre-payment amt, which the server is trusted with.
         """
         assert self.network
         assert self.lnwatcher
@@ -1007,7 +1007,7 @@ class SwapManager(Logger):
             raise Exception("rswap check failed: inconsistent RHASH and invoice")
         if fee_invoice:
             fee_lnaddr = self.lnworker._check_bolt11_invoice(fee_invoice)
-            if fee_lnaddr.get_amount_sat() > server_mining_fee_sat * 2:
+            if fee_lnaddr.get_amount_sat() > prepayment_sat:
                 raise SwapServerError(_("Mining fee requested by swap-server larger "
                                         "than what was announced in their offer."))
             invoice_amount += fee_lnaddr.get_amount_sat()

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -248,8 +248,8 @@ if [[ $1 == "swapserver_success" ]]; then
     echo "alice initiates swap"
     dryrun=$($alice reverse_swap 0.02 dryrun)
     onchain_amount=$(echo $dryrun| jq -r ".onchain_amount")
-    swapserver_mining_fee=$(echo $dryrun| jq -r ".provider_mining_fee")
-    swap=$($alice reverse_swap 0.02 $onchain_amount --provider_mining_fee $swapserver_mining_fee)
+    prepayment=$(echo $dryrun| jq -r ".prepayment")
+    swap=$($alice reverse_swap 0.02 $onchain_amount --prepayment $prepayment)
     echo $swap | jq
     funding_txid=$(echo $swap| jq -r ".funding_txid")
     new_blocks 1
@@ -273,8 +273,8 @@ if [[ $1 == "swapserver_forceclose" ]]; then
     echo "alice initiates swap"
     dryrun=$($alice reverse_swap 0.02 dryrun)
     onchain_amount=$(echo $dryrun| jq -r ".onchain_amount")
-    swapserver_mining_fee=$(echo $dryrun| jq -r ".provider_mining_fee")
-    swap=$($alice reverse_swap 0.02 $onchain_amount --provider_mining_fee $swapserver_mining_fee)
+    prepayment=$(echo $dryrun| jq -r ".prepayment")
+    swap=$($alice reverse_swap 0.02 $onchain_amount --prepayment $prepayment)
     echo $swap | jq
     funding_txid=$(echo $swap| jq -r ".funding_txid")
     ctx_id=$($bob close_channel --force $channel)
@@ -309,8 +309,8 @@ if [[ $1 == "swapserver_refund" ]]; then
     echo "alice initiates swap"
     dryrun=$($alice reverse_swap 0.02 dryrun)
     onchain_amount=$(echo $dryrun| jq -r ".onchain_amount")
-    swapserver_mining_fee=$(echo $dryrun| jq -r ".provider_mining_fee")
-    swap=$($alice reverse_swap 0.02 $onchain_amount --provider_mining_fee $swapserver_mining_fee)
+    prepayment=$(echo $dryrun| jq -r ".prepayment")
+    swap=$($alice reverse_swap 0.02 $onchain_amount --prepayment $prepayment)
     echo $swap | jq
     funding_txid=$(echo $swap| jq -r ".funding_txid")
     new_blocks 140

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -696,14 +696,14 @@ class TestCommandsTestnet(ElectrumTestCase):
                 "max_forward_sat": offer1.pairs.max_forward,
                 "max_reverse_sat": offer1.pairs.max_reverse,
                 "min_amount_sat": offer1.pairs.min_amount,
-                "provider_mining_fee": offer1.pairs.mining_fee,
+                "prepayment": 2 * offer1.pairs.mining_fee,
             },
             offer2.server_npub: {
                 "percentage_fee": offer2.pairs.percentage,
                 "max_forward_sat": offer2.pairs.max_forward,
                 "max_reverse_sat": offer2.pairs.max_reverse,
                 "min_amount_sat": offer2.pairs.min_amount,
-                "provider_mining_fee": offer2.pairs.mining_fee,
+                "prepayment": 2 * offer2.pairs.mining_fee,
             }
         }
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
'prepayment', which corresponds to the trusted part of the lightning payment.

We use 2*sm.mining_fee, where 'mining_fee' is the flat part of the server fee. However, future protocol should probably allow to set a value that does not depend on 'mining_fee'. (note that LND uses a hardcoded amount).