### PR TITLE
qt: wizard: add wizard data to wizard exception

### DIFF
--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -508,6 +508,8 @@ class ElectrumGui(BaseElectrumGui, Logger):
                 return
             db.put('x3', wizard.get_wizard_data()['x3'])
             db.write_and_force_consolidation()  # TODO API for db is a bit weird: there should be a close method
+        except InvalidPassword as e:  # the GUI should have already validated the password
+            raise Exception(f"wizard_data: {wizard.sanitize_stack_item(d)}") from e
 
         wallet = self.daemon.load_wallet(wallet_file, password, upgrade=True)
         return wallet

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -168,7 +168,8 @@ class AbstractWizard:
         logstr += f'\nc: {hex(id(self._current.wizard_data))} - {repr(sci)}'
         self._logger.debug(logstr)
 
-    def sanitize_stack_item(self, _stack_item) -> dict:
+    @staticmethod
+    def sanitize_stack_item(_stack_item) -> dict:
         whitelist = [
             "wallet_name", "wallet_exists", "wallet_is_open", "wallet_needs_hw_unlock",
             "wallet_type", "keystore_type", "seed_variant", "seed_type", "seed_extend",


### PR DESCRIPTION
Enrich `InvalidPassword` thrown by `daemon.load_wallet` during `ElectrumGui._start_wizard_to_select_or_create_wallet` with the sanitized wizard data to help debugging #10623.
The wizard should have already refused the invalid password, though it is not clear to me how the invalid password escaped the wizard, maybe this helps.