### PR TITLE
qml: fix lightning payment status string race

### DIFF
--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -65,6 +65,7 @@ class QEInvoice(QObject, QtEventListener):
         self._invoiceType = QEInvoice.Type.Invalid
         self._effectiveInvoice = None  # type: Optional[Invoice]
         self._userinfo = ''
+        self._paid_in_this_session = False
         self._lnprops = {}
         self._amount = QEAmount()
         self._amountOverride = QEAmount()
@@ -88,7 +89,7 @@ class QEInvoice(QObject, QtEventListener):
         if wallet == self._wallet.wallet and key == self.key:
             self.statusChanged.emit()
             self.determine_can_pay()
-            self.userinfo = _('Paid!')
+            self.update_userinfo()
 
     @event_listener
     def on_event_payment_failed(self, wallet, key, reason):
@@ -265,6 +266,7 @@ class QEInvoice(QObject, QtEventListener):
         return (lnworker.lnpeermgr.get_node_alias(node_id) if lnworker else None) or node_id.hex()
 
     def set_effective_invoice(self, invoice: Invoice):
+        self._paid_in_this_session = False
         self._effectiveInvoice = invoice
 
         if invoice is None:
@@ -333,6 +335,8 @@ class QEInvoice(QObject, QtEventListener):
 
         if status in [PR_UNPAID, PR_FAILED]:
             x, self.userinfo = self.check_can_pay_amount(amount)
+        elif status == PR_PAID and self._paid_in_this_session:
+            self.userinfo = _('Paid!')
         else:
             self.userinfo = userinfo_for_invoice_status(status)
 
@@ -389,6 +393,7 @@ class QEInvoice(QObject, QtEventListener):
                 raise Exception('can not pay 0 amount')
             amount_msat = self.amountOverride.msatsInt
 
+        self._paid_in_this_session = True
         self._wallet.pay_lightning_invoice(self._effectiveInvoice, amount_msat)
 
     def get_max_spendable_onchain(self):

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -602,26 +602,27 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     def broadcast(self, tx):
         assert tx.is_complete()
 
-        def broadcast_thread():
+        async def broadcast_coro():
             self.wallet.set_broadcasting(tx, broadcasting_status=PR_BROADCASTING)
             try:
-                self._logger.info('running broadcast in thread')
-                self.wallet.network.run_from_another_thread(self.wallet.network.broadcast_transaction(tx))
+                self._logger.info('broadcasting tx in coroutine')
+                await self.wallet.network.broadcast_transaction(tx)
             except TxBroadcastError as e:
                 self._logger.error(repr(e))
                 self.broadcastFailed.emit(tx.txid(), '', e.get_message_for_gui())
-                self.wallet.set_broadcasting(tx, broadcasting_status=None)
             except BestEffortRequestFailed as e:
                 self._logger.error(repr(e))
                 self.broadcastFailed.emit(tx.txid(), '', repr(e))
-                self.wallet.set_broadcasting(tx, broadcasting_status=None)
+            except Exception:
+                self._logger.exception("failed to broadcast tx")
             else:
                 self._logger.info('broadcast success')
                 self.broadcastSucceeded.emit(tx.txid())
                 self.historyModel.requestRefresh.emit()  # via qt thread
-                self.wallet.set_broadcasting(tx, broadcasting_status=PR_BROADCAST)
+            finally:
+                self.wallet.set_broadcasting(tx, broadcasting_status=None)
 
-        threading.Thread(target=broadcast_thread, daemon=True).start()
+        asyncio.run_coroutine_threadsafe(broadcast_coro(), get_asyncio_loop())
 
         # TODO: properly catch server side errors, e.g. bad-txns-inputs-missingorspent
 
@@ -663,16 +664,14 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         if self._invoiceModel:
             self._invoiceModel.initModel()
 
-        def pay_thread():
+        async def pay_coro():
             try:
-                coro = self.wallet.lnworker.pay_invoice(invoice, amount_msat=amount_msat)
-                fut = asyncio.run_coroutine_threadsafe(coro, get_asyncio_loop())
-                fut.result()
+                await self.wallet.lnworker.pay_invoice(invoice, amount_msat=amount_msat)
             except Exception as e:
                 self._logger.error(f'pay_invoice failed! {e!r}')
                 self.paymentFailed.emit(invoice.get_id(), str(e))
 
-        threading.Thread(target=pay_thread, daemon=True).start()
+        asyncio.run_coroutine_threadsafe(pay_coro(), get_asyncio_loop())
 
     @pyqtSlot()
     def deleteExpiredRequests(self):


### PR DESCRIPTION
When paying a lightning invoice there was a race between the
`on_event_payment_succeeded` and `on_event_invoice_status` callbacks.
Depending on which was called last the string at the top
of the invoice view would either say "Paid!" (correct) or
"This invoice was already paid" (technically correct but confusing).

By keeping state if the invoice payment attempt was initiated in this
session the subsequent calls to `update_userinfo` can correctly
determine which string to show.

Can be reproduced with this diff:
```
diff --git a/electrum/gui/qml/qeinvoice.py b/electrum/gui/qml/qeinvoice.py
index 696506ffd..ff02c4cc6 100644
--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import threading
 from enum import IntEnum
@@ -98,8 +99,9 @@ class QEInvoice(QObject, QtEventListener):
             self.userinfo = _('Payment failed: ') + reason
 
     @event_listener
-    def on_event_invoice_status(self, wallet, key, status):
+    async def on_event_invoice_status(self, wallet, key, status):
         if self._wallet and wallet == self._wallet.wallet and key == self.key:
+           await asyncio.sleep(1)
             self.update_userinfo()
             self.determine_can_pay()
             self.statusChanged.emit()
```