### PR TITLE
daemon: get_wallet: handle OSError for weiiird paths

### DIFF
--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -38,7 +38,7 @@ class QEWalletListModel(QAbstractListModel):
     _ROLE_KEYS = range(Qt.ItemDataRole.UserRole, Qt.ItemDataRole.UserRole + len(_ROLE_NAMES))
     _ROLE_MAP  = dict(zip(_ROLE_KEYS, [bytearray(x.encode()) for x in _ROLE_NAMES]))
 
-    def __init__(self, daemon, parent=None):
+    def __init__(self, daemon: 'Daemon', parent=None):
         QAbstractListModel.__init__(self, parent)
         self.daemon = daemon
         self._wallets = []


### PR DESCRIPTION
I think `_wallet_key_from_path` should not raise.
This is probably the sane way to deal with this.
Though all this is assuming that os.path.realpath can be treated as consistent/stateless.

closes https://github.com/spesmilo/electrum/issues/10182