### PR TITLE
Support for Ledger Nano Gen5

### DIFF
--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -1228,7 +1228,7 @@ class LedgerPlugin(HW_PluginBase):
                   (0x2c97, 0x0005),  # Nano-S Plus
                   (0x2c97, 0x0006),  # Stax
                   (0x2c97, 0x0007),  # Flex
-                  (0x2c97, 0x0008),  # RFU
+                  (0x2c97, 0x0008),  # Nano Gen5
                   (0x2c97, 0x0009),  # RFU
                   (0x2c97, 0x000a)]  # RFU
     VENDOR_IDS = (0x2c97,)
@@ -1238,6 +1238,7 @@ class LedgerPlugin(HW_PluginBase):
         0x50: "Ledger Nano S Plus",
         0x60: "Ledger Stax",
         0x70: "Ledger Flex",
+        0x80: "Ledger Nano Gen5",
     }
 
     SUPPORTED_XTYPES = ('standard', 'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')
@@ -1289,6 +1290,8 @@ class LedgerPlugin(HW_PluginBase):
                 return True, "Ledger Stax"
             if product_key == (0x2c97, 0x0007):
                 return True, "Ledger Flex"
+            if product_key == (0x2c97, 0x0008):
+                return True, "Ledger Nano Gen5"
             return True, None
         # modern product_keys
         if product_key[0] == 0x2c97:


### PR DESCRIPTION
This is the ledger device/model data source for the Nano Gen5: https://github.com/LedgerHQ/device-sdk-ts/blob/9e9a430b1f4686ea0687db24c0ce0e40c7c3f458/packages/device-management-kit/src/api/device-model/data/StaticDeviceModelDataSource.ts#L96

