### PR TITLE
qt: followup #10277: change icons depending on context

### DIFF
--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -125,7 +125,7 @@ class AddressList(MyTreeView):
         self.main_window.show_address(addr)
 
     def create_toolbar(self, config: 'SimpleConfig'):
-        toolbar, menu = self.create_toolbar_with_menu('')
+        toolbar, menu = self.create_toolbar_with_menu('', 'tab_addresses.png')
         self.num_addr_label = toolbar.itemAt(0).widget()
         self._toolbar_checkbox = menu.addToggle(_("Show Filter"), lambda: self.toggle_toolbar())
         menu.addConfig(config.cv.FX_SHOW_FIAT_BALANCE_FOR_ADDRESSES, callback=self.main_window.app.update_fiat_signal.emit)

--- a/electrum/gui/qt/channels_list.py
+++ b/electrum/gui/qt/channels_list.py
@@ -358,7 +358,7 @@ class ChannelsList(MyTreeView):
         self.can_send_label.setText(msg)
 
     def create_toolbar(self, config):
-        toolbar, menu = self.create_toolbar_with_menu('')
+        toolbar, menu = self.create_toolbar_with_menu('', 'lightning.png')
         self.can_send_label = toolbar.itemAt(0).widget()
         menu.addAction(_('Rebalance channels'), lambda: self.on_rebalance())
         menu.addAction(read_QIcon('update.png'), _('Submarine swap'), lambda: self.main_window.run_swap_dialog())

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -433,6 +433,8 @@ class TxEditor(WindowModalDialog):
         self.pref_menu.addConfig(self.config.cv.WALLET_COIN_CHOOSER_OUTPUT_ROUNDING, callback=self.trigger_update)
         self.pref_button = QToolButton()
         self.pref_button.setIcon(read_QIcon("preferences.png"))
+        self.pref_button.setText(' ' + _('Tools'))
+        self.pref_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.pref_button.setMenu(self.pref_menu)
         self.pref_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         self.pref_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)

--- a/electrum/gui/qt/contact_list.py
+++ b/electrum/gui/qt/contact_list.py
@@ -143,7 +143,7 @@ class ContactList(MyTreeView):
         return self.get_role_data_from_coordinate(row, col, role=self.ROLE_CONTACT_KEY)
 
     def create_toolbar(self, config):
-        toolbar, menu = self.create_toolbar_with_menu('')
+        toolbar, menu = self.create_toolbar_with_menu('', 'tab_contacts.png')
         menu.addAction(_("&New contact"), self.main_window.new_contact_dialog)
         menu.addAction(_("Import"), lambda: self.main_window.import_contacts())
         menu.addAction(_("Export"), lambda: self.main_window.export_contacts())

--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -544,7 +544,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
         self.hide_rows()
 
     def create_toolbar(self, config: 'SimpleConfig'):
-        toolbar, menu = self.create_toolbar_with_menu('')
+        toolbar, menu = self.create_toolbar_with_menu('', 'tab_history.png')
         self.num_tx_label = toolbar.itemAt(0).widget()
         self._toolbar_checkbox = menu.addToggle(_("Filter by Date"), lambda: self.toggle_toolbar())
         self.menu_fiat = menu.addConfig(config.cv.FX_HISTORY_RATES, short_desc=_('Show Fiat Values'), callback=self.main_window.app.update_fiat_signal.emit)

--- a/electrum/gui/qt/my_treeview.py
+++ b/electrum/gui/qt/my_treeview.py
@@ -107,11 +107,11 @@ class QMenuWithConfig(QMenu):
             callback()
 
 
-def create_toolbar_with_menu(config: 'SimpleConfig', title):
+def create_toolbar_with_menu(config: 'SimpleConfig', title, icon_name: str = 'preferences.png'):
     menu = QMenuWithConfig(config)
     toolbar_button = QToolButton()
-    toolbar_button.setText(_('Tools'))
-    toolbar_button.setIcon(read_QIcon("preferences.png"))
+    toolbar_button.setText(' ' + _('Tools'))
+    toolbar_button.setIcon(read_QIcon(icon_name))
     toolbar_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
     toolbar_button.setMenu(menu)
     toolbar_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
@@ -418,8 +418,8 @@ class MyTreeView(QTreeView):
         self.toolbar_buttons = buttons
         return hbox
 
-    def create_toolbar_with_menu(self, title):
-        return create_toolbar_with_menu(self.config, title)
+    def create_toolbar_with_menu(self, title: str, icon: str):
+        return create_toolbar_with_menu(self.config, title, icon)
 
     configvar_show_toolbar = None  # type: Optional[ConfigVarWithConfig]
     _toolbar_checkbox = None  # type: Optional[QAction]

--- a/electrum/gui/qt/receive_tab.py
+++ b/electrum/gui/qt/receive_tab.py
@@ -141,7 +141,7 @@ class ReceiveTab(QWidget, MessageBoxMixin, Logger):
         from .request_list import RequestList
         self.request_list = RequestList(self)
         # toolbar
-        self.toolbar, menu = self.request_list.create_toolbar_with_menu('')
+        self.toolbar, menu = self.request_list.create_toolbar_with_menu('', 'tab_receive.png')
 
         self.toggle_qr_button = QPushButton('')
         self.toggle_qr_button.setIcon(get_icon_qrcode())

--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -182,7 +182,7 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
 
         self.invoices_label = QLabel(_('Invoices'))
         self.invoice_list = InvoiceList(self)
-        self.toolbar, menu = self.invoice_list.create_toolbar_with_menu('')
+        self.toolbar, menu = self.invoice_list.create_toolbar_with_menu('', 'tab_send.png')
 
         add_input_actions_to_context_menu(self.payto_e, menu)
         self.paytomany_menu = menu.addToggle(_("&Pay to many"), self.toggle_paytomany)

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -87,7 +87,7 @@ class UTXOList(MyTreeView):
         self.setSortingEnabled(True)
 
     def create_toolbar(self, config):
-        toolbar, menu = self.create_toolbar_with_menu('')
+        toolbar, menu = self.create_toolbar_with_menu('', 'tab_coins.png')
         self.num_coins_label = toolbar.itemAt(0).widget()
         menu.addAction(_('Coin control'), lambda: self.add_selection_to_coincontrol())
 


### PR DESCRIPTION
Changes the icons of the "Tools" button to the same icon as the tab in which the button is located to make it visible that the available tools are dependent on the buttons context.

<img width="1206" height="188" alt="Screenshot_20251104_142408" src="https://github.com/user-attachments/assets/41f5ca10-8069-4843-970b-e8193064dd84" />
<img width="1213" height="171" alt="Screenshot_20251104_142350" src="https://github.com/user-attachments/assets/45d2c176-69a6-4a7b-88a2-eb606dcd4daa" />
