### PR TITLE
qt: SettingsDialog: update ln fee config on slider moved

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -146,10 +146,6 @@ class SettingsDialog(QDialog, QtEventListener):
             pos = lnfee_slider.sliderPosition()
             fee_val = lnfee_map[pos]
             lnfee_update_vlabel(fee_val)
-
-        def lnfee_slider_released():
-            pos = lnfee_slider.sliderPosition()
-            fee_val = lnfee_map[pos]
             self.config.LIGHTNING_PAYMENT_FEE_MAX_MILLIONTHS = fee_val
 
         lnfee_slider = QSlider(Qt.Orientation.Horizontal)
@@ -163,7 +159,6 @@ class SettingsDialog(QDialog, QtEventListener):
         lnfee_vlabel = QLabel("")
         lnfee_update_vlabel(self.config.LIGHTNING_PAYMENT_FEE_MAX_MILLIONTHS)
         lnfee_slider.valueChanged.connect(lnfee_slider_moved)
-        lnfee_slider.sliderReleased.connect(lnfee_slider_released)
         lnfee_hbox = QHBoxLayout()
         lnfee_hbox.setContentsMargins(0, 0, 0, 0)
         lnfee_hbox.addWidget(lnfee_vlabel)


### PR DESCRIPTION
When moving the lightning fee slider in the SettingsDialog by clicking on the range instead of pulling the slider the new fee value wouldn't get stored in the config as the sliderRelased signal is only emitted when the slider is pulled.
This change updates it on valueChanged.