### PR TITLE
qt: allow opening BalanceDialog if warning is set and balance is 0

### DIFF
--- a/electrum/gui/qt/balance_dialog.py
+++ b/electrum/gui/qt/balance_dialog.py
@@ -105,6 +105,10 @@ class BalanceToolButton(QToolButton, PieChartObject):
         self._update_size()
         self._warning = False
 
+    @property
+    def has_warning(self) -> bool:
+        return bool(self._warning)
+
     def update_list(self, l, warning: bool):
         self._warning = warning
         self._list = l

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1804,7 +1804,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
     def show_balance_dialog(self):
         balance = self.wallet.get_balances_for_piechart().total()
-        if balance == 0:
+        if balance == 0 and not self.balance_label.has_warning:
             return
         from .balance_dialog import BalanceDialog
         d = BalanceDialog(self, wallet=self.wallet)


### PR DESCRIPTION
Allow to open the BalanceDialog, by clicking on the warning icon in the bottom left corner of the main window, if there is an active warning, even if the wallets balance is 0. 
Right now the user can see the warning icon for the lighting channel reserve, but cannot click on the icon to read the actual warning if there is no balance in the wallet.

<img width="495" height="483" alt="Screenshot_20251029_105025" src="https://github.com/user-attachments/assets/2b83cd50-6f12-43ad-a539-8d91b12f5e2a" />
