### PR TITLE
cli: add command to export preimage, return preimage from check_hold_invoice

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1514,9 +1514,21 @@ class Commands(Logger):
             plist = wallet.lnworker.get_payments(status='settled')[bfh(payment_hash)]
             _dir, amount_msat, _fee, _ts = wallet.lnworker.get_payment_value(info, plist)
             result["received_amount_sat"] = amount_msat // 1000
+            result['preimage'] = wallet.lnworker.get_preimage_hex(payment_hash)
         if info is not None:
             result["invoice_amount_sat"] = (info.amount_msat or 0) // 1000
         return result
+
+    @command('wl')
+    async def export_lightning_preimage(self, payment_hash: str, wallet: 'Abstract_Wallet' = None) -> Optional[str]:
+        """
+        Returns the stored preimage of the given payment_hash if it is known.
+
+        arg:str:payment_hash: Hash of the preimage
+        """
+        preimage = wallet.lnworker.get_preimage_hex(payment_hash)
+        assert preimage is None or crypto.sha256(bytes.fromhex(preimage)).hex() == payment_hash
+        return preimage
 
     @command('w')
     async def addtransaction(self, tx, wallet: Abstract_Wallet = None):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2930,8 +2930,11 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if x.is_lightning():
             d['rhash'] = x.rhash
             d['lightning_invoice'] = self.get_bolt11_invoice(x)
-            if self.lnworker and status == PR_UNPAID:
-                d['can_receive'] = self.lnworker.can_receive_invoice(x)
+            if self.lnworker:
+                if status == PR_UNPAID:
+                    d['can_receive'] = self.lnworker.can_receive_invoice(x)
+                elif status == PR_PAID and (preimage := self.lnworker.get_preimage(x.payment_hash)):
+                    d['preimage'] = preimage.hex()
         if address := x.get_address():
             d['address'] = address
             d['URI'] = self.get_request_URI(x)


### PR DESCRIPTION
Adds `export_lightning_preimage` cli command to export the preimage for a payment hash.

Adds preimage to the result of `Abstract_Wallet.export_request()` if the request is paid, `export_request()` is exposed in the `get_request` and `list_requests` and `add_request` cli commands. However always exposing the preimage could be unsafe if users of the cli expose the request directly to a payer. 
So if the payee wants to get the preimage before the request has been paid they should export it explicitly with `export_lightning_preimage`. 

Adds preimage to the return value of `check_hold_invoice` if hold invoice has been settled.

Closes https://github.com/spesmilo/electrum/issues/10176