### PR TITLE
submarine_swaps: Reintroduce support for the old submarine swap protocol

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1868,6 +1868,7 @@ class LNWallet(Logger):
             full_path: LNPaymentPath = None,
             channels: Optional[Sequence[Channel]] = None,  # my own direct channels
             budget: Optional[PaymentFeeBudget] = None,  # to limit max fee
+            probe_only: bool = False,  # checks if a route for the payment exists, without actually sending the payment
     ) -> Tuple[bool, List[HtlcLog]]:
         """Attempt to pay a Lightning invoice (find routes, do MPP, send HTLCs).
 
@@ -1912,7 +1913,7 @@ class LNWallet(Logger):
             attempts = 30
         success = False
         try:
-            await self.pay_to_node(
+            probe_only_result = await self.pay_to_node(
                 node_pubkey=invoice_pubkey,
                 payment_hash=payment_hash,
                 payment_secret=payment_secret,
@@ -1924,7 +1925,12 @@ class LNWallet(Logger):
                 full_path=full_path,
                 channels=channels,
                 budget=budget,
+                probe_only=probe_only,
             )
+
+            if probe_only:
+                return probe_only_result, []
+
             success = True
         except PaymentFailure as e:
             self.logger.info(f'payment failure: {e!r}')
@@ -1959,10 +1965,13 @@ class LNWallet(Logger):
             budget: PaymentFeeBudget,
             channels: Optional[Sequence[Channel]] = None,
             fw_payment_key: str = None,  # for forwarding
-    ) -> None:
+            probe_only: bool = False,  # checks if a route for the payment exists, without actually sending the payment
+    ) -> bool:
         """
         Can raise PaymentFailure, ChannelDBNotLoaded,
         or OnionRoutingFailure (if forwarding trampoline).
