### PR TITLE
crash_reporter: detect more altcoin-forks, don't send reports

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -89,13 +89,19 @@ class BaseCrashReporter(Logger):
 
     def send_report(self, asyncio_loop, proxy: 'ProxySettings', *, timeout=None) -> CrashReportResponse:
         # FIXME the caller needs to catch generic "Exception", as this method does not have a well-defined API...
-        if (constants.net.GENESIS[-4:] not in [
+        bitcoinlike_genesis = constants.net.GENESIS[-4:] in [
             "e26f",  # mainnet
             "4943",  # testnet 3
             "f043",  # testnet 4
             "1ef6",  # signet
-        ] and ".electrum.org" in BaseCrashReporter.report_server):
-            # Gah! Some kind of altcoin wants to send us crash reports.
+        ]
+        is_forked_codebase = not bitcoinlike_genesis or "/spesmilo/" not in constants.GIT_REPO_URL
+        if is_forked_codebase and ".electrum.org" in BaseCrashReporter.report_server:
+            # Some kind of altcoin wants to send us crash reports... ?
+            # - You, the reader, yes *you*: if you forked the codebase e.g. to support an altcoin,
+            #   please consider that upstream Electrum does NOT want to receive automated crash reports
+            #   from your users.  You should set up your own crash report server,
+            #   and change `BaseCrashReporter.report_server` accordingly, or just disable reporting.
             raise Exception(_("Missing report URL."))
         report = self.get_traceback_info(*self.exc_args)
         report.update(self.get_additional_info())


### PR DESCRIPTION
A [new crash report](https://github.com/spesmilo/electrum/issues/10610) looks to be [from a fork](https://github.com/palladium-coin/pallectrum/blob/0df81c6af8d36f3549739576681d3df9969e32fd/electrum/constants.py#L194) where the altcoin has the same genesis block as Bitcoin. But ofc "branding" is important, so they updated the URLs to point to their fork -- so we could also test against that.