### PR TITLE
Skip write on read-only config file

### DIFF
--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -455,9 +455,12 @@ class SimpleConfig(Logger):
             with open(path, "w", encoding='utf-8') as f:
                 os_chmod(path, stat.S_IREAD | stat.S_IWRITE)  # set restrictive perms *before* we write data
                 f.write(s)
+        except PermissionError:
+            # Skip write if we don't have permission... e.g. read-only config file
+            return
         except OSError:
             # datadir probably deleted while running... e.g. portable exe running on ejected USB drive
-            # (in which case it is typically either FileNotFoundError or PermissionError,
+            # (in which case it is typically FileNotFoundError,
             #  but let's just catch the more generic OSError and test explicitly)
             if os.path.exists(self.path):  # or maybe not?
                 raise


### PR DESCRIPTION
**Motive:** When you open electrum, it opens your last used wallet **immediately**, which may be undesirable if that happened to be a hidden / large balance wallet, from people who are near you.

**Current behaviour:** On application startup, a read-only config file results in a "Cannot load wallet" exception, as it tries to write the config key/value for "recently_open" and "current_wallet".

**Improvement:** Separate the PermissionError exception from the more generic OSError exception, and continue.
