### PR TITLE
regtest: make fw_fail_htlc less flaky

### DIFF
--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -758,13 +758,8 @@ if [[ $1 == "fw_fail_htlc" ]]; then
     wait_until_spent $ctx_id $output_index
     new_blocks 1   # confirm 2nd stage.
     sleep 1
-    new_blocks 100 # deep
-    sleep 5        # give bob time to fail incoming htlc
-    unsettled=$($alice list_channels | jq '.[] | .local_unsettled_sent')
-    if [[ "$unsettled" != "0" ]]; then
-        echo 'alice htlc was not failed'
-        exit 1
-    fi
+    new_blocks 100 # deep enough for is_deeply_mined (>20 confs)
+    wait_until_htlcs_settled alice  # bob propagates the failure back once the HTLC-timeout tx is deeply mined
 fi
 
 if [[ $1 == "just_in_time" ]]; then

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -22,7 +22,7 @@ function wait_until_htlcs_settled()
 {
     msg="wait until $1's local_unsettled_sent is zero"
     cmd="./run_electrum --regtest -D /tmp/$1"
-    declare -i timeout_sec=30
+    declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
     while unsettled=$($cmd list_channels | jq '.[] | .local_unsettled_sent') && [ $unsettled != "0" ]; do
@@ -44,7 +44,7 @@ function wait_for_balance()
 {
     msg="wait until $1's balance reaches $2"
     cmd="./run_electrum --regtest -D /tmp/$1"
-    declare -i timeout_sec=30
+    declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
     while balance=$($cmd getbalance | jq '[.confirmed, .unconfirmed] | to_entries | map(select(.value != null).value) | map(tonumber) | add ') && (( $(echo "$balance < $2" | bc -l) )); do
@@ -65,7 +65,7 @@ function wait_until_channel_open()
 {
     msg="wait until $1 sees channel open"
     cmd="./run_electrum --regtest -D /tmp/$1"
-    declare -i timeout_sec=30
+    declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
     while channel_state=$($cmd list_channels | jq '.[0] | .state' | tr -d '"') && [ $channel_state != "OPEN" ]; do
@@ -86,7 +86,7 @@ function wait_until_channel_closed()
 {
     msg="wait until $1 sees channel closed"
     cmd="./run_electrum --regtest -D /tmp/$1"
-    declare -i timeout_sec=30
+    declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
     while [[ $($cmd list_channels | jq '.[0].state' | tr -d '"') != "CLOSED" ]]; do
@@ -107,7 +107,7 @@ function wait_until_preimage()
 {
     msg="wait until $1 has preimage for $2"
     cmd="./run_electrum --regtest -D /tmp/$1"
-    declare -i timeout_sec=30
+    declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
     while [[ $($cmd get_invoice $2 | jq '.preimage' | tr -d '"') == "null" ]]; do
@@ -127,7 +127,7 @@ function wait_until_preimage()
 function wait_until_spent()
 {
     msg="wait until $1:$2 is spent"
-    declare -i timeout_sec=30
+    declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
     while [[ $($bitcoin_cli gettxout $1 $2) ]]; do


### PR DESCRIPTION
On master fw_fail_htlc is, especially on the CI, flaky. We mine 100 blocks, then wait fixed 5 seconds, then check if bob has failed back the htlcs to alice.
However if the test runs slowly (CI) 5 seconds can be too short for bob to catch up to the new 100 mined blocks.
Instead we should just use the wait_until_htlcs_settled helper function which polls Alice local_unsettled_sent with ~30~120 sec timeout, allowing bob to take a bit longer (or be faster) than 5 s.

```
.***** test_fw_fail_htlc ******
initializing alice
funding alice
a101c8c4c22043ff42029bcab2f0bf6ce5482a60d656294cbec3a4df557e2687
initializing bob
funding bob
d323d572c54817116d185c91f15e449550c651eb4ed76891d3011e0a8eb4ef9a
initializing carol
funding carol
bbf3503663876a4ae00f70c7e58ad49318e83d5cf99d6effe692e113d10910c2
mining 1 blocks
starting daemon (PID 5559)
/tmp/alice/regtest/wallets/default_wallet
true
starting daemon (PID 5577)
/tmp/bob/regtest/wallets/default_wallet
true
starting daemon (PID 5595)
/tmp/carol/regtest/wallets/default_wallet
true
alice and carol open channels with bob
mining 3 blocks
wait until alice sees channel open.
wait until alice sees channel open..
wait until alice sees channel open...
alice pays carol
Daemon stopped
mining 1 blocks
mining 150 blocks
wait until 99ad1d44b9054f5a85c2fb45e9a9b93eb13c785104ed0664be5cf866d79d38fc:2 is spent.
...
wait until 99ad1d44b9054f5a85c2fb45e9a9b93eb13c785104ed0664be5cf866d79d38fc:2 is spent............................
mining 1 blocks
mining 100 blocks
alice htlc was not failed
FDaemon stopped
```