### PR TITLE
LNGossip: put maintain_db on thread

### DIFF
--- a/electrum/channel_db.py
+++ b/electrum/channel_db.py
@@ -732,6 +732,7 @@ class ChannelDB(SqlDB):
         now = int(time.time())
         return list(k for k, v in _policies.items() if v.timestamp <= now - delta)
 
+    @profiler(min_threshold=0.2)
     def prune_old_policies(self, delta):
         old_policies = self.get_old_policies(delta)
         if old_policies:
@@ -744,6 +745,7 @@ class ChannelDB(SqlDB):
             self.update_counts()
             self.logger.info(f'Deleting {len(old_policies)} old policies')
 
+    @profiler(min_threshold=0.2)
     def prune_orphaned_channels(self):
         with self.lock:
             orphaned_chans = self._chans_with_0_policies.copy()

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -723,8 +723,10 @@ class LNGossip(Logger):
         await self.channel_db.data_loaded.wait()
         while True:
             if len(self.unknown_ids) == 0:
-                self.channel_db.prune_old_policies(self.max_age)
-                self.channel_db.prune_orphaned_channels()
+                def _maintain():
+                    self.channel_db.prune_old_policies(self.max_age)
+                    self.channel_db.prune_orphaned_channels()
+                await asyncio.to_thread(_maintain)
             await asyncio.sleep(120)
 
     async def _maintain_forwarding_gossip(self):


### PR DESCRIPTION
I regularly see asyncio (debug) warnings that `LNGossip.maintain_db()` is blocking the event loop on my relatively fast laptop.

E.g. 3 warnings during a single session:
```
2.41 | I | channel_db.ChannelDB | Deleting 903 old policies
2.68 | I | channel_db.ChannelDB | Deleting 3954 orphaned channels
2.68 | W | asyncio | Executing <Task pending name='Task-22' coro=<LNGossip.maintain_db() running at /var/home/user/code/vibecoding_vm/electrum/electrum/lnworker.py:728> wait_for=<Future pending cb=[Task.task_wakeup()] created at /usr/lib64/python3.14/asyncio/base_events.py:459> cb=[set.discard(), TaskGroup._on_done()] created at /var/home/user/code/vibecoding_vm/electrum/electrum/util.py:1756> took 0.335 seconds
...
242.71 | I | channel_db.ChannelDB | Deleting 151 old policies
243.69 | I | channel_db.ChannelDB | Deleting 11819 orphaned channels
243.69 | W | asyncio | Executing <Task pending name='Task-22' coro=<LNGossip.maintain_db() running at /var/home/user/code/vibecoding_vm/electrum/electrum/lnworker.py:728> wait_for=<Future pending cb=[Task.task_wakeup()] created at /usr/lib64/python3.14/asyncio/base_events.py:459> cb=[set.discard(), TaskGroup._on_done()] created at /var/home/user/code/vibecoding_vm/electrum/electrum/util.py:1756> took 1.010 seconds
...
363.72 | I | channel_db.ChannelDB | Deleting 108 old policies
363.90 | I | channel_db.ChannelDB | Deleting 2922 orphaned channels
363.90 | W | asyncio | Executing <Task pending name='Task-22' coro=<LNGossip.maintain_db() running at /var/home/user/code/vibecoding_vm/electrum/electrum/lnworker.py:728> wait_for=<Future pending cb=[Task.task_wakeup()] created at /usr/lib64/python3.14/asyncio/base_events.py:459> cb=[set.discard(), TaskGroup._on_done()] created at /var/home/user/code/vibecoding_vm/electrum/electrum/util.py:1756> took 0.205 seconds
```