### PR TITLE
contrib: check for unsigned apk in release.sh

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -164,7 +164,12 @@ do
         if [ ! -z "$RELEASEMANAGER" ] ; then
             ./contrib/android/build.sh qml $arch release $password
         else
-            ./contrib/android/build.sh qml $arch release-unsigned
+            if test -f "dist/$apk_unsigned"; then
+                # has already been built separately before
+                info "found unsigned: $apk_unsigned"
+            else
+                ./contrib/android/build.sh qml $arch release-unsigned
+            fi
             mv "dist/$apk_unsigned" "dist/$apk"
         fi
     fi


### PR DESCRIPTION
release.sh expects signed apks. 
if a non-releasemanager uses release.sh to build it will build the apks unsigned and then rename them to the same name as the signed apks. 
However if the apks have already been built separately and are still named *-unsigned.apk it will not detect them and instead try to build them again. 
Instead it should just rename them to *-release.apk as if built directly through release.sh.