### PR TITLE
lnworker: fix _get_next_peers_to_try regression

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -486,7 +486,7 @@ class LNPeerManager(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
                 continue
             if not self.is_good_peer(peer):
                 continue
-            if peer.is_onion() and not self.network.proxy or not self.network.proxy.enabled:
+            if peer.is_onion() and not self.network.is_proxy_tor:
                 continue
             return [peer]
         # try random peer from graph
@@ -564,7 +564,7 @@ class LNPeerManager(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         for host, port, timestamp in sorted(addr_list, key=lambda a: -a[2]):
             if is_ip_address(host):
                 return host, port, timestamp
-        if not self.network.proxy or not self.network.proxy.enabled:
+        if not self.network.is_proxy_tor:
             addr_list = [(h, p, ts) for h, p, ts in addr_list if not h.endswith('.onion')]
         if not addr_list:
             return None

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -73,6 +73,7 @@ class MockNetwork:
         self.lngossip = MockLNGossip()
         self.tx_queue = asyncio.Queue()
         self.proxy = ProxySettings()
+        self.is_proxy_tor = None
         self._blockchain = MockBlockchain()
 
     def get_local_height(self):

--- a/tests/test_lnpeermgr.py
+++ b/tests/test_lnpeermgr.py
@@ -73,7 +73,7 @@ class TestLNPeerManager(ElectrumTestCase):
         self.assertEqual(result, ("10.0.0.1", 9735, 150))  # Most recent IP
 
         # no IP, proxy disabled, filter .onion and choose random
-        self.assertFalse(peermgr.network.proxy.enabled)
+        self.assertFalse(peermgr.network.is_proxy_tor)
         addr_list = [("host.com", 9735, 100), ("host.onion", 9735, 200)]
         result = peermgr.choose_preferred_address(addr_list)
         self.assertEqual(result, ("host.com", 9735, 100))
@@ -84,7 +84,7 @@ class TestLNPeerManager(ElectrumTestCase):
         self.assertIsNone(result)
 
         # return onion if proxy enabled
-        peermgr.network.proxy.enabled = True
+        peermgr.network.is_proxy_tor = True
         addr_list = [("host.onion", 9735, 100)]
         result = peermgr.choose_preferred_address(addr_list)
         self.assertEqual(result, ("host.onion", 9735, 100))


### PR DESCRIPTION
`LNPeerManager._get_next_peers_to_try` would skip all recent peers if no proxy is enabled due to incorrect operator precedence. Fixes regression introduced by 79ef429b3.