### PR TITLE
onion_message: sending through trampoline, improvements

### DIFF
--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -452,6 +452,7 @@ class LNPathFinder(Logger):
             end_node: bytes,
             payment_amt_msat: int,
             ignore_costs=False,
+            ignore_amount_constraints: bool = False,
             is_mine=False,
             my_channels: Dict[ShortChannelID, 'Channel'] = None,
             private_route_edges: Dict[ShortChannelID, RouteEdge] = None,
@@ -481,14 +482,15 @@ class LNPathFinder(Logger):
             return float('inf'), 0
         if channel_policy.is_disabled():
             return float('inf'), 0
-        if payment_amt_msat < channel_policy.htlc_minimum_msat:
-            return float('inf'), 0  # payment amount too little
-        if channel_info.capacity_sat is not None and \
-                payment_amt_msat // 1000 > channel_info.capacity_sat:
-            return float('inf'), 0  # payment amount too large
-        if channel_policy.htlc_maximum_msat is not None and \
-                payment_amt_msat > channel_policy.htlc_maximum_msat:
-            return float('inf'), 0  # payment amount too large
+        if not ignore_amount_constraints:
+            if payment_amt_msat < channel_policy.htlc_minimum_msat:
+                return float('inf'), 0  # payment amount too little
+            if channel_info.capacity_sat is not None and \
+                    payment_amt_msat // 1000 > channel_info.capacity_sat:
+                return float('inf'), 0  # payment amount too large
+            if channel_policy.htlc_maximum_msat is not None and \
+                    payment_amt_msat > channel_policy.htlc_maximum_msat:
+                return float('inf'), 0  # payment amount too large
         route_edge = private_route_edges.get(short_channel_id, None)
         if route_edge is None:
             node_info = self.channel_db.get_node_info_for_node_id(node_id=end_node)
@@ -513,7 +515,7 @@ class LNPathFinder(Logger):
         # - The larger the payment amount, and the longer the CLTV,
         #   the more irritating it is if the HTLC gets stuck.
         # - Paying lower fees is better. :)
-        if ignore_costs:
+        if ignore_costs or ignore_amount_constraints:
             return DEFAULT_PENALTY_BASE_MSAT, 0
         fee_msat = route_edge.fee_for_edge(payment_amt_msat)
         cltv_cost = route_edge.cltv_delta * payment_amt_msat * 15 / 1_000_000_000
@@ -528,10 +530,10 @@ class LNPathFinder(Logger):
             *,
             nodeA: bytes, # nodeA is expected to be our node id if channels are passed in my_sending_channels
             nodeB: bytes,
-            invoice_amount_msat: int,
+            invoice_amount_msat: Optional[int],
             my_sending_channels: Dict[ShortChannelID, 'Channel'] = None,
             private_route_edges: Dict[ShortChannelID, RouteEdge] = None,
-            node_filter: Optional[Callable[[bytes, NodeInfo], bool]] = None
+            node_filter: Optional[Callable[[bytes, Optional[NodeInfo]], bool]] = None,
     ) -> Dict[bytes, PathEdge]:
         # note: we don't lock self.channel_db, so while the path finding runs,
         #       the underlying graph could potentially change... (not good but maybe ~OK?)
@@ -545,11 +547,12 @@ class LNPathFinder(Logger):
         # run Dijkstra
         # The search is run in the REVERSE direction, from nodeB to nodeA,
         # to properly calculate compound routing fees.
+        ignore_amount_constraints = invoice_amount_msat is None  # e.g. onion messages
         distance_from_start = defaultdict(lambda: float('inf'))
         distance_from_start[nodeB] = 0
         previous_hops = {}  # type: Dict[bytes, PathEdge]
         nodes_to_explore = queue.PriorityQueue()
-        nodes_to_explore.put((0, invoice_amount_msat, nodeB))  # order of fields (in tuple) matters!
+        nodes_to_explore.put((0, invoice_amount_msat or 0, nodeB))  # order of fields (in tuple) matters!
         now = int(time.time())
 
         # main loop of search
@@ -592,7 +595,8 @@ class LNPathFinder(Logger):
                 if edge_startnode == nodeA and my_sending_channels:  # payment outgoing, on our channel
                     if edge_channel_id not in my_sending_channels:
                         continue
