### PR TITLE
interface: remove prefix from donation addresses

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -1560,12 +1560,15 @@ class Interface(Logger):
         # check response
         if not res:  # ignore empty string
             return ''
-        if not bitcoin.is_address(res):
+        if not isinstance(res, str):
+            raise RequestCorrupted(f'{res!r} should be a str')
+        address = res.removeprefix('bitcoin:')
+        if not bitcoin.is_address(address):
             # note: do not hard-fail -- allow server to use future-type
             #       bitcoin address we do not recognize
             self.logger.info(f"invalid donation address from server: {repr(res)}")
-            res = ''
-        return res
+            return ''
+        return address
 
     async def get_relay_fee(self) -> int:
         """Returns the min relay feerate in sat/kbyte."""


### PR DESCRIPTION
Some servers seem to serve their donation address with `bitcoin:` prefix, preventing them from getting donations. This removes the prefix.

E.g.:
```
262.63 | I | interface.[2ex.digitaleveryware.com:50002] | invalid donation address from server: 'bitcoin:bc1q0q6lcajak7r8h8c8luzp0zj35v0usqd4pdzqjg'
```