### PR TITLE
qt: remove outdated help string in SendTab

### DIFF
--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -111,7 +111,6 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
 
         msg = (_('The amount to be received by the recipient.') + ' '
                + _('Fees are paid by the sender.') + '\n\n'
-               + _('The amount will be displayed in red if you do not have enough funds in your wallet.') + ' '
                + _('Note that if you have frozen some of your addresses, the available funds will be lower than your total balance.') + '\n\n'
                + _('Keyboard shortcut: type "!" to send all your coins.'))
         amount_label = HelpLabel(_('Amount'), msg)


### PR DESCRIPTION
The amount edit box is not turning red anymore if the amount is higher than the wallet balance, so this string can be removed. Alternatively it could be made red again but seems like no one missed it anyways.