### PR TITLE
wallet_db: convert PaymentInfo amounts from 0 to None

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -143,8 +143,10 @@ class PaymentInfo:
 
     def validate(self):
         assert isinstance(self.payment_hash, bytes) and len(self.payment_hash) == 32
-        assert self.amount_msat is None or isinstance(self.amount_msat, int)
         assert isinstance(self.direction, int)
+        assert self.amount_msat is None or isinstance(self.amount_msat, int)
+        if self.direction == RECEIVED:
+            assert self.amount_msat != 0  # use amount_msat=None instead!
         assert isinstance(self.status, int)
         assert isinstance(self.min_final_cltv_delta, int)
         assert isinstance(self.expiry_delay, int) and self.expiry_delay > 0, repr(self.expiry_delay)
@@ -2611,6 +2613,8 @@ class LNWallet(Logger):
         exp_delay: int = LN_EXPIRY_NEVER,
         write_to_disk=True
     ) -> bytes:
+        if amount_msat == 0:
+            raise ValueError("amount_msat must not be 0. Use None instead.")
         payment_preimage = os.urandom(32)
         payment_hash = sha256(payment_preimage)
         min_final_cltv_delta = min_final_cltv_delta or MIN_FINAL_CLTV_DELTA_ACCEPTED

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3020,7 +3020,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         amount_msat = req.get_amount_msat() or None
         assert (amount_msat is None or amount_msat > 0), amount_msat
         info = self.lnworker.get_payment_info(payment_hash, direction=RECEIVED)
-        assert info.amount_msat == amount_msat, f"{info.amount_msat=} != {amount_msat=}"
+        assert info.amount_msat == amount_msat, f"{info.amount_msat=} != {amount_msat=}"  # info.amount_msat or None
         lnaddr, invoice = self.lnworker.get_bolt11_invoice(
             payment_info=info,
             message=req.message,

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -69,7 +69,7 @@ class WalletUnfinished(WalletFileException):
 # seed_version is now used for the version of the wallet file
 OLD_SEED_VERSION = 4        # electrum versions < 2.0
 NEW_SEED_VERSION = 11       # electrum versions >= 2.0
-FINAL_SEED_VERSION = 68     # electrum >= 2.7 will set this to prevent
+FINAL_SEED_VERSION = 69     # electrum >= 2.7 will set this to prevent
                             # old versions from overwriting new format
 
 
@@ -243,6 +243,7 @@ class WalletDBUpgrader(Logger):
         self._convert_version_66()
         self._convert_version_67()
         self._convert_version_68()
+        self._convert_version_69()
         self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
 
     def _convert_wallet_type(self):
@@ -1364,6 +1365,25 @@ class WalletDBUpgrader(Logger):
             new_preimages[_hash] = (preimage, False)
         self.data['lightning_preimages'] = new_preimages
         self.data['seed_version'] = 68
+
+    def _convert_version_69(self):
+        """Convert PaymentInfo amounts from 0 to None"""
+        if not self._is_upgrade_method_needed(68, 68):
+            return
+        new_payment_infos = {}
+        old_payment_infos = self.data.get('lightning_payments', {})
+        for key, old_v in old_payment_infos.items():
+            #amount_msat, status, min_final_cltv_delta, expiry_delay, creation_ts, invoice_features = old_v
+            amount_msat = old_v[0]
+            rhash, direction = key.split(":")  # key is "RHASH:direction"
+            direction = int(direction)
+            if direction == 1:  # RECEIVED
+                if amount_msat == 0:
+                    amount_msat = None
+            new_v = (amount_msat, *old_v[1:])
+            new_payment_infos[key] = new_v
+        self.data['lightning_payments'] = new_payment_infos
+        self.data['seed_version'] = 69
 
     def _convert_imported(self):
         if not self._is_upgrade_method_needed(0, 13):

--- a/tests/test_lnwallet.py
+++ b/tests/test_lnwallet.py
@@ -24,7 +24,6 @@ class TestLNWallet(ElectrumTestCase):
         wallet = self.lnwallet_anchors
         tests = (
             (100_000, 200, 100),
-            (0, 200, 100),
             (None, 200, 100),
             (None, None, LN_EXPIRY_NEVER),
             (100_000, None, 0),
@@ -43,3 +42,13 @@ class TestLNWallet(ElectrumTestCase):
             self.assertEqual(pi.db_key, f"{payment_hash.hex()}:{int(pi.direction)}")
             self.assertEqual(pi.status, PR_UNPAID)
         self.assertIsNone(wallet.get_payment_info(os.urandom(32), direction=RECEIVED))
+
+    def test_create_payment_info__amount_must_not_be_zero(self):
+        wallet = self.lnwallet_anchors
+        amount_msat, min_final_cltv_delta, exp_delay = (0, 200, 100)
+        with self.assertRaises(ValueError):
+            wallet.create_payment_info(
+                amount_msat=amount_msat,
+                min_final_cltv_delta=min_final_cltv_delta,
+                exp_delay=exp_delay,
+            )


### PR DESCRIPTION
When creating a "zero-amount" payment request, currently we save a PaymentInfo with a "None" amount. I think there were a few releases in 2023 that saved PaymentInfos with a `0` amount instead. This was changed in [#8659](https://github.com/spesmilo/electrum/pull/8659), but [as said there](https://github.com/spesmilo/electrum/pull/8659#issuecomment-1777101285
), a DB upgrade was not done.

Now a [newer assert is failing](https://github.com/spesmilo/electrum/commit/286fc4b86e4d23cb9af15b9061b3d709e7592bcb) due to this inconsistency, for affected old wallets.
- I think to trigger that, one needs a wallet that has a payment request (with a `0` amount) created around that time, which is still unpaid.

This patch tries to restore consistency by enforcing None amounts.

fixes https://github.com/spesmilo/electrum/issues/10501
