### PR TITLE
Update my Electrum server details in servers.json

### DIFF
--- a/electrum/chains/mainnet/servers.json
+++ b/electrum/chains/mainnet/servers.json
@@ -249,11 +249,11 @@
         "t": "50001",
         "version": "1.4"
     },
-    "electrum.jochen-hoenicke.de": {
+    "electrum.jhoenicke.de": {
         "pruning": "-",
-        "s": "50006",
-        "t": "50099",
-        "version": "1.4.5"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.6"
     },
     "electrum.pabu.io": {
         "pruning": "-",


### PR DESCRIPTION
I moved my node to standard port again because the address with port 50006 is apparently hardcoded in some malware as C&C server.  I also updated the domain name (both work at the moment, but I prefer the shorter one).