### PR TITLE
qml: android: add padding to report dialog in ExcDialog

### DIFF
--- a/electrum/gui/qml/components/ExceptionDialog.qml
+++ b/electrum/gui/qml/components/ExceptionDialog.qml
@@ -115,11 +115,14 @@ ElDialog
             width: parent.width
             height: parent.height
             z: 1001  // above root
+            needsSystemBarPadding: false
 
             header: null
 
             Flickable {
                 anchors.fill: parent
+                anchors.topMargin: app.statusBarHeight
+                anchors.bottomMargin: app.navigationBarHeight
                 contentHeight: reportLabel.implicitHeight
                 interactive: height < contentHeight
 


### PR DESCRIPTION
Adds padding to the report content dialog in the QML ExceptionDialog if required on android.
Followup https://github.com/spesmilo/electrum/pull/10178

<img width="461" height="958" alt="Screenshot_20250902_103809" src="https://github.com/user-attachments/assets/58c9b155-41d8-4dd5-a8d8-45d37eedc059" />
