### PR TITLE
keystore: fix memory leak for LRU cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -225,7 +225,7 @@ task:
         # - https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
         # - https://github.com/PyCQA/flake8-bugbear/tree/8c0e7eb04217494d48d0ab093bf5b31db0921989#list-of-warnings
         ELECTRUM_LINTERS: E9,E101,E129,E273,E274,E703,E71,E722,F5,F6,F7,F8,W191,W29,B,B909
-        ELECTRUM_LINTERS_IGNORE: B007,B009,B010,B019,B036,B042,F541,F841
+        ELECTRUM_LINTERS_IGNORE: B007,B009,B010,B036,B042,F541,F841
     - name: "linter: Flake8 Non-Mandatory"
       env:
         ELECTRUM_LINTERS: E,F,W,C90,B


### PR DESCRIPTION
Using `@functools.lru_cache` on an instance method behaves in interesting ways. The cache kept a ref around for `self`, so in effect we were never GC-ing keystore objects. Effectively there was a single global cache for derive_pubkey, with keys `(keystore, for_change, n)`.

This PR now changes the caching to be per-keystore: each ks has a cache, keyed `(for_change, n)`.
GC-ing individual keystores should now be possible, which should result in cleaning up just their own cache.

This also enables the corresponding previously silenced flake8-bugbear check for `@functools.lru_cache`. (note that the check can selectively be disabled by adding a comment on the relevant line: `# noqa: B019`)