### PR TITLE
build: appimage: fix fresh_clone builds for type2-runtime

### DIFF
--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -48,7 +48,7 @@ fi
 
 # build the type2-runtime binary, this build step uses a separate docker container
 # defined in the type2-runtime repo (patched with type2-runtime-reproducible-build.patch)
-"$CONTRIB_APPIMAGE/make_type2_runtime.sh" || fail "Error building type2-runtime."
+"$PROJECT_ROOT_OR_FRESHCLONE_ROOT/contrib/build-linux/appimage/make_type2_runtime.sh" || fail "Error building type2-runtime."
 
 DOCKER_RUN_FLAGS=""
 if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then

--- a/contrib/build-linux/appimage/make_type2_runtime.sh
+++ b/contrib/build-linux/appimage/make_type2_runtime.sh
@@ -3,7 +3,6 @@
 set -e
 
 PROJECT_ROOT="$(dirname "$(readlink -e "$0")")/../../.."
-PROJECT_ROOT_OR_FRESHCLONE_ROOT="$PROJECT_ROOT"
 CONTRIB="$PROJECT_ROOT/contrib"
 CONTRIB_APPIMAGE="$CONTRIB/build-linux/appimage"
 
@@ -14,7 +13,7 @@ TYPE2_RUNTIME_REPO="https://github.com/AppImage/type2-runtime.git"
 . "$CONTRIB"/build_tools_util.sh
 
 
-TYPE2_RUNTIME_REPO_DIR="$PROJECT_ROOT_OR_FRESHCLONE_ROOT/contrib/build-linux/appimage/.cache/appimage/type2-runtime"
+TYPE2_RUNTIME_REPO_DIR="$PROJECT_ROOT/contrib/build-linux/appimage/.cache/appimage/type2-runtime"
 if [ -f "$TYPE2_RUNTIME_REPO_DIR/runtime-x86_64" ]; then
     info "type2-runtime already built, skipping"
     exit 0


### PR DESCRIPTION
Building the appimage with ELECBUILD_COMMIT unset would work,
however building with it set would not.

regression from https://github.com/spesmilo/electrum/commit/daaf7b7c6bd6eaa2975777f1092dc01248c680fd