### PR TITLE
lnpeer: clean-up channel_type and enforce all newly opened channels use anchors

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1243,12 +1243,15 @@ class Peer(Logger, EventListener):
         if channel_type is None:
             raise Exception("channel_type MUST be present in open_channel, but missing")
         # MUST fail the channel if channel_type is not suitable.
-        # TODO fail if channel_type does not have anchors
-        else:
-            channel_type = ChannelType.from_bytes(channel_type['type'], byteorder='big').discard_unknown_and_check()
-            if not channel_type.complies_with_features(self.features):
-                raise Exception("sender has sent a channel type we don't support")
-        assert isinstance(channel_type, ChannelType)
+        channel_type = ChannelType.from_bytes(channel_type['type'], byteorder='big').discard_unknown_and_check()
+        if not channel_type.complies_with_features(self.features):
+            raise Exception("sender has sent a channel type we don't support")
+        assert channel_type & ChannelType.OPTION_STATIC_REMOTEKEY, "new legacy channel?!"
+        if not self.config.TEST_LN_OPEN_SRK_CHANNELS:
+            if not channel_type & ChannelType.OPTION_ANCHORS:
+                # note: BOLT-02 does NOT forbid opening new SRK chan
+                #       just because ANCHORS has been negotiated as peer feature
+                raise Exception("refusing to open new static_remotekey channel")
 
         is_zeroconf = bool(channel_type & ChannelType.OPTION_ZEROCONF)
         if is_zeroconf and not self.config.ZEROCONF_TRUSTED_NODE.startswith(self.pubkey.hex()):

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1088,13 +1088,16 @@ class Peer(Logger, EventListener):
             payload, 'accept')
 
         accept_channel_tlvs = payload.get('accept_channel_tlvs')
