### PR TITLE
docs: clarify TL;DR installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ but not everything. The following sections describe how to run from source, but 
 is a TL;DR:
 
 ```
+Note:
+- The following commands are intended for Linux systems.
+- The environment variable  `ELECTRUM_ECC_DONT_COMPILE=1` tells Electrum
+  to use the system-installed `libsecp256k1` instead of compiling it locally.
+
 $ sudo apt-get install libsecp256k1-dev
 $ ELECTRUM_ECC_DONT_COMPILE=1 python3 -m pip install --user ".[gui,crypto]"
 ```


### PR DESCRIPTION
This PR adds a short clarification explaining that the TL;DR
installation commands are Linux-specific and describes the
purpose of the ELECTRUM_ECC_DONT_COMPILE=1 environment variable,
to reduce confusion for new users.
