### PR TITLE
qml: make 2fa secret copyable, open 2fa app for user

### DIFF
--- a/electrum/gui/qml/components/controls/QRImage.qml
+++ b/electrum/gui/qml/components/controls/QRImage.qml
@@ -8,6 +8,8 @@ Item {
     property bool enableToggleText: false  // if true, clicking the QR code shows the encoded text
     property bool isTextState: false    // internal state, if the above is enabled
 
+    signal clicked()
+
     property var _qrprops: QRIP.getDimensions(qrdata)
 
     width: r.width
@@ -71,6 +73,8 @@ Item {
         onClicked: {
             if (enableToggleText) {
                 root.isTextState = !root.isTextState
+            } else {
+                root.clicked()
             }
         }
     }

--- a/electrum/plugins/trustedcoin/qml/ShowConfirmOTP.qml
+++ b/electrum/plugins/trustedcoin/qml/ShowConfirmOTP.qml
@@ -40,6 +40,16 @@ WizardComponent {
             qrdata: encodeURI('otpauth://totp/Electrum 2FA ' + wizard_data['wallet_name']
                     + '?secret=' + plugin.otpSecret + '&digits=6')
             render: plugin.otpSecret
+            onClicked: {
+                if (plugin.otpSecret) {
+                    if (AppController.isAndroid()) {
+                        Qt.openUrlExternally(qrdata)
+                    } else {
+                        AppController.textToClipboard(plugin.otpSecret)
+                        toaster.show(this, qsTr('Copied!'))
+                    }
+                }
+            }
         }
 
         Item {
@@ -68,7 +78,7 @@ WizardComponent {
             Layout.fillWidth: true
             visible: !otpVerified && plugin.otpSecret
             wrapMode: Text.Wrap
-            text: qsTr('Enter or scan into authenticator app. Then authenticate below')
+            text: qsTr('Tap the QR code to open in your authenticator app, or scan it manually. Then authenticate below')
         }
 
         Label {

--- a/electrum/plugins/trustedcoin/qml/ShowConfirmOTP.qml
+++ b/electrum/plugins/trustedcoin/qml/ShowConfirmOTP.qml
@@ -42,13 +42,25 @@ WizardComponent {
             render: plugin.otpSecret
         }
 
-        TextHighlightPane {
+        Item {
             Layout.alignment: Qt.AlignHCenter
             visible: plugin.otpSecret
-            Label {
-                text: plugin.otpSecret
-                font.family: FixedFont
-                font.bold: true
+            implicitWidth: otpSecretPane.implicitWidth
+            implicitHeight: otpSecretPane.implicitHeight
+            TextHighlightPane {
+                id: otpSecretPane
+                Label {
+                    text: plugin.otpSecret
+                    font.family: FixedFont
+                    font.bold: true
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    AppController.textToClipboard(plugin.otpSecret)
+                    toaster.show(otpSecretPane, qsTr('Copied!'))
+                }
             }
         }
 
@@ -116,6 +128,10 @@ WizardComponent {
         plugin = AppController.plugin('trustedcoin')
         plugin.createKeystore()
         otp_auth.forceActiveFocus()
+    }
+
+    Toaster {
+        id: toaster
     }
 
     Connections {


### PR DESCRIPTION
The 2fa setup step on Android is quite user-unfriendly as the 2fa secret is not selectable or copyable, so if the user wants to use an authenticator app on the same phone they have to manually write down the secret somehow and then enter it again.

This changes two things:
1. Makes the otp secret copy on click, so the user can tap on the secret and it gets copied to the clipboard.
2. If the user clicks on the qr it will automatically open their 2fa app with the secret, this is much more user friendly.

This screen:

<img width="488" height="805" alt="Screenshot_20260324_150926" src="https://github.com/user-attachments/assets/e184d894-944b-468b-8549-74f789a9ea55" />