-        their_channel_type = accept_channel_tlvs.get('channel_type') if accept_channel_tlvs else None
-        if their_channel_type:
-            their_channel_type = ChannelType.from_bytes(their_channel_type['type'], byteorder='big').discard_unknown_and_check()
-            # if channel_type is set, and channel_type was set in open_channel,
-            # and they are not equal types: MUST reject the channel.
-            if open_channel_tlvs.get('channel_type') is not None and their_channel_type != our_channel_type:
-                raise Exception("Channel type is not the one that we sent.")
+        if accept_channel_tlvs is None:
+            raise Exception("accept_channel_tlvs MUST be present in accept_channel, but missing")
+        their_channel_type = accept_channel_tlvs.get('channel_type')
+        if their_channel_type is None:
+            raise Exception("channel_type MUST be present in accept_channel, but missing")
+        their_channel_type = ChannelType.from_bytes(their_channel_type['type'], byteorder='big').discard_unknown_and_check()
+        # if channel_type is set, and channel_type was set in open_channel,
+        # and they are not equal types: MUST reject the channel.
+        if their_channel_type != our_channel_type:
+            raise Exception("channel_type is not the one that we sent.")
 
         remote_config = RemoteConfig(
             payment_basepoint=OnlyPubkeyKeypair(payload['payment_basepoint']),
@@ -1237,11 +1240,11 @@ class Peer(Logger, EventListener):
             raise Exception('wrong chain_hash')
 
         open_channel_tlvs = payload.get('open_channel_tlvs')
-        channel_type = open_channel_tlvs.get('channel_type') if open_channel_tlvs else None
-        # The receiving node MAY fail the channel if:
-        # option_channel_type was negotiated but the message doesn't include a channel_type
+        if open_channel_tlvs is None:
+            raise Exception("open_channel_tlvs MUST be present in open_channel, but missing")
+        channel_type = open_channel_tlvs.get('channel_type')
         if channel_type is None:
-            raise Exception("sender has advertised option_channel_type, but hasn't sent the channel type")
+            raise Exception("channel_type MUST be present in open_channel, but missing")
         # MUST fail the channel if it supports channel_type,
         # channel_type was set, and the type is not suitable.
         else:

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1007,6 +1007,7 @@ class Peer(Logger, EventListener):
             our_channel_type |= ChannelType(ChannelType.OPTION_ZEROCONF)
         # We do not set the option_scid_alias bit in channel_type because LND rejects it.
         # Eclair accepts channel_type with that bit, but does not require it.
+        assert our_channel_type.complies_with_features(self.features), f"{our_channel_type=!r}, {self.features=!r}"
 
         # if option_channel_type is negotiated: MUST set channel_type
         # if it includes channel_type: MUST set it to a defined type representing the type it wants.
@@ -1092,9 +1093,11 @@ class Peer(Logger, EventListener):
         their_channel_type = accept_channel_tlvs.get('channel_type')
         if their_channel_type is None:
             raise Exception("channel_type MUST be present in accept_channel, but missing")
-        their_channel_type = ChannelType.from_bytes(their_channel_type['type'], byteorder='big').discard_unknown_and_check()
+        their_channel_type = ChannelType.from_bytes(their_channel_type['type'], byteorder='big')
+        # if channel_type does not match the channel_type from open_channel:
+        #     MUST fail the channel.
         if their_channel_type != our_channel_type:
-            raise Exception("channel_type is not the one that we sent.")
+            raise Exception(f"channel_type is not the one that we sent. {our_channel_type=}. {their_channel_type=}.")
 
         remote_config = RemoteConfig(
             payment_basepoint=OnlyPubkeyKeypair(payload['payment_basepoint']),
@@ -1243,7 +1246,7 @@ class Peer(Logger, EventListener):
         if channel_type is None:
             raise Exception("channel_type MUST be present in open_channel, but missing")
         # MUST fail the channel if channel_type is not suitable.
-        channel_type = ChannelType.from_bytes(channel_type['type'], byteorder='big').discard_unknown_and_check()
+        channel_type = ChannelType.from_bytes(channel_type['type'], byteorder='big')
         if not channel_type.complies_with_features(self.features):
             raise Exception("sender has sent a channel type we don't support")
         assert channel_type & ChannelType.OPTION_STATIC_REMOTEKEY, "new legacy channel?!"

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -922,9 +922,6 @@ class Peer(Logger, EventListener):
     def is_upfront_shutdown_script(self):
         return self.features.supports(LnFeatures.OPTION_UPFRONT_SHUTDOWN_SCRIPT_OPT)
 
-    def use_anchors(self) -> bool:
-        return self.features.supports(LnFeatures.OPTION_ANCHORS_OPT)
-
     def upfront_shutdown_script_from_payload(self, payload, msg_identifier: str) -> Optional[bytes]:
         if msg_identifier not in ['accept', 'open']:
             raise ValueError("msg_identifier must be either 'accept' or 'open'")
@@ -994,16 +991,18 @@ class Peer(Logger, EventListener):
 
         channel_flags = CF_ANNOUNCE_CHANNEL if public else 0
         feerate: Optional[int] = self.lnworker.current_target_feerate_per_kw(
-            has_anchors=self.use_anchors()
+            has_anchors=not self.config.TEST_LN_OPEN_SRK_CHANNELS,
         )
         if feerate is None:
             raise NoDynamicFeeEstimates()
         # we set a channel type for internal bookkeeping
         open_channel_tlvs = {}
-        assert self.their_features.supports(LnFeatures.OPTION_STATIC_REMOTEKEY_OPT)
-        our_channel_type = ChannelType(ChannelType.OPTION_STATIC_REMOTEKEY)
-        if self.use_anchors():
-            our_channel_type |= ChannelType(ChannelType.OPTION_ANCHORS)
+        assert self.features.supports(LnFeatures.OPTION_STATIC_REMOTEKEY_OPT)
+        assert self.features.supports(LnFeatures.OPTION_ANCHORS_OPT)
+        if self.config.TEST_LN_OPEN_SRK_CHANNELS:
+            our_channel_type = ChannelType(ChannelType.OPTION_STATIC_REMOTEKEY)
+        else:  # anchors
+            our_channel_type = ChannelType(ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS)
         if zeroconf:
             our_channel_type |= ChannelType(ChannelType.OPTION_ZEROCONF)
         # We do not set the option_scid_alias bit in channel_type because LND rejects it.
@@ -1094,8 +1093,6 @@ class Peer(Logger, EventListener):
         if their_channel_type is None:
             raise Exception("channel_type MUST be present in accept_channel, but missing")
         their_channel_type = ChannelType.from_bytes(their_channel_type['type'], byteorder='big').discard_unknown_and_check()
-        # if channel_type is set, and channel_type was set in open_channel,
-        # and they are not equal types: MUST reject the channel.
         if their_channel_type != our_channel_type:
             raise Exception("channel_type is not the one that we sent.")
 
@@ -1245,8 +1242,8 @@ class Peer(Logger, EventListener):
         channel_type = open_channel_tlvs.get('channel_type')
         if channel_type is None:
             raise Exception("channel_type MUST be present in open_channel, but missing")
-        # MUST fail the channel if it supports channel_type,
-        # channel_type was set, and the type is not suitable.
+        # MUST fail the channel if channel_type is not suitable.
+        # TODO fail if channel_type does not have anchors
         else:
             channel_type = ChannelType.from_bytes(channel_type['type'], byteorder='big').discard_unknown_and_check()
             if not channel_type.complies_with_features(self.features):

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1622,21 +1622,6 @@ class ChannelType(IntFlag):
     OPTION_SCID_ALIAS = 1 << 46  # variation flag
     OPTION_ZEROCONF = 1 << 50    # variation flag
 
-    def discard_unknown_and_check(self) -> 'ChannelType':
-        """Discards unknown flags and checks flag combination."""
-        flags = list_enabled_bits(self)
-        known_channel_types = []
-        for flag in flags:
-            channel_type = ChannelType(1 << flag)
-            if channel_type.name:
-                known_channel_types.append(channel_type)
-        final_channel_type = known_channel_types[0]
-        for channel_type in known_channel_types[1:]:
-            final_channel_type |= channel_type
-
-        final_channel_type.check_combinations()
-        return final_channel_type
-
     def check_combinations(self):
         """Raises if invalid flag combination."""
         basic_type = self & ~(ChannelType.OPTION_SCID_ALIAS | ChannelType.OPTION_ZEROCONF)
@@ -1644,7 +1629,7 @@ class ChannelType(IntFlag):
                 ChannelType.OPTION_STATIC_REMOTEKEY,
                 ChannelType.OPTION_ANCHORS | ChannelType.OPTION_STATIC_REMOTEKEY
         ]:
-            raise ValueError("Channel type is not a valid flag combination.")
+            raise ValueError(f"Channel type is not a valid flag combination: {self}")
 
     def complies_with_features(self, peer_features: LnFeatures) -> bool:
         """Returns whether channel_type complies with peer_features.
@@ -1655,6 +1640,7 @@ class ChannelType(IntFlag):
               For example, even if opt_anchors is a negotiated peer_feature, (as per my reading of BOLT-02),
               it is still allowed to open an SRK channel (by setting channel_type accordingly).
         """
+        self.check_combinations()  # test if raises
         cflags = list_enabled_bits(self)
         # channel flags must be a SUBSET of peer_features
         for cflag in cflags:

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1619,8 +1619,8 @@ class ChannelType(IntFlag):
     OPTION_LEGACY_CHANNEL = 0
     OPTION_STATIC_REMOTEKEY = 1 << 12
     OPTION_ANCHORS = 1 << 22
-    OPTION_SCID_ALIAS = 1 << 46
-    OPTION_ZEROCONF = 1 << 50
+    OPTION_SCID_ALIAS = 1 << 46  # variation flag
+    OPTION_ZEROCONF = 1 << 50    # variation flag
 
     def discard_unknown_and_check(self) -> 'ChannelType':
         """Discards unknown flags and checks flag combination."""
@@ -1638,6 +1638,7 @@ class ChannelType(IntFlag):
         return final_channel_type
 
     def check_combinations(self):
+        """Raises if invalid flag combination."""
         basic_type = self & ~(ChannelType.OPTION_SCID_ALIAS | ChannelType.OPTION_ZEROCONF)
         if basic_type not in [
                 ChannelType.OPTION_STATIC_REMOTEKEY,
@@ -1645,13 +1646,22 @@ class ChannelType(IntFlag):
         ]:
             raise ValueError("Channel type is not a valid flag combination.")
 
-    def complies_with_features(self, features: LnFeatures) -> bool:
-        flags = list_enabled_bits(self)
-        complies = True
-        for flag in flags:
-            feature = LnFeatures(1 << flag)
-            complies &= features.supports(feature)
-        return complies
+    def complies_with_features(self, peer_features: LnFeatures) -> bool:
+        """Returns whether channel_type complies with peer_features.
+        peer_features is negotiated features for the peer session.
+
+        note: enforces channel_type is-SUBSET-of peer_features
+              but does NOT enforce cflag-related-peer_features is-SUBSET-of channel_type.
+              For example, even if opt_anchors is a negotiated peer_feature, (as per my reading of BOLT-02),
+              it is still allowed to open an SRK channel (by setting channel_type accordingly).
+        """
+        cflags = list_enabled_bits(self)
+        # channel flags must be a SUBSET of peer_features
+        for cflag in cflags:
+            feature = LnFeatures(1 << cflag)
+            if not peer_features.supports(feature):
+                return False
+        return True
 
     def to_bytes_minimal(self):
         # MUST use the smallest bitmap possible to represent the channel type.

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1690,6 +1690,7 @@ class LNWallet(Logger):
         upfront_shutdown_script = b''
 
         assert channel_type is not None
+        channel_type.check_combinations()  # test if raises
         if channel_type & ChannelType.OPTION_ANCHORS:  # anchors
             static_payment_key = self.static_payment_key
             static_remotekey = None

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1695,7 +1695,7 @@ class LNWallet(Logger):
             static_remotekey = None
         else:  # static_remotekey
             assert channel_type & channel_type.OPTION_STATIC_REMOTEKEY
-            #assert self.config.TEST_LN_OPEN_SRK_CHANNELS
+            assert self.config.TEST_LN_OPEN_SRK_CHANNELS
             wallet = self.wallet
             assert wallet.txin_type == 'p2wpkh'
             addr = wallet.get_new_sweep_address_for_channel()

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -199,6 +199,7 @@ LNWALLET_FEATURES = (
     BASE_FEATURES
     | LnFeatures.OPTION_DATA_LOSS_PROTECT_REQ
     | LnFeatures.OPTION_STATIC_REMOTEKEY_REQ
+    | LnFeatures.OPTION_ANCHORS_REQ
     | LnFeatures.VAR_ONION_REQ
     | LnFeatures.PAYMENT_SECRET_REQ
     | LnFeatures.BASIC_MPP_OPT
@@ -1014,8 +1015,6 @@ class LNWallet(Logger):
         Logger.__init__(self)
         if features is None:
             features = LNWALLET_FEATURES
-            if self.config.ENABLE_ANCHOR_CHANNELS:
-                features |= LnFeatures.OPTION_ANCHORS_OPT
             if self.config.OPEN_ZEROCONF_CHANNELS:
                 features |= LnFeatures.OPTION_ZEROCONF_OPT
             if self.config.EXPERIMENTAL_LN_FORWARD_PAYMENTS or self.config.EXPERIMENTAL_LN_FORWARD_TRAMPOLINE_PAYMENTS:
@@ -1597,8 +1596,7 @@ class LNWallet(Logger):
             zeroconf: bool = False,
             opening_base_fee_msat: Optional[int] = None,
             password=None):
-        if self.config.ENABLE_ANCHOR_CHANNELS:
-            self.wallet.unlock(password)
+        self.wallet.unlock(password)
         coins = self.wallet.get_spendable_coins(None)
         node_id = peer.pubkey
         fee_policy = FeePolicy(self.config.FEE_POLICY)
@@ -1697,6 +1695,7 @@ class LNWallet(Logger):
             static_remotekey = None
         else:  # static_remotekey
             assert channel_type & channel_type.OPTION_STATIC_REMOTEKEY
+            #assert self.config.TEST_LN_OPEN_SRK_CHANNELS
             wallet = self.wallet
             assert wallet.txin_type == 'p2wpkh'
             addr = wallet.get_new_sweep_address_for_channel()
@@ -1772,8 +1771,7 @@ class LNWallet(Logger):
             coins=coins,
             outputs=outputs,
             fee_policy=fee_policy,
-            # we do not know yet if peer accepts anchors, just assume they do
-            is_anchor_channel_opening=self.config.ENABLE_ANCHOR_CHANNELS,
+            is_anchor_channel_opening=not self.config.TEST_LN_OPEN_SRK_CHANNELS,
         )
         tx.set_rbf(False)
         # rm randomness from locktime, as we use the locktime as entropy for deriving the funding_privkey
