### PR TITLE
LNWallet: make anchor channels required

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1015,7 +1015,7 @@ class LNWallet(Logger):
         if features is None:
             features = LNWALLET_FEATURES
             if self.config.ENABLE_ANCHOR_CHANNELS:
-                features |= LnFeatures.OPTION_ANCHORS_ZERO_FEE_HTLC_OPT
+                features |= LnFeatures.OPTION_ANCHORS_ZERO_FEE_HTLC_REQ
             if self.config.OPEN_ZEROCONF_CHANNELS:
                 features |= LnFeatures.OPTION_ZEROCONF_OPT
             if self.config.EXPERIMENTAL_LN_FORWARD_PAYMENTS or self.config.EXPERIMENTAL_LN_FORWARD_TRAMPOLINE_PAYMENTS:


### PR DESCRIPTION
If config.ENABLE_ANCHOR_CHANNELS is set, signal
OPTION_ANCHORS_ZERO_FEE_HTLC_REQ instead of OPT.

This will prevent opening new outgoing and incoming SRK channels. 
It will also prevent connecting to peers that don't signal anchor support at all (INIT features), so existing channels to them would need to get force closed or the peer needs to be bullied into updating their node software.
Existing SRK channels with peers that signal anchor support (e.g. SRK channel opened to Electrum Trampoline) remain usable.