### PR TITLE
ci: code review: improvements (use system prompt, give more permissions)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -264,7 +264,9 @@ task:
   install_script:
     - npm install -g @anthropic-ai/claude-code
   review_script:
-    - python3 contrib/ci/claude_security_review.py
+    # the script is executed as 'node' user as claude refuses to run with root permissions
+    - chown -R node:node .
+    - su node -c "python3 contrib/ci/claude_security_review.py"
 
 # Cron jobs configured in https://cirrus-ci.com/settings/...
 # - job "nightly" on branch "master" at "0 30 2 * * ?"  (every day at 02:30Z)

--- a/contrib/ci/claude_security_review.py
+++ b/contrib/ci/claude_security_review.py
@@ -80,20 +80,22 @@ def changed_files_from_diff(diff: str) -> str:
     )
 
 
-def build_prompt(diff: str, changed_files: str, commit_messages: str) -> str:
+def read_system_prompt() -> str:
     with open(PROMPT_FILE) as f:
-        instructions = f.read()
+        return f.read()
 
+
+def build_user_prompt(diff: str, changed_files: str, commit_messages: str) -> str:
     return (
-        f"{instructions}\n\n"
-        f"---\n\n"
+        "Review the following PR diff according to the review "
+        "guidelines in your system prompt.\n\n"
         f"## Changed files\n\n```\n{changed_files}\n```\n\n"
         f"## Commit messages\n\n```\n{commit_messages}\n```\n\n"
         f"## Diff\n\n```diff\n{diff}\n```"
     )
 
 
-def run_claude(prompt: str) -> str | None:
+def run_claude(user_prompt: str, system_prompt: str) -> str | None:
     """Invoke Claude Code CLI in print mode. Returns review text or None on failure.
 
     Passes the prompt via stdin to avoid OS argument length limits (MAX_ARG_STRLEN).
@@ -105,12 +107,13 @@ def run_claude(prompt: str) -> str | None:
         "--model", CLAUDE_MODEL,
         "--effort", CLAUDE_EFFORT,
         "--output-format", "text",
+        "--append-system-prompt", system_prompt,
     ]
 
     try:
         result = subprocess.run(
             cmd,
-            input=prompt,
+            input=user_prompt,
             capture_output=True,
             text=True,
             timeout=CLAUDE_TIMEOUT_SECONDS,
@@ -237,10 +240,11 @@ def main() -> int:
         print(f"ERROR: diff is {len(diff)} chars, exceeds maximum of {MAX_DIFF_CHARS}. Skipping review.")
         return 2
 
-    prompt = build_prompt(diff, changed_files, commit_messages)
+    user_prompt = build_user_prompt(diff, changed_files, commit_messages)
+    system_prompt = read_system_prompt()
 
     print(f"\nRunning Claude Code review (model: {CLAUDE_MODEL})...\n")
-    review = run_claude(prompt)
+    review = run_claude(user_prompt, system_prompt)
 
     if review is None:
         print("Review failed to produce output.")

--- a/contrib/ci/claude_security_review.py
+++ b/contrib/ci/claude_security_review.py
@@ -158,7 +158,7 @@ def post_github_comment(body: str, *, repo: str, pr: str) -> None:
         f"## Security Review -- Issues Found\n\n"
         f"{body}\n\n"
         f"---\n"
-        f"*Reviewed by Claude Code ({CLAUDE_MODEL})*"
+        f"*Reviewed by Claude Code ({CLAUDE_MODEL}) at {CLAUDE_EFFORT} effort*"
     )
     if log_url:
         comment += f" | [Full CI log]({log_url})"
@@ -243,7 +243,7 @@ def main() -> int:
     user_prompt = build_user_prompt(diff, changed_files, commit_messages)
     system_prompt = read_system_prompt()
 
-    print(f"\nRunning Claude Code review (model: {CLAUDE_MODEL})...\n")
+    print(f"\nRunning Claude Code review (model: {CLAUDE_MODEL}) at {CLAUDE_EFFORT} effort...\n")
     review = run_claude(user_prompt, system_prompt)
 
     if review is None:

--- a/contrib/ci/claude_security_review.py
+++ b/contrib/ci/claude_security_review.py
@@ -101,6 +101,7 @@ def run_claude(prompt: str) -> str | None:
     cmd = [
         "claude",
         "-p",
+        "--dangerously-skip-permissions",
         "--model", CLAUDE_MODEL,
         "--effort", CLAUDE_EFFORT,
         "--output-format", "text",

--- a/contrib/ci/claude_security_review.py
+++ b/contrib/ci/claude_security_review.py
@@ -34,7 +34,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROMPT_FILE = os.path.join(SCRIPT_DIR, "security_review_prompt.md")
 
 MAX_DIFF_CHARS = 800_000
-CLAUDE_TIMEOUT_SECONDS = 20 * 60
+CLAUDE_TIMEOUT_SECONDS = 60 * 60
 CLAUDE_MODEL = "claude-opus-4-7"
 CLAUDE_EFFORT = "max"
 

--- a/contrib/ci/security_review_prompt.md
+++ b/contrib/ci/security_review_prompt.md
@@ -8,10 +8,10 @@ developer time and erodes trust in this review.
 
 ## Scope
 
-Focus your findings on the diff provided below -- only flag issues introduced or worsened by
-changes in this PR. You have access to the full Electrum codebase; use it freely to read
-surrounding code, trace call chains, and understand what the diff actually does. But do not
-audit code outside the diff -- the codebase is context, not the review target.
+Focus your findings on the diff provided in the user message -- only flag issues introduced
+or worsened by changes in this PR. You have access to the full Electrum codebase; use it
+freely to read surrounding code, trace call chains, and understand what the diff actually
+does. But do not audit code outside the diff -- the codebase is context, not the review target.
 Focus on changes that introduce, worsen, or fail to mitigate security vulnerabilities.
 Only flag issues introduced or worsened by the diff. Do not flag
 pre-existing issues visible in context lines unless the change makes them newly exploitable.


### PR DESCRIPTION
Skimming through the [headless docs](https://code.claude.com/docs/en/headless) I think these changes could improve the results of the CI:
* pass `--dangerously-skip-permissions` so it can actually execute and modify code
* append the prompt text to the system prompt, this prioritizes it higher and keeps it more available in the context
* log effort level
* increase timeout: 20 -> 60 min (20 are too short for complex/large contexts)