@@ -3707,10 +3705,7 @@ class LNWallet(Logger):
         to sweep funds after a channel has been force closed).
 
         The creation of lightning channels in watching-only wallets
-        has been disabled for anchor channels. Note that it is still
-        possible to create non-anchor channels, see
-        config.ENABLE_ANCHOR_CHANNELS.
-
+        has been disabled for anchor channels.
         """
         xpub = self.wallet.get_fingerprint()
         backup_bytes = self.create_channel_backup(channel_id).to_bytes()

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -779,6 +779,7 @@ Warning: setting this to too low will result in lots of payment failures."""),
     TEST_SHUTDOWN_FEE = ConfigVar('test_shutdown_fee', default=None, type_=int)
     TEST_SHUTDOWN_FEE_RANGE = ConfigVar('test_shutdown_fee_range', default=None)
     TEST_SHUTDOWN_LEGACY = ConfigVar('test_shutdown_legacy', default=False, type_=bool)
+    TEST_LN_OPEN_SRK_CHANNELS = ConfigVar('test_ln_open_srk_channels', default=False, type_=bool)
 
     # fee_policy is a dict: fee_policy_name -> fee_policy_descriptor
     FEE_POLICY = ConfigVar('fee_policy.default', default='eta:2', type_=str)  # exposed to GUI
