### PR TITLE
qml: add top padding to nostr relay url list

### DIFF
--- a/electrum/gui/qml/components/NostrConfigDialog.qml
+++ b/electrum/gui/qml/components/NostrConfigDialog.qml
@@ -70,6 +70,7 @@ ElDialog {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     font.family: FixedFont
+                    topPadding: constants.paddingLarge
                     wrapMode: TextEdit.WrapAnywhere
                     onTextChanged: valid = verify(text)
                     inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase

--- a/electrum/gui/qml/components/controls/ElTextArea.qml
+++ b/electrum/gui/qml/components/controls/ElTextArea.qml
@@ -19,6 +19,7 @@ Flickable {
     property alias inputMethodHints: edit.inputMethodHints
     property alias placeholderText: edit.placeholderText
     property alias color: edit.color
+    property alias topPadding: rootpane.topPadding
     readonly property bool anyActiveFocus: activeFocus || edit.activeFocus
 
     contentWidth: rootpane.width


### PR DESCRIPTION
The first relay url was close to the top of the ElTextArea and looked a bit sliced. Adding some padding looks better.

before:
<img width="519" height="129" alt="Screenshot_20260414_082519" src="https://github.com/user-attachments/assets/5403c892-e553-490b-9f90-075d24d3e401" />

after:
<img width="466" height="161" alt="Screenshot_20260414_083117" src="https://github.com/user-attachments/assets/757a4809-d362-4e07-ad51-f700421a3f42" />
