### PR TITLE
Fix Signet Lightning usability: remove restrictive sync and trampolin…

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1597,7 +1597,6 @@ class Peer(Logger, EventListener):
             self._send_channel_reestablish(chan)
             return
         if self.network.blockchain().is_tip_stale() \
-                or not self.lnworker.wallet.is_up_to_date() \
                 or self.lnworker.current_target_feerate_per_kw(has_anchors=chan.has_anchors()) \
             is None:
             # don't try to reestablish until we can do fee estimation and are up-to-date

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -3186,8 +3186,7 @@ class LNWallet(Logger):
     def get_channels_for_sending(self):
         for c in self.channels.values():
             if c.is_active() and not c.is_frozen_for_sending():
-                if self.channel_db or self.is_trampoline_peer(c.node_id):
-                    yield c
+                yield c
 
     def estimate_fee_reserve_for_total_amount(self, amount_sat: int | Decimal) -> int:
         """


### PR DESCRIPTION
checks (#10420)
This PR addresses several usability issues with Lightning channels, particularly on Signet, where channels could get stuck in the "Funded" state or report 0 mBTC capacity even when active.

### Changes:
- **Improved State Transitions**: In `electrum/lnpeer.py`, I removed the `is_up_to_date()` check in `reestablish_channel`. This ensures that channels can complete the Lightning handshake as soon as their funding transaction is confirmed, without waiting for the entire wallet history to sync (which is problematic on slow Signet nodes).
- **Inclusive Capacity Reporting**: In `electrum/lnworker.py`, I removed a restrictive filter in `get_channels_for_sending` that excluded active channels if they weren't to recognized trampoline nodes or if the local gossip database was empty. This fixes the confusing "Your channels can send 0. mBTC" error for users with private or direct peer channels.