### PR TITLE
lnwatcher: introduce loop to trigger callbacks

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -24,24 +24,21 @@ from enum import IntEnum, Enum
 from typing import (
     Optional, Dict, List, Tuple, NamedTuple,
     Iterable, Sequence, TYPE_CHECKING, Iterator, Union, Mapping)
-import time
-import threading
 from abc import ABC, abstractmethod
 import itertools
 
 from aiorpcx import NetAddress
-import attr
 
 import electrum_ecc as ecc
 from electrum_ecc import ECPubkey
 
 from . import constants, util
-from .util import bfh, chunks, TxMinedInfo, error_text_bytes_to_safe_str
+from .util import bfh, chunks, TxMinedInfo, error_text_bytes_to_safe_str, now
 from .bitcoin import redeem_script_to_address
 from .crypto import sha256, sha256d
 from .transaction import Transaction, PartialTransaction, TxInput, Sighash
 from .logging import Logger
-from .lntransport import LNPeerAddr, extract_nodeid, ConnStringFormatError
+from .lntransport import LNPeerAddr
 from .lnonion import OnionRoutingFailure
 from . import lnutil
 from .lnutil import (Outpoint, LocalConfig, RemoteConfig, Keypair, OnlyPubkeyKeypair, ChannelConstraints,
@@ -170,8 +167,6 @@ class RemoteCtnTooFarInFuture(Exception): pass
 def htlcsum(htlcs: Iterable[UpdateAddHtlc]):
     return sum([x.amount_msat for x in htlcs])
 
-def now():
-    return int(time.time())
 
 class HTLCWithStatus(NamedTuple):
     channel_id: bytes

--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -2,11 +2,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file LICENCE or http://www.opensource.org/licenses/mit-license.php
 
+import asyncio
 from typing import TYPE_CHECKING, Optional, Dict, Callable, Awaitable
 
 from . import util
-from .util import TxMinedInfo, BelowDustLimit, NoDynamicFeeEstimates
-from .util import EventListener, event_listener, log_exceptions, ignore_exceptions
+from .util import (
+    TxMinedInfo, BelowDustLimit, NoDynamicFeeEstimates, OldTaskGroup, EventListener, event_listener, log_exceptions,
+    ignore_exceptions, now
+)
 from .transaction import Transaction, TxOutpoint
 from .logging import Logger
 from .address_synchronizer import TX_HEIGHT_LOCAL
@@ -20,6 +23,8 @@ if TYPE_CHECKING:
 
 
 class LNWatcher(Logger, EventListener):
+    MAX_CALLBACK_TRIGGER_DELAY_SEC = 600
+    CALLBACK_LOOP_POLL_INTERVAL_SEC = 5
 
     def __init__(self, lnworker: 'LNWallet'):
         self.lnworker = lnworker
@@ -30,12 +35,42 @@ class LNWatcher(Logger, EventListener):
         self.network = None
         self.register_callbacks()
         self._pending_force_closes = set()
+        self.taskgroup = OldTaskGroup()
+        self._last_callback_trigger_ts = 0
 
     def start_network(self, network: 'Network'):
+        assert not self.network, "already started?"
         self.network = network
+        asyncio.run_coroutine_threadsafe(self._main_loop(), util.get_asyncio_loop())
 
-    def stop(self):
+    async def stop(self):
+        await self.taskgroup.cancel_remaining()
         self.unregister_callbacks()
+
+    async def _main_loop(self):
+        self.logger.debug("starting taskgroup")
+        try:
+            async with self.taskgroup as group:
+                await group.spawn(self._callback_loop())  # keeps group alive
+        except Exception:
+            self.logger.exception("taskgroup crashed")
+        finally:
+            self.logger.debug("taskgroup stopped")
+
+    async def _callback_loop(self):
+        """
+        Triggers the callbacks if no event has triggered them within the
+        last MAX_CALLBACK_TRIGGER_DELAY_SEC (e.g. during a prolonged time without new blocks)
+        """
+        ts_start = now()
+        while True:
+            max_delay = self.MAX_CALLBACK_TRIGGER_DELAY_SEC
+            if now() - ts_start < max_delay:
+                max_delay /= 10  # if wallet just recently opened, be much more eager
+            time_since_last_cb_trigger = now() - self._last_callback_trigger_ts
+            if time_since_last_cb_trigger > max_delay:
+                await self.trigger_callbacks()
+            await asyncio.sleep(self.CALLBACK_LOOP_POLL_INTERVAL_SEC)
 
     def remove_callback(self, address: str) -> None:
         self.callbacks.pop(address, None)
@@ -59,7 +94,7 @@ class LNWatcher(Logger, EventListener):
 
     async def trigger_callbacks(self, *, requires_synchronizer: bool = True):
         if requires_synchronizer and not self.adb.synchronizer:
-            self.logger.info("synchronizer not set yet")
+            self.logger.debug("synchronizer not set yet")
             return
         for address, callback in list(self.callbacks.items()):
             try:
@@ -68,6 +103,7 @@ class LNWatcher(Logger, EventListener):
                 self.logger.exception(f"LNWatcher callback failed {address=}")
         # send callback to GUI
         util.trigger_callback('wallet_updated', self.lnworker.wallet)
+        self._last_callback_trigger_ts = now()
 
     @event_listener
     async def on_event_blockchain_updated(self, *args):

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1216,7 +1216,6 @@ class LNWallet(Logger):
         self.onion_message_manager.start_network(network=network)
 
         for coro in [
-                self.lnwatcher.trigger_callbacks(),  # shortcut (don't block) if funding tx locked and verified
                 self.reestablish_peers_and_channels(),
                 self.sync_with_remote_watchtower(),
         ]:
@@ -1231,7 +1230,7 @@ class LNWallet(Logger):
             await self.wait_for_received_pending_htlcs_to_get_removed()
         await self.lnpeermgr.stop()
         if self.lnwatcher:
-            self.lnwatcher.stop()
+            await self.lnwatcher.stop()
             self.lnwatcher = None
         if self.swap_manager and self.swap_manager.network:  # may not be present in tests
             await self.swap_manager.stop()

--- a/electrum/onion_message.py
+++ b/electrum/onion_message.py
@@ -45,9 +45,9 @@ from electrum.lnutil import LnFeatures, MIN_FINAL_CLTV_DELTA_ACCEPTED, MAXIMUM_R
 from electrum.util import OldTaskGroup, log_exceptions, random_shuffled_copy
 
 
-def now():
+def now() -> float:
     return time.time()
-
+assert type(now()) == float, "OnionMessageManager requires float timestamps"
 
 if TYPE_CHECKING:
     from electrum.lnworker import LNWallet

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -34,7 +34,7 @@ from .transaction import (
 from .util import (
     log_exceptions, ignore_exceptions, BelowDustLimit, OldTaskGroup, ca_path, gen_nostr_ann_pow,
     get_nostr_ann_pow_amount, make_aiohttp_proxy_connector, get_running_loop, get_asyncio_loop, wait_for2,
-    run_sync_function_on_asyncio_thread, trigger_callback, NoDynamicFeeEstimates, UserFacingException,
+    run_sync_function_on_asyncio_thread, trigger_callback, NoDynamicFeeEstimates, UserFacingException, now
 )
 from . import lnutil
 from .lnutil import hex_to_bytes, REDEEM_AFTER_DOUBLE_SPENT_DELAY, Keypair
@@ -160,10 +160,6 @@ class SwapServerError(Exception):
         if self.message:
             return self.message
         return _("The swap server errored or is unreachable.")
-
-
-def now():
-    return int(time.time())
 
 
 @attr.s(frozen=True)
@@ -295,7 +291,7 @@ class SwapManager(Logger):
             await transport.is_connected.wait()
             self.logger.info(f'nostr is connected')
             # will publish a new announcement if liquidity changed or every OFFER_UPDATE_INTERVAL_SEC
-            last_update = time.time()
+            last_update = now()
             while True:
                 await asyncio.sleep(transport.LIQUIDITY_UPDATE_INTERVAL_SEC)
 
@@ -313,11 +309,11 @@ class SwapManager(Logger):
                 mining_fees_changed = self.mining_fee != previous_mining_fee
                 if liquidity_changed or mining_fees_changed:
                     self.logger.debug(f"updating announcement: {liquidity_changed=}, {mining_fees_changed=}")
-                elif time.time() - last_update < transport.OFFER_UPDATE_INTERVAL_SEC:
+                elif now() - last_update < transport.OFFER_UPDATE_INTERVAL_SEC:
                     continue
 
                 await transport.publish_offer(self)
-                last_update = time.time()
+                last_update = now()
 
     @log_exceptions
     async def main_loop(self):
@@ -1762,8 +1758,7 @@ class NostrTransport(SwapServerTransport):
 
     def get_recent_offers(self) -> Sequence[SwapOffer]:
         # filter to fresh timestamps
-        now = int(time.time())
-        recent_offers = [x for x in self._offers.values() if now - x.timestamp < 3600]
+        recent_offers = [x for x in self._offers.values() if now() - x.timestamp < 3600]
         # sort by proof-of-work
         recent_offers = sorted(recent_offers, key=lambda x: x.pow_bits, reverse=True)
         # cap list size
@@ -1789,7 +1784,7 @@ class NostrTransport(SwapServerTransport):
         # the first value of a single letter tag is indexed and can be filtered for
         tags = [['d', f'electrum-swapserver-{self.NOSTR_EVENT_VERSION}'],
                 ['r', 'net:' + constants.net.NET_NAME],
-                ['expiration', str(int(time.time() + self.OFFER_UPDATE_INTERVAL_SEC + 10))]]
+                ['expiration', str(now() + self.OFFER_UPDATE_INTERVAL_SEC + 10)]]
         try:
             event_id = await aionostr._add_event(
                 self.relay_manager,
@@ -1847,7 +1842,7 @@ class NostrTransport(SwapServerTransport):
             "limit": 10,
             "#d": [f"electrum-swapserver-{self.NOSTR_EVENT_VERSION}"],
             "#r": [f"net:{constants.net.NET_NAME}"],
-            "since": int(time.time()) - 60 * 60,
+            "since": now() - 60 * 60,
         }
         async for event in self.relay_manager.get_events(query, single_event=False, only_stored=False):
             try:
@@ -1862,8 +1857,8 @@ class NostrTransport(SwapServerTransport):
                 continue
             if tags.get('r') != f"net:{constants.net.NET_NAME}":
                 continue
-            if (event.created_at > int(time.time()) + 60 * 60
-                    or event.created_at < int(time.time()) - 60 * 60):
+            if (event.created_at > now() + 60 * 60
+                    or event.created_at < now() - 60 * 60):
                 continue
             # check if this is the most recent event for this pubkey
             pubkey = event.pubkey

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -901,6 +901,10 @@ def format_time(timestamp: Union[int, float, None]) -> str:
     return date.isoformat(' ', timespec="minutes") if date else _("Unknown")
 
 
+def now() -> int:
+    return int(time.time())
+
+
 def age(
     from_date: Union[int, float, None],  # POSIX timestamp
     *,

--- a/tests/test_lnwallet.py
+++ b/tests/test_lnwallet.py
@@ -339,6 +339,7 @@ class TestLNWallet(ElectrumTestCase):
         wallet.close_channel = mock.AsyncMock(side_effect=Exception("peer disconnected"))
         wallet.remove_channel = mock.Mock()
         wallet.lnwatcher = mock.Mock()
+        wallet.lnwatcher.stop = mock.AsyncMock()
         wallet.lnwatcher.adb = mock.Mock()
         wallet.lnwatcher.adb.remove_transaction = mock.Mock()
 


### PR DESCRIPTION
Introduce a taskgroup and polling loop to LNWatcher to guarantee
the callbacks get called at least once every
LNWatcher.MAX_CALLBACK_TRIGGER_DELAY_SEC (10 min).
This should prevent callbacks that operate on time instead of
blockheight from becoming (very) stale if there are no blockchain
events triggering the callbacks for a longer time.
Not entirely set about the 10 min delay, might as well be 5/2/1 min?

Related to https://github.com/spesmilo/electrum/pull/10654