### PR TITLE
qml: add close no-op to QEQRScanner to fix type error

### DIFF
--- a/electrum/gui/qml/qeqrscanner.py
+++ b/electrum/gui/qml/qeqrscanner.py
@@ -56,6 +56,11 @@ class QEQRScanner(QObject):
         activity.bind(on_activity_result=self.on_qr_activity_result)
         jpythonActivity.startActivityForResult(intent, 0)
 
+    @pyqtSlot()
+    def close(self):
+        # no-op to prevent qml type error
+        pass
+
     def on_qr_activity_result(self, requestCode, resultCode, intent):
         try:
             if resultCode == -1:  # RESULT_OK:


### PR DESCRIPTION
Adds close() no-op method to `QEQRScanner` class to prevent this type error (and similar ones calling close on a QEQRScanner dialog):

```
01-02 17:28:09.645 10543 10565 I python  : 162.27 | W | gui.qml.qeapp | file:///data/data/org.electrum.electrum/files/app/electrum/gui/qml/components/SweepDialog.qml:123: TypeError: Property 'close' of object QEQRScanner(0xdd32f66fb600)
is not a function
```

The call to close() is only required for the desktop qml scanner dialog, on android it can be a no-op as the scanner is the java activity view.