### PR TITLE
qt: trustedcoin: only allow signing with broadcast

### DIFF
--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -370,7 +370,13 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
                 tx.swap_payment_hash = swap.payment_hash
 
         if is_preview:
-            self.window.show_transaction(tx, external_keypairs=external_keypairs, invoice=invoice)
+            self.window.show_transaction(
+                tx,
+                external_keypairs=external_keypairs,
+                invoice=invoice,
+                show_sign_button=self.wallet.wallet_type != '2fa',
+                show_broadcast_button=self.wallet.wallet_type != '2fa',
+            )
             return
         self.save_pending_invoice()
         def sign_done(success):


### PR DESCRIPTION
Only allow signing a transaction if it also gets broadcast by disabling the `Sign` and `Broadcast` button of the preview dialog when creating a new tx, so the 'only' way to sign is by clicking `Ok` in the `ConfirmTxDialog` which will then automatically broadcast the tx. Makes it a bit less trivial to accidentally not pay the service fees.