### PR TITLE
lnutil: change ReceivedMPPStatus.htlcs to frozenset, i.e. immutable

### DIFF
--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1980,7 +1980,7 @@ class ReceivedMPPHtlc(NamedTuple):
 
 class ReceivedMPPStatus(NamedTuple):
     resolution: RecvMPPResolution
-    htlcs: set[ReceivedMPPHtlc]
+    htlcs: frozenset[ReceivedMPPHtlc]
     # parent_set_key is needed as trampoline allows MPP to be nested, the parent_set_key is the
     # payment key of the final mpp set (derived from inner trampoline onion payment secret)
     # to which the separate trampoline sets htlcs get added once they are complete.
@@ -2005,7 +2005,7 @@ class ReceivedMPPStatus(NamedTuple):
     @stored_in('received_mpp_htlcs', tuple)
     def from_tuple(resolution, htlc_list, parent_set_key=None) -> 'ReceivedMPPStatus':
         assert isinstance(resolution, int)
-        htlc_set = set(ReceivedMPPHtlc.from_tuple(*htlc_data) for htlc_data in htlc_list)
+        htlc_set = frozenset(ReceivedMPPHtlc.from_tuple(*htlc_data) for htlc_data in htlc_list)
         return ReceivedMPPStatus(
             resolution=RecvMPPResolution(resolution),
             htlcs=htlc_set,

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -331,7 +331,7 @@ class MyEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             # note: if there is a timezone specified, this will include the offset
             return obj.isoformat(' ', timespec="minutes")
-        if isinstance(obj, set):
+        if isinstance(obj, (set, frozenset)):
             return list(obj)
         if isinstance(obj, bytes): # for nametuples in lnchannel
             return obj.hex()


### PR DESCRIPTION
As ThomasV says:

> ReceivedMPPStatus is a Namedtuple, which is immutable, but it contains
> a mutable field. Since ReceivedMPPStatus is not a StoredObject,
> no patch will be created when the htlcs list is modified, and we may
> end up not saving the change to disk if partial writes are enabled.

patch taken from https://github.com/spesmilo/electrum/pull/10395#pullrequestreview-3634244541
closes https://github.com/spesmilo/electrum/pull/10395