### PR TITLE
plugin: nwc: handle missing params dict in request

### DIFF
--- a/electrum/plugins/nwc/nwcserver.py
+++ b/electrum/plugins/nwc/nwcserver.py
@@ -344,7 +344,7 @@ class NWCServer(Logger, EventListener):
                 content = json.loads(content)
                 if not isinstance(content, dict):
                     raise Exception("malformed content, not dict")
-                params: dict = content['params']
+                params: dict = content.get('params', {})
                 if not isinstance(params, dict):
                     raise Exception("malformed params, not dict")
             except Exception:


### PR DESCRIPTION
Even though the NIP-47 specification [kind of defines](https://github.com/nostr-protocol/nips/blob/2a77e2fdda188779f5420954ad6ff396b4578ce5/47.md?plain=1#L391) that requests should always pass a params dict in their request i witnessed way too often that clients don't include it in some requests where it is technically not neccessary and we fail on it.
Handling this gracefully improves compatibility without obvious downsides.