### PR TITLE
qt: make ElectrumWindow.lightning_button wider

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1941,7 +1941,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             self.lightning_button.setText('')
             self.lightning_button.setToolTip(_("The Lightning Network graph is fully synced."))
         else:
-            self.lightning_button.setMaximumWidth(25 + 5 * char_width_in_lineedit())
+            self.lightning_button.setMaximumWidth(25 + 6 * char_width_in_lineedit())
             self.lightning_button.setText(progress_str)
             self.lightning_button.setToolTip(_("The Lightning Network graph is syncing...\n"
                                                "Payments are more likely to succeed with a more complete graph."))


### PR DESCRIPTION
Qt was showing the lightning_button percentage string while syncing gossip as `...` instead of the percentage as the minimum width of the button seemed too small. Increasing this a bit fixes the issue.

<img width="301" height="85" alt="Screenshot_20251212_094401" src="https://github.com/user-attachments/assets/5cadb361-ab82-4ef1-a63f-dd57e8506ed0" />
<img width="306" height="69" alt="Screenshot_20251212_094518" src="https://github.com/user-attachments/assets/ffc7fb2a-59bc-4ea7-942f-68624e74b2cc" />
