### PR TITLE
electrum refuses to exchange gossip with CLN nodes, due to missing feature OPTION_CHANNEL_TYPE_OPT

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -162,7 +162,7 @@ class ErrorAddingPeer(Exception): pass
 
 
 # set some feature flags as baseline for both LNWallet and LNGossip
-# note that e.g. DATA_LOSS_PROTECT is needed for LNGossip as many peers require it
+# note that e.g. DATA_LOSS_PROTECT and OPTION_CHANNEL_TYPE_OPT are needed for LNGossip as many peers require it
 BASE_FEATURES = (
     LnFeatures(0)
     | LnFeatures.OPTION_DATA_LOSS_PROTECT_OPT
@@ -170,6 +170,7 @@ BASE_FEATURES = (
     | LnFeatures.VAR_ONION_OPT
     | LnFeatures.PAYMENT_SECRET_OPT
     | LnFeatures.OPTION_UPFRONT_SHUTDOWN_SCRIPT_OPT
+    | LnFeatures.OPTION_CHANNEL_TYPE_OPT
 )
 
 # we do not want to receive unrequested gossip (see lnpeer.maybe_save_remote_update)
@@ -182,7 +183,6 @@ LNWALLET_FEATURES = (
     | LnFeatures.BASIC_MPP_OPT
     | LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT_ELECTRUM
     | LnFeatures.OPTION_SHUTDOWN_ANYSEGWIT_OPT
-    | LnFeatures.OPTION_CHANNEL_TYPE_OPT
     | LnFeatures.OPTION_SCID_ALIAS_OPT
     | LnFeatures.OPTION_SUPPORT_LARGE_CHANNEL_OPT
 )


### PR DESCRIPTION
Not sure if we should advertise this feature or if CLN should relax gossip-only connections, but this PR is a 
workaround, adds CHANNEL_TYPE to BASE_FEATURES.