+
+        returns bool: In case of probe_only, true/false denoting if a route to the destination exists.
         """
 
         assert budget
@@ -2021,8 +2030,15 @@ class LNWallet(Logger):
                             channels=channels,
                             budget=budget._replace(fee_msat=remaining_fee_budget_msat),
                         )
+
+                        can_route = False
+
                         # 2. send htlcs
                         async for sent_htlc_info, cltv_delta, trampoline_onion in routes:
+                            if probe_only:
+                                can_route = True
+                                continue
+
                             await self.pay_to_route(
                                 paysession=paysession,
                                 sent_htlc_info=sent_htlc_info,
@@ -2030,6 +2046,9 @@ class LNWallet(Logger):
                                 trampoline_onion=trampoline_onion,
                                 fw_payment_key=fw_payment_key,
                             )
+
+                        if probe_only:
+                            return can_route
                     # invoice_status is triggered in self.set_invoice_status when it actually changes.
                     # It is also triggered here to update progress for a lightning payment in the GUI
                     # (e.g. attempt counter)
@@ -2053,11 +2072,18 @@ class LNWallet(Logger):
                 # max attempts or timeout
                 if (attempts is not None and len(log) >= attempts) or (attempts is None and time.time() - paysession.start_time > self.PAYMENT_TIMEOUT):
                     raise PaymentFailure('Giving up after %d attempts'%len(log))
+
+            return False
         except PaymentSuccess:
             pass
+        except Exception:
+            if probe_only:
+                return False
+    
+            raise
         finally:
             paysession.is_active = False
-            if paysession.can_be_deleted():
+            if probe_only or paysession.can_be_deleted():
                 self._paysessions.pop(payment_key)
             paysession.logger.info(f"pay_to_node ending session for RHASH={payment_hash.hex()}")
 

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2079,7 +2079,7 @@ class LNWallet(Logger):
         except Exception:
             if probe_only:
                 return False
-    
+
             raise
         finally:
             paysession.is_active = False

--- a/electrum/plugins/swapserver/server.py
+++ b/electrum/plugins/swapserver/server.py
@@ -132,5 +132,5 @@ class HttpSwapServer(Logger, EventListener):
 
     async def create_swap(self, r):
         request = await r.json()
-        response = self.sm.server_create_swap(request)
+        response = await self.sm.server_create_swap(request)
         return web.json_response(response)

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -80,7 +80,7 @@ assert MAX_LOCKTIME_DELTA < MIN_FINAL_CLTV_DELTA_FOR_CLIENT
 # different length which would still allow for claiming the onchain
 # coins but the invoice couldn't be settled
 
-# Unified witness-script for all swaps.  Historically with Boltz-backend, this was the reverse-swap script.
+# Witness-script for all reverse swaps and the new normal swap following the new flow. Historically with Boltz-backend, this was the reverse-swap script.
 WITNESS_TEMPLATE_SWAP = [
     opcodes.OP_SIZE,
     OPPushDataGeneric(None),               # idx 1. length of preimage
@@ -96,6 +96,22 @@ WITNESS_TEMPLATE_SWAP = [
     opcodes.OP_CHECKLOCKTIMEVERIFY,
     opcodes.OP_DROP,
     OPPushDataPubkey,                      # idx 13. refund_pubkey
+    opcodes.OP_ENDIF,
+    opcodes.OP_CHECKSIG
+]
+
+# Witness-script for old forward swap flow.
+WITNESS_TEMPLATE_SWAP_V1 = [
+    opcodes.OP_HASH160,
+    OPPushDataGeneric(lambda x: x == 20),  # idx 1. payment_hash
+    opcodes.OP_EQUAL,
+    opcodes.OP_IF,
+    OPPushDataPubkey,                      # idx 4. server_pubkey
+    opcodes.OP_ELSE,
+    OPPushDataGeneric(None),               # idx 6. locktime
+    opcodes.OP_CHECKLOCKTIMEVERIFY,
+    opcodes.OP_DROP,
+    OPPushDataPubkey,                      # idx 9. client_pubkey
     opcodes.OP_ENDIF,
     opcodes.OP_CHECKSIG
 ]
@@ -151,6 +167,21 @@ def _construct_swap_scriptcode(
     return construct_script(
         WITNESS_TEMPLATE_SWAP,
         values={1: 32, 5: ripemd(payment_hash), 7: claim_pubkey, 10: locktime, 13: refund_pubkey}
+    )
+
+def _construct_swap_scriptcode_v1(
+    payment_hash: bytes,
+    locktime: int,
+    server_pubkey: bytes,
+    client_pubkey: bytes,
+) -> bytes:
+    assert isinstance(payment_hash, bytes) and len(payment_hash) == 32
+    assert isinstance(locktime, int) and (0 <= locktime <= bitcoin.NLOCKTIME_BLOCKHEIGHT_MAX)
+    assert isinstance(server_pubkey, bytes) and len(server_pubkey) == 33
+    assert isinstance(client_pubkey, bytes) and len(client_pubkey) == 33
+    return construct_script(
+        WITNESS_TEMPLATE_SWAP_V1,
+        values={1: ripemd(payment_hash), 4: server_pubkey, 6: locktime, 9: client_pubkey}
     )
 
 
@@ -780,6 +811,47 @@ class SwapManager(Logger):
             lightning_amount_sat=lightning_amount_sat)
         return swap
 
+    def create_reverse_swap_v1(self, *, invoice: Invoice, refund_pubkey: bytes) -> SwapData:
+        """ server method for v1 workflow:
+
+        - User generates an LN invoice with RHASH, and knows preimage.
+        - User creates on-chain output locked to RHASH.
+        - Server pays LN invoice. By completing payment, user reveals preimage.
+        - Server spends the on-chain output using preimage.
+        """
+
+        height = self.network.get_local_height()
+        locktime = height + LOCKTIME_DELTA_REFUND
+        if self.network.blockchain().is_tip_stale():
+            raise Exception("our blockchain tip is stale")
+        lnaddr = lndecode(invoice)
+        payment_hash = lnaddr.paymenthash
+        lightning_amount_sat = int(lnaddr.get_amount_sat()) # should return int
+
+        privkey = os.urandom(32)
+        our_pubkey = ECPrivkey(privkey).get_public_key_bytes(compressed=True)
+        onchain_amount_sat = self._get_send_amount(lightning_amount_sat, is_reverse=False)
+
+        if not onchain_amount_sat:
+            raise Exception("no onchain amount")
+
+        self.logger.info(f'client requested forward swap; lightning_amount_sat={lightning_amount_sat}, '
+                         f'onchain_amount_sat={onchain_amount_sat}, height={height}, locktime={locktime}')
+        redeem_script = _construct_swap_scriptcode_v1(
+            payment_hash=payment_hash,
+            locktime=locktime,
+            server_pubkey=our_pubkey,
+            client_pubkey=refund_pubkey,
+        )
+        swap = self.add_reverse_swap_v1(
+            redeem_script=redeem_script,
+            locktime=locktime,
+            privkey=privkey,
+            payment_hash=payment_hash,
+            onchain_amount_sat=onchain_amount_sat,
+            lightning_amount_sat=lightning_amount_sat)
+        return swap
+
     def add_reverse_swap(
         self,
         *,
@@ -826,6 +898,40 @@ class SwapManager(Logger):
         self.add_lnwatcher_callback(swap)
         return swap
 
+    def add_reverse_swap_v1(
+        self,
+        *,
+        redeem_script: bytes,
+        locktime: int,  # onchain
+        privkey: bytes,
+        lightning_amount_sat: int,
+        onchain_amount_sat: int,
+        payment_hash: bytes
+    ) -> SwapData:
+        if payment_hash.hex() in self._swaps:
+            raise Exception("payment_hash already in use")
+
+        lockup_address = script_to_p2wsh(redeem_script)
+        swap = SwapData(
+            redeem_script=redeem_script,
+            locktime=locktime,
+            privkey=privkey,
+            preimage=None,
+            prepay_hash=None,
+            lockup_address=lockup_address,
+            onchain_amount=onchain_amount_sat,
+            claim_to_output=None,
+            lightning_amount=lightning_amount_sat,
+            is_reverse=True,
+            is_redeemed=False,
+            funding_txid=None,
+            spending_txid=None,
+        )
+        swap._payment_hash = payment_hash
+        self._add_or_reindex_swap(swap, is_new=True)
+        self.add_lnwatcher_callback(swap)
+        return swap
+
     def server_add_swap_invoice(self, request: dict) -> dict:
         """ server method.
         (client-forward-swap phase2)
