### PR TITLE
trampoline: allow trampoline onion packets of arbitrary size

### DIFF
--- a/electrum/lnwire/onion_wire.csv
+++ b/electrum/lnwire/onion_wire.csv
@@ -22,10 +22,7 @@ tlvdata,payload,outgoing_node_id,outgoing_node_id,byte,33
 tlvtype,payload,invoice_routing_info,66099
 tlvdata,payload,invoice_routing_info,invoice_routing_info,byte,...
 tlvtype,payload,trampoline_onion_packet,66100
-tlvdata,payload,trampoline_onion_packet,version,byte,1
-tlvdata,payload,trampoline_onion_packet,public_key,byte,33
-tlvdata,payload,trampoline_onion_packet,hops_data,byte,400
-tlvdata,payload,trampoline_onion_packet,hmac,byte,32
+tlvdata,payload,trampoline_onion_packet,trampoline_onion_packet,byte,...
 tlvtype,encrypted_data_tlv,padding,1
 tlvdata,encrypted_data_tlv,padding,padding,byte,...
 tlvtype,encrypted_data_tlv,short_channel_id,2

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -4094,10 +4094,7 @@ class LNWallet(Logger):
             self.logger.info(f'adding trampoline onion to final payload')
             trampoline_payload = dict(hops_data[-1].payload)
             trampoline_payload["trampoline_onion_packet"] = {
-                "version": trampoline_onion.version,
-                "public_key": trampoline_onion.public_key,
-                "hops_data": trampoline_onion.hops_data,
-                "hmac": trampoline_onion.hmac
+                "trampoline_onion_packet": trampoline_onion.to_bytes()
             }
             hops_data[-1] = dataclasses.replace(hops_data[-1], payload=trampoline_payload)
             if t_hops_data := trampoline_onion._debug_hops_data:  # None if trampoline-forwarding

--- a/electrum/trampoline.py
+++ b/electrum/trampoline.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 
 from .lnutil import LnFeatures, PaymentFeeBudget, FeeBudgetExceeded
 from .lnonion import (
-    calc_hops_data_for_payment, new_onion_packet, OnionPacket, TRAMPOLINE_HOPS_DATA_SIZE, PER_HOP_HMAC_SIZE
+    calc_hops_data_for_payment, new_onion_packet, OnionPacket, PER_HOP_HMAC_SIZE
 )
 from .lnrouter import TrampolineEdge, is_route_within_budget, LNPaymentTRoute
 from .lnutil import NoPathFound
@@ -39,6 +39,8 @@ TRAMPOLINE_NODES_SIGNET = {
 }
 
 _TRAMPOLINE_NODES_UNITTESTS = {}  # used in unit tests
+
+TRAMPOLINE_HOPS_MAX_DATA_SIZE = 500
 
 
 def hardcoded_trampoline_nodes() -> Mapping[str, LNPeerAddr]:
@@ -332,7 +334,7 @@ def create_trampoline_onion(
         payload = dict(hops_data[index].payload)
         # try different r_tag order on each attempt
         invoice_routing_info = random_shuffled_copy(route[index].invoice_routing_info)
-        remaining_payload_space = TRAMPOLINE_HOPS_DATA_SIZE \
+        remaining_payload_space = TRAMPOLINE_HOPS_MAX_DATA_SIZE \
                                   - sum(len(hop.to_bytes()) + PER_HOP_HMAC_SIZE for hop in hops_data)
         routing_info_to_use = []
         for encoded_r_tag in invoice_routing_info:

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -2742,10 +2742,7 @@ class TestPeerForwarding(TestPeer):
                 assert len(hops_data) == 1
                 new_payload = dict(hops_data[0].payload)
                 new_payload['trampoline_onion_packet'] = {
-                    "version": modified_trampoline_onion.version,
-                    "public_key": modified_trampoline_onion.public_key,
-                    "hops_data": modified_trampoline_onion.hops_data,
-                    "hmac": modified_trampoline_onion.hmac,
+                    "trampoline_onion_packet": modified_trampoline_onion.to_bytes()
                 }
                 hops_data[0] = dataclasses.replace(hops_data[0], payload=MappingProxyType(new_payload))
                 modified_trampoline_onion = None


### PR DESCRIPTION
This commit was cherry-picked from the lazy_trampoline branch.
Apparently, variable size trampoline onions are needed for bolt12.