### PR TITLE
test_lnpeer: use PeerInTests instead if Peer

### DIFF
--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -535,7 +535,7 @@ class TestPeer(ElectrumTestCase):
 
         # create peers
         for ab in channels.keys():
-            peers[ab] = Peer(workers[ab[0]], keys[ab[1]].pubkey, transports[ab])
+            peers[ab] = PeerInTests(workers[ab[0]], keys[ab[1]].pubkey, transports[ab])
 
         # add peers to workers
         for a, w in workers.items():


### PR DESCRIPTION
ec65c53 (unintentionally?) replaces the usage of `PeerInTest` with `Peer` in test_lnpeer.py.
`PeerInTests` sets `Peer.DELAY_INC_MSG_PROCESSING_SLEEP` to 0 so all incoming messages get processed immediately. Because `Peer` was used instead of `TestInPeer` the delay caused `test_reestablish_with_old_state` to fail regularly because Bob receives the old channel state and kills the OldTaskGroup of the unittest with `GracefulDisconnect` before Alice processed the answer of Bob and is still in `ChannelState.REESTABLISHING` when being cancelled.

```
FAILED tests/test_lnpeer.py::TestPeerDirect::test_reestablish_with_old_state - AssertionError: <PeerState.REESTABLISHING: 1> != <PeerState.BAD: 3>
```