### PR TITLE
lightning: fix race when doing concurrent payments

### DIFF
--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -218,6 +218,7 @@ class MockLNWallet(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         self._payment_bundles_pkey_to_canon = {}       # type: Dict[bytes, bytes]
         self._payment_bundles_canon_to_pkeylist = {}   # type: Dict[bytes, Sequence[bytes]]
         self.config.INITIAL_TRAMPOLINE_FEE_LEVEL = 0
+        self._channel_sending_capacity_lock = asyncio.Lock()
 
         self.logger.info(f"created LNWallet[{name}] with nodeID={local_keypair.pubkey.hex()}")
 


### PR DESCRIPTION
There is a race when initiating multiple lightning payments concurrently
(e.g. when doing a reverse swap with prepayment + swap payment).
suggest_splits might overallocate
split amounts for a channel as the splitting of both invoice amounts runs
concurrently and before acutal htlcs that reduce the channels balance
have been added to the channel yet. This results in a "not
enough balance" PaymentFailure once we try to send the htlcs and the
other payment attempt already reduced the available balance of the
channel.

This fix takes a lock from splitting the amount until the htlcs are
put on the channel, so suggest_splits always acts on the correct channel
balance.