### PR TITLE
perform filesystem R/W checks at startup

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -740,3 +740,18 @@ class Daemon(Logger):
             recent = recent[:5]
         self.config.RECENTLY_OPEN_WALLET_FILES = recent
         util.trigger_callback('recently_opened_wallets_update')
+
+
+def check_fs_permissions(config: 'SimpleConfig'):
+    electrum_path = config.electrum_path()
+    if not os.access(electrum_path, os.R_OK | os.W_OK):
+        raise Exception('can not read/write root folder at ' + electrum_path)
+    for f in ['config', 'blockchain_headers', 'recent_servers']:
+        fpath = os.path.join(electrum_path, f)
+        if os.path.exists(fpath):
+            if not os.access(fpath, os.R_OK | os.W_OK):
+                raise Exception(f'can not read/write {f} file at ' + electrum_path)
+    fpath = os.path.join(electrum_path, 'wallets')
+    if not os.access(fpath, os.R_OK | os.W_OK):
+        raise Exception('can not read/write wallet folder at ' + fpath)
+

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -67,6 +67,7 @@ if sys.platform == "linux" and os.environ.get("APPIMAGE"):
     os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
 from electrum.i18n import _, set_language
+from electrum.daemon import check_fs_permissions
 from electrum.plugin import run_hook
 from electrum.util import (UserCancelled, profiler, send_exception_to_crash_reporter,
                            WalletFileException, get_new_wallet_name, InvalidPassword,
@@ -571,6 +572,14 @@ class ElectrumGui(BaseElectrumGui, Logger):
         signal.signal(signal.SIGINT, lambda *args: self.app.quit())
         # hook for crash reporter
         Exception_Hook.maybe_setup(config=self.config)
+
+        # check filesystem
+        try:
+            check_fs_permissions(self.daemon.config)
+        except Exception as e:
+            custom_message_box(icon=QMessageBox.Icon.Critical, parent=None, title=_('filesystem error'), text=str(e))
+            raise
+
         # start network, and maybe show first-start network-setup
         try:
             self.ask_terms_of_use()

--- a/run_electrum
+++ b/run_electrum
@@ -26,6 +26,7 @@
 import os
 import sys
 
+from electrum.daemon import check_fs_permissions
 
 MIN_PYTHON_VERSION = "3.10.0"  # FIXME duplicated from setup.py
 _min_python_version_tuple = tuple(map(int, (MIN_PYTHON_VERSION.split("."))))
@@ -528,6 +529,7 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
         if fd is not None:
             # run daemon
             d = daemon.Daemon(config, fd)
+            check_fs_permissions(config)
             d.run_daemon()
             sys_exit(0)
         else:
@@ -570,6 +572,7 @@ def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
                 _logger.exception("error running command (with daemon)")
                 sys_exit(1)
         else:
+            check_fs_permissions(config)
             if cmd.requires_network:
                 print_msg("This command cannot be run offline")
                 sys_exit(1)


### PR DESCRIPTION
perform filesystem R/W checks at startup. This avoids raising Exceptions later when actual writes are performed (e.g. #4151).

Not sure yet how portable this is, needs testing on win and mac