### PR TITLE
tests: try to make "backup" regtest less flaky

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -151,6 +151,7 @@ class Peer(Logger, EventListener):
         raw_msg = encode_msg(message_name, **kwargs)
         self._store_raw_msg_if_local_update(raw_msg, message_name=message_name, channel_id=kwargs.get("channel_id"))
         self.transport.send_bytes(raw_msg)
+        # could `await self.transport.writer.drain()`, but not async
 
     def _store_raw_msg_if_local_update(self, raw_msg: bytes, *, message_name: str, channel_id: Optional[bytes]):
         is_commitment_signed = message_name == "commitment_signed"
@@ -907,6 +908,7 @@ class Peer(Logger, EventListener):
         try:
             if self.transport:
                 self.transport.close()
+                # could `await self.transport.writer.wait_closed()` with a timeout?  but not async
         except Exception:
             pass
         self.lnworker.lnpeermgr.peer_closed(self)

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -3818,6 +3818,9 @@ class LNWallet(Logger):
                     async with OldTaskGroup(wait=any) as group:
                         await group.spawn(peer._message_loop())
                         await group.spawn(peer.request_force_close(channel_id))
+                    async with util.async_timeout(1):
+                        peer.transport.close()
+                        await peer.transport.writer.wait_closed()  # flush write-buffer
                     return True
                 except Exception as e:
                     self.logger.info(f'failed to connect {host} {e}')

--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -252,6 +252,11 @@ fi
 
 
 if [[ $1 == "backup" ]]; then
+    # Alice has two channels with Bob.
+    # - chan1 has on-chain op_return backups,
+    # - chan2 has an imported backup.
+    # Alice restores from seed, and also imports backup for chan2.
+    # Test "request_force_close" works for both channels.
     wait_for_balance alice 1
     echo "alice opens channel"
     bob_node=$($bob nodeid)
@@ -260,7 +265,7 @@ if [[ $1 == "backup" ]]; then
     $alice setconfig use_recoverable_channels False
     channel2=$($alice open_channel $bob_node 0.15 --password='')
     new_blocks 3
-    wait_until_channel_open alice
+    wait_until_channel_open alice  # FIXME wait for *both* channels?
     backup=$($alice export_channel_backup $channel2)
     seed=$($alice getseed --password='')
     $alice stop


### PR DESCRIPTION
Kind of shooting in the dark, but looking at logs, when the "backup" test fails,
Alice logs "Sending CHANNEL_REESTABLISH" and "Sending ERROR",
but Bob never receives them, instead he logs "Disconnecting: LightningPeerConnectionClosed()".
Maybe Alice's TCP socket should just be flushed, as done here.