### PR TITLE
wizard: fix exception when loading new tc wallet

### DIFF
--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -502,11 +502,9 @@ class ElectrumGui(BaseElectrumGui, Logger):
                 self.logger.info('wizard dialog cancelled by user')
                 return
             db.put('x3', wizard.get_wizard_data()['x3'])
-            db.write()
+            db.write_and_force_consolidation()  # TODO API for db is a bit weird: there should be a close method
 
-        wallet = Wallet(db, config=self.config)
-        wallet.start_network(self.daemon.network)
-        self.daemon.add_wallet(wallet)
+        wallet = self.daemon.load_wallet(wallet_file, password, upgrade=True)
         return wallet
 
     def close_window(self, window: ElectrumWindow):

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -736,7 +736,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         return True
 
     def update_recently_opened_menu(self):
-        recent = self.config.RECENTLY_OPEN_WALLET_FILES
+        recent = self.config.RECENTLY_OPEN_WALLET_FILES or []
         self.recently_visited_menu.clear()
         for i, k in enumerate(recent):
             b = os.path.basename(k)


### PR DESCRIPTION
I tried to reproduce https://github.com/spesmilo/electrum/issues/8815#issuecomment-2094259186, which triggered the following exception:

```
Traceback (most recent call last):
  File "/home/user/code/electrum-fork/electrum/gui/qt/__init__.py", line 409, in start_new_window
    window = self._create_window_for_wallet(wallet)
  File "/home/user/code/electrum-fork/electrum/gui/qt/__init__.py", line 329, in _create_window_for_wallet
    w = ElectrumWindow(self, wallet)
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 290, in __init__
    self.load_wallet(wallet)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/home/user/code/electrum-fork/electrum/util.py", line 495, in do_profile
    o = func(*args, **kw_args)
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 589, in load_wallet
    self.update_recently_opened_menu()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/user/code/electrum-fork/electrum/gui/qt/main_window.py", line 741, in update_recently_opened_menu
    for i, k in enumerate(recent):
                ~~~~~~~~~^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

This happens because the trustedcoin wallet is loaded outside of `Daemon.load_wallet()` so `Daemon.update_recently_opened_wallets()` is not getting called and `config.RECENTLY_OPEN_WALLET_FILES` is still None when we try to iterate through it.
As fix i now call `Daemon.update_recently_opened_wallets()` directly in `Daemon.add_wallet()` and additionally handle
`config.RECENTLY_OPEN_WALLET_FILES` being None in
`ElectrumWindow.update_recently_opened_menu()`. Both fix the issue independently.

PR https://github.com/spesmilo/electrum/pull/10121 would have sent this exception to the crash reporter so we might have noticed it earlier. I think we should not just catch all exceptions in the wizard like on master as it causes us to repeatedly miss regressions in the wizard that could be sent to the crash reporter.