### PR TITLE
Defer hidden Coins tab model rebuilds

### DIFF
--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -100,11 +100,17 @@ class UTXOList(MyTreeView):
 
     @profiler(min_threshold=0.05)
     def update(self):
-        # not calling maybe_defer_update() as it interferes with coincontrol status bar
-        self.proxy.setDynamicSortFilter(False)  # temp. disable re-sorting after every change
+        # We need to keep coincontrol state/bar fresh even while the tab is hidden,
+        # but the expensive model rebuild can still be deferred like other tabs.
         utxos = self.wallet.get_utxos()
         self._maybe_reset_coincontrol(utxos)
         self._utxo_dict = dict([(utxo.prevout.to_str(), utxo) for utxo in utxos])
+        self.update_coincontrol_bar()
+        self.num_coins_label.setText(_('{} unspent transaction outputs').format(len(utxos)))
+        if self.maybe_defer_update():
+            return
+
+        self.proxy.setDynamicSortFilter(False)  # temp. disable re-sorting after every change
         self.std_model.clear()
         self.update_headers(self.__class__.headers)
         for idx, utxo in enumerate(utxos):


### PR DESCRIPTION
This is a focused partial fix for #6625.

`UTXOList.update()` intentionally avoided `maybe_defer_update()` so the coin-control status bar stayed current, but that also meant the Coins tab kept doing the full row/model rebuild path even while hidden. With very large wallets, hidden-tab work can still contribute to GUI refresh stalls.

This patch keeps the lightweight coin-control bookkeeping up to date on every call:

- fetch current UTXOs
- reset stale coin-control selections / context menu state when needed
- refresh `_utxo_dict`
- update the coin-control status bar and coin count

Then it defers the expensive model clear/rebuild/filter/sort path when the tab is hidden or an editor is open. `MyTreeView.showEvent()` already forces a full update when the tab becomes visible again.

This is intentionally separate from the existing PRs that skip unchanged History / Addresses / Coins model rebuilds: it avoids doing the Coins model rebuild path at all while the Coins tab is not visible, without losing the status-bar behavior that previously prevented simply calling `maybe_defer_update()` at the top.

Verification:

- `python3 -m py_compile electrum/gui/qt/utxo_list.py`
- `git diff --check`
