### PR TITLE
lnpeer: log name of wallet file in each line

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -199,7 +199,8 @@ class Peer(Logger, EventListener):
         return chan
 
     def diagnostic_name(self):
-        return self.lnworker.__class__.__name__ + ', ' + self.transport.name()
+        lnw_name = self.lnworker.diagnostic_name() or self.lnworker.__class__.__name__
+        return lnw_name + ', ' + self.transport.name()
 
     async def ping_if_required(self):
         if time.time() - self.last_message_time > 30:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -225,7 +225,6 @@ class LNPeerManager(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         features: LnFeatures,
         config: 'SimpleConfig',
     ):
-        Logger.__init__(self)
         NetworkRetryManager.__init__(
             self,
             max_retry_delay_normal=3600,
@@ -236,6 +235,7 @@ class LNPeerManager(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         self.lock = threading.RLock()
         self.node_keypair = node_keypair
         self._lnwallet_or_lngossip = lnwallet_or_lngossip
+        Logger.__init__(self)
         self._peers = {}  # type: Dict[bytes, Peer]  # pubkey -> Peer  # needs self.lock
         self._channelless_incoming_peers = set()  # type: Set[bytes]  # node_ids  # needs self.lock
         self.taskgroup = OldTaskGroup()
@@ -245,6 +245,10 @@ class LNPeerManager(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         self.config = config
         self.stopping_soon = False  # whether we are being shut down
         self.register_callbacks()
+
+    def diagnostic_name(self):
+        lnw = self._lnwallet_or_lngossip
+        return lnw.diagnostic_name() or lnw.__class__.__name__
 
     @property
     def channel_db(self) -> 'ChannelDB':


### PR DESCRIPTION
- if multiple LN-enabled wallets are open, need to know which peer is for which wallet
- note: LNGossip is a singleton
  - if a wallet is named LNGossip, can't distinguish. I think that's ok.

compare log lines:
before:
```
84.82 | I | lnpeer.Peer.[LNWallet, 034cc6216f-f8dcaa6e] | Disconnecting: GracefulDisconnect('Failed to initialize: TimeoutError()')
17.97 | D | lnpeer.Peer.[LNGossip, 0259d4116d-1618547b] | Sending INIT
```
after:
```
 5.80 | D | lnpeer.Peer.[test_segwit_2, 038863cf8a-fd53ef9c] | Sending CHANNEL_READY
 5.92 | D | lnpeer.Peer.[LNGossip, 038863cf8a-6286ffd4] | Received INIT
```