### PR TITLE
channel: give peer some time to fail htlc offchain on startup

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1972,12 +1972,15 @@ class Channel(AbstractChannel):
         # If there is an offered HTLC which has already expired (+ some grace period after), we
         # will unilaterally close the channel and time out the HTLC
         offered_htlc_deadline_delta = lnutil.NBLOCK_DEADLINE_DELTA_AFTER_EXPIRY_FOR_OFFERED_HTLCS
+        time_since_startup = now() - self.lnworker.instantiation_timestamp
         for sub, dir, ctn in ((LOCAL, SENT, self.get_latest_ctn(LOCAL)),
                               (REMOTE, RECEIVED, self.get_oldest_unrevoked_ctn(REMOTE)),
                               (REMOTE, RECEIVED, self.get_latest_ctn(REMOTE)),):
             for htlc_id, htlc in self.hm.htlcs_by_direction(subject=sub, direction=dir, ctn=ctn).items():
                 if htlc.cltv_abs + offered_htlc_deadline_delta > local_height:
                     continue
+                if time_since_startup < lnutil.TIME_FOR_OFFERED_HTLCS_TO_GET_FAILED_OFFCHAIN_ON_RESTART:
+                    continue  # give the peer some time to fail the htlc offchain
                 htlcs_we_could_reclaim[(SENT, htlc_id)] = htlc
         # Note: previously we used a threshold concept, "min_value_worth_closing_channel_over_sat", and
         #       only force-closed the channel if the total value of these expiring htlcs was large enough.

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -529,6 +529,8 @@ MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED = 2016
 # timeout after which we consider a zeroconf channel without funding tx to be failed
 ZEROCONF_TIMEOUT = 60 * 10
 
+TIME_FOR_OFFERED_HTLCS_TO_GET_FAILED_OFFCHAIN_ON_RESTART = 30
+
 
 class RevocationStore:
     # closely based on code in lightningnetwork/lnd

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1008,6 +1008,7 @@ class LNWallet(Logger):
         self.wallet = wallet
         self.config = wallet.config
         self.db = wallet.db
+        self.instantiation_timestamp = int(time.time())
         self.node_keypair = generate_keypair(BIP32Node.from_xkey(xprv), LnKeyFamily.NODE_KEY)
         self.backup_key = generate_keypair(BIP32Node.from_xkey(xprv), LnKeyFamily.BACKUP_CIPHER).privkey
         self.static_payment_key = generate_keypair(BIP32Node.from_xkey(xprv), LnKeyFamily.PAYMENT_BASE)

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -37,7 +37,7 @@ from electrum import bitcoin
 from electrum import lnpeer
 from electrum import lnchannel
 from electrum import lnutil
-from electrum.crypto import privkey_to_pubkey
+from electrum.crypto import sha256
 from electrum.lnutil import (
     SENT, LOCAL, REMOTE, RECEIVED, UpdateAddHtlc, LnFeatures, secret_to_pubkey, ChannelType,
     effective_htlc_tx_weight, LocalConfig, RemoteConfig, OnlyPubkeyKeypair, ZEROCONF_TIMEOUT,
@@ -847,6 +847,53 @@ class TestChannel(ElectrumTestCase):
         # check that channel got removed, now that funding has timed out
         self.assertIsNone(self.alice_lnwallet.get_channel_by_id(chan.channel_id))
         self.assertIsNone(self.alice_lnwallet.db.get('channels').get(chan.channel_id.hex()))
+
+    async def test_should_be_closed_due_to_expiring_htlcs_offered_htlcs(self):
+        alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        bob_lnwallet = self.create_mock_lnwallet(name="bob")
+        alice_channel, bob_channel = create_test_channels(alice_lnwallet=alice_lnwallet, bob_lnwallet=bob_lnwallet)
+
+        # no htlcs
+        self.assertFalse(alice_channel.should_be_closed_due_to_expiring_htlcs(local_height=100))
+
+        # one offered htlc, not expired
+        htlc = UpdateAddHtlc(payment_hash=sha256(os.urandom(32)), amount_msat=one_bitcoin_in_msat, cltv_abs=1000)
+        alice_channel.add_htlc(htlc)
+        alice_channel.sign_next_commitment()
+        self.assertFalse(alice_channel.should_be_closed_due_to_expiring_htlcs(local_height=100))
+
+        # expired offered htlc, within startup grace period
+        expired_local_height = 1000 + lnutil.NBLOCK_DEADLINE_DELTA_AFTER_EXPIRY_FOR_OFFERED_HTLCS + 5
+        self.assertFalse(alice_channel.should_be_closed_due_to_expiring_htlcs(expired_local_height))
+
+        # expired offered htlc, past startup grace period
+        alice_lnwallet.instantiation_timestamp -= (lnutil.TIME_FOR_OFFERED_HTLCS_TO_GET_FAILED_OFFCHAIN_ON_RESTART + 10)
+        self.assertTrue(alice_channel.should_be_closed_due_to_expiring_htlcs(expired_local_height))
+
+    async def test_should_be_closed_due_to_expiring_htlcs_received_htlcs(self):
+        alice_lnwallet = self.create_mock_lnwallet(name="alice")
+        bob_lnwallet = self.create_mock_lnwallet(name="bob")
+        alice_channel, bob_channel = create_test_channels(alice_lnwallet=alice_lnwallet, bob_lnwallet=bob_lnwallet)
+
+        preimage = os.urandom(32)
+        htlc = UpdateAddHtlc(payment_hash=sha256(preimage), amount_msat=one_bitcoin_in_msat, cltv_abs=100)
+        expired_height = 100 + lnutil.NBLOCK_DEADLINE_DELTA_BEFORE_EXPIRY_FOR_RECEIVED_HTLCS + 5
+        alice_channel.add_htlc(htlc)
+        bob_htlc_id =  bob_channel.receive_htlc(htlc).htlc_id
+        force_state_transition(alice_channel, bob_channel)
+
+        # preimage wasn't released
+        self.assertFalse(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
+
+        # now the preimage is released
+        bob_channel.settle_htlc(preimage, bob_htlc_id)
+
+        # still in 30s grace period waiting for peers revack
+        self.assertFalse(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
+
+        # now the settled htlc is past the grace period
+        bob_channel.htlc_settle_time[bob_htlc_id] = int(time.time()) - 60
+        self.assertTrue(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
 
 
 class TestChannelAnchors(TestChannel):


### PR DESCRIPTION
Resolves this path of unnecessary force closes:
1. Alice sends out HTLC through Bob
2. Alice closes wallet with pending HTLC
3. HTLC gets failed back to Bob
4. HTLC times out, but Bob doesn't force close
5. Alice starts her wallet and immediately force closes

With this patch, Alice will instead give Bob 30 seconds at step 5 to fail the HTLC offchain before force closing the channel. This can prevent some force closes.
