### PR TITLE
util: use FileNotFoundError for dangling symlink

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -1172,7 +1172,7 @@ def make_dir(path, *, allow_symlink=True):
     """
     if not os.path.exists(path):
         if not allow_symlink and os.path.islink(path):
-            raise Exception('Dangling link: ' + path)
+            raise FileNotFoundError('Dangling link: ' + path)
         try:
             os.mkdir(path)
         except FileExistsError:


### PR DESCRIPTION
Use FileNotFoundError instead of a generic Exception when a dangling
symlink is encountered.

This makes the error type more precise without changing behavior.
