### PR TITLE
qt: console: allow changing font size

### DIFF
--- a/electrum/gui/qt/console.py
+++ b/electrum/gui/qt/console.py
@@ -1,4 +1,3 @@
-
 # source: http://stackoverflow.com/questions/2758159/how-to-embed-a-python-interpreter-in-a-pyqt-widget
 
 import sys
@@ -48,17 +47,22 @@ class OverlayLabel(QtWidgets.QLabel):
 
 
 class Console(QtWidgets.QPlainTextEdit):
+    DEFAULT_FONT_SIZE = 10
+    MIN_FONT_SIZE = 6
+    MAX_FONT_SIZE = 32
+
     def __init__(self, parent=None):
         QtWidgets.QPlainTextEdit.__init__(self, parent)
 
         self.history = []
         self.namespace = {}
         self.construct = []
+        self.font_size = self.DEFAULT_FONT_SIZE
 
         self.setGeometry(50, 75, 600, 400)
         self.setWordWrapMode(QtGui.QTextOption.WrapMode.WrapAnywhere)
         self.setUndoRedoEnabled(False)
-        self.setFont(QtGui.QFont(MONOSPACE_FONT, 10, QtGui.QFont.Weight.Normal))
+        self.setFont(QtGui.QFont(MONOSPACE_FONT, self.font_size, QtGui.QFont.Weight.Normal))
         self.newPrompt("")  # make sure there is always a prompt, even before first server.banner
 
         self.updateNamespace({'run':self.run_script})
@@ -71,6 +75,11 @@ class Console(QtWidgets.QPlainTextEdit):
             _("Click here to hide this message.")
         )
         self.messageOverlay = OverlayLabel(warning_text, self)
+
+    def set_font_size(self, size: int):
+        size = max(self.MIN_FONT_SIZE, min(self.MAX_FONT_SIZE, size))
+        self.font_size = size
+        self.setFont(QtGui.QFont(MONOSPACE_FONT, self.font_size, QtGui.QFont.Weight.Normal))
 
     def resizeEvent(self, e):
         super().resizeEvent(e)
@@ -308,6 +317,12 @@ class Console(QtWidgets.QPlainTextEdit):
         elif event.key() == Qt.Key.Key_C and event.modifiers() == Qt.KeyboardModifier.ControlModifier:
             if not self.textCursor().selectedText():
                 self.keyboard_interrupt()
+        elif event.key() == Qt.Key.Key_Plus and Qt.KeyboardModifier.ControlModifier in event.modifiers():
+            self.set_font_size(self.font_size + 1)
+            return
+        elif event.key() == Qt.Key.Key_Minus and Qt.KeyboardModifier.ControlModifier in event.modifiers():
+            self.set_font_size(self.font_size - 1)
+            return
 
         super(Console, self).keyPressEvent(event)
 


### PR DESCRIPTION
Allows changing the font size in the qt Console with `Ctrl` + `+` and `Ctrl` + `-`.

<img width="462" height="278" alt="image" src="https://github.com/user-attachments/assets/0178f6b1-e7e4-4ed9-95f2-0c4d1c04bd52" />
