### PR TITLE
trustedcoin: qt: set higher minimumHeight for QR component

### DIFF
--- a/electrum/plugins/trustedcoin/qt.py
+++ b/electrum/plugins/trustedcoin/qt.py
@@ -460,6 +460,18 @@ class WCShowConfirmOTP(WalletWizardComponent):
         self.wizard.trustedcoin_qhelper.otpError.connect(self.on_otp_error)
         self.wizard.trustedcoin_qhelper.remoteKeyError.connect(self.on_remote_key_error)
 
+        # set higher minHeight so the qr code and the input field are shown without scrolling
+        prev_height = self.wizard.height()
+        prev_min_height = self.wizard.minimumHeight()
+        def restore_prev_height():
+            self.wizard.setMinimumHeight(prev_min_height)
+            self.wizard.resize(self.wizard.width(), prev_height)
+            self.wizard.next_button.clicked.disconnect(restore_prev_height)
+            self.wizard.back_button.clicked.disconnect(restore_prev_height)
+        self.wizard.setMinimumHeight(530)
+        self.wizard.next_button.clicked.connect(restore_prev_height)
+        self.wizard.back_button.clicked.connect(restore_prev_height)
+
         self._is_online_continuation = 'seed' not in self.wizard_data
         if self._is_online_continuation:
             self.knownsecretlabel.setText(_('Authenticate below to finalize wallet creation'))


### PR DESCRIPTION
The default minimumHeight for wizard components is a bit small for the 2fa confirmation component as it only shows the QR code but not the input field. This seems to confuse users as its not intuitive to scroll down if there is no large text shown (as for example in the ToS component). This change increases the minimumHeight and restores it to the previous height once the user leaves the component again.

Before:
<img width="620" height="451" alt="Screenshot_20251022_132303" src="https://github.com/user-attachments/assets/10ee35c7-a7ce-4dfa-8ac9-9b693bf751e5" />

After:
<img width="624" height="581" alt="Screenshot_20251022_142222" src="https://github.com/user-attachments/assets/5af03509-998b-47a5-8736-0d42c0ba832d" />
