### PR TITLE
Fix consistent fee units in history CSV export (#10445)

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -886,7 +886,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
                     item['bc_value'],
                     item['ln_value'],
                     item.get('fiat_value', ''),
-                    fees_sat,
+                    Satoshis(fees_sat),
                     str(fees_fiat),
                     item['date']
                 ]
@@ -903,7 +903,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
                                       "amount_chain_bc",
                                       "amount_lightning_bc",
                                       "fiat_value",
-                                      "network_fee_satoshi",
+                                      "network_fee",
                                       "fiat_fee",
                                       "timestamp"])
                 for line in lines:


### PR DESCRIPTION
This PR ensures that transaction fees in the exported CSV file use the same units (BTC) as the transaction amounts, addressing issue #10445.

### Changes:
- **Consistent Units**: Wrapped `fees_sat` in the `Satoshis` class in `electrum/gui/qt/history_list.py`. This ensures that fees are formatted as BTC strings (e.g., `0.00005000`) instead of raw satoshi integers (e.g., `5000`), matching the formatting of the amount columns.
- **Header Update**: Renamed the CSV column header from `network_fee_satoshi` to `network_fee` to reflect the consistent unit usage.