### PR TITLE
lnwatcher: catch callback exceptions

### DIFF
--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -56,7 +56,10 @@ class LNWatcher(Logger, EventListener):
             self.logger.info("synchronizer not set yet")
             return
         for address, callback in list(self.callbacks.items()):
-            await callback()
+            try:
+                await callback()
+            except Exception:
+                self.logger.exception(f"LNWatcher callback failed {address=}")
         # send callback to GUI
         util.trigger_callback('wallet_updated', self.lnworker.wallet)
 


### PR DESCRIPTION
Catch exceptions happening in lnwatcher callbacks to continue calling the remaining callbacks. Otherwise if one callback throws an exception it prevents execution of the following callbacks.