### PR TITLE
qt: fix toolbar action exc in offline mode

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -855,7 +855,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             self.help_menu.addAction(_("&Bitcoin Paper"), self.show_bitcoin_paper)
         self.help_menu.addAction(_("&Report Bug"), self.show_report_bug)
         self.help_menu.addSeparator()
-        self.help_menu.addAction(_("&Donate to server"), self.donate_to_server)
+        if self.network:
+            self.help_menu.addAction(_("&Donate to server"), self.donate_to_server)
 
         run_hook('init_menubar', self)
         self.setMenuBar(menubar)
@@ -885,7 +886,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             def fetch_bitcoin_paper():
                 s = self._fetch_tx_from_network("54e48e5f5c656b26c3bca14a8c95aa583d07ebe84dde3b7dd4a78f4e4186e713")
                 if not s:
-                    return
+                    raise concurrent.futures.CancelledError
                 s = s.split("0100000000000000")[1:-1]
                 out = ''.join(x[6:136] + x[138:268] + x[270:400] if len(x) > 136 else x[6:] for x in s)[16:-20]
                 with open(filename, 'wb') as f:


### PR DESCRIPTION
Fix exception when clicking on "Donate to server" in offline mode by not showing the "Donate to server" menu action when no network is set.

Raise CancelledError in `fetch_bitcoin_paper` as
`_fetch_tx_from_network` already shows an according error message so the second, subsequent error message shown by `on_error` is not useful if `_fetch_tx_from_network` already failed.

```
63.53 | E | gui.qt.exception_window.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
 File "/home/user/Documents/electrum/electrum/gui/qt/main_window.py", line 864, in donate_to_server
   d = self.network.get_donation_address()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_donation_address'
```