### PR TITLE
qml: QERequestDetails process request update via event loop.

### DIFF
--- a/electrum/gui/qml/qerequestdetails.py
+++ b/electrum/gui/qml/qerequestdetails.py
@@ -16,7 +16,7 @@ from electrum.network import Network
 
 from .qewallet import QEWallet
 from .qetypes import QEAmount
-from .util import QtEventListener, event_listener, status_update_timer_interval
+from .util import QtEventListener, qt_event_listener, status_update_timer_interval
 
 
 class QERequestDetails(QObject, QtEventListener):
@@ -65,7 +65,7 @@ class QERequestDetails(QObject, QtEventListener):
             self._timer.stop()
             self._timer = None
 
-    @event_listener
+    @qt_event_listener
     def on_event_request_status(self, wallet, key, status):
         if wallet == self._wallet.wallet and key == self._key:
             self._logger.debug('request status %d for key %s' % (status, key))


### PR DESCRIPTION
This allows backend to process all callbacks before we start querying the payment database

should fix #10116

Before this change, within `on_event_request_status` the payment was consistently not in lightning history in state `settled`, with this change, it usually (well, at least during my testing, it might still race with backend moving payment to `settled` state) it is. 