@@ -848,6 +954,37 @@ class SwapManager(Logger):
             redeem_script = _construct_swap_scriptcode(
                 payment_hash=payment_hash, locktime=swap.locktime, refund_pubkey=their_pubkey, claim_pubkey=our_pubkey,
             )
+            assert swap.redeem_script == redeem_script
+            assert key not in self.invoices_to_pay
+            self.invoices_to_pay[key] = 0
+            assert self.wallet.get_invoice(invoice.get_id()) is None
+            self.wallet.save_invoice(invoice)
+        return {}
+
+    def server_add_swap_invoice_v1(self, invoice: str, refundPublicKey: str) -> dict:
+        """ server method.
+        (client-forward-swap v1)
+        """
+        invoice = Invoice.from_bech32(invoice)
+        key = invoice.rhash
+        payment_hash = bytes.fromhex(key)
+        their_pubkey = bytes.fromhex(refundPublicKey)
+        with self.swaps_lock:
+            assert key in self._swaps
+            swap = self._swaps[key]
+            self.logger.info(f'server_add_swap_invoice: found swap is: {swap}')
+
+            assert swap.lightning_amount == int(invoice.get_amount_sat())
+            assert swap.is_reverse is True
+            assert swap.spending_txid is None
+            # check their_pubkey by recalculating redeem_script
+            our_pubkey = ECPrivkey(swap.privkey).get_public_key_bytes(compressed=True)
+            redeem_script = _construct_swap_scriptcode_v1(
+                payment_hash=payment_hash, locktime=swap.locktime, server_pubkey=our_pubkey, client_pubkey=their_pubkey,
+            )
+            self.logger.info(f'server_add_swap_invoice: redeem scripts:')
+            self.logger.info(f'server_add_swap_invoice: - {redeem_script}')
+            self.logger.info(f'server_add_swap_invoice: - {swap.redeem_script}')
             assert swap.redeem_script == redeem_script
             assert key not in self.invoices_to_pay
             self.invoices_to_pay[key] = 0
@@ -1442,12 +1579,11 @@ class SwapManager(Logger):
         return response
 
     def server_create_swap(self, request):
-        # reverse for client, forward for server
-        # requesting a normal swap (old protocol) will raise an exception
         #request = await r.json()
         req_type = request['type']
         assert request['pairId'] == 'BTC/BTC'
         if req_type == 'reversesubmarine':
+            # reverse for client, forward for server
             lightning_amount_sat=request['invoiceAmount']
             payment_hash=bytes.fromhex(request['preimageHash'])
             their_pubkey=bytes.fromhex(request['claimPublicKey'])
