### PR TITLE
appimage: update Dockerfile dependencies

### DIFF
--- a/contrib/build-linux/appimage/patches/type2-runtime-reproducible-build.patch
+++ b/contrib/build-linux/appimage/patches/type2-runtime-reproducible-build.patch
@@ -115,10 +115,10 @@ index 07b6533..fba9c6e 100644
 +    meson=1.6.1-r0 \
 +    zstd-dev=1.5.6-r2 \
 +    zstd-static=1.5.6-r2 \
-+    zlib-dev=1.3.1-r2 \
-+    zlib-static=1.3.1-r2 \
++    zlib-dev=1.3.2-r0 \
++    zlib-static=1.3.2-r0 \
 +    clang19=19.1.4-r0 \
-+    musl-dev=1.2.5-r9 \
++    musl-dev=1.2.5-r11 \
 +    mimalloc2-dev=2.1.7-r0
 
  COPY scripts/common/install-dependencies.sh /tmp/scripts/common/install-dependencies.sh


### PR DESCRIPTION
Otherwise, building AppImage fails with:
```
 > [2/6] RUN apk add --no-cache     bash=5.2.37-r0     alpine-sdk=1.1-r0     util-linux=2.40.4-r1     strace=6.12-r0     file=5.46-r2     autoconf=2.72-r0     automake=1.17-r0     libtool=2.4.7-r3     xz=5.6.3-r1     eudev-dev=3.2.14-r5     gettext-dev=0.22.5-r0     linux-headers=6.6-r1     meson=1.6.1-r0     zstd-dev=1.5.6-r2     zstd-static=1.5.6-r2     zlib-dev=1.3.1-r2     zlib-static=1.3.1-r2     clang19=19.1.4-r0     musl-dev=1.2.5-r9     mimalloc2-dev=2.1.7-r0:                                                                                            
0.140 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
0.384 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
0.905 ERROR: unable to select packages:
0.906   musl-dev-1.2.5-r11:
0.906     breaks: world[musl-dev=1.2.5-r9]
0.906     satisfies: clang19-19.1.4-r0[musl-dev]
0.906                g++-14.2.0-r4[musl-dev]
0.906                build-base-0.5-r3[libc-dev]
0.907   zlib-dev-1.3.2-r0:
0.907     breaks: world[zlib-dev=1.3.1-r2]
0.907   zlib-static-1.3.2-r0:
0.907     breaks: world[zlib-static=1.3.1-r2]
```

Found when testing #10465.