### PR TITLE
plugin: make DeviceMgr.run non-blocking, fix lock

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -378,10 +378,14 @@ class DaemonThread(threading.Thread, Logger):
         # malformed or malicious server responses
         with self.job_lock:
             for job in self.jobs:
+                start = time.perf_counter()
                 try:
                     job.run()
                 except Exception as e:
                     self.logger.exception('')
+                duration = time.perf_counter() - start
+                if duration > 0.5:
+                    self.logger.warning(f"thread job {job} blocked {self} DaemonThread for {duration:.2f} s")
 
     def remove_jobs(self, jobs):
         with self.job_lock:


### PR DESCRIPTION
If something in the `_hwd_comms_executor` thread is waiting for user input, e.g. when setting up a hww in the wizard the user needs to unlock the hww for `HardwareClientBase.get_xpub()` to return, the `_hwd_comms_executor` is blocked. If then `DeviceMgr.run()` gets called by the `Plugins` `DaemonThread` concurrently and tries to check the hww timeout on the `_hwd_comms_executor` as well, the `DaemonThread` is blocked too until the `_hwd_comms_executor` continues (and the `DaemonThread.job_lock` is taken.

Now if something tries to take the `DaemonThread.job_lock` it blocks as well, as it is taken while the jobs are being executed, so if a user e.g. tries to load a new plugin from the plugins dialog the whole gui thread will freeze until the hww gets unlocked.

To fix this I schedule the timeout check to run on the thread instead of awaiting its result, this way the `Plugins` `DaemonThread` doesn't get blocked.

There was a similar issue in https://github.com/Electron-Cash/Electron-Cash/pull/3173, but their approach is different. I think its better if `DeviceMgr.run()` doesn't block the `Plugins` `DaemonThread` as other jobs might also want to run.