### PR TITLE
qt: add Changelog to Help menu in toolbar

### DIFF
--- a/electrum/constants.py
+++ b/electrum/constants.py
@@ -57,6 +57,7 @@ def create_fallback_node_list(fallback_nodes_dict: dict[str, dict]) -> List[LNPe
 
 GIT_REPO_URL = "https://github.com/spesmilo/electrum"
 GIT_REPO_ISSUES_URL = "https://github.com/spesmilo/electrum/issues"
+RELEASE_NOTES_URL = "https://raw.githubusercontent.com/spesmilo/electrum/refs/heads/master/RELEASE-NOTES"
 BIP39_WALLET_FORMATS = read_json('bip39_wallet_formats.json')
 
 

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -847,6 +847,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             about_action.triggered.connect(self.show_about)
             about_action.setMenuRole(QAction.MenuRole.AboutRole)  # make sure OS recognizes it as "About"
             self.help_menu.addAction(about_action)
+        self.help_menu.addAction(_("&Changelog"), lambda: webopen(constants.RELEASE_NOTES_URL))
         self.help_menu.addAction(_("&Check for updates"), self.show_update_check)
         self.help_menu.addAction(_("&Official website"), lambda: webopen("https://electrum.org"))
         self.help_menu.addSeparator()


### PR DESCRIPTION
Adds a `Changelog` item to the Help menu of the toolbar. Clicking on the item opens the changelog in the browser (github text-only form). 

<img width="439" height="280" alt="Screenshot_20260122_155817" src="https://github.com/user-attachments/assets/413fc753-3047-454d-addb-716497cd0abb" />
