### PR TITLE
qt history: skip unchanged refreshes

### DIFF
--- a/electrum/gui/qt/history_list.py
+++ b/electrum/gui/qt/history_list.py
@@ -302,9 +302,14 @@ class HistoryModel(CustomModel, Logger):
             onchain_domain=self.get_domain(),
             include_lightning=self.should_include_lightning_payments(),
         )
+        if transactions == self.transactions:
+            self.view.filter()
+            if self.view:
+                self.view.num_tx_label.setText(_("{} transactions").format(len(self.transactions)))
+            return
         old_length = self._root.childCount()
         if old_length != 0:
-            self.beginRemoveRows(QModelIndex(), 0, old_length)
+            self.beginRemoveRows(QModelIndex(), 0, old_length - 1)
             self.transactions.clear()
             self._root = HistoryNode(self, None)
             self.endRemoveRows()
@@ -331,9 +336,12 @@ class HistoryModel(CustomModel, Logger):
                 self.tx_status_cache[txid] = self.window.wallet.get_tx_status(txid, tx_mined_info)
 
         new_length = self._root.childCount()
-        self.beginInsertRows(QModelIndex(), 0, new_length-1)
-        self.transactions = transactions
-        self.endInsertRows()
+        if new_length:
+            self.beginInsertRows(QModelIndex(), 0, new_length - 1)
+            self.transactions = transactions
+            self.endInsertRows()
+        else:
+            self.transactions = transactions
 
         if selected_row:
             self.view.selectionModel().select(


### PR DESCRIPTION
Refs #6625.

This reduces unnecessary Qt history-list churn for large wallets by returning early when `wallet.get_full_history()` produces the same transaction data already displayed. In that case the model still reapplies the active filter and transaction counter, but avoids removing every row, recreating every `HistoryNode`, rebuilding status cache, and triggering a full insert/sort cycle.

The patch also fixes the inclusive row range passed to `beginRemoveRows()` and avoids calling `beginInsertRows()` for an empty model.

This does not claim to fully solve #6625 by itself; it targets one remaining expensive no-op refresh path in the large-history case.

Verification:
- `git diff --check`
- `python3 -m compileall -q electrum/gui/qt/history_list.py`

I could not run Qt GUI tests locally because the system Python environment in this workspace does not have `PyQt6` installed.