### PR TITLE
qt: MyTreeView: close menu if its context changes

### DIFF
--- a/electrum/gui/qt/channels_list.py
+++ b/electrum/gui/qt/channels_list.py
@@ -281,7 +281,7 @@ class ChannelsList(MyTreeView):
                 menu.addAction(_("Delete"), lambda: self.remove_channel_backup(channel_id))
             else:
                 menu.addAction(_("Delete"), lambda: self.remove_channel(channel_id))
-        menu.exec(self.viewport().mapToGlobal(position))
+        self.open_menu(menu, position)
 
     @QtCore.pyqtSlot(Abstract_Wallet, AbstractChannel)
     def do_update_single_row(self, wallet: Abstract_Wallet, chan: AbstractChannel):

--- a/electrum/gui/qt/contact_list.py
+++ b/electrum/gui/qt/contact_list.py
@@ -101,7 +101,7 @@ class ContactList(MyTreeView):
                 menu.addAction(_("View on block explorer"), lambda: [webopen(u) for u in URLs])
 
         run_hook('create_contact_menu', menu, selected_keys)
-        menu.exec(self.viewport().mapToGlobal(position))
+        self.open_menu(menu, position)
 
     def update(self):
         if self.maybe_defer_update():

--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -799,7 +799,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
                 menu_invs.addAction(_("View invoice"), lambda inv=inv: self.main_window.show_onchain_invoice(inv))
         if tx_URL:
             menu.addAction(_("View on block explorer"), lambda: webopen(tx_URL))
-        menu.exec(self.viewport().mapToGlobal(position))
+        self.open_menu(menu, position)
 
     def remove_local_tx(self, tx_hash: str):
         num_child_txs = len(self.wallet.adb.get_depending_transactions(tx_hash))

--- a/electrum/gui/qt/invoice_list.py
+++ b/electrum/gui/qt/invoice_list.py
@@ -195,7 +195,7 @@ class InvoiceList(MyTreeView):
             if log:
                 menu.addAction(_("View log"), lambda: self.show_log(key, log))
         menu.addAction(_("Delete"), lambda: self.delete_invoices([key]))
-        menu.exec(self.viewport().mapToGlobal(position))
+        self.open_menu(menu, position)
 
     def show_log(self, key, log: Sequence[HtlcLog]):
         d = WindowModalDialog(self, _("Payment log"))

--- a/electrum/gui/qt/my_treeview.py
+++ b/electrum/gui/qt/my_treeview.py
@@ -256,11 +256,25 @@ class MyTreeView(QTreeView):
         self._pending_update = False
         self._forced_update = False
 
+        self._currently_open_menu = None  # type: Optional[QMenu]
+
         self._default_bg_brush = QStandardItem().background()
         self.proxy = None # history, and address tabs use a proxy
 
     def create_menu(self, position: QPoint) -> None:
         pass
+
+    def open_menu(self, menu: QMenu, position) -> None:
+        try:
+            self._currently_open_menu = menu
+            menu.exec(self.viewport().mapToGlobal(position))
+        finally:
+            self._currently_open_menu = None
+
+    def close_menu(self):
+        if self._currently_open_menu:
+            self._currently_open_menu.close()
+            self._currently_open_menu = None
 
     def set_editability(self, items):
         for idx, i in enumerate(items):

--- a/electrum/gui/qt/request_list.py
+++ b/electrum/gui/qt/request_list.py
@@ -209,7 +209,7 @@ class RequestList(MyTreeView):
         #    menu.addAction(_("View in web browser"), lambda: webopen(req['view_url']))
         menu.addAction(_("Delete"), lambda: self.delete_requests([key]))
         run_hook('receive_list_menu', self.main_window, menu, key)
-        menu.exec(self.viewport().mapToGlobal(position))
+        self.open_menu(menu, position)
 
     def delete_requests(self, keys):
         self.wallet.delete_requests(keys)

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -230,12 +230,17 @@ class UTXOList(MyTreeView):
         return copy.deepcopy(utxos)  # copy so that side-effects don't affect utxo_dict
 
     def _maybe_reset_coincontrol(self, current_wallet_utxos: Sequence[PartialTxInput]) -> None:
-        if not bool(self._spend_set):
+        if not self._spend_set and not self._currently_open_menu:
             return
-        # if we spent one of the selected UTXOs, just reset selection
         utxo_set = {utxo.prevout.to_str() for utxo in current_wallet_utxos}
-        if not all([prevout_str in utxo_set for prevout_str in self._spend_set]):
-            self._spend_set.clear()
+        if self._currently_open_menu:
+            # if we spent one of the qt-highlighted UTXOs, close context-menu
+            if not all(prevout_str in utxo_set for prevout_str in self.get_selected_outpoints()):
+                self.close_menu()
+        if self._spend_set:
+            # if we spent one of the green-marked UTXOs, just reset selection
+            if not all([prevout_str in utxo_set for prevout_str in self._spend_set]):
+                self._spend_set.clear()
 
     def can_swap_coins(self, coins):
         # fixme: min and max_amounts are known only after first request
@@ -369,7 +374,7 @@ class UTXOList(MyTreeView):
                 act.setToolTip(MSG_FREEZE_ADDRESS)
 
         run_hook('qt_utxo_menu', menu, coins, self.wallet)
-        menu.exec(self.viewport().mapToGlobal(position))
+        self.open_menu(menu, position)
 
     def get_filter_data_from_coordinate(self, row, col):
         if col == self.Columns.OUTPOINT:


### PR DESCRIPTION
Stores the currently open (right-click) menu as `MyTreeView` attribute
and adds a `close_menu()` method so inheritants can cleanly
close the menu again if the context it was opened upon has changed.

This is utilized by `AddressList` and `UTXOList` to close the menu
if `update()` changes the address list in some way or
removed a utxo from the list to prevent the user from trying to use
a utxo that doesn't exist anymore.

Fixes https://github.com/spesmilo/electrum/issues/10464