### PR TITLE
commands: use format_satoshis consistently. don't use sci-notation

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -793,10 +793,11 @@ def format_satoshis_plain(
         x: Union[int, float, Decimal, str],  # amount in satoshis,
         *,
         decimal_point: int = 8,  # how much to shift decimal point to left (default: sat->BTC)
+        is_max_allowed: bool = True,
 ) -> str:
     """Display a satoshi amount scaled.  Always uses a '.' as a decimal
     point and has no thousands separator"""
-    if parse_max_spend(x):
+    if is_max_allowed and parse_max_spend(x):
         return f'max({x})'
     assert isinstance(x, (int, float, Decimal)), f"{x!r} should be a number"
     scale_factor = pow(10, decimal_point)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -171,6 +171,21 @@ class TestCommands(ElectrumTestCase):
         with self.assertRaises(binascii.Error):  # perhaps it should raise some nice UserFacingException instead
             await cmds.decrypt(pubkey, ciphertext+"trailinggarbage", wallet=wallet)
 
+    def test_format_satoshis(self):
+        format_satoshis = electrum.commands.format_satoshis
+        # input type is highly polymorphic:
+        self.assertEqual(format_satoshis(None), None)
+        self.assertEqual(format_satoshis(1), "0.00000001")
+        self.assertEqual(format_satoshis(1.0), "0.00000001")
+        self.assertEqual(format_satoshis(Decimal(1)), "0.00000001")
+        # trailing zeroes are cut
+        self.assertEqual(format_satoshis(51000), "0.00051")
+        self.assertEqual(format_satoshis(123456_12345670), "123456.1234567")
+        # sub-satoshi precision is rounded
+        self.assertEqual(format_satoshis(Decimal(123.456)), "0.00000123")
+        self.assertEqual(format_satoshis(Decimal(123.5)), "0.00000124")
+        self.assertEqual(format_satoshis(Decimal(123.789)), "0.00000124")
+
 
 class TestCommandsTestnet(ElectrumTestCase):
     TESTNET = True


### PR DESCRIPTION
old behaviour:
```
>>> from electrum.commands import format_satoshis
>>> format_satoshis(1)
'1E-8'
```