### PR TITLE
fix balances in get_lightning_history

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1498,7 +1498,7 @@ class Channel(AbstractChannel):
                         error_bytes=None,
                         failure_message=failure)
 
-    def balance(self, whose: HTLCOwner, *, ctx_owner=HTLCOwner.LOCAL, ctn: int = None) -> int:
+    def balance(self, whose: HTLCOwner, *, ctx_owner: HTLCOwner = None, ctn: int = None) -> int:
         assert type(whose) is HTLCOwner
         initial = self.config[whose].initial_msat
         return self.hm.get_balance_msat(whose=whose,

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1349,7 +1349,6 @@ class LNWallet(Logger):
         lb = sum(chan.balance(LOCAL) if not chan.is_closed_or_closing() else 0
                  for chan in self.channels.values())
         if balance_msat != lb:
-            # this typically happens when a channel is recently force closed
             self.logger.info(f'get_lightning_history: balance mismatch {balance_msat - lb}')
         return out
 

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -573,7 +573,7 @@ class TestChannel(ElectrumTestCase):
         tx4 = str(alice_channel.force_close_tx())
         self.assertNotEqual(tx3, tx4)
 
-        self.assertEqual(alice_channel.balance(LOCAL), 500000000000)
+        self.assertEqual(alice_channel.balance(LOCAL, ctx_owner=LOCAL), 500000000000)
         self.assertEqual(1, alice_channel.get_oldest_unrevoked_ctn(LOCAL))
         self.assertEqual(len(alice_channel.included_htlcs(LOCAL, RECEIVED, ctn=2)), 0)
         aliceRevocation2 = alice_channel.revoke_current_commitment()


### PR DESCRIPTION
lnhtlc.get_balance_msat accepts ctx_owner=None.
In that case, it considers a htlc settled if its preimage was released, in order to return a value that is consistent with lnworker.get_payment_value.