### PR TITLE
qt: add text to toolbar button

### DIFF
--- a/electrum/gui/qt/my_treeview.py
+++ b/electrum/gui/qt/my_treeview.py
@@ -110,7 +110,9 @@ class QMenuWithConfig(QMenu):
 def create_toolbar_with_menu(config: 'SimpleConfig', title):
     menu = QMenuWithConfig(config)
     toolbar_button = QToolButton()
+    toolbar_button.setText(_('Tools'))
     toolbar_button.setIcon(read_QIcon("preferences.png"))
+    toolbar_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
     toolbar_button.setMenu(menu)
     toolbar_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
     toolbar_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)


### PR DESCRIPTION
The toolbar button is very small and some users probably don't even notice it. As we have lots of space in the toolbar anyways i think it makes sense to add some text to it to make it more visible and easier to click. Maybe this is also useful for screen readers.