### PR TITLE
lnonion: rm is_onion_message param from process_onion_packet

### DIFF
--- a/electrum/lnonion.py
+++ b/electrum/lnonion.py
@@ -434,13 +434,13 @@ def process_onion_packet(
         *,
         associated_data: bytes = b'',
         is_trampoline=False,
-        is_onion_message=False,
         tlv_stream_name='payload') -> ProcessedOnionPacket:
     # TODO: check Onion features ( PERM|NODE|3 (required_node_feature_missing )
     if onion_packet.version != 0:
         raise UnsupportedOnionPacketVersion()
     if not ecc.ECPubkey.is_pubkey_bytes(onion_packet.public_key):
         raise InvalidOnionPubkey()
+    is_onion_message = tlv_stream_name == 'onionmsg_tlv'
     shared_secret = get_ecdh(our_onion_private_key, onion_packet.public_key)
     # check message integrity
     mu_key = get_bolt04_onion_key(b'mu', shared_secret)

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -835,7 +835,7 @@ class OnionMessageManager(Logger):
 
     def process_onion_message_packet(self, blinding: bytes, onion_packet: OnionPacket) -> None:
         our_privkey = blinding_privkey(self.lnwallet.node_keypair.privkey, blinding)
-        processed_onion_packet = process_onion_packet(onion_packet, our_privkey, is_onion_message=True, tlv_stream_name='onionmsg_tlv')
+        processed_onion_packet = process_onion_packet(onion_packet, our_privkey, tlv_stream_name='onionmsg_tlv')
         payload = processed_onion_packet.hop_data.payload
 
         self.logger.debug(f'onion peeled: {processed_onion_packet!r}')

--- a/tests/test_onion_message.py
+++ b/tests/test_onion_message.py
@@ -173,7 +173,7 @@ class TestOnionMessage(ElectrumTestCase):
         our_privkey_int = our_privkey_int * b_hmac_int % ecc.CURVE_ORDER
         our_privkey = our_privkey_int.to_bytes(32, byteorder="big")
 
-        p = process_onion_packet(o, our_privkey, is_onion_message=True, tlv_stream_name='onionmsg_tlv')
+        p = process_onion_packet(o, our_privkey, tlv_stream_name='onionmsg_tlv')
 
         self.assertEqual(p.hop_data.blind_fields, {})
         self.assertEqual(p.hop_data.hmac, bfh('a5296325ba478ba1e1a9d1f30a2d5052b2e2889bbd64f72c72bc71d8817288a2'))


### PR DESCRIPTION
lnonion.process_onion_packet() can decide internally if the given onion is a onion message through the tlv_stream_name.