### PR TITLE
qml: fix: allow opening passwordless wallets

### DIFF
--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -192,12 +192,15 @@ class QEDaemon(AuthMixin, QObject):
 
         self._logger.debug('load wallet ' + str(self._path))
 
-        # map empty string password to None
+        # password unification helper:
+        # - if pw not given (None), try pw of current wallet.
+        # - but "" empty str passwords are kept as-is, to open passwordless wallets
+        if password is None:
+            password = self._password
+
+        # map explicit empty str password to None. the backend disallows empty str passwords.
         if password == '':
             password = None
-
-        if not password:
-            password = self._password
 
         wallet_already_open = self.daemon.get_wallet(self._path)
         if wallet_already_open is not None:


### PR DESCRIPTION
This must be an old regression.
The GUI was not allowing to open a wallet that did not have a password set: it prompted for a password and did not accept any string (should at least accept empty "").

Without this, it was only possible to open a passwordless wallet if that was the first wallet the user opened (as otherwise we would overwrite the empty pw with the pw of the current wallet).