### PR TITLE
qt: WalletInfoDialog: sort keystores by root fingerprint

### DIFF
--- a/electrum/gui/qt/wallet_info_dialog.py
+++ b/electrum/gui/qt/wallet_info_dialog.py
@@ -112,7 +112,7 @@ class WalletInfoDialog(WindowModalDialog):
         labels_clayout = None
 
         if wallet.is_deterministic():
-            keystores = wallet.get_keystores()
+            keystores = sorted(wallet.get_keystores(), key=lambda _ks: _ks.get_root_fingerprint() or '')
 
             self.keystore_tabs = QTabWidget()
 


### PR DESCRIPTION
Sort the keystore tabs of the WalletInfoDialog by their root fingerprints. This makes it less confusing when looking at different wallet instances of the same multisig setup as the tabs will always have the same order.

Before:
<img width="1915" height="301" alt="Screenshot_20260108_091023" src="https://github.com/user-attachments/assets/2d35aaa1-bac9-4008-85c3-7742a22abcc2" />

After:
<img width="1913" height="324" alt="Screenshot_20260108_093809" src="https://github.com/user-attachments/assets/24d4ec7e-b19a-402b-9633-994907b84c46" />
