### PR TITLE
Remove non-existing electrum server on owner's request

### DIFF
--- a/electrum/chains/mainnet/servers.json
+++ b/electrum/chains/mainnet/servers.json
@@ -366,11 +366,6 @@
         "t": "50001",
         "version": "1.4.2"
     },
-    "lavahost.org": {
-        "pruning": "-",
-        "s": "50002",
-        "version": "1.4.2"
-    },
     "node.degga.net": {
         "pruning": "-",
         "s": "50002",


### PR DESCRIPTION
Remove lavahost.org from servers.json as the host does not host a public electrum instance.

As the owner of the domain I ask you to please remove the entry as I get bombarded with requests to the non-existing electrum server.
I have published a DNS TXT record on the domain lavahost.org confirming that request and authenticating it.