### PR TITLE
qml: InvoiceDialog: rename "Remote Pubkey" -> "Recipient Pubkey"

### DIFF
--- a/electrum/gui/qml/components/InvoiceDialog.qml
+++ b/electrum/gui/qml/components/InvoiceDialog.qml
@@ -319,7 +319,7 @@ ElDialog {
                     Layout.columnSpan: 2
                     Layout.topMargin: constants.paddingSmall
                     visible: invoice.invoiceType == Invoice.LightningInvoice
-                    text: qsTr('Remote Pubkey')
+                    text: qsTr('Recipient Pubkey')
                     color: Material.accentColor
                 }
 


### PR DESCRIPTION
"Remote Pubkey" is somewhat misleading in the context of paying a lightning invoice.
The german translation ("Entfernter öffentlicher Schlüssel") is also quite weird in this context.