### PR TITLE
pi: fix incorrectly parsing emaillike with 'ln' prefix as bech32 ln pi

### DIFF
--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -293,9 +293,9 @@ class PaymentIdentifier(Logger):
                 self._type = PaymentIdentifierType.EMAILLIKE
                 self.emaillike = contact['address']
                 self.set_state(PaymentIdentifierState.NEED_RESOLVE)
-        elif re.match(RE_EMAIL, text):
+        elif re.match(RE_EMAIL, (maybe_emaillike := remove_uri_prefix(text, prefix=LIGHTNING_URI_SCHEME))):
             self._type = PaymentIdentifierType.EMAILLIKE
-            self.emaillike = text
+            self.emaillike = maybe_emaillike
             self.set_state(PaymentIdentifierState.NEED_RESOLVE)
         elif re.match(RE_DOMAIN, text):
             self._type = PaymentIdentifierType.DOMAINLIKE

--- a/tests/test_payment_identifier.py
+++ b/tests/test_payment_identifier.py
@@ -378,6 +378,11 @@ class TestPaymentIdentifier(ElectrumTestCase):
             'lnbcuser@some.domain',
             'lnurluser@some.domain',
             'bc1quser@some.domain',
+            'lightning:user@some.domain',
+            'lightning:user@some.weird.but.valid.domain',
+            'lightning:lnbcuser@some.domain',
+            'lightning:lnurluser@some.domain',
+            'lightning:bc1quser@some.domain',
         )
         for pi_str in email_pi_strings:
             pi = PaymentIdentifier(None, pi_str)


### PR DESCRIPTION
On master we incorrectly attempt to parse email like payment identifiers beginning with a 'ln' prefix as bech32 lightning payment identifiers. This obviously fails and the pi is reported to be invalid. E.g. `lntest@lnaddress.com` cannot be paid.

Also allows email like payment identifiers starting with `lightning:` uri prefix. I encountered this on a website and it makes sense to put a `lightning:` in front of a lightning address as the device somehow needs to differentiate between a email address and a lightning address, so we should allow this construction as well.