### PR TITLE
crash_reporter: flag reports where console was used in app_version

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -39,6 +39,12 @@ if TYPE_CHECKING:
     from .network import ProxySettings
 
 
+_tainted_by_console = False
+def taint_reports_by_console_usage():
+    global _tainted_by_console
+    _tainted_by_console = True
+
+
 class CrashReportResponse(NamedTuple):
     status: Optional[str]
     text: str
@@ -153,8 +159,11 @@ class BaseCrashReporter(Logger):
         return sha256(str(_id))
 
     def get_additional_info(self):
+        app_version = (get_git_version() or ELECTRUM_VERSION)
+        if _tainted_by_console:
+            app_version += "-consoletaint"
         args = {
-            "app_version": get_git_version() or ELECTRUM_VERSION,
+            "app_version": app_version,
             "python_version": sys.version,
             "os": describe_os_version(),
             "wallet_type": "unknown",

--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -11,6 +11,7 @@ from PyQt6.QtCore import Qt
 
 from electrum import util
 from electrum.i18n import _
+from electrum.base_crash_reporter import taint_reports_by_console_usage
 
 from .util import MONOSPACE_FONT, font_height
 
@@ -83,7 +84,7 @@ class Console(QtWidgets.QPlainTextEdit):
         with open(filename) as f:
             script = f.read()
 
-        self.exec_command(script)
+        self._exec_command(script)
 
     def updateNamespace(self, namespace):
         self.namespace.update(namespace)
@@ -221,12 +222,13 @@ class Console(QtWidgets.QPlainTextEdit):
         command = self.getConstruct(command)
 
         if command:
-            self.exec_command(command)
+            self._exec_command(command)
         self.newPrompt('')
         self.set_json(False)
 
-    def exec_command(self, command):
+    def _exec_command(self, command):
         tmp_stdout = sys.stdout
+        taint_reports_by_console_usage()
 
         class StdoutProxy:
             def __init__(self, write_func):


### PR DESCRIPTION
This appends a  `-consoletaint` suffix to the `app_version` field of TARS crash reports if the user has executed any command in the Qt console tab in the current process lifecycle.
So we don't waste time on weird reports where the user modified internals at runtime.

ref
https://github.com/spesmilo/electrum/issues/10217
https://github.com/spesmilo/electrum/issues/10218

---

One thing to keep in mind is that the `app_version` field is used for comparison between reports, to see if a given report is from a newer code version than any prior ones, which should keep working. See here:
https://github.com/bauerj/crashhub/blob/3bab6f15b6f430598bb879f9228aa7d47b3e6fa7/lib/issues.py#L98-L103

---

See this report for example:
https://github.com/spesmilo/electrum/issues/5485#issuecomment-3281938609