### PR TITLE
qml: fix invalid QEInvoiceParser state

### DIFF
--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -451,7 +451,7 @@ class QEInvoiceParser(QEInvoice):
 
     @pyqtSlot(object)
     def fromResolvedPaymentIdentifier(self, resolved_pi: PaymentIdentifier) -> None:
-        self.canPay = False
+        self.clear()
         self.amountOverride = QEAmount()
         if resolved_pi:
             assert not resolved_pi.need_resolve()
@@ -653,7 +653,8 @@ class QEInvoiceParser(QEInvoice):
         if orig_amount * 1000 != invoice.amount_msat:  # TODO msat precision can cause trouble here
             raise Exception('Unexpected amount in invoice, differs from lnurl-pay specified amount')
 
-        self.fromResolvedPaymentIdentifier(
+        self.amountOverride = QEAmount()
+        self.validateRecipient(
             PaymentIdentifier(self._wallet.wallet, invoice.lightning_invoice)
         )
 


### PR DESCRIPTION
Fixes #10406  .
When scanning a lightning invoice we would pass it to `QEInvoiceParser.fromResolvedPaymentIdentifier()`, however `fromResolvedPaymentIdentifier()` doesn't reset the state of `QEInvoiceParser._lnurlData` which is used in QML to evaluate `payImmediately: invoiceParser.isLnurlPay` in the `onValidationSuccess` connection.

This change calls `clear()` in `fromResolvedPaymentIdentifier()` to ensure that `QEInvoiceParser` state gets reset when loading a new invoice. However when retrieving a bolt11 from a lnurl-pay callback we don't wan't to reset `QEInvoiceParser._lnurlData` so that `payImmediately` is true when confirming the lnurl pay dialog, for that I skip calling `fromResolvedPaymentIdentifier()` and instead call `validateRecipient()` directly so the `QEInvoiceParser` state doesn't get reset in this case.