@@ -1468,7 +1604,25 @@ class SwapManager(Logger):
                 "onchainAmount": swap.onchain_amount,
             }
         elif req_type == 'submarine':
-            raise Exception('Deprecated API. Please upgrade your version of Electrum')
+            # client is doing a normal swap (old protocol)
+            their_invoice = request['invoice']
+            refund_pubkey = bytes.fromhex(request['refundPublicKey'])
+            assert len(refund_pubkey) == 33
+            swap = self.create_reverse_swap_v1(
+                invoice=their_invoice,
+                refund_pubkey=refund_pubkey
+            )
+
+            self.server_add_swap_invoice_v1(request['invoice'], request['refundPublicKey'])
+
+            response = {
+                "id": swap.payment_hash.hex(),
+                "acceptZeroConf": False,
+                "expectedAmount": swap.onchain_amount,
+                "timeoutBlockHeight": swap.locktime,
+                "address": swap.lockup_address,
+                "redeemScript": swap.redeem_script.hex()
+            }
         else:
             raise Exception('unsupported request type:' + req_type)
         return response
@@ -1988,7 +2142,7 @@ class NostrTransport(SwapServerTransport):
                 self.logger.info(f'handle_request: id={event_id} {method} {request}')
                 if method == 'addswapinvoice':  # client-forward-swap phase2
                     r = self.sm.server_add_swap_invoice(request)
-                elif method == 'createswap':  # client-reverse-swap
+                elif method == 'createswap':  # v1: client-forward-swap & client-reverse-swap
                     r = self.sm.server_create_swap(request)
                 elif method == 'createnormalswap':  # client-forward-swap phase1
                     r = self.sm.server_create_normal_swap(request)

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -824,7 +824,7 @@ class SwapManager(Logger):
         locktime = height + LOCKTIME_DELTA_REFUND
         if self.network.blockchain().is_tip_stale():
             raise Exception("our blockchain tip is stale")
-        lnaddr = lndecode(invoice)
+        lnaddr = decode_bolt11_invoice(invoice)
         payment_hash = lnaddr.paymenthash
         lightning_amount_sat = int(lnaddr.get_amount_sat()) # should return int
 

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -987,7 +987,7 @@ class SwapManager(Logger):
             self.logger.info(f'server_add_swap_invoice: - {swap.redeem_script}')
             assert swap.redeem_script == redeem_script
             assert key not in self.invoices_to_pay
-            self.invoices_to_pay[key] = 0
+
             assert self.wallet.get_invoice(invoice.get_id()) is None
             self.wallet.save_invoice(invoice)
         return {}

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -100,6 +100,8 @@ WITNESS_TEMPLATE_SWAP = [
     opcodes.OP_CHECKSIG
 ]
 
+CAP_FORWARD_V1 = "forwardv1"               # supports forward swaps with v1 flow
+
 
 def _check_swap_scriptcode(
     *,
@@ -1785,6 +1787,7 @@ class NostrTransport(SwapServerTransport):
             'max_reverse_amount': sm._max_reverse,
             'relays': sm.config.NOSTR_RELAYS,
             'pow_nonce': hex(sm.config.SWAPSERVER_ANN_POW_NONCE),
+            'capabilities': [ CAP_FORWARD_V1 ], # announce support for the old forward swap protocol flow
         }
         # the first value of a single letter tag is indexed and can be filtered for
         tags = [['d', f'electrum-swapserver-{self.NOSTR_EVENT_VERSION}'],

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -38,7 +38,7 @@ from .util import (
     run_sync_function_on_asyncio_thread, trigger_callback, NoDynamicFeeEstimates, UserFacingException, now
 )
 from . import lnutil
-from .lnutil import hex_to_bytes, REDEEM_AFTER_DOUBLE_SPENT_DELAY, Keypair
+from .lnutil import hex_to_bytes, REDEEM_AFTER_DOUBLE_SPENT_DELAY, Keypair, NoPathFound
 from .bolt11 import decode_bolt11_invoice
 from .stored_dict import StoredObject, stored_at
 from . import constants
@@ -811,7 +811,7 @@ class SwapManager(Logger):
             lightning_amount_sat=lightning_amount_sat)
         return swap
 
