### PR TITLE
AddressSynchronizer: invalidate balance cache on spv

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -652,6 +652,7 @@ class AddressSynchronizer(Logger, EventListener):
         with self.lock:
             self.unverified_tx.pop(tx_hash, None)
             self.db.add_verified_tx(tx_hash, info)
+            self.invalidate_cache()
         util.trigger_callback('adb_added_verified_tx', self, tx_hash)
 
     @with_lock


### PR DESCRIPTION
There was a race incorrectly counting transactions with one
confirmations to the unconfirmed balance instead of the confirmed
balance (in the pie chart and the qml total balance shown above the history).

This happened because the balance cache of AddressSynchronizer got
invalidated after `on_event_blockchain_updated` and then again after
`receive_history_callback`->`add_transaction`, however when calling
`AddressSynchronizer.get_balance()` before the tx got spv verified the
height would still be counted as 0 (unconfirmed), populating the balance
cache again with the unconfirmed balance.

I noticed this only on QML due to timing differences to Qt.
Invalidating the cache in `AddressSynchronizer.add_verified_tx()` after
the tx got verified causes the balance to get recalculated and shown
correctly.