-                    if not my_sending_channels[edge_channel_id].can_pay(amount_msat, check_frozen=True):
+                    if not ignore_amount_constraints \
+                            and not my_sending_channels[edge_channel_id].can_pay(amount_msat, check_frozen=True):
                         continue
                 edge_cost, fee_for_edge_msat = self._edge_cost(
                     short_channel_id=edge_channel_id,
@@ -600,6 +604,7 @@ class LNPathFinder(Logger):
                     end_node=edge_endnode,
                     payment_amt_msat=amount_msat,
                     ignore_costs=(edge_startnode == nodeA),
+                    ignore_amount_constraints=ignore_amount_constraints,
                     is_mine=is_mine,
                     my_channels=my_sending_channels,
                     private_route_edges=private_route_edges,
@@ -626,15 +631,15 @@ class LNPathFinder(Logger):
             *,
             nodeA: bytes,
             nodeB: bytes,
-            invoice_amount_msat: int,
+            invoice_amount_msat: Optional[int],
             my_sending_channels: Dict[ShortChannelID, 'Channel'] = None,
             private_route_edges: Dict[ShortChannelID, RouteEdge] = None,
-            node_filter: Optional[Callable[[bytes, NodeInfo], bool]] = None
+            node_filter: Optional[Callable[[bytes, Optional[NodeInfo]], bool]] = None
     ) -> Optional[LNPaymentPath]:
         """Return a path from nodeA to nodeB."""
         assert type(nodeA) is bytes
         assert type(nodeB) is bytes
-        assert type(invoice_amount_msat) is int
+        assert type(invoice_amount_msat) is int or invoice_amount_msat is None
         if my_sending_channels is None:
             my_sending_channels = {}
 
@@ -658,6 +663,28 @@ class LNPathFinder(Logger):
             path += [edge]
             edge_startnode = edge.node_id
         return path
