### PR TITLE
regtests: swaps: add test for forward-swap success case, and small fix

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -2117,7 +2117,7 @@ class Commands(Logger):
                 )
 
         return {
-            'txid': txid,
+            'txid': txid,  # FIXME sync name with reverse_swap cmd that uses "funding_txid"
             'lightning_amount': format_satoshis(lightning_amount_sat),
             'onchain_amount': format_satoshis(onchain_amount_sat),
         }

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -101,8 +101,11 @@ class TestLightningSwapserver(TestLightning):
         }
     }
 
-    def test_swapserver_success(self):
-        self.run_shell(['swapserver_success'])
+    def test_swapserver_success_forward(self):
+        self.run_shell(['swapserver_success_forward'])
+
+    def test_swapserver_success_reverse(self):
+        self.run_shell(['swapserver_success_reverse'])
 
     def test_swapserver_forceclose(self):
         self.run_shell(['swapserver_forceclose'])

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -292,23 +292,44 @@ if [[ $1 == "collaborative_close" ]]; then
 fi
 
 
-if [[ $1 == "swapserver_success" ]]; then
+if [[ $1 == "swapserver_success_reverse" ]]; then
     wait_for_balance alice 1
     echo "alice opens channel"
     bob_node=$($bob nodeid)
     channel=$($alice open_channel $bob_node 0.15 --password='')
     new_blocks 3
     wait_until_channel_open alice
-    echo "alice initiates swap"
+    echo "alice initiates reverse-swap"
     dryrun=$($alice reverse_swap 0.02 dryrun)
     onchain_amount=$(echo $dryrun| jq -r ".onchain_amount")
     prepayment=$(echo $dryrun| jq -r ".prepayment")
     swap=$($alice reverse_swap 0.02 $onchain_amount --prepayment $prepayment)
     echo $swap | jq
     funding_txid=$(echo $swap| jq -r ".funding_txid")
+    assert_utxo_exists $funding_txid 0
     new_blocks 1
     wait_until_spent $funding_txid 0
     wait_until_htlcs_settled alice
+fi
+
+
+if [[ $1 == "swapserver_success_forward" ]]; then
+    wait_for_balance alice 1
+    echo "alice opens channel"
+    bob_node=$($bob nodeid)
+    channel=$($alice open_channel $bob_node 0.15 --password='' --push_amount=0.075)
+    new_blocks 3
+    wait_until_channel_open alice
+    echo "alice initiates forward-swap"
+    dryrun=$($alice normal_swap 0.02 dryrun)
+    lightning_amount=$(echo $dryrun| jq -r ".lightning_amount")
+    swap=$($alice normal_swap 0.02 $lightning_amount)
+    echo $swap | jq
+    funding_txid=$(echo $swap| jq -r ".txid")
+    assert_utxo_exists $funding_txid 0
+    new_blocks 1
+    wait_until_spent $funding_txid 0
+    wait_until_htlcs_settled bob
 fi
 
 

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -130,7 +130,9 @@ function wait_until_spent()
     declare -i timeout_sec=120
     declare -i elapsed_sec=0
 
-    while [[ $($bitcoin_cli gettxout $1 $2) ]]; do
+    while true; do
+        utxo=$($bitcoin_cli gettxout $1 $2)
+        if [[ -z "$utxo" ]]; then break; fi  # utxo is spent (or never existed!)
         if ((elapsed_sec > timeout_sec)); then
             printf "Timeout of %i s exceeded\n" "$elapsed_sec"
             exit 1


### PR DESCRIPTION
Previously only the reverse-swaps were tested.
Note that what is reverse for the client, is forward for the server, hence testing different scenarios for reverse-swaps (success case, different failure cases) already exercises some of the logic of forward-swaps.

However the swap-protocol request construction and validation is specific to swap direction, and that was not exercised for forward-swaps at all prior to this.

(but duplicating the other testcases probably is not worth)