### PR TITLE
tests: lnpeer: uncomment testcase: test_modern_shutdown_no_overlap

### DIFF
--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -1571,16 +1571,19 @@ class TestPeerDirect(TestPeer):
             alice_fee_range={'min_fee_satoshis': 1, 'max_fee_satoshis': 10},
             bob_fee_range={'min_fee_satoshis': 10, 'max_fee_satoshis': 300})
 
-    ## This test works but it is too slow (LN_P2P_NETWORK_TIMEOUT)
-    ## because tests do not use a proper LNWorker object
-    #def test_modern_shutdown_no_overlap(self):
-    #    self.assertRaises(Exception, lambda: asyncio.run(
-    #        self._test_shutdown(
-    #            alice_fee=1,
-    #            bob_fee=200,
-    #            alice_fee_range={'min_fee_satoshis': 1, 'max_fee_satoshis': 10},
-    #            bob_fee_range={'min_fee_satoshis': 50, 'max_fee_satoshis': 300})
-    #    ))
+    @mock.patch('electrum.lnpeer.LN_P2P_NETWORK_TIMEOUT', 0.05)
+    async def test_modern_shutdown_no_overlap(self):
+        with self.assertLogs('electrum', level='ERROR') as logs:
+            with self.assertRaisesRegex(Exception, "closing_signed not received"):
+                await self._test_shutdown(
+                    alice_fee=1,
+                    bob_fee=200,
+                    alice_fee_range={'min_fee_satoshis': 1, 'max_fee_satoshis': 10},
+                    bob_fee_range={'min_fee_satoshis': 50, 'max_fee_satoshis': 300})
+        self.assertTrue(any(("bob->alice" in msg and "There is no overlap between between their and our fee range." in msg) for msg in logs.output))
+        self.assertTrue(any(("alice->bob" in msg and "closing_signed not received, force closing." in msg) for msg in logs.output))
+        # note: "Task exception was never retrieved" for "Exception: There is no overlap [...]"
+        #       is because we don't start peer.main_loop and hence peer.taskgroup is never joined.
 
     async def _test_shutdown(self, alice_fee, bob_fee, alice_fee_range=None, bob_fee_range=None):
         graph = self.prepare_chans_and_peers_in_graph(self.GRAPH_DEFINITIONS['single_chan'])


### PR DESCRIPTION
This test case has always been disabled, but looks like the justification is easy to fix.