### PR TITLE
android: make app compatible with edge-to-edge layout

### DIFF
--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -108,7 +108,7 @@ android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE, POST_NOTIFICATIO
 android.api = 31
 
 # (int) Android targetSdkVersion
-android.target_sdk_version = 34
+android.target_sdk_version = 35
 
 # (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
 android.minapi = 23

--- a/electrum/gui/qml/components/BIP39RecoveryDialog.qml
+++ b/electrum/gui/qml/components/BIP39RecoveryDialog.qml
@@ -18,6 +18,8 @@ ElDialog {
     property string derivationPath
     property string scriptType
 
+    needsSystemBarPadding: false
+
     z: 1 // raise z so it also covers wizard dialog
 
     anchors.centerIn: parent

--- a/electrum/gui/qml/components/ExceptionDialog.qml
+++ b/electrum/gui/qml/components/ExceptionDialog.qml
@@ -18,10 +18,14 @@ ElDialog
     width: parent.width
     height: parent.height
     z: 1000  // assure topmost of all other dialogs. note: child popups need even higher!
+    // disable padding in ElDialog as it is overwritten here and shows no effect, this dialog needs padding though
+    needsSystemBarPadding: false
 
     header: null
 
     ColumnLayout {
+        anchors.topMargin: app.statusBarHeight  // edge-to-edge layout padding
+        anchors.bottomMargin: app.navigationBarHeight
         anchors.fill: parent
         enabled: !_sending
 

--- a/electrum/gui/qml/components/LnurlPayRequestDialog.qml
+++ b/electrum/gui/qml/components/LnurlPayRequestDialog.qml
@@ -16,6 +16,7 @@ ElDialog {
     property InvoiceParser invoiceParser
 
     padding: 0
+    needsSystemBarPadding: false
 
     property bool commentValid: comment.text.length <= invoiceParser.lnurlData['comment_allowed']
     property bool amountValid: amountBtc.textAsSats.satsInt >= parseInt(invoiceParser.lnurlData['min_sendable_sat'])

--- a/electrum/gui/qml/components/LoadingWalletDialog.qml
+++ b/electrum/gui/qml/components/LoadingWalletDialog.qml
@@ -18,6 +18,7 @@ ElDialog {
     x: Math.floor((parent.width - implicitWidth) / 2)
     y: Math.floor((parent.height - implicitHeight) / 2)
     // anchors.centerIn: parent // this strangely pixelates the spinner
+    needsSystemBarPadding: false
 
     function open() {
         showTimer.start()

--- a/electrum/gui/qml/components/LoadingWalletDialog.qml
+++ b/electrum/gui/qml/components/LoadingWalletDialog.qml
@@ -32,6 +32,10 @@ ElDialog {
 
             running: Daemon.loading
         }
+
+        Item {
+            Layout.preferredHeight: 20
+        }
     }
 
     Connections {

--- a/electrum/gui/qml/components/MessageDialog.qml
+++ b/electrum/gui/qml/components/MessageDialog.qml
@@ -21,6 +21,7 @@ ElDialog {
     anchors.centerIn: parent
 
     padding: 0
+    needsSystemBarPadding: false
 
     width: rootLayout.width
 

--- a/electrum/gui/qml/components/NostrSwapServersDialog.qml
+++ b/electrum/gui/qml/components/NostrSwapServersDialog.qml
@@ -15,6 +15,8 @@ ElDialog {
 
     property string selectedPubkey
 
+    needsSystemBarPadding: false
+
     anchors.centerIn: parent
 
     padding: 0

--- a/electrum/gui/qml/components/OpenWalletDialog.qml
+++ b/electrum/gui/qml/components/OpenWalletDialog.qml
@@ -25,6 +25,7 @@ ElDialog {
     anchors.centerIn: parent
 
     padding: 0
+    needsSystemBarPadding: false
 
     ColumnLayout {
         spacing: 0

--- a/electrum/gui/qml/components/PasswordDialog.qml
+++ b/electrum/gui/qml/components/PasswordDialog.qml
@@ -20,6 +20,7 @@ ElDialog {
     anchors.centerIn: parent
     width: parent.width * 4/5
     padding: 0
+    needsSystemBarPadding: false
 
     ColumnLayout {
         id: rootLayout

--- a/electrum/gui/qml/components/Pin.qml
+++ b/electrum/gui/qml/components/Pin.qml
@@ -25,6 +25,7 @@ ElDialog {
     focus: true
     closePolicy: canCancel ? Popup.CloseOnEscape | Popup.CloseOnPressOutside : Popup.NoAutoClose
     allowClose: canCancel
+    needsSystemBarPadding: false
 
     anchors.centerIn: parent
 

--- a/electrum/gui/qml/components/ReceiveDetailsDialog.qml
+++ b/electrum/gui/qml/components/ReceiveDetailsDialog.qml
@@ -20,6 +20,7 @@ ElDialog {
     property bool isLightning: false
 
     padding: 0
+    needsSystemBarPadding: false
 
     ColumnLayout {
         width: parent.width

--- a/electrum/gui/qml/components/controls/ElDialog.qml
+++ b/electrum/gui/qml/components/controls/ElDialog.qml
@@ -9,10 +9,15 @@ Dialog {
     property bool allowClose: true
     property string iconSource
     property bool resizeWithKeyboard: true
+    // inheriting classes can set needsSystemBarPadding this false to disable padding
+    property bool needsSystemBarPadding: true
 
     property bool _result: false
     // workaround: remember opened state, to inhibit closed -> closed event
     property bool _wasOpened: false
+
+    // Add bottom padding for Android navigation bar if needed
+    bottomPadding: needsSystemBarPadding ? app.navigationBarHeight : 0
 
     // called to finally close dialog after checks by onClosing handler in main.qml
     function doClose() {
@@ -64,6 +69,13 @@ Dialog {
 
     header: ColumnLayout {
         spacing: 0
+
+        // Add top padding for status bar on Android when using edge-to-edge
+        Item {
+            visible: needsSystemBarPadding && app.statusBarHeight > 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: app.statusBarHeight
+        }
 
         RowLayout {
             spacing: 0

--- a/electrum/gui/qml/components/controls/HelpDialog.qml
+++ b/electrum/gui/qml/components/controls/HelpDialog.qml
@@ -16,6 +16,7 @@ ElDialog {
     anchors.centerIn: parent
 
     padding: 0
+    needsSystemBarPadding: false
 
     width: rootPane.width
 

--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -19,6 +19,9 @@ ApplicationWindow
 
     visible: false // initial value
 
+    readonly property int statusBarHeight: AppController ? AppController.getStatusBarHeight() : 0
+    readonly property int navigationBarHeight: AppController ? AppController.getNavigationBarHeight() : 0
+
     // dimensions ignored on android
     width: 480
     height: 800
@@ -117,6 +120,9 @@ ApplicationWindow
 
     header: ToolBar {
         id: toolbar
+ 
+        // Add top margin for status bar on Android when using edge-to-edge
+        topPadding: app.statusBarHeight
 
         background: Rectangle {
             implicitHeight: 48
@@ -133,7 +139,7 @@ ApplicationWindow
             spacing: 0
             anchors.left: parent.left
             anchors.right: parent.right
-            height: toolbar.height
+            height: toolbar.availableHeight
 
             RowLayout {
                 id: toolbarTopLayout
@@ -276,6 +282,13 @@ ApplicationWindow
                     mainStackView.push(item)
                 }
             }
+        }
+
+        // Add bottom padding for navigation bar on Android when UI is edge-to-edge
+        Item {
+            visible: app.navigationBarHeight > 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: app.navigationBarHeight
         }
     }
 

--- a/electrum/gui/qml/java_classes/org/electrum/qr/SimpleScannerActivity.java
+++ b/electrum/gui/qml/java_classes/org/electrum/qr/SimpleScannerActivity.java
@@ -2,6 +2,7 @@ package org.electrum.qr;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.os.Build;
 import android.util.Log;
 import android.content.Intent;
 import android.Manifest;
@@ -12,6 +13,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowInsets;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -68,6 +70,7 @@ public class SimpleScannerActivity extends Activity {
                 }
             }
         });
+        setupEdgeToEdge();
     }
 
     @Override
@@ -156,4 +159,51 @@ public class SimpleScannerActivity extends Activity {
         }
     }
 
+    private boolean enforcesEdgeToEdge() {
+        // if true the UI needs to be padded to be e2e compatible
+        return Build.VERSION.SDK_INT >= 35;
+    }
+
+    private void setupEdgeToEdge() {
+        if (!enforcesEdgeToEdge()) {
+            return;
+        }
+
+        // Get the root view and set up insets listener
+        getWindow().getDecorView().setOnApplyWindowInsetsListener((v, insets) -> {
+            android.graphics.Insets systemBars = insets.getInsets(WindowInsets.Type.systemBars());
+            
+            // Apply padding to content frame to keep scanner focus area centered
+            ViewGroup contentFrame = findViewById(R.id.content_frame);
+            if (contentFrame != null) {
+                contentFrame.setPadding(
+                    systemBars.left,
+                    systemBars.top,
+                    systemBars.right,
+                    systemBars.bottom
+                );
+            }
+
+            // Apply top padding to hint text for status bar
+            TextView hintTextView = findViewById(R.id.hint);
+            if (hintTextView != null) {
+                hintTextView.setPadding(
+                    hintTextView.getPaddingLeft(),
+                    systemBars.top,
+                    hintTextView.getPaddingRight(),
+                    hintTextView.getPaddingBottom()
+                );
+            }
+
+            // Apply bottom margin to paste button for navigation bar  
+            Button pasteButton = findViewById(R.id.paste_btn);
+            if (pasteButton != null) {
+                ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) pasteButton.getLayoutParams();
+                params.bottomMargin = systemBars.bottom;
+                pasteButton.setLayoutParams(params);
+            }
+
+            return insets;
+        });
+    }
 }

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -422,7 +422,7 @@ class QEAppController(BaseCrashReporter, QObject):
             return False
         return bool(systemSdkVersion >= 35)
 
-    @profiler(min_threshold=0.05)
+    @profiler(min_threshold=0.02)
     def _getSystemBarHeight(self, bar_type: str) -> int:
         if not self.enforcesEdgeToEdge():
             return 0

--- a/electrum/plugins/psbt_nostr/qml/PsbtReceiveDialog.qml
+++ b/electrum/plugins/psbt_nostr/qml/PsbtReceiveDialog.qml
@@ -26,6 +26,7 @@ ElDialog {
     anchors.centerIn: parent
 
     padding: 0
+    needsSystemBarPadding: false
 
     width: rootLayout.width
 


### PR DESCRIPTION
This PR makes the QML gui and the java android barcode scanner view compatible with the android edge-to-edge layout which is enforced from sdk version 35. The first commit also bumps the sdk version to 35.
It works by fetching the size of the status- and navigation bar from the android API and applying padding to the gui elements so that nothing is overlapped by the system bars.
I tested on Pixel 9, Android 16; Pixel 9 XL Android 16 emulator; Pixel 4a Android 13 emulator and Galaxy Tab A (2016) Android 8.1 (armv7).
Also tested with the 16kb patch commit of https://github.com/spesmilo/electrum/pull/10148.
If the edge-to-edge layout is not enforced (Android < 15) it doesn't opt-in and the UI stays as before.

Fixes #10139
Part of #9899