### PR TITLE
android build: bump python version (3.10.18->3.11.14)

### DIFF
--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -207,7 +207,7 @@ RUN cd /opt \
     && /opt/venv/bin/python3 -m pip install --no-build-isolation --no-dependencies -e .
 
 # install python-for-android
-ENV P4A_CHECKOUT_COMMIT="e91310fbf88857b2fbd9f9a5f591300ae5da90b5"
+ENV P4A_CHECKOUT_COMMIT="a01269f7799587ad74ee40e0b642d917b8db7d4e"
 # ^ from branch electrum_20251211 (note: careful with force-pushing! see #8162)
 RUN cd /opt \
     && git clone https://github.com/spesmilo/python-for-android \

--- a/contrib/android/p4a_recipes/hostpython3/__init__.py
+++ b/contrib/android/p4a_recipes/hostpython3/__init__.py
@@ -11,8 +11,9 @@ assert HostPython3Recipe.python_depends == []
 
 
 class HostPython3RecipePinned(util.InheritedRecipeMixin, HostPython3Recipe):
-    version = "3.10.18"
-    sha512sum = "494a76de4e92122b9722240d6c33a3e2345072240e0b60938010bc6da34ec7ff7961f329585c140cb6ea0a254d987f1e4b1a678ba9ec7d8feeb8bb262be65a06"
+    # PYTHON_VERSION=    # < line here so that I can grep the codebase and teleport here
+    version = "3.11.14"
+    sha512sum = "41fb3ae22ce4ac0e8bb6b9ae8db88a810af1001d944e3f1abc9e86824ae4be31347e3e3a70425ab12271c6b7eeef552f00164ef23cfffa2551c3c9d1fe5ab91f"
 
 
 recipe = HostPython3RecipePinned()

--- a/contrib/android/p4a_recipes/python3/__init__.py
+++ b/contrib/android/p4a_recipes/python3/__init__.py
@@ -11,8 +11,9 @@ assert Python3Recipe.python_depends == []
 
 
 class Python3RecipePinned(util.InheritedRecipeMixin, Python3Recipe):
-    version = "3.10.18"
-    sha512sum = "494a76de4e92122b9722240d6c33a3e2345072240e0b60938010bc6da34ec7ff7961f329585c140cb6ea0a254d987f1e4b1a678ba9ec7d8feeb8bb262be65a06"
+    # PYTHON_VERSION=    # < line here so that I can grep the codebase and teleport here
+    version = "3.11.14"
+    sha512sum = "41fb3ae22ce4ac0e8bb6b9ae8db88a810af1001d944e3f1abc9e86824ae4be31347e3e3a70425ab12271c6b7eeef552f00164ef23cfffa2551c3c9d1fe5ab91f"
 
 
 recipe = Python3RecipePinned()


### PR DESCRIPTION
Bump the python version used on Android from 3.10 to 3.11.
The substance is the [backport](https://github.com/SomberNight/python-for-android/commit/a01269f7799587ad74ee40e0b642d917b8db7d4e) of the corresponding commit `[0]` from upstream p4a.

I tested the apk is still reproducible by doing two full builds. I also used the apk a bit and it seems to work at runtime. :)

`[0]`: https://github.com/kivy/python-for-android/pull/2850/commits/78db83223f4f481598343237a6b8788fb4731a00  (which got squashed into https://github.com/kivy/python-for-android/commit/83e74cac0fa230231f63b7d7e4f1e8581fd9e2ce)