### PR TITLE
qt: fix ServerWidget (Network Tab)

### DIFF
--- a/electrum/network.py
+++ b/electrum/network.py
@@ -1155,19 +1155,15 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         chosen_iface = random.choice(interfaces_on_selected_chain)  # type: Interface
         # switch to server (and save to config)
         net_params = self.get_parameters()
-        net_params = net_params._replace(server=chosen_iface.server)
+        # we select a random interface, so set connection mode back to autoconnect
+        net_params = net_params._replace(server=chosen_iface.server, auto_connect=True, oneserver=False)
         await self.set_parameters(net_params)
 
-    async def follow_chain_given_server(self, server: ServerAddr) -> None:
+    def follow_chain_given_server(self, server: ServerAddr) -> None:
         # note that server_str should correspond to a connected interface
-        iface = self.interfaces.get(server)
-        if iface is None:
-            return
+        iface = self.interfaces[server]
         self._set_preferred_chain(iface.blockchain)
-        # switch to server (and save to config)
-        net_params = self.get_parameters()
-        net_params = net_params._replace(server=server)
-        await self.set_parameters(net_params)
+        self.logger.debug(f"following {self.config.BLOCKCHAIN_PREFERRED_BLOCK=}")
 
     def get_server_height(self) -> int:
         """Length of header chain, as claimed by main interface."""


### PR DESCRIPTION
The ServerWidget was not working properly, when switching from "Manual Mode" to "Auto Connect" with an empty server field the change wouldn't get applied (but shown until the next restart) as it depended on having a correct server string entered (which isn't necessary for Auto Connect).
Also makes the widget behave more sane and predictable by cleaning the server input if Auto Connect is enabled and switching to Manual Mode if the user manually selects a server.

Updates the ServerWidget every time it is shown (on initialization and also when the user opens it again or switches between network dialog tabs).
This will clean it up if the user has entered some invalid server and closes it, otherwise this server would stay in the input field until the application is restarted and the widget might show something that doesn't actually represent the current configuration.