### PR TITLE
qml: ElTextArea default topPadding, hide placeholderText on input 

### DIFF
--- a/electrum/gui/qml/components/NostrConfigDialog.qml
+++ b/electrum/gui/qml/components/NostrConfigDialog.qml
@@ -74,7 +74,6 @@ ElDialog {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     font.family: FixedFont
-                    topPadding: constants.paddingLarge
                     wrapMode: TextEdit.WrapAnywhere
                     onTextChanged: valid = verify(text)
                     inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase

--- a/electrum/gui/qml/components/controls/ElTextArea.qml
+++ b/electrum/gui/qml/components/controls/ElTextArea.qml
@@ -49,6 +49,7 @@ Flickable {
         width: root.width
         height: Math.max(root.height, edit.height + topPadding + bottomPadding)
         padding: constants.paddingXSmall
+        topPadding: constants.paddingLarge
         TextArea {
             id: edit
             width: parent.width

--- a/electrum/gui/qml/components/controls/ElTextArea.qml
+++ b/electrum/gui/qml/components/controls/ElTextArea.qml
@@ -17,7 +17,7 @@ Flickable {
     property alias background: rootpane.background
     property alias font: edit.font
     property alias inputMethodHints: edit.inputMethodHints
-    property alias placeholderText: edit.placeholderText
+    property string placeholderText
     property alias color: edit.color
     property alias topPadding: rootpane.topPadding
     readonly property bool anyActiveFocus: activeFocus || edit.activeFocus
@@ -55,6 +55,7 @@ Flickable {
             width: parent.width
             focus: true
             wrapMode: TextEdit.Wrap
+            placeholderText: edit.text.length ? "" : root.placeholderText
             onCursorRectangleChanged: root.ensureVisible(cursorRectangle)
             onTextChanged: root.textChanged()
             background: Rectangle {


### PR DESCRIPTION
Sets a larger (than `padding`) default `topPadding` on the `ElTextArea` as i noticed that all ElTextAreas look better with some more padding at the top
Followup to https://github.com/spesmilo/electrum/pull/10579

Also hides the `placeholderText` of `ElTextArea` as soon as the user enters something, otherwise it would conflict with the user input and look broken.

E.g. lnurlpay dialog:
before:
<img width="453" height="146" alt="Screenshot_20260417_120555" src="https://github.com/user-attachments/assets/0ac6b4d1-3993-4ca8-8072-d13400e8c83a" />

after:
<img width="501" height="129" alt="Screenshot_20260417_120446" src="https://github.com/user-attachments/assets/69b8cb95-5985-4609-ab2f-ccd68298d906" />
