### PR TITLE
wallet: fix AttributeError when getting help text

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3443,8 +3443,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             self.lnworker and len([chan for chan in self.lnworker.channels.values() if chan.is_open()]) > 0
         )
         lightning_online = self.lnworker and self.lnworker.num_peers() > 0
-        can_receive = self.lnworker.num_sats_can_receive()
-        can_receive_lightning = self.lnworker and can_receive > 0 and amount_sat <= can_receive
+        num_sats_can_receive = self.lnworker.num_sats_can_receive() if self.lnworker else 0
+        can_receive_lightning = self.lnworker and num_sats_can_receive > 0 and amount_sat <= num_sats_can_receive
         try:
             zeroconf_nodeid = extract_nodeid(self.config.ZEROCONF_TRUSTED_NODE)[0]
         except Exception:


### PR DESCRIPTION
Fixes AttributeError when calling `num_sats_can_receive()` while getting a request help text in wallets without lnworker. Fixes https://github.com/spesmilo/electrum/issues/8100#issuecomment-3294556043.

```
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/electrum/gui/qt/request_list.py", line 103, in selection_changed
    self.receive_tab.update_current_request()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/electrum/gui/qt/receive_tab.py", line 237, in update_current_request
    help_texts = self.wallet.get_help_texts_for_receive_request(req)
  File "/usr/lib/python3.13/site-packages/electrum/wallet.py", line 3446, in get_help_texts_for_receive_request
    can_receive = self.lnworker.num_sats_can_receive()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'num_sats_can_receive'
```