### PR TITLE
contrib: "set -e" behaves weird in subshells followed by OR. don't use.

### DIFF
--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -50,7 +50,7 @@ else
     info "not doing fresh clone."
 fi
 
-# build the type2-runtime binary, this build step uses a separate docker container 
+# build the type2-runtime binary, this build step uses a separate docker container
 # defined in the type2-runtime repo (patched with type2-runtime-reproducible-build.patch)
 TYPE2_RUNTIME_REPO_DIR="$PROJECT_ROOT_OR_FRESHCLONE_ROOT/contrib/build-linux/appimage/.cache/appimage/type2-runtime"
 (
@@ -74,7 +74,7 @@ TYPE2_RUNTIME_REPO_DIR="$PROJECT_ROOT_OR_FRESHCLONE_ROOT/contrib/build-linux/app
     rm -rf "$TYPE2_RUNTIME_REPO_DIR/out"
 
     info "runtime build successful: $(sha256sum "$TYPE2_RUNTIME_REPO_DIR/runtime-x86_64")"
-) || fail "Failed to build type2-runtime"
+)
 
 info "building binary..."
 # check uid and maybe chown. see #8261

--- a/contrib/build-linux/appimage/make_appimage.sh
+++ b/contrib/build-linux/appimage/make_appimage.sh
@@ -181,7 +181,7 @@ info "finalizing AppDir."
     mv usr/include usr/include.tmp
     delete_blacklisted
     mv usr/include.tmp usr/include
-) || fail "Could not finalize AppDir"
+)
 
 info "Copying additional libraries"
 (

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -95,7 +95,7 @@ info "Building PyInstaller."
     popd
     # sanity check bootloader is there:
     [[ -e "PyInstaller/bootloader/Windows-$PYINST_ARCH-intel/runw.exe" ]] || fail "Could not find runw.exe in target dir!"
-) || fail "PyInstaller build failed"
+)
 info "Installing PyInstaller."
 $WINE_PYTHON -m pip install --no-build-isolation --no-dependencies --no-warn-script-location ./pyinstaller
 

--- a/contrib/osx/make_osx.sh
+++ b/contrib/osx/make_osx.sh
@@ -117,7 +117,7 @@ PYINSTALLER_COMMIT="306d4d92580fea7be7ff2c89ba112cdc6f73fac1"
     popd
     # sanity check bootloader is there:
     [[ -e "PyInstaller/bootloader/Darwin-64bit/runw" ]] || fail "Could not find runw in target dir!"
-) || fail "PyInstaller build failed"
+)
 info "Installing PyInstaller."
 python3 -m pip install --no-build-isolation --no-dependencies \
     --cache-dir "$PIP_CACHE_DIR" --no-warn-script-location "$CACHEDIR/pyinstaller"
@@ -144,7 +144,7 @@ info "preparing electrum-locale."
     "$CONTRIB/locale/build_cleanlocale.sh"
     # we want the binary to have only compiled (.mo) locale files; not source (.po) files
     rm -r "$PROJECT_ROOT/electrum/locale/locale"/*/electrum.po
-) || fail "failed generating locale"
+)
 
 
 if ls "$DLL_TARGET_DIR"/libsecp256k1.*.dylib 1> /dev/null 2>&1; then


### PR DESCRIPTION
We should avoid using this `(...) || ...` construct as it behaves completely un-intuitively.

This exits as expected:
```
$ cat s1.sh
#!/bin/bash
set -e
(
    echo "a"
    false
    echo "b"
)

$ ./s1.sh
a
```
This does NOT exit, seemingly because of the outer context?!
```
$ cat s2.sh
#!/bin/bash
set -e
(
    echo "a"
    false
    echo "b"
) || echo "c"

$ ./s2.sh
a
b
```

ref https://unix.stackexchange.com/questions/65532/why-does-set-e-not-work-inside-subshells-with-parenthesis-followed-by-an-or