### PR TITLE
plugin: nwc: qt: fix thread safety bug

### DIFF
--- a/electrum/plugins/nwc/nwcserver.py
+++ b/electrum/plugins/nwc/nwcserver.py
@@ -39,7 +39,7 @@ from electrum.plugin import BasePlugin, hook
 from electrum.logging import Logger
 from electrum.util import log_exceptions, ca_path, OldTaskGroup, get_asyncio_loop, InvoiceError, \
     LightningHistoryItem, event_listener, EventListener, make_aiohttp_proxy_connector, \
-    get_running_loop
+    get_running_loop, run_sync_function_on_asyncio_thread
 from electrum.invoices import Invoice, Request, PR_UNKNOWN, PR_PAID, BaseInvoice, PR_INFLIGHT
 from electrum import constants
 from electrum.lnutil import RECEIVED
@@ -278,7 +278,7 @@ class NWCServer(Logger, EventListener):
     def restart_event_handler(self) -> None:
         """To be called when the connections change so we restart with a new filter"""
         if self.event_handler_task:
-            self.event_handler_task.cancel()
+            run_sync_function_on_asyncio_thread(self.event_handler_task.cancel, block=True)
 
     @event_listener
     def on_event_proxy_set(self, *args):


### PR DESCRIPTION
Call `NWCServer.event_handler_task.cancel()` on asyncio thread.

```
 File "/home/user/Documents/electrum/electrum/plugins/nwc/nwcserver.py", line 281, in restart_event_handler
   self.event_handler_task.cancel()
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
 File "/usr/lib64/python3.14/asyncio/base_events.py", line 829, in call_soon
   self._check_thread()
   ~~~~~~~~~~~~~~~~~~^^
 File "/usr/lib64/python3.14/asyncio/base_events.py", line 866, in _check_thread
   raise RuntimeError(
       "Non-thread-safe operation invoked on an event loop other "
       "than the current one")
RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
```