@@ -951,8 +952,6 @@ Warning: setting this to too low will result in lots of payment failures."""),
         ]),
     )
 
-    # anchor outputs channels
-    ENABLE_ANCHOR_CHANNELS = ConfigVar('enable_anchor_channels', default=True, type_=bool)
     # zeroconf channels
     OPEN_ZEROCONF_CHANNELS = ConfigVar('open_zeroconf_channels', default=False, type_=bool)
     ZEROCONF_TRUSTED_NODE = ConfigVar('zeroconf_trusted_node', default='', type_=str)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -525,7 +525,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         # we want static_remotekey to be a wallet address
         if not self.txin_type == 'p2wpkh':
             return False
-        if self.config.ENABLE_ANCHOR_CHANNELS:
+        if not self.config.TEST_LN_OPEN_SRK_CHANNELS:  # anchors
             if not self.keystore:
                 return False
             if self.keystore.is_watching_only():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -37,7 +37,7 @@ class ElectrumTestCase(unittest.IsolatedAsyncioTestCase, Logger):
 
     TESTNET = False  # there is also an @as_testnet decorator to run single tests in testnet mode
     REGTEST = False
-    TEST_ANCHOR_CHANNELS = False
+    TEST_ANCHOR_CHANNELS = True
     WALLET_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_storage_upgrade")
     # maxDiff = None  # for debugging
 
@@ -103,11 +103,10 @@ class ElectrumTestCase(unittest.IsolatedAsyncioTestCase, Logger):
         self,
         *,
         name: str,
-        has_anchors: bool,
     ) -> 'MockLNWallet':
         from .test_lnpeer import _create_mock_lnwallet
         data_dir = tempfile.mkdtemp(prefix="lnwallet-", dir=self.unittest_base_path)
-        lnwallet = _create_mock_lnwallet(name=name, has_anchors=has_anchors, data_dir=data_dir)
+        lnwallet = _create_mock_lnwallet(name=name, has_anchors=self.TEST_ANCHOR_CHANNELS, data_dir=data_dir)
         self._lnworkers_created.append(lnwallet)
         return lnwallet
 

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -2,7 +2,7 @@
 export HOME=~
 set -eu
 
-TEST_ANCHOR_CHANNELS=True
+TEST_SRK_CHANNELS=False
 
 # alice -> bob -> carol
 
@@ -167,7 +167,7 @@ if [[ $1 == "init" ]]; then
     rm -rf /tmp/$2/
     agent="./run_electrum --regtest -D /tmp/$2"
     $agent create --offline > /dev/null
-    $agent setconfig --offline enable_anchor_channels $TEST_ANCHOR_CHANNELS
+    $agent setconfig --offline test_ln_open_srk_channels $TEST_SRK_CHANNELS
     $agent setconfig --offline log_to_file True
     $agent setconfig --offline use_gossip True
     $agent setconfig --offline server 127.0.0.1:51001:t
@@ -335,9 +335,9 @@ if [[ $1 == "swapserver_forceclose" ]]; then
     new_blocks 1
     wait_until_spent $funding_txid 0 # alice reveals preimage
     new_blocks 1
-    if [ $TEST_ANCHOR_CHANNELS = True ] ; then
+    if [ $TEST_SRK_CHANNELS != True ] ; then  # anchors
         output_index=3  # received_htlc_output in bob's ctx. FIXME index depends on Alice not using MPP
-    else
+    else  # srk
         output_index=1
     fi
     # wait until Bob finds preimage onchain and uses it to create an htlc_success tx
@@ -419,12 +419,12 @@ if [[ $1 == "lnwatcher_waits_until_fees_go_down" ]]; then
     new_blocks 1
     wait_until_channel_closed alice
     ctx_id=$($alice list_channels | jq -r ".[0].closing_txid")
-    if [ $TEST_ANCHOR_CHANNELS = True ] ; then
+    if [ $TEST_SRK_CHANNELS != True ] ; then  # anchors
         htlc_output_index1=2
         htlc_output_index2=3
         to_alice_index=4  # Bob's to_remote
         wait_until_spent $ctx_id $to_alice_index
-    else
+    else  # srk
         htlc_output_index1=0
         htlc_output_index2=1
         to_alice_index=2
@@ -669,12 +669,12 @@ if [[ $1 == "breach_with_spent_htlc" ]]; then
     $alice load_wallet -w /tmp/alice/regtest/wallets/toxic_wallet
     # wait until alice has spent both ctx outputs
     echo "alice spends to_local and htlc outputs"
-    if [ $TEST_ANCHOR_CHANNELS = True ] ; then
+    if [ $TEST_SRK_CHANNELS != True ] ; then  # anchors
         # to_local_anchor/to_remote_anchor: 0 and 1 (both are present due to untrimmed htlcs)
         # htlc: 2, to_local: 3
         wait_until_spent $ctx_id 2
         wait_until_spent $ctx_id 3
-    else
+    else  # srk
         # htlc: 0, to_local: 1
         wait_until_spent $ctx_id 0
         wait_until_spent $ctx_id 1
@@ -717,9 +717,9 @@ if [[ $1 == "watchtower" ]]; then
     ctx_id=$($bitcoin_cli sendrawtransaction $ctx)
     echo "alice breaches with old ctx:" $ctx_id
     echo "watchtower publishes justice transaction"
-    if [ $TEST_ANCHOR_CHANNELS = True ] ; then
+    if [ $TEST_SRK_CHANNELS != True ] ; then  # anchors
         output_index=3
-    else
+    else  # srk
         output_index=1
     fi
     wait_until_spent $ctx_id $output_index  # alice's to_local gets punished
@@ -750,9 +750,9 @@ if [[ $1 == "fw_fail_htlc" ]]; then
     sleep 1
     new_blocks 150 # cltv before bob can broadcast
     # index of htlc
-    if [ $TEST_ANCHOR_CHANNELS = True ] ; then
+    if [ $TEST_SRK_CHANNELS != True ] ; then  # anchors
         output_index=2
-    else
+    else  # srk
         output_index=0
     fi
     wait_until_spent $ctx_id $output_index

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -130,7 +130,6 @@ def create_test_channels(
     local_msat=None,
     remote_msat=None,
     random_seed=None,
-    anchor_outputs: bool = False,
     local_max_inflight=None,
     remote_max_inflight=None,
     max_accepted_htlcs=5,
@@ -154,9 +153,11 @@ def create_test_channels(
         config.LIGHTNING_MAX_FUNDING_SAT = max(config.LIGHTNING_MAX_FUNDING_SAT, funding_sat)
 
     peer_features = alice_lnwallet.features | LnFeatures.OPTION_SUPPORT_LARGE_CHANNEL_OPT
-    channel_type = ChannelType.OPTION_STATIC_REMOTEKEY
-    if anchor_outputs:
-        channel_type |= ChannelType.OPTION_ANCHORS
+    assert alice_lnwallet.config.TEST_LN_OPEN_SRK_CHANNELS == bob_lnwallet.config.TEST_LN_OPEN_SRK_CHANNELS
+    if alice_lnwallet.config.TEST_LN_OPEN_SRK_CHANNELS:
+        channel_type = ChannelType.OPTION_STATIC_REMOTEKEY
+    else:
+        channel_type = ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS
     # create alice's local config
     alice_lconfig = alice_lnwallet.make_local_config_for_new_channel(
         funding_sat=funding_sat,
@@ -273,7 +274,6 @@ class TestFee(ElectrumTestCase):
             feerate=253,
             local_msat=10_000_000_000,
             remote_msat=5_000_000_000,
-            anchor_outputs=self.TEST_ANCHOR_CHANNELS,
             alice_lnwallet=self.alice_lnwallet,
             bob_lnwallet=self.bob_lnwallet,
         )
@@ -308,7 +308,7 @@ class TestChannel(ElectrumTestCase):
         # unittest. The channel will be funded evenly with Alice having 5 BTC,
         # and Bob having 5 BTC.
         self.alice_channel, self.bob_channel = create_test_channels(
-            anchor_outputs=self.TEST_ANCHOR_CHANNELS, alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
+            alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
 
         self.paymentPreimage = b"\x01" * 32
         paymentHash = bitcoin.sha256(self.paymentPreimage)
@@ -861,7 +861,7 @@ class TestAvailableToSpend(ElectrumTestCase):
 
     async def test_DesyncHTLCs(self):
         alice_channel, bob_channel = create_test_channels(
-            anchor_outputs=self.TEST_ANCHOR_CHANNELS, alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
+            alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
         self.assertEqual(499986152000 if not alice_channel.has_anchors() else 499980692000, alice_channel.available_to_spend(LOCAL))
         self.assertEqual(500000000000, bob_channel.available_to_spend(LOCAL))
 
@@ -908,7 +908,6 @@ class TestAvailableToSpend(ElectrumTestCase):
 
     async def test_single_payment(self):
         alice_channel, bob_channel = create_test_channels(
-            anchor_outputs=self.TEST_ANCHOR_CHANNELS,
             local_msat=4000000000,
             remote_msat=4000000000,
             local_max_inflight=1000000000,
@@ -975,7 +974,7 @@ class TestChanReserve(ElectrumTestCase):
         await super().asyncSetUp()
         alice_lnwallet = self.create_mock_lnwallet(name="alice", has_anchors=self.TEST_ANCHOR_CHANNELS)
         bob_lnwallet = self.create_mock_lnwallet(name="bob", has_anchors=self.TEST_ANCHOR_CHANNELS)
-        alice_channel, bob_channel = create_test_channels(anchor_outputs=False, alice_lnwallet=alice_lnwallet, bob_lnwallet=bob_lnwallet)
+        alice_channel, bob_channel = create_test_channels(alice_lnwallet=alice_lnwallet, bob_lnwallet=bob_lnwallet)
         alice_min_reserve = int(.5 * one_bitcoin_in_msat // 1000)
         # We set Bob's channel reserve to a value that is larger than
         # his current balance in the channel. This will ensure that
@@ -1115,7 +1114,7 @@ class TestDust(ElectrumTestCase):
 
     async def test_DustLimit(self):
         """Test that addition of an HTLC below the dust limit changes the balances."""
-        alice_channel, bob_channel = create_test_channels(anchor_outputs=self.TEST_ANCHOR_CHANNELS, alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
+        alice_channel, bob_channel = create_test_channels(alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
         dust_limit_alice = alice_channel.config[LOCAL].dust_limit_sat
         dust_limit_bob = bob_channel.config[LOCAL].dust_limit_sat
         self.assertLess(dust_limit_alice, dust_limit_bob)

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -266,8 +266,8 @@ class TestFee(ElectrumTestCase):
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.alice_lnwallet = self.create_mock_lnwallet(name="alice", has_anchors=self.TEST_ANCHOR_CHANNELS)
-        self.bob_lnwallet = self.create_mock_lnwallet(name="bob", has_anchors=self.TEST_ANCHOR_CHANNELS)
+        self.alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        self.bob_lnwallet = self.create_mock_lnwallet(name="bob")
 
     async def test_fee(self):
         alice_channel, bob_channel = create_test_channels(
@@ -301,8 +301,8 @@ class TestChannel(ElectrumTestCase):
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.alice_lnwallet = self.create_mock_lnwallet(name="alice", has_anchors=self.TEST_ANCHOR_CHANNELS)
-        self.bob_lnwallet = self.create_mock_lnwallet(name="bob", has_anchors=self.TEST_ANCHOR_CHANNELS)
+        self.alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        self.bob_lnwallet = self.create_mock_lnwallet(name="bob")
 
         # Create a test channel which will be used for the duration of this
         # unittest. The channel will be funded evenly with Alice having 5 BTC,
@@ -856,8 +856,8 @@ class TestChannelAnchors(TestChannel):
 class TestAvailableToSpend(ElectrumTestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.alice_lnwallet = self.create_mock_lnwallet(name="alice", has_anchors=self.TEST_ANCHOR_CHANNELS)
-        self.bob_lnwallet = self.create_mock_lnwallet(name="bob", has_anchors=self.TEST_ANCHOR_CHANNELS)
+        self.alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        self.bob_lnwallet = self.create_mock_lnwallet(name="bob")
 
     async def test_DesyncHTLCs(self):
         alice_channel, bob_channel = create_test_channels(
@@ -972,8 +972,8 @@ class TestAvailableToSpendAnchors(TestAvailableToSpend):
 class TestChanReserve(ElectrumTestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        alice_lnwallet = self.create_mock_lnwallet(name="alice", has_anchors=self.TEST_ANCHOR_CHANNELS)
-        bob_lnwallet = self.create_mock_lnwallet(name="bob", has_anchors=self.TEST_ANCHOR_CHANNELS)
+        alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        bob_lnwallet = self.create_mock_lnwallet(name="bob")
         alice_channel, bob_channel = create_test_channels(alice_lnwallet=alice_lnwallet, bob_lnwallet=bob_lnwallet)
         alice_min_reserve = int(.5 * one_bitcoin_in_msat // 1000)
         # We set Bob's channel reserve to a value that is larger than
@@ -1109,8 +1109,8 @@ class TestChanReserveAnchors(TestChanReserve):
 class TestDust(ElectrumTestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.alice_lnwallet = self.create_mock_lnwallet(name="alice", has_anchors=self.TEST_ANCHOR_CHANNELS)
-        self.bob_lnwallet = self.create_mock_lnwallet(name="bob", has_anchors=self.TEST_ANCHOR_CHANNELS)
+        self.alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        self.bob_lnwallet = self.create_mock_lnwallet(name="bob")
 
     async def test_DustLimit(self):
         """Test that addition of an HTLC below the dust limit changes the balances."""

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -484,7 +484,7 @@ class TestPeer(ElectrumTestCase):
     def prepare_lnwallets(self, graph_definition) -> Mapping[str, MockLNWallet]:
         workers = {}  # type: Dict[str, MockLNWallet]
         for a, definition in graph_definition.items():
-            workers[a] = self.create_mock_lnwallet(name=a, has_anchors=self.TEST_ANCHOR_CHANNELS)
+            workers[a] = self.create_mock_lnwallet(name=a)
         return workers
 
     def prepare_chans_and_peers_in_graph(
@@ -3047,11 +3047,13 @@ class TestPeerForwarding(TestPeer):
                 await run_test(trampoline)
 
 
-class TestPeerDirectAnchors(TestPeerDirect):
-    TEST_ANCHOR_CHANNELS = True
+class TestPeerDirectNoAnchors(TestPeerDirect):
+    assert TestPeerDirect.TEST_ANCHOR_CHANNELS is True
+    TEST_ANCHOR_CHANNELS = False
 
-class TestPeerForwardingAnchors(TestPeerForwarding):
-    TEST_ANCHOR_CHANNELS = True
+class TestPeerForwardinNoAnchors(TestPeerForwarding):
+    assert TestPeerForwarding.TEST_ANCHOR_CHANNELS is True
+    TEST_ANCHOR_CHANNELS = False
 
 
 def run(coro):

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -133,7 +133,7 @@ class MockStandardWallet(Standard_Wallet):
 
 def _create_mock_lnwallet(*, name, has_anchors, data_dir: str) -> 'MockLNWallet':
     config = SimpleConfig({}, read_user_dir_function=lambda: data_dir)
-    config.ENABLE_ANCHOR_CHANNELS = has_anchors
+    config.TEST_LN_OPEN_SRK_CHANNELS = not has_anchors
     config.INITIAL_TRAMPOLINE_FEE_LEVEL = 0
 
     network = MockNetwork(config=config)

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -517,7 +517,6 @@ class TestPeer(ElectrumTestCase):
                         bob_lnwallet=workers[b],
                         local_msat=channel_def['local_balance_msat'],
                         remote_msat=channel_def['remote_balance_msat'],
-                        anchor_outputs=self.TEST_ANCHOR_CHANNELS
                     )
                     channels[(a, b)], channels[(b, a)] = channel_ab, channel_ba
                 workers[a]._add_channel(channel_ab)

--- a/tests/test_lnpeermgr.py
+++ b/tests/test_lnpeermgr.py
@@ -19,7 +19,7 @@ class TestLNPeerManager(ElectrumTestCase):
         console_stderr_handler.setLevel(logging.DEBUG)
 
     async def asyncSetUp(self):
-        lnwallet = self.create_mock_lnwallet(name='mock_lnwallet_anchors', has_anchors=True)
+        lnwallet = self.create_mock_lnwallet(name='mock_lnwallet_anchors')
         self.lnpeermgr = lnwallet.lnpeermgr
         await super().asyncSetUp()
 

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -1089,11 +1089,6 @@ class TestLNUtil(ElectrumTestCase):
         ctype = ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS
         self.assertTrue(ctype.complies_with_features(pfeatures))
 
-    def test_channel_type__ignore_unknown(self):
-        # ignore unknown channel types
-        channel_type = ChannelType(0b10000000001000000000010).discard_unknown_and_check()
-        self.assertEqual(ChannelType(0b10000000001000000000000), channel_type)
-
     @as_testnet
     async def test_decode_imported_channel_backup_v0(self):
         encrypted_cb = "channel_backup:Adn87xcGIs9H2kfp4VpsOaNKWCHX08wBoqq37l1cLYKGlJamTeoaLEwpJA81l1BXF3GP/mRxqkY+whZG9l51G8izIY/kmMSvnh0DOiZEdwaaT/1/MwEHfsEomruFqs+iW24SFJPHbMM7f80bDtIxcLfZkKmgcKBAOlcqtq+dL3U3yH74S8BDDe2L4snaxxpCjF0JjDMBx1UR/28D+QlIi+lbvv1JMaCGXf+AF1+3jLQf8+lVI+rvFdyArws6Ocsvjf+ANQeSGUwW6Nb2xICQcMRgr1DO7bO4pgGu408eYRr2v3ayJBVtnKwSwd49gF5SDSjTDAO4CCM0uj9H5RxyzH7fqotkd9J80MBr84RiBXAeXKz+Ap8608/FVqgQ9BOcn6LhuAQdE5zXpmbQyw5jUGkPvHuseR+rzthzncy01odUceqTNg=="

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -1054,14 +1054,42 @@ class TestLNUtil(ElectrumTestCase):
             None,
             LNWallet._decode_channel_update_msg(bytes.fromhex("0101") + msg_without_prefix))
 
-    def test_channel_type(self):
-        # test compliance and non compliance with LN features
-        features = LnFeatures(LnFeatures.BASIC_MPP_OPT | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT)
-        self.assertTrue(ChannelType.OPTION_STATIC_REMOTEKEY.complies_with_features(features))
+    def test_channel_type__complies_with_features(self):
+        """test compliance and-non compliance with LN features"""
+        # non-cflag-related peer_features should be ignored (e.g. BASIC_MPP_REQ):
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY
+        self.assertTrue(ctype.complies_with_features(pfeatures))
 
-        features = LnFeatures(LnFeatures.BASIC_MPP_OPT | LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT_ELECTRUM)
-        self.assertFalse(ChannelType.OPTION_STATIC_REMOTEKEY.complies_with_features(features))
+        # SRK missing from pfeatures:
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_TRAMPOLINE_ROUTING_OPT_ELECTRUM)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY
+        self.assertFalse(ctype.complies_with_features(pfeatures))
 
+        # ANCHORS missing from pfeatures:
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS
+        self.assertFalse(ctype.complies_with_features(pfeatures))
+
+        # SRK channel_type still allowed, even though ANCHORS has been negotiated:
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT | LnFeatures.OPTION_ANCHORS_OPT)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY
+        self.assertTrue(ctype.complies_with_features(pfeatures))
+        # same, *even if* ANCHORS is set to REQ. OPT or REQ no longer matters after negotiation finishes:
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT | LnFeatures.OPTION_ANCHORS_REQ)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY
+        self.assertTrue(ctype.complies_with_features(pfeatures))
+
+        # ANCHORS ctype allowed if pfeatures are correctly negotiated:
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT | LnFeatures.OPTION_ANCHORS_OPT)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS
+        self.assertTrue(ctype.complies_with_features(pfeatures))
+        # again, OPT or REQ does not matter:
+        pfeatures = LnFeatures(LnFeatures.BASIC_MPP_REQ | LnFeatures.OPTION_STATIC_REMOTEKEY_OPT | LnFeatures.OPTION_ANCHORS_REQ)
+        ctype = ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS
+        self.assertTrue(ctype.complies_with_features(pfeatures))
+
+    def test_channel_type__ignore_unknown(self):
         # ignore unknown channel types
         channel_type = ChannelType(0b10000000001000000000010).discard_unknown_and_check()
         self.assertEqual(ChannelType(0b10000000001000000000000), channel_type)

--- a/tests/test_lnwallet.py
+++ b/tests/test_lnwallet.py
@@ -79,8 +79,8 @@ class TestLNWallet(ElectrumTestCase):
         regular_peer = self.create_mock_lnwallet(name='regular_peer', has_anchors=True)
         regular_pubkey = regular_peer.node_keypair.pubkey
 
-        chan_t, _ = create_test_channels(alice_lnwallet=wallet, bob_lnwallet=trampoline_peer, anchor_outputs=True)
-        chan_r, _ = create_test_channels(alice_lnwallet=wallet, bob_lnwallet=regular_peer, anchor_outputs=True)
+        chan_t, _ = create_test_channels(alice_lnwallet=wallet, bob_lnwallet=trampoline_peer)
+        chan_r, _ = create_test_channels(alice_lnwallet=wallet, bob_lnwallet=regular_peer)
         wallet._add_channel(chan_t)
         wallet._add_channel(chan_r)
 

--- a/tests/test_lnwallet.py
+++ b/tests/test_lnwallet.py
@@ -21,6 +21,7 @@ from electrum.crypto import sha256
 
 class TestLNWallet(ElectrumTestCase):
     TESTNET = True
+    TEST_ANCHOR_CHANNELS = True
 
     @classmethod
     def setUpClass(cls):
@@ -28,7 +29,7 @@ class TestLNWallet(ElectrumTestCase):
         console_stderr_handler.setLevel(logging.DEBUG)
 
     async def asyncSetUp(self):
-        self.lnwallet_anchors = self.create_mock_lnwallet(name='mock_lnwallet_anchors', has_anchors=True)
+        self.lnwallet_anchors = self.create_mock_lnwallet(name='mock_lnwallet_anchors')
         await super().asyncSetUp()
 
     def test_create_payment_info(self):
@@ -73,10 +74,10 @@ class TestLNWallet(ElectrumTestCase):
         wallet = self.lnwallet_anchors
         self.assertFalse(wallet.uses_trampoline())
 
-        trampoline_peer = self.create_mock_lnwallet(name='trampoline_peer', has_anchors=True)
+        trampoline_peer = self.create_mock_lnwallet(name='trampoline_peer')
         trampoline_pubkey = trampoline_peer.node_keypair.pubkey
 
-        regular_peer = self.create_mock_lnwallet(name='regular_peer', has_anchors=True)
+        regular_peer = self.create_mock_lnwallet(name='regular_peer')
         regular_pubkey = regular_peer.node_keypair.pubkey
 
         chan_t, _ = create_test_channels(alice_lnwallet=wallet, bob_lnwallet=trampoline_peer)

--- a/tests/test_onion_message.py
+++ b/tests/test_onion_message.py
@@ -373,7 +373,7 @@ class TestOnionMessageManager(ElectrumTestCase):
 
     async def test_request_and_reply(self):
         n = MockNetwork()
-        lnw = self.create_mock_lnwallet(name='test_request_and_reply', has_anchors=False)
+        lnw = self.create_mock_lnwallet(name='test_request_and_reply')
 
         # mock add_peer for direct connection fallback
         async def mock__add_peer(host, port, node_id):
@@ -431,7 +431,7 @@ class TestOnionMessageManager(ElectrumTestCase):
 
     async def test_forward(self):
         n = MockNetwork()
-        lnw = self.create_mock_lnwallet(name='alice', has_anchors=False)
+        lnw = self.create_mock_lnwallet(name='alice')
         lnw.node_keypair = self.alice
 
         self.was_sent = False
@@ -468,7 +468,7 @@ class TestOnionMessageManager(ElectrumTestCase):
 
     async def test_receive_unsolicited(self):
         n = MockNetwork()
-        lnw = self.create_mock_lnwallet(name='dave', has_anchors=False)
+        lnw = self.create_mock_lnwallet(name='dave')
         lnw.node_keypair = self.dave
 
         t = OnionMessageManager(lnw)


### PR DESCRIPTION
alternative to https://github.com/spesmilo/electrum/pull/10620
and lots of related clean-up

As in https://github.com/spesmilo/electrum/pull/10620#issue-4357139535 :

> This will prevent opening new outgoing and incoming SRK channels.
> It will also prevent connecting to peers that don't signal anchor support at all (INIT features), so existing channels to them would need to get force closed or the peer needs to be bullied into updating their node software.
> Existing SRK channels with peers that signal anchor support (e.g. SRK channel opened to Electrum Trampoline) remain usable.

- also rm the `config.ENABLE_ANCHOR_CHANNELS` config var, which some users might have set (maybe even forgot they did)
  - some power-users might have set that to False, esp as that was a loophole to keep using a hardware-signer-backed wallet or a watch-only wallet with lightning 
  - instead add a new `config.TEST_LN_OPEN_SRK_CHANNELS`, explicitly for testing
    - if some user fiddles with config vars that have TEST or EXPERIMENTAL in their name, they are on their own
