### PR TITLE
qml: PasswordDialog: show error on invalid password

### DIFF
--- a/electrum/gui/qml/components/PasswordDialog.qml
+++ b/electrum/gui/qml/components/PasswordDialog.qml
@@ -14,8 +14,10 @@ ElDialog {
     iconSource: Qt.resolvedUrl('../../icons/lock.png')
 
     property bool confirmPassword: false
-    property string password
     property string infotext
+    property string errorMessage
+
+    signal passwordEntered(string password)
 
     anchors.centerIn: parent
     width: parent.width * 4/5
@@ -84,6 +86,16 @@ ElDialog {
                     password: pw_1.text
                 }
             }
+
+            Label {
+                Layout.maximumWidth: parent.width
+                Layout.alignment: Qt.AlignHCenter
+                text: errorMessage
+                wrapMode: Text.Wrap
+                visible: errorMessage
+                color: constants.colorError
+                font.pixelSize: constants.fontSizeLarge
+            }
         }
 
         FlatButton {
@@ -92,10 +104,13 @@ ElDialog {
             icon.source: '../../icons/confirmed.png'
             enabled: confirmPassword ? pw_1.text.length >= 6 && pw_1.text == pw_2.text : true
             onClicked: {
-                password = pw_1.text
-                passworddialog.doAccept()
+                passwordEntered(pw_1.text)
             }
         }
     }
 
+    function clearPassword() {
+        pw_1.text = ""
+        pw_2.text = ""
+    }
 }

--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -852,11 +852,13 @@ ApplicationWindow
         // 'payment_auth' should have been converted to 'wallet' at this point
         if (method === 'wallet' || method === 'wallet_password_only') {
             var dialog = app.passwordDialog.createObject(app, authMessage ? {'title': authMessage} : {})
-            dialog.accepted.connect(function() {
-                if (Daemon.currentWallet.verifyPassword(dialog.password)) {
+            dialog.passwordEntered.connect(function(password) {
+                if (Daemon.currentWallet.verifyPassword(password)) {
+                    dialog.close()
                     qtobject.authProceed()
                 } else {
-                    qtobject.authCancel()
+                    dialog.clearPassword()
+                    dialog.errorMessage = qsTr("Invalid Password")
                 }
             })
             dialog.rejected.connect(function() {


### PR DESCRIPTION
Currently the PasswordDialog on QML would just close if the user enters an incorrect password. This is confusing as the user doesn't know why the dialog closed and if it initiated any action or not.

With the change the PasswordDialog will get the ability to show an error message and will show "Invalid Password" if an incorrect password is entered.
I also used it for the password unification warning ("Need to enter similar password ...") instead of showing a separate popup.

<img width="477" height="413" alt="Screenshot_20260120_123858" src="https://github.com/user-attachments/assets/03504a11-71a9-4c6b-afb1-e70ef78dcbe6" />
