### PR TITLE
ExchangeRate: return NaN if rate is 0

### DIFF
--- a/electrum/exchange_rate.py
+++ b/electrum/exchange_rate.py
@@ -209,7 +209,7 @@ class ExchangeBase(Logger):
         if ccy == 'BTC':
             return Decimal(1)
         rate = self._quotes.get(ccy)
-        if rate is None:
+        if not rate:  # don't return 0 to prevent DivisionByZero exceptions
             return Decimal('NaN')
         if self._quotes_timestamp + SPOT_RATE_EXPIRY < time.time():
             # Our rate is stale. Probably better to return no rate than an incorrect one.


### PR DESCRIPTION
Prevent `DivisionByZero` exceptions by returning `Decimal('NaN')` instead of `Decimal(0)` if the exchange rate is 0.

Fixes https://github.com/spesmilo/electrum/issues/10403

```
>>> bool(Decimal(0))
False
```