### PR TITLE
qml: QERequestDetails: handle _wallet = None in callback

### DIFF
--- a/electrum/gui/qml/qerequestdetails.py
+++ b/electrum/gui/qml/qerequestdetails.py
@@ -69,7 +69,7 @@ class QERequestDetails(QObject, QtEventListener):
 
     @qt_event_listener
     def on_event_request_status(self, wallet, key, status):
-        if wallet == self._wallet.wallet and key == self._key:
+        if self._wallet and wallet == self._wallet.wallet and key == self._key:
             self._logger.debug('request status %d for key %s' % (status, key))
             self.statusChanged.emit()
 


### PR DESCRIPTION
Handle `QERequestDetails._wallet` being `None` in the `on_event_request_status` callback.

Fixes #10617 