### PR TITLE
qt: add missing fiat values in csv/json history export

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -43,7 +43,7 @@ from electrum.address_synchronizer import TX_HEIGHT_LOCAL
 from electrum.i18n import _
 from electrum.util import (block_explorer_URL, profiler, TxMinedInfo,
                            OrderedDictWithIndex, timestamp_to_datetime,
-                           Satoshis, format_time)
+                           Satoshis, format_time, Fiat)
 from electrum.logging import get_logger, Logger
 from electrum.simple_config import SimpleConfig
 
@@ -853,26 +853,32 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
         self.main_window.show_message(_("Your wallet history has been successfully exported."))
 
     def do_export_history(self, file_name, is_csv):
-        txns = self.wallet.get_full_history(fx=self.main_window.fx)
+        txns = self.wallet.get_full_history(fx=self.main_window.fx, include_fiat=self.main_window.fx.is_enabled())
         lines = []
 
-        def get_all_fees_paid_sat(h_item: dict) -> int:
+        def get_all_fees_paid_by_item(h_item: dict) -> Tuple[int, Fiat]:
             # gets all fees paid in an item (or group), as the outer group doesn't contain the
             # transaction fees paid by the children
             fees_sat = 0
+            fees_fiat = Fiat(ccy=self.main_window.fx.ccy, value=Decimal())
             for child in h_item.get('children', []):
                 fees_sat += child['fee_sat'] or 0 if 'fee_sat' in child \
                                 else (child.get('fee_msat', 0) or 0) // 1000
+                if child_fiat_fee := child.get('fiat_fee'):
+                    fees_fiat += child_fiat_fee
 
             fees_sat += h_item['fee_sat'] or 0 if 'fee_sat' in h_item \
                             else (h_item.get('fee_msat', 0) or 0) // 1000
-            return fees_sat
+            if h_item_fiat_fee := h_item.get('fiat_fee'):
+                fees_fiat += h_item_fiat_fee
+            return fees_sat, fees_fiat
 
         if is_csv:
             # sort by timestamp so the generated csv is more understandable on first sight
             txns = dict(sorted(txns.items(), key=lambda h_item: h_item[1]['timestamp'] or 0))
             for item in txns.values():
                 # tx groups will are shown as single element
+                fees_sat, fees_fiat = get_all_fees_paid_by_item(item)
                 line = [
                     item.get('txid', ''),
                     item.get('payment_hash', ''),
@@ -881,8 +887,8 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
                     item['bc_value'],
                     item['ln_value'],
                     item.get('fiat_value', ''),
-                    get_all_fees_paid_sat(item),
-                    item.get('fiat_fee', ''),
+                    fees_sat,
+                    str(fees_fiat),
                     item['date']
                 ]
                 lines.append(line)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1514,17 +1514,20 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             item['value'] = item.get('bc_value', Satoshis(0)) + item.get('ln_value', Satoshis(0))
             for child in item.get('children', []):
                 child['value'] = child.get('bc_value', Satoshis(0)) + child.get('ln_value', Satoshis(0))
-            if include_fiat:
-                value = item['value'].value
-                txid = item.get('txid')
-                if not item.get('lightning') and txid:
-                    fiat_fields = self.get_tx_item_fiat(tx_hash=txid, amount_sat=value, fx=fx, tx_fee=item['fee_sat'])
-                    item.update(fiat_fields)
+            if not include_fiat:
+                continue
+            # add fiat values to both the root item and its children
+            for add_fiat_item in [item] + children:
+                value = add_fiat_item['value'].value
+                txid = add_fiat_item.get('txid')
+                if not add_fiat_item.get('lightning') and txid:
+                    fiat_fields = self.get_tx_item_fiat(tx_hash=txid, amount_sat=value, fx=fx, tx_fee=add_fiat_item['fee_sat'])
+                    add_fiat_item.update(fiat_fields)
                 else:
-                    timestamp = item['timestamp'] or now
+                    timestamp = add_fiat_item['timestamp'] or now
                     fiat_value = value / Decimal(bitcoin.COIN) * fx.timestamp_rate(timestamp)
-                    item['fiat_value'] = Fiat(fiat_value, fx.ccy)
-                    item['fiat_default'] = True
+                    add_fiat_item['fiat_value'] = Fiat(fiat_value, fx.ccy)
+                    add_fiat_item['fiat_default'] = True
         return transactions
 
     @profiler


### PR DESCRIPTION
Fixes missing fiat values in the CSV and JSON history export. 

Fixes #10199
