### PR TITLE
Example: using GET_MASTER_FINGERPRINT for Legacy Client to get the master public key fingerprint

### DIFF
--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -14,7 +14,7 @@ hidapi>=0.7.99.post15
 libusb1>=1.6
 
 # device plugin: ledger
-ledger-bitcoin>=0.2.0,<1.0
+ledger-bitcoin>=0.4.1,<1.0
 hidapi
 
 # device plugin: coldcard

--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -1251,7 +1251,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
 
 class LedgerPlugin(HW_PluginBase):
     keystore_class = Ledger_KeyStore
-    minimum_library = (0, 2, 0)
+    minimum_library = (0, 4, 1)
     maximum_library = (1, 0)
     DEVICE_IDS = [(0x2581, 0x1807),  # HW.1 legacy btchip            # not supported anymore (but we log an exception)
                   (0x2581, 0x2b7c),  # HW.1 transitional production  # not supported anymore

--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -347,8 +347,9 @@ class Ledger_Client(HardwareClientBase, ABC):
     def __init__(self, *, plugin: HW_PluginBase):
         HardwareClientBase.__init__(self, plugin=plugin)
 
+    @abstractmethod
     def get_master_fingerprint(self) -> bytes:
-        return self.request_root_fingerprint_from_device()
+        pass
 
     @abstractmethod
     def show_address(self, address_path: str, txin_type: str):
@@ -390,6 +391,31 @@ class Ledger_Client_Legacy(Ledger_Client):
         self._product_key = product_key
         self._soft_device_id = None
 
+    def _get_master_fingerprint(self) -> bytes:
+        """Return the 4-byte master (root) key fingerprint.
+
+        Tries the dedicated GET_MASTER_FINGERPRINT APDU first (INS 0xD0),
+        which does NOT require DERIVE_MASTER permission.  If the device
+        does not support it (old firmware), falls back to
+        getWalletPublicKey("") + HASH160.
+        """
+        try:
+            return self.dongleObject.getMasterFingerprint()
+        except BTChipException as e:
+            if e.sw in (0x6d00, 0x6a80):  # INS not supported / bad data
+                _logger.info("getMasterFingerprint APDU not supported (sw=0x%04x), "
+                             "falling back to getWalletPublicKey", e.sw)
+            else:
+                raise
+        return self._get_node_fingerprint("")
+
+    def _get_node_fingerprint(self, bip32_path: str) -> bytes:
+        """Return the 4-byte fingerprint for an arbitrary BIP32 node
+        by calling getWalletPublicKey + HASH160.
+        """
+        nodeData = self.dongleObject.getWalletPublicKey(bip32_path)
+        return hash_160(compress_public_key(nodeData['publicKey']))[0:4]
+
     def is_pairable(self):
         return True
 
@@ -424,7 +450,7 @@ class Ledger_Client_Legacy(Ledger_Client):
             # modern ledger can provide xpub without user interaction
             # (hw1 would prompt for PIN)
             if not self.is_hw1():
-                self._soft_device_id = self.request_root_fingerprint_from_device()
+                self._soft_device_id = self._get_master_fingerprint().hex()
         return self._soft_device_id
 
     def is_hw1(self) -> bool:
@@ -432,6 +458,14 @@ class Ledger_Client_Legacy(Ledger_Client):
 
     def device_model_name(self):
         return LedgerPlugin.device_name_from_product_key(self._product_key)
+
+    @runs_in_hwd_thread
+    def request_root_fingerprint_from_device(self) -> str:
+        return self._get_master_fingerprint().hex()
+
+    @runs_in_hwd_thread
+    def get_master_fingerprint(self) -> bytes:
+        return self._get_master_fingerprint()
 
     @runs_in_hwd_thread
     def has_usable_connection_with_device(self):
@@ -460,9 +494,10 @@ class Ledger_Client_Legacy(Ledger_Client):
         bip32_path = bip32_path[2:]  # cut off "m/"
         if len(bip32_intpath) >= 1:
             prevPath = bip32.convert_bip32_intpath_to_strpath(bip32_intpath[:-1])[2:]
-            nodeData = self.dongleObject.getWalletPublicKey(prevPath)
-            publicKey = compress_public_key(nodeData['publicKey'])
-            fingerprint_bytes = hash_160(publicKey)[0:4]
+            if len(prevPath) == 0:
+                fingerprint_bytes = self._get_master_fingerprint()
+            else:
+                fingerprint_bytes = self._get_node_fingerprint(prevPath)
             childnum_bytes = bip32_intpath[-1].to_bytes(length=4, byteorder="big")
         else:
             fingerprint_bytes = bytes(4)


### PR DESCRIPTION
**This PR provides an example of how new GET_MASTER_FINGERPRINT instruction of Ledger app-bitcoin can be adopted in a software wallet. 
It overrides https://github.com/spesmilo/electrum/pull/10582 one.** 

### Scope
Since the hardening introduced in https://github.com/LedgerHQ/app-bitcoin/pull/297 (and in https://github.com/LedgerHQ/app-bitcoin/pull/299 for `bitcoin_testnet_legacy`), it is no longer possible to get the public key at the master level. Therefore, the new `GET_MASTER_FINGERPRINT` instruction was introduced to replace it.
 
The changes in this PR apply only to the legacy `app-bitcoin` starting from version `2.4.11` (and the `Ledger_Client_Legacy` part). Specifically for Electrum, this only affects the `bitcoin_testnet_legacy` app variant (`Bitcoin Test Legacy`), as there is no hardening applied to the `bitcoin_legacy` variant (`Bitcoin Legacy`). 
For `app-bitcoin-new` and the corresponding `Ledger_Client_New`, everything is already handled well through the `get_master_fingerprint()` call.

The new behavior is to first try the new instruction. If an error is returned (meaning the instruction does not exist in the app), it falls back to `getWalletPublicKey()`. This ensures backward compatibility with app versions older than v2.4.11.

### Tests
This has been successfully tested as follows:
1. Wallet creation with the previous unhardened version of `app-bitcoin` (using the `m/84h/1h/0h` path corresponding to `testnet`), and connecting to it with the hardened version of the app.
2. Wallet creation and connection using the already hardened version.

In the corresponding traces, it was observed that `INS_GET_WALLET_PUBLIC_KEY` commands with `bip32Path.length = 0` were effectively replaced by `INS_GET_MASTER_FINGERPRINT` calls.
