### PR TITLE
ci: claude security review: prompt to verify commit messages

### DIFF
--- a/contrib/ci/claude_security_review.py
+++ b/contrib/ci/claude_security_review.py
@@ -70,13 +70,17 @@ def get_pr_diff(base: str) -> str:
     return git("diff", f"origin/{base}...HEAD")
 
 
+def get_commit_messages(base: str) -> str:
+    return git("log", f"origin/{base}..HEAD")
+
+
 def changed_files_from_diff(diff: str) -> str:
     return "\n".join(
         m.group(1) for m in re.finditer(r"^diff --git a/.+ b/(.+)$", diff, re.MULTILINE)
     )
 
 
-def build_prompt(diff: str, changed_files: str) -> str:
+def build_prompt(diff: str, changed_files: str, commit_messages: str) -> str:
     with open(PROMPT_FILE) as f:
         instructions = f.read()
 
@@ -84,6 +88,7 @@ def build_prompt(diff: str, changed_files: str) -> str:
         f"{instructions}\n\n"
         f"---\n\n"
         f"## Changed files\n\n```\n{changed_files}\n```\n\n"
+        f"## Commit messages\n\n```\n{commit_messages}\n```\n\n"
         f"## Diff\n\n```diff\n{diff}\n```"
     )
 
@@ -217,6 +222,12 @@ def main() -> int:
         print("Empty diff -- nothing to review.")
         return 0
 
+    try:
+        commit_messages = get_commit_messages(base_branch)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: git log failed: {exc}")
+        return 2
+
     changed_files = changed_files_from_diff(diff)
     file_count = len(changed_files.splitlines())
     print(f"Reviewing changes across {file_count} file(s)...")
@@ -225,7 +236,7 @@ def main() -> int:
         print(f"ERROR: diff is {len(diff)} chars, exceeds maximum of {MAX_DIFF_CHARS}. Skipping review.")
         return 2
 
-    prompt = build_prompt(diff, changed_files)
+    prompt = build_prompt(diff, changed_files, commit_messages)
 
     print(f"\nRunning Claude Code review (model: {CLAUDE_MODEL})...\n")
     review = run_claude(prompt)

--- a/contrib/ci/security_review_prompt.md
+++ b/contrib/ci/security_review_prompt.md
@@ -24,6 +24,20 @@ sophisticated real-world attackers -- Electrum is a high-value target where supp
 compromise, malicious Electrum servers, and rogue Lightning peers are realistic threat
 vectors.
 
+## Verifying commit message claims
+
+Use commit messages to understand intent -- but verify, do not trust them. If a
+commit message claims, in any phrasing, that it only **moves**, **relocates**,
+**renames**, **extracts**, **splits**, or otherwise rearranges code without
+behavioral change, strictly verify the claim against the diff: removed and added
+lines must match aside from cosmetic adjustments inherent to the move
+(indentation, import paths, file/module names). Any logic change, condition
+change, branch reordering, altered error handling, modified call signature, new
+side effect, or removed validation hiding inside such a commit must be flagged
+at the severity of the hidden change itself -- these are easy for human
+reviewers to miss. Explicitly note in the finding that the change was concealed
+inside a commit claiming to be a pure code move.
+
 ## Severity Definitions
 
 ### CRITICAL


### PR DESCRIPTION
Instructs the claude pr review CI to verify the claims made in commit messages.