### PR TITLE
swaps: only set swap redeemed if preimage is available

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -464,7 +464,7 @@ class SwapManager(Logger):
             if spent_height in [TX_HEIGHT_LOCAL, TX_HEIGHT_FUTURE]:
                 spent_height = None
             if spent_height is not None:
-                if spent_height > 0:
+                if spent_height > 0 and swap.preimage:
                     if current_height - spent_height > REDEEM_AFTER_DOUBLE_SPENT_DELAY:
                         self.logger.info(f'stop watching swap {swap.lockup_address}')
                         swap.is_redeemed = True


### PR DESCRIPTION
For forward swaps this will ensure that the swap only gets set redeemed and cleaned up after the preimage has been extracted, as it could happen that `current_height - spent_height > REDEEM_AFTER_DOUBLE_SPENT_DELAY` is true even if the preimage has not been extracted yet. This would make the client fail the pending htlcs if the following preimage extraction step is not successful due to any reason or if an async context switch happens in between (currently there is no await in the code between those steps).

For reverse swaps this changes nothing as they have the preimage stored from the beginning.