-    def create_reverse_swap_v1(self, *, invoice: Invoice, refund_pubkey: bytes) -> SwapData:
+    async def create_reverse_swap_v1(self, *, invoice: str, refund_pubkey: bytes) -> SwapData:
         """ server method for v1 workflow:
 
         - User generates an LN invoice with RHASH, and knows preimage.
@@ -834,6 +834,14 @@ class SwapManager(Logger):
 
         if not onchain_amount_sat:
             raise Exception("no onchain amount")
+
+        success, log = await self.lnworker.pay_invoice(
+            Invoice.from_bech32(invoice),
+            probe_only=True
+        )
+
+        if not success:
+            raise NoPathFound("no LN route to pay the invoice found")
 
         self.logger.info(f'client requested forward swap; lightning_amount_sat={lightning_amount_sat}, '
                          f'onchain_amount_sat={onchain_amount_sat}, height={height}, locktime={locktime}')
@@ -1578,7 +1586,7 @@ class SwapManager(Logger):
         }
         return response
 
-    def server_create_swap(self, request):
+    async def server_create_swap(self, request):
         #request = await r.json()
         req_type = request['type']
         assert request['pairId'] == 'BTC/BTC'
@@ -1608,7 +1616,8 @@ class SwapManager(Logger):
             their_invoice = request['invoice']
             refund_pubkey = bytes.fromhex(request['refundPublicKey'])
             assert len(refund_pubkey) == 33
-            swap = self.create_reverse_swap_v1(
+
+            swap = await self.create_reverse_swap_v1(
                 invoice=their_invoice,
                 refund_pubkey=refund_pubkey
             )
@@ -2143,7 +2152,7 @@ class NostrTransport(SwapServerTransport):
                 if method == 'addswapinvoice':  # client-forward-swap phase2
                     r = self.sm.server_add_swap_invoice(request)
                 elif method == 'createswap':  # v1: client-forward-swap & client-reverse-swap
-                    r = self.sm.server_create_swap(request)
+                    r = await self.sm.server_create_swap(request)
                 elif method == 'createnormalswap':  # client-forward-swap phase1
                     r = self.sm.server_create_normal_swap(request)
                 else:


### PR DESCRIPTION
Closes #10611

This PR

- Reintroduces the old v1 flow for submarine swaps.
    - A preliminary check ensures the LN payment route has a high chance of success before proceeding.
- Updates the swap server to signal support for `forwardv1` (the old protocol).

## Motivation

We've been trying to expand Electrum Swap ecosystem by creating interface &ndash; https://whales.exchange &ndash; for people who do not use Electrum Wallet. We have released the first public version of https://whales.exchange where we implemented support for reverse swaps. We would like to support forward swap as well in order to provide complete swap gateway to Electrum Swaps.

The current implementation of submarine swaps in Electrum require control over user's LN wallet which https://whales.exchange does not control (see the [design](https://github.com/AITIS-s-r-o/whales-exchange-web-app#design)). However, Electrum used to implement a different protocol, so called _old flow_ or simply _v1 flow_, for submarine swaps which did not have the requirement. The old implementation was removed [because](https://x.com/ElectrumWallet/status/2048328014459490491):

> The old flow was removed because servers sometimes fail to find a route for the LN payment, in which case users have to get an on-chain refund (funds locked + mining fees). The new flow cannot be supported with bolt11 invoices; it requires a wallet that supports hold invoices.

This PR attempts to bring back the old flow, so Electrum would support the old and the new submarine protocols. Moreover, to address the above issue, a new preliminary "is-there-a-LN-payment-route" check was added to somewhat mitigate the issue.

A short description of both protocols follows:

Old submarine swap flow (v1) is

- User generates an LN invoice with RHASH, and knows preimage. 
- User creates on-chain output locked to RHASH.
- **Server checks if there is a LN payment route, otherwise the swap is rejected** [new]
- Server pays LN invoice. By completing payment, user reveals preimage.
- Server spends the on-chain output using preimage.


[New submarine swap flow](https://github.com/spesmilo/electrum/pull/8566) is:

- User requests swap  (RPC 'createnormalswap')
- Server creates preimage, sends RHASH to user
- User creates hold invoice, sends it to server  (RPC 'addswapinvoice')
- Server sends HTLC, user holds it
- User creates on-chain output locked to RHASH
- Server spends the on-chain output using preimage (revealing the preimage)
- User fulfills HTLC using preimage

## Discussions

* #10611
* https://x.com/ElectrumWallet/status/2048374535578062988

(edit: Rebased to b9be9749f61224d51c6c96ab6b693385b9904172. Originally, it was based on 9b26c18.)