### PR TITLE
lnpeer: fix callback exception handling, fix type hint

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -8,7 +8,7 @@ from collections import OrderedDict, defaultdict
 import asyncio
 import os
 import time
-from typing import Tuple, Dict, TYPE_CHECKING, Optional, Union, Set, Callable, Awaitable, List
+from typing import Tuple, Dict, TYPE_CHECKING, Optional, Union, Set, Callable, Coroutine, List, Any
 from datetime import datetime
 import functools
 from functools import partial
@@ -2972,7 +2972,7 @@ class Peer(Logger, EventListener):
     ) -> Tuple[
         Optional[Union[OnionRoutingFailure, OnionFailureCode, bytes]],  # error types used to fail the set
         Optional[bytes],  # preimage to settle the set
-        Optional[Callable[[], Awaitable[None]]],  # callback
+        Optional[Callable[[], Coroutine[Any, Any, None]]],  # callback
     ]:
         """
         Returns what to do next with the given set of htlcs:


### PR DESCRIPTION
The done_callback for the callback tasks in _run_htlc_switch_iteration
tried to access mpp_sets by key but they might already have been deleted
when the callback is called, causing an KeyError. Instead forward the
exceptions to the crash reporter so we get notice of them and they get
logged correctly.

```
20251219T131356.946565Z |    ERROR | asyncio | Exception in callback Peer._run_htlc_switch_iteration.<locals>.<lambda>(<Task finishe.../util.py:1773>) at /home/user/code/electrum-fork/electrum/lnpeer.py:2907
handle: <Handle Peer._run_htlc_switch_iteration.<locals>.<lambda>(<Task finishe.../util.py:1773>) at /home/user/code/electrum-fork/electrum/lnpeer.py:2907 created at /usr/lib64/python3.14/asyncio/events.py:94>
source_traceback: Object created at (most recent call last):
  File "/usr/lib64/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
  File "/home/user/code/electrum-fork/electrum/util.py", line 1145, in run_with_except_hook
    run_original(*args2, **kwargs2)
  File "/usr/lib64/python3.14/threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
  File "/home/user/code/electrum-fork/electrum/util.py", line 1705, in run_event_loop
    loop.run_until_complete(stopping_fut)
  File "/usr/lib64/python3.14/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "/usr/lib64/python3.14/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "/usr/lib64/python3.14/asyncio/base_events.py", line 2038, in _run_once
    handle._run()
  File "/usr/lib64/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
Traceback (most recent call last):
  File "/usr/lib64/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/lnpeer.py", line 2909, in <lambda>
    f"{self.lnworker.received_mpp_htlcs[pk]=}", exc_info=t.exception()) if t.exception() else None
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
KeyError: '0000980000010001:1'
```