### PR TITLE
tests: regtest: make test_just_in_time less flaky

### DIFF
--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -144,6 +144,28 @@ function wait_until_spent()
     printf "\n"
 }
 
+function wait_for_chain_tip()
+{
+    msg="waiting until $1 catches up to chain tip"
+    cmd="./run_electrum --regtest -D /tmp/$1"
+    declare -i timeout_sec=120
+    declare -i elapsed_sec=0
+
+    printf "$msg"
+    while (( $($cmd getinfo | jq '.blockchain_height') < $($bitcoin_cli getblockcount) )); do
+        if ((elapsed_sec > timeout_sec)); then
+            printf "Timeout of %i s exceeded\n" "$elapsed_sec"
+            exit 1
+        fi
+        sleep 1
+        elapsed_sec=$((elapsed_sec + 1))
+        printf '.'
+    done
+
+    $cmd wait_for_sync > /dev/null
+    printf "\n"
+}
+
 function assert_utxo_exists()
 {
     utxo=$($bitcoin_cli gettxout $1 $2)
@@ -781,6 +803,7 @@ if [[ $1 == "just_in_time" ]]; then
     fi
     # try again, multiple jit openings should work without issues
     new_blocks 3
+    wait_for_chain_tip bob
     echo "carol pays alice again"
     invoice=$($alice add_request 0.04 --lightning --memo "invoice2" | jq -r ".lightning_invoice")
     success=$($carol lnpay $invoice | jq -r ".success")


### PR DESCRIPTION
The regtest `just_in_time` is flaky on the (slow) CI because it tries to open two channels right after each other (mining 3 blocks in between). 
If the channel opener (LSP/Bob) hasn't caught up yet and is still on the same height as the previous channel open it will refuse to open another channel due to the anchor channel key derivation limitation.

This adds a helper to pause the test until bob has caught up to the newly mined 3 blocks before attempting the second open.

See bobs logs:
```
20260513T101716.349323Z |    ERROR | lnworker.LNWallet.[default_wallet] | Exception in _open_channel_coroutine: Exception('Refusing to reuse multisig_funding_keypair for new channel. Wait one block before opening another channel with th
is peer.')
Traceback (most recent call last):
  File "/tmp/cirrus-ci-build/electrum/util.py", line 1212, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/cirrus-ci-build/electrum/lnworker.py", line 1649, in _open_channel_coroutine
    chan, funding_tx = await util.wait_for2(coro, LN_P2P_NETWORK_TIMEOUT)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/cirrus-ci-build/electrum/util.py", line 1474, in wait_for2
    return await asyncio.wait_for(fut, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
    return await fut
           ^^^^^^^^^
  File "/tmp/cirrus-ci-build/electrum/lnpeer.py", line 951, in wrapper
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/cirrus-ci-build/electrum/lnpeer.py", line 1025, in channel_establishment_flow
    local_config = self.lnworker.make_local_config_for_new_channel(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/cirrus-ci-build/electrum/lnworker.py", line 1710, in make_local_config_for_new_channel
    raise Exception(
Exception: Refusing to reuse multisig_funding_keypair for new channel. Wait one block before opening another channel with this peer.
```