### PR TITLE
SECURITY.md: enable "private vuln reports" on GitHub

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,17 @@
-# Security Policy
+Two main ways to responsibly report security issues privately:
 
-## Reporting a Vulnerability
+1. (preferred) if you have a GitHub account, use the built-in
+  ["Report a vulnerability"](https://github.com/spesmilo/electrum/security/advisories/new)
+  flow, or
+2. you can send an email to the addresses listed below.
+  (Not for support. Support requests will be *ignored*.)
 
-To report security issues, send an email to the addresses listed below.
-(Not for support. Support requests will be *ignored*.)
-
-Please send any report to *all* emails listed here.
-
-The following GPG keys may be used to communicate sensitive information.
-
+If using email, please send any report to *all* emails listed here.
 
 | Name        | Email                                  | GPG fingerprint                                   |
 |-------------|----------------------------------------|---------------------------------------------------|
 | ThomasV     | thomasv [AT] electrum [DOT] org        | 6694 D8DE 7BE8 EE56 31BE D950 2BD5 824B 7F94 70E6 |
 | SomberNight | somber.night [AT] protonmail [DOT] com | 4AD6 4339 DFA0 5E20 B3F6 AD51 E7B7 48CD AF5E 5ED9 |
 
-
-#### Where to find GPG keys
-
-You can import a key by running the following command with that
-individual’s fingerprint: `gpg --recv-keys "<fingerprint>"`
-
-These public keys can also be found in the Electrum git repository,
+These GPG public keys can be found in the Electrum git repository,
 in the top-level `pubkeys` folder.


### PR DESCRIPTION
ref https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability

I also tried to save some vertical screen space here, due to how the web interface displays https://github.com/spesmilo/electrum/security (when not logged in)