+
+    def find_path_for_onion_message(
+            self,
+            *,
+            nodeA: bytes,
+            nodeB: bytes,
+            my_sending_channels: Dict[ShortChannelID, 'Channel'] = None,
+            private_route_edges: Dict[ShortChannelID, RouteEdge] = None,
+    ) -> Optional[LNPaymentPath]:
+        from .onion_message import is_onion_message_node
+        def _node_filter(edge_startnode, node_info):
+            if edge_startnode == nodeA:
+                return True  # assume the sending node does support onion messages
+            return is_onion_message_node(edge_startnode, node_info)
+        return self.find_path_for_payment(
+            nodeA=nodeA,
+            nodeB=nodeB,
+            my_sending_channels=my_sending_channels,
+            private_route_edges=private_route_edges,
+            node_filter=_node_filter,
+            invoice_amount_msat=None,
+        )
 
     def create_route_from_path(
             self,

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -414,61 +414,22 @@ def get_blinded_paths_to_me(
                        lnwallet.lnpeermgr.get_peer_by_pubkey(chan.node_id).their_features.supports(LnFeatures.OPTION_ONION_MESSAGE_OPT)]
 
     result = []
-    payinfo = []
+    payinfos = []
     mynodeid = lnwallet.node_keypair.pubkey
-    local_height = lnwallet.network.get_local_height()
-
     if len(my_channels):
         rchans = random_shuffled_copy(my_channels)
         for chan in rchans[:max_paths]:
             hop_extras = None
             if not onion_message:  # add hop_extras and payinfo, assumption: len(blinded_path) == 2 (us and peer)
-                # get policy
-                cp = get_mychannel_policy(chan.short_channel_id, chan.node_id, {chan.short_channel_id: chan})
-
-                dest_max_cltv_expiry = local_height + MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED
-
-                # TODO: for longer paths (>2), reverse traverse and calculate max_cltv_expiry at each intermediate hop
-                # and determine the cltv delta sums and fee sums of the hops for the payinfo struct.
-                # current assumption is len(blinded_path) == 2 (us and peer)
-                sum_cltv_expiry_delta = cp.cltv_delta
-                sum_fee_base_msat = cp.fee_base_msat
-                sum_fee_proportional_millionths = cp.fee_proportional_millionths
-                # path htlc limits
-                blinded_path_min_htlc_msat = cp.htlc_minimum_msat
-                blinded_path_max_htlc_msat = cp.htlc_maximum_msat
-
-                hop_extras = [{
-                    # spec: MUST include encrypted_data_tlv.payment_relay for each non-final node.
-                    'payment_relay': {
-                        'cltv_expiry_delta': cp.cltv_delta,
-                        'fee_base_msat': cp.fee_base_msat,
-                        'fee_proportional_millionths': cp.fee_proportional_millionths,
-                    },
-                    # spec: MUST set encrypted_data_tlv.payment_constraints for each non-final node and MAY set it for the final node:
-                    #
-                    #     max_cltv_expiry to the largest block height at which the route is allowed to be used, starting
-                    #     from the final node's chosen max_cltv_expiry height at which the route should expire, adding
-                    #     the final node's min_final_cltv_expiry_delta and then adding
-                    #     encrypted_data_tlv.payment_relay.cltv_expiry_delta at each hop.
-                    #
-                    #     htlc_minimum_msat to the largest minimum HTLC value the nodes will allow.
-                    'payment_constraints': {
-                        'max_cltv_expiry': dest_max_cltv_expiry + cp.cltv_delta,
-                        'htlc_minimum_msat': blinded_path_min_htlc_msat
-                    }
-                }]
-                payinfo.append({
-                    'fee_base_msat': sum_fee_base_msat,
-                    'fee_proportional_millionths': sum_fee_proportional_millionths,
-                    'cltv_expiry_delta': sum_cltv_expiry_delta + MIN_FINAL_CLTV_DELTA_ACCEPTED,
-                    'htlc_minimum_msat': blinded_path_min_htlc_msat,
-                    'htlc_maximum_msat': blinded_path_max_htlc_msat,
-                    'flen': 0,
-                    'features': bytes(0)
-                })
-            blinded_path = create_blinded_path(os.urandom(32), [chan.node_id, mynodeid], final_recipient_data,
-                                               hop_extras=hop_extras, channels=[chan] if not onion_message else None)
+                payinfo, hop_extras = _get_payinfo_for_blinded_path(chan, lnwallet)
+                payinfos.append(payinfo)
+            blinded_path = create_blinded_path(
+                session_key=os.urandom(32),
+                path=[chan.node_id, mynodeid],
+                final_recipient_data=final_recipient_data,
+                hop_extras=hop_extras,
+                channels=[chan] if not onion_message else None,
+            )
             result.append(blinded_path)
     elif onion_message:
         # we can use peers even without channels for onion messages
@@ -480,7 +441,53 @@ def get_blinded_paths_to_me(
                 blinded_path = create_blinded_path(os.urandom(32), [peer.pubkey, mynodeid], final_recipient_data)
                 result.append(blinded_path)
 
-    return result, payinfo
+    return result, payinfos
+
+
+def _get_payinfo_for_blinded_path(chan: 'Channel', lnwallet: 'LNWallet'):
+    cp = get_mychannel_policy(chan.short_channel_id, chan.node_id, {chan.short_channel_id: chan})
+    sum_cltv_expiry_delta = cp.cltv_delta
+    sum_fee_base_msat = cp.fee_base_msat
+    sum_fee_proportional_millionths = cp.fee_proportional_millionths
+    # path htlc limits
+    blinded_path_min_htlc_msat = cp.htlc_minimum_msat
+    blinded_path_max_htlc_msat = cp.htlc_maximum_msat
+
+    # TODO: for longer paths (>2), reverse traverse and calculate max_cltv_expiry at each intermediate hop
+    # and determine the cltv delta sums and fee sums of the hops for the payinfo struct.
+    # current assumption is len(blinded_path) == 2 (us and peer)
+    local_height = lnwallet.network.get_local_height()
+    dest_max_cltv_expiry = local_height + MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED
+    hop_extras = [{
+        # spec: MUST include encrypted_data_tlv.payment_relay for each non-final node.
+        'payment_relay': {
+            'cltv_expiry_delta': cp.cltv_delta,
+            'fee_base_msat': cp.fee_base_msat,
+            'fee_proportional_millionths': cp.fee_proportional_millionths,
+        },
+        # spec: MUST set encrypted_data_tlv.payment_constraints for each non-final node and MAY set it for the final node:
+        #
+        #     max_cltv_expiry to the largest block height at which the route is allowed to be used, starting
+        #     from the final node's chosen max_cltv_expiry height at which the route should expire, adding
+        #     the final node's min_final_cltv_expiry_delta and then adding
+        #     encrypted_data_tlv.payment_relay.cltv_expiry_delta at each hop.
+        #
+        #     htlc_minimum_msat to the largest minimum HTLC value the nodes will allow.
+        'payment_constraints': {
+            'max_cltv_expiry': dest_max_cltv_expiry + cp.cltv_delta,
+            'htlc_minimum_msat': blinded_path_min_htlc_msat
+        }
+    }]
+    payinfo = {
+        'fee_base_msat': sum_fee_base_msat,
+        'fee_proportional_millionths': sum_fee_proportional_millionths,
+        'cltv_expiry_delta': sum_cltv_expiry_delta + MIN_FINAL_CLTV_DELTA_ACCEPTED,
+        'htlc_minimum_msat': blinded_path_min_htlc_msat,
+        'htlc_maximum_msat': blinded_path_max_htlc_msat,
+        'flen': 0,
+        'features': b'',
+    }
+    return payinfo, hop_extras
 
 
 class Timeout(Exception): pass

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -66,6 +66,10 @@ REQUEST_REPLY_PATHS_MAX = 3
 PAYMENT_PATHS_MAX = 3
 
 
+class NoOnionMessagePeers(Exception): pass
+class NoRouteBlindingChannelPeers(Exception): pass
+
+
 class NoRouteFound(Exception):
     def __init__(self, *args, peer_address: 'LNPeerAddr' = None):
         Exception.__init__(self, *args)
@@ -413,23 +417,25 @@ def get_blinded_paths_to_me(
 ) -> Tuple[Sequence[dict], Sequence[dict]]:
     """construct a list of blinded paths.
        current logic:
-       - uses channels peers if not onion_message
-       - uses current onion_message capable channel peers if exist and if onion_message
-       - otherwise, uses current onion_message capable peers if onion_message
-       - reply_path introduction points are direct peers only (TODO: longer paths)"""
+       - uses active channel peers if my_channels not provided
+       - if onion_message, filters channels for onion_message feature
+       - if not onion_message, filters channels for route_blinding feature
+       - if onion_message and no suitable channel peers, tries onion_message capable peers
+       - raises if no blinded path could be generated
+       - reply_path introduction points are direct peers only (TODO: longer paths)
+    """
     # TODO: build longer paths and/or add dummy hops to increase privacy
     if not my_channels:
-        my_active_channels = [chan for chan in lnwallet.channels.values() if chan.is_active()]
-        my_channels = my_active_channels
+        my_channels = [chan for chan in lnwallet.channels.values() if chan.is_active()]
 
-    if onion_message:
-        my_channels = [chan for chan in my_channels if lnwallet.lnpeermgr.get_peer_by_pubkey(chan.node_id) and
-                       lnwallet.lnpeermgr.get_peer_by_pubkey(chan.node_id).their_features.supports(LnFeatures.OPTION_ONION_MESSAGE_OPT)]
+    required_features = LnFeatures.OPTION_ONION_MESSAGE_OPT if onion_message else LnFeatures.OPTION_ROUTE_BLINDING_OPT
+    my_channels = [chan for chan in my_channels if lnwallet.lnpeermgr.get_peer_by_pubkey(chan.node_id) and
+                   lnwallet.lnpeermgr.get_peer_by_pubkey(chan.node_id).their_features.supports(required_features)]
 
     result = []
     payinfos = []
     mynodeid = lnwallet.node_keypair.pubkey
-    if len(my_channels):
+    if my_channels:
         rchans = random_shuffled_copy(my_channels)
         for chan in rchans[:max_paths]:
             hop_extras = None
@@ -448,16 +454,22 @@ def get_blinded_paths_to_me(
                 channels=[chan] if not onion_message else None,
             )
             result.append(blinded_path)
-    elif onion_message:
-        # we can use peers even without channels for onion messages
-        my_onionmsg_peers = [peer for peer in lnwallet.lnpeermgr.peers.values() if
-                             peer.their_features.supports(LnFeatures.OPTION_ONION_MESSAGE_OPT)]
-        if len(my_onionmsg_peers):
+
+    if not result:
+        if not onion_message:
+            raise NoRouteBlindingChannelPeers('no OPTION_ROUTE_BLINDING capable channel peers')
+        else:
+            # fall back to peers without channels for onion messages
+            my_onionmsg_peers = [peer for peer in lnwallet.lnpeermgr.peers.values() if
+                                 peer.their_features.supports(LnFeatures.OPTION_ONION_MESSAGE_OPT)]
+            if not my_onionmsg_peers:
+                raise NoOnionMessagePeers('no ONION_MESSAGE capable peers')
             rpeers = random_shuffled_copy(my_onionmsg_peers)
             for peer in rpeers[:max_paths]:
                 blinded_path = create_blinded_path(os.urandom(32), [peer.pubkey, mynodeid], final_recipient_data)
                 result.append(blinded_path)
 
+    assert result
     return result, payinfos
 
 
@@ -709,9 +721,6 @@ class OnionMessageManager(Logger):
             # unless explicitly set in payload, generate reply_path here
             path_id = self._path_id_from_payload_and_key(payload, key)
             reply_paths = get_blinded_reply_paths(self.lnwallet, path_id, max_paths=1)
-            if not reply_paths:
-                raise Exception(f'Could not create a reply_path for {key=}. No active peers?')
-
             final_payload['reply_path'] = {'path': reply_paths}
 
         # NOTE: we could also try alternate paths to introduction point (the non-blinded part of the route)

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -173,11 +173,10 @@ def create_onion_message_route_to(lnwallet: 'LNWallet', node_id: bytes) -> Seque
             if chan.short_channel_id is not None
         }
 
-        if path := lnwallet.network.path_finder.find_path_for_payment(
+        # TODO: if this blocks the event loop too long it might needs to go on a thread
+        if path := lnwallet.network.path_finder.find_path_for_onion_message(
             nodeA=lnwallet.node_keypair.pubkey,
             nodeB=node_id,
-            invoice_amount_msat=10000,  # TODO: do this without amount constraints
-            node_filter=lambda x, y: True if x == lnwallet.node_keypair.pubkey else is_onion_message_node(x, y),
             my_sending_channels=my_sending_channels
         ):
             # first edge must be to our peer

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, NamedTuple, Tuple, Union
 import electrum_ecc as ecc
 
 from electrum.channel_db import get_mychannel_policy
-from electrum.lnrouter import PathEdge
+from electrum.lnrouter import PathEdge, NoChannelPolicy
 from electrum.logging import get_logger, Logger
 from electrum.crypto import sha256, get_ecdh
 from electrum.lnmsg import OnionWireSerializer
@@ -422,7 +422,11 @@ def get_blinded_paths_to_me(
         for chan in rchans[:max_paths]:
             hop_extras = None
             if not onion_message:  # add hop_extras and payinfo, assumption: len(blinded_path) == 2 (us and peer)
-                payinfo, hop_extras = _get_payinfo_for_blinded_path(chan, lnwallet)
+                try:
+                    payinfo, hop_extras = _get_payinfo_for_blinded_path(chan, lnwallet)
+                except NoChannelPolicy:
+                    logger.warning(f"missing remote channel_update for {chan.short_channel_id}")
+                    continue
                 payinfos.append(payinfo)
             blinded_path = create_blinded_path(
                 session_key=os.urandom(32),
@@ -447,6 +451,8 @@ def get_blinded_paths_to_me(
 
 def _get_payinfo_for_blinded_path(chan: 'Channel', lnwallet: 'LNWallet'):
     cp = get_mychannel_policy(chan.short_channel_id, chan.node_id, {chan.short_channel_id: chan})
+    if not cp:
+        raise NoChannelPolicy(chan.short_channel_id)
     sum_cltv_expiry_delta = cp.cltv_delta
     sum_fee_base_msat = cp.fee_base_msat
     sum_fee_proportional_millionths = cp.fee_proportional_millionths

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -41,7 +41,8 @@ from electrum.lnonion import (get_bolt04_onion_key, OnionPacket, process_onion_p
                               OnionHopsDataSingle, decrypt_onionmsg_data_tlv, encrypt_onionmsg_data_tlv,
                               get_shared_secrets_along_route, new_onion_packet, encrypt_hops_recipient_data,
                               next_blinding_from_shared_secret)
-from electrum.lnutil import LnFeatures, MIN_FINAL_CLTV_DELTA_ACCEPTED, MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED
+from electrum.lnutil import (LnFeatures, MIN_FINAL_CLTV_DELTA_ACCEPTED, MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED,
+                             MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE)
 from electrum.util import OldTaskGroup, log_exceptions, random_shuffled_copy
 
 
@@ -481,7 +482,7 @@ def _get_payinfo_for_blinded_path(chan: 'Channel', lnwallet: 'LNWallet'):
     payinfo = {
         'fee_base_msat': sum_fee_base_msat,
         'fee_proportional_millionths': sum_fee_proportional_millionths,
-        'cltv_expiry_delta': sum_cltv_expiry_delta + MIN_FINAL_CLTV_DELTA_ACCEPTED,
+        'cltv_expiry_delta': sum_cltv_expiry_delta + MIN_FINAL_CLTV_DELTA_ACCEPTED + MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE,
         'htlc_minimum_msat': blinded_path_min_htlc_msat,
         'htlc_maximum_msat': blinded_path_max_htlc_msat,
         'flen': 0,

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -27,6 +27,7 @@ import io
 import os
 import threading
 import time
+import random
 
 from typing import TYPE_CHECKING, Optional, Sequence, NamedTuple, Tuple, Union
 
@@ -151,18 +152,27 @@ def is_onion_message_node(node_id: bytes, node_info: Optional['NodeInfo']) -> bo
 
 
 def create_onion_message_route_to(lnwallet: 'LNWallet', node_id: bytes) -> Sequence[PathEdge]:
-    """Constructs a route to the destination node_id, first by starting with peers with existing channels,
-       and if no route found, opening a direct peer connection if node_id is found with an address in
-       channel_db."""
-    # TODO: is this the proper way to set up my_sending_channels?
-    my_active_channels = [
-        chan for chan in lnwallet.channels.values() if
-        chan.is_active() and not chan.is_frozen_for_sending()]
-    my_sending_channels = {chan.short_channel_id: chan for chan in my_active_channels
-                           if chan.short_channel_id is not None}
-    # find route to introduction point over existing channel mesh
-    # NOTE: nodes that are in channel_db but are offline are not removed from the set
-    if lnwallet.network.path_finder:
+    """
+    Constructs a route for sending an onion message to node_id.
+    With Gossip: Tries to find a route through the graph. If no route can be found, raise NoRouteFound.
+                 If a connection address is known for node_id it is added to NoRouteFound for potential direct connection.
+    With Trampoline: Construct a route: us -> random trampoline peer -> node_id.
+                     We hope the trampoline peer will open a direct connection to node_id and forward the message.
+                     NOTE: Eclair only does this with the relay-policy config set to relay-all!
+    """
+    # destination is existing peer, use direct route
+    if lnwallet.lnpeermgr.get_peer_by_pubkey(node_id):
+        return [PathEdge(short_channel_id=None, start_node=None, end_node=node_id)]
+
+    if not lnwallet.uses_trampoline():
+        # find route to introduction point over existing channel mesh
+        # NOTE: nodes that are in channel_db but are offline are not removed from the set
+        my_active_channels = [chan for chan in lnwallet.channels.values() if chan.is_active()]
+        my_sending_channels = {
+            chan.short_channel_id: chan for chan in my_active_channels
+            if chan.short_channel_id is not None
+        }
+
         if path := lnwallet.network.path_finder.find_path_for_payment(
             nodeA=lnwallet.node_keypair.pubkey,
             nodeB=node_id,
@@ -174,15 +184,18 @@ def create_onion_message_route_to(lnwallet: 'LNWallet', node_id: bytes) -> Seque
             peer = lnwallet.lnpeermgr.get_peer_by_pubkey(path[0].end_node)
             assert peer, 'first hop not a peer'
             return path
-
-    # alt: dest is existing peer?
-    if lnwallet.lnpeermgr.get_peer_by_pubkey(node_id):
-        return [PathEdge(short_channel_id=None, start_node=None, end_node=node_id)]
-
-    # if we have an address, pass it.
-    if lnwallet.channel_db:
-        if peer_addr := lnwallet.channel_db.get_last_good_address(node_id):
+        elif peer_addr := lnwallet.channel_db.get_last_good_address(node_id):
+            # if we have an address, pass it.
             raise NoRouteFound('no path found, peer_addr available', peer_address=peer_addr)
+    else:
+        # if we use trampoline just assume the trampoline will open a direct connection to the next_node_id
+        trampoline_peers = [p for p in lnwallet.lnpeermgr.peers.values() if lnwallet.is_trampoline_peer(p.pubkey)]
+        if trampoline_peers:
+            random_trampoline_peer = random.choice(trampoline_peers)
+            return [
+                PathEdge(short_channel_id=None, start_node=None, end_node=random_trampoline_peer.pubkey),
+                PathEdge(short_channel_id=None, start_node=random_trampoline_peer.pubkey, end_node=node_id),
+            ]
 
     raise NoRouteFound('no path found')
 
@@ -539,7 +552,7 @@ class OnionMessageManager(Logger):
 
     def __init__(self, lnwallet: 'LNWallet'):
         Logger.__init__(self)
-        self.network = None  # type: Optional['Network']
+        self.network = None  # type: Optional[Network]
         self.taskgroup = None  # type: OldTaskGroup
         self.lnwallet = lnwallet
         self.pending = {}  # type: dict[bytes, OnionMessageManager.Request]

--- a/tests/test_lnrouter.py
+++ b/tests/test_lnrouter.py
@@ -523,32 +523,39 @@ class Test_LNRouter(ElectrumTestCase):
 
     async def test_find_path_for_onion_message(self):
         self.prepare_graph()
-        amount_to_send = 1000  # we route along channels, and we use find_path_for_payment, so dummy this.
 
-        path = self.path_finder.find_path_for_payment(
-            nodeA=node('a'),
-            nodeB=node('c'),
-            invoice_amount_msat=amount_to_send,
-            node_filter=is_onion_message_node)
+        path = self.path_finder.find_path_for_onion_message(nodeA=node('a'), nodeB=node('c'))
         self.assertEqual([
             PathEdge(start_node=node('a'), end_node=node('d'), short_channel_id=channel(6)),
             PathEdge(start_node=node('d'), end_node=node('c'), short_channel_id=channel(4)),
         ], path)
 
-        # impossible routes
-        path = self.path_finder.find_path_for_payment(
-            nodeA=node('e'),
-            nodeB=node('a'),
-            invoice_amount_msat=amount_to_send,
-            node_filter=is_onion_message_node)
+        # node e doesn't support onion messages
+        path = self.path_finder.find_path_for_onion_message(nodeA=node('a'), nodeB=node('e'))
         self.assertIsNone(path)
 
+    async def test_find_path_for_onion_message_ignores_amount_constraints(self):
+        self.prepare_graph()
+
+        # bump htlc_minimum_msat on channel(4) d->c direction
+        key = (node('d'), channel(4))
+        self.cdb._policies[key] = self.cdb._policies[key]._replace(htlc_minimum_msat=10_000_000)
+
+        # a small payment can no longer be routed
         path = self.path_finder.find_path_for_payment(
             nodeA=node('a'),
-            nodeB=node('e'),
-            invoice_amount_msat=amount_to_send,
-            node_filter=is_onion_message_node)
+            nodeB=node('c'),
+            invoice_amount_msat=1000,
+            node_filter=is_onion_message_node,
+        )
         self.assertIsNone(path)
+
+        # but an onion message still routes through the same hop
+        path = self.path_finder.find_path_for_onion_message(nodeA=node('a'), nodeB=node('c'))
+        self.assertEqual([
+            PathEdge(start_node=node('a'), end_node=node('d'), short_channel_id=channel(6)),
+            PathEdge(start_node=node('d'), end_node=node('c'), short_channel_id=channel(4)),
+        ], path)
 
 
 def _tramp_edge(start: str, end: str, *, fee_base=PLACEHOLDER_FEE, fee_prop=PLACEHOLDER_FEE, cltv=576) -> TrampolineEdge:

--- a/tests/test_onion_message.py
+++ b/tests/test_onion_message.py
@@ -23,7 +23,7 @@ from electrum.lnutil import (LnFeatures, Keypair, MIN_FINAL_CLTV_DELTA_ACCEPTED,
                              MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE)
 from electrum.onion_message import (
     create_blinded_path, OnionMessageManager, NoRouteFound, Timeout,
-    create_route_to_introduction_point, get_blinded_paths_to_me
+    create_route_to_introduction_point, get_blinded_paths_to_me, NoOnionMessagePeers
 )
 from electrum.util import bfh, read_json_file, OldTaskGroup, get_asyncio_loop
 from electrum.logging import console_stderr_handler
@@ -272,12 +272,13 @@ class MockNetwork:
         self.config.EXPERIMENTAL_LN_FORWARD_PAYMENTS = True
 
 
-class MockPeer:
-    their_features = LnFeatures(LnFeatures.OPTION_ONION_MESSAGE_OPT)
+ONION_MESSAGE_CAPABLE_PEER_FEATURES = LnFeatures(LnFeatures.OPTION_ONION_MESSAGE_OPT)
 
-    def __init__(self, pubkey, on_send_message=None):
+class MockPeer:
+    def __init__(self, pubkey, on_send_message=None, their_features=ONION_MESSAGE_CAPABLE_PEER_FEATURES):
         self.pubkey = pubkey
         self.on_send_message = on_send_message
+        self.their_features = their_features
 
     async def wait_one_htlc_switch_iteration(self, *args):
         pass
@@ -502,6 +503,7 @@ class TestOnionMessageUtils(TestPeer):
         bob_update = decode_msg(bob_update_raw)[1]
         bob_update['raw'] = bob_update_raw
         alice_chan.set_remote_update(bob_update)
+        alice.lnpeermgr.get_peer_by_pubkey(bob.node_keypair.pubkey).their_features |= LnFeatures.OPTION_ROUTE_BLINDING_OPT
 
         final_recipient_data = {'path_id': {'data': os.urandom(32)}}
         paths, payinfos = get_blinded_paths_to_me(alice, final_recipient_data, onion_message=False)

--- a/tests/test_onion_message.py
+++ b/tests/test_onion_message.py
@@ -19,7 +19,8 @@ from electrum.lnonion import (
     encrypt_hops_recipient_data, blinding_privkey, decrypt_onionmsg_data_tlv)
 from electrum.crypto import get_ecdh, privkey_to_pubkey
 from electrum.lntransport import LNPeerAddr
-from electrum.lnutil import LnFeatures, Keypair, MIN_FINAL_CLTV_DELTA_ACCEPTED, REMOTE
+from electrum.lnutil import (LnFeatures, Keypair, MIN_FINAL_CLTV_DELTA_ACCEPTED, REMOTE,
+                             MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE)
 from electrum.onion_message import (
     create_blinded_path, OnionMessageManager, NoRouteFound, Timeout,
     create_route_to_introduction_point, get_blinded_paths_to_me
@@ -511,7 +512,7 @@ class TestOnionMessageUtils(TestPeer):
         self.assertEqual(payinfos[0], {
             'fee_base_msat': bob_chan.forwarding_fee_base_msat,
             'fee_proportional_millionths': bob_chan.forwarding_fee_proportional_millionths,
-            'cltv_expiry_delta': bob_chan.forwarding_cltv_delta + MIN_FINAL_CLTV_DELTA_ACCEPTED,
+            'cltv_expiry_delta': bob_chan.forwarding_cltv_delta + MIN_FINAL_CLTV_DELTA_ACCEPTED + MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE,
             'htlc_minimum_msat': bob_chan.config[REMOTE].htlc_minimum_msat,
             'htlc_maximum_msat': min(bob_chan.config[REMOTE].max_htlc_value_in_flight_msat, 1000 * bob_chan.constraints.capacity),
             'flen': 0,


### PR DESCRIPTION
* splits `get_blinded_paths_to_me` for more maintainability
* handles missing remote channel updates when assembling blinded paths
* introduces using trampoline peers to deliver onion messages if gossip is unavailable
* changes pathfinding for onion messages to not rely on channel amount constraints
* filter channels by features when creating blinded paths, raise exc if none are available