### PR TITLE
refactor(paymentrequest): use f-string in error message

### DIFF
--- a/electrum/paymentrequest.py
+++ b/electrum/paymentrequest.py
@@ -403,7 +403,7 @@ def verify_cert_chain(chain):
             hashBytes = bytearray(hashlib.sha512(data).digest())
             verify = pubkey.verify(sig, x509.PREFIX_RSA_SHA512 + hashBytes)
         else:
-            raise Exception("Algorithm not supported: {}".format(algo))
+            raise Exception(f"Algorithm not supported: {algo}")
         if not verify:
             raise Exception("Certificate not Signed by Provided CA Certificate Chain")
 


### PR DESCRIPTION
This PR replaces a single .format() call with a Python f-string in
`electrum/paymentrequest.py`.

Benefits:
- Improves readability and consistency with modern Python style (PEP 498).
- Slightly more efficient at runtime.
- No change to behavior or functionality.

This is a style-only refactor and should be safe to merge.
