### PR TITLE
unit tests: do not mock save_db

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -99,11 +99,10 @@ class TestCommands(ElectrumTestCase):
             for xkey2, xtype2 in xprvs:
                 self.assertEqual(xkey2, await cmds.convert_xkey(xkey1, xtype2))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_encrypt_decrypt(self, mock_save_db):
+    async def test_encrypt_decrypt(self):
         wallet = restore_wallet_from_text__for_unittest(
             'p2wpkh:L4rYY5QpfN6wJEF4SEKDpcGhTPnCe9zcGs6hiSnhpprZqVywFifN',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
         cleartext = "asdasd this is the message"
@@ -111,11 +110,10 @@ class TestCommands(ElectrumTestCase):
         ciphertext = await cmds.encrypt(pubkey, cleartext)
         self.assertEqual(cleartext, await cmds.decrypt(pubkey, ciphertext, wallet=wallet))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_export_private_key_imported(self, mock_save_db):
+    async def test_export_private_key_imported(self):
         wallet = restore_wallet_from_text__for_unittest(
             'p2wpkh:L4rYY5QpfN6wJEF4SEKDpcGhTPnCe9zcGs6hiSnhpprZqVywFifN p2wpkh:L4jkdiXszG26SUYvwwJhzGwg37H2nLhrbip7u6crmgNeJysv5FHL',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
         # single address tests
@@ -131,11 +129,10 @@ class TestCommands(ElectrumTestCase):
         self.assertEqual(['p2wpkh:L4jkdiXszG26SUYvwwJhzGwg37H2nLhrbip7u6crmgNeJysv5FHL', 'p2wpkh:L4rYY5QpfN6wJEF4SEKDpcGhTPnCe9zcGs6hiSnhpprZqVywFifN'],
                          await cmds.getprivatekeys(['bc1q2ccr34wzep58d4239tl3x3734ttle92a8srmuw', 'bc1q9pzjpjq4nqx5ycnywekcmycqz0wjp2nq604y2n'], wallet=wallet))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_export_private_key_deterministic(self, mock_save_db):
+    async def test_export_private_key_deterministic(self):
         wallet = restore_wallet_from_text__for_unittest(
             'bitter grass shiver impose acquire brush forget axis eager alone wine silver',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
         # single address tests
@@ -159,12 +156,11 @@ class TestCommands(ElectrumTestCase):
         self.assertTrue(await cmds.verifymessage(addr, sig, msg))
         self.assertFalse(await cmds.verifymessage(addr, sig+"trailinggarbage", msg))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_decrypt_enforces_strict_base64(self, mock_save_db):
+    async def test_decrypt_enforces_strict_base64(self):
         cmds = Commands(config=self.config)
         wallet = restore_wallet_from_text__for_unittest(
             '9dk',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']  # type: Abstract_Wallet
         plaintext = "hello there"
         ciphertext = "QklFMQJEFgxfkXj+UNblbHR+4y6ZA2rGEeEhWo7h84lBFjlRY5JOPfV1zyC1fw5YmhIr7+3ceIV11lpf/Yv7gSqQCQ5Wuf1aGXceHZO0GjKVxBsuew=="
@@ -280,11 +276,10 @@ class TestCommandsTestnet(ElectrumTestCase):
         self.assertEqual("0200000000010139c5375fe9da7bd377c1783002b129f8c57d3e724d62f5eacb9739ca691a229d0100000000fdffffff01301b0f0000000000160014ac0e2d229200bffb2167ed6fd196aef9d687d8bb0247304402201c551df0458528d19ba1dd79b134dcf0055f7b029dfc3d0d024e6253d069d13e02206d03cfc85a6fc648acb6fc6be630e4567d1dd00ddbcdee551ee0711414e2f33f0121021f110909ded653828a254515b58498a6bafc96799fb0851554463ed44ca7d9da00000000",
                          await cmds.serialize(jsontx))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_getprivatekeyforpath(self, mock_save_db):
+    async def test_getprivatekeyforpath(self):
         wallet = restore_wallet_from_text__for_unittest(
             'north rent dawn bunker hamster invest wagon market romance pig either squeeze',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
         self.assertEqual("p2wpkh:cUzm7zPpWgLYeURgff4EsoMjhskCpsviBH4Y3aZcrBX8UJSRPjC2",
@@ -294,11 +289,10 @@ class TestCommandsTestnet(ElectrumTestCase):
         self.assertEqual("p2wpkh:cQAj4WGf1socCPCJNMjXYCJ8Bs5JUAk5pbDr4ris44QdgAXcV24S",
                          await cmds.getprivatekeyforpath("m/5h/100000/88h/7", wallet=wallet))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_payto(self, mock_save_db):
+    async def test_payto(self):
         wallet = restore_wallet_from_text__for_unittest(
             'disagree rug lemon bean unaware square alone beach tennis exhibit fix mimic',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         # bootstrap wallet
         funding_tx = Transaction('0200000000010165806607dd458280cb57bf64a16cf4be85d053145227b98c28932e953076b8e20000000000fdffffff02ac150700000000001600147e3ddfe6232e448a8390f3073c7a3b2044fd17eb102908000000000016001427fbe3707bc57e5bb63d6f15733ec88626d8188a02473044022049ce9efbab88808720aa563e2d9bc40226389ab459c4390ea3e89465665d593502206c1c7c30a2f640af1e463e5107ee4cfc0ee22664cfae3f2606a95303b54cdef80121026269e54d06f7070c1f967eb2874ba60de550dfc327a945c98eb773672d9411fd77181e00')
@@ -329,12 +323,11 @@ class TestCommandsTestnet(ElectrumTestCase):
         self.assertEqual("02000000000101a0a8800d2d6bb0a4a8b93b793f39439c4139a40d30e634cf5cd601e5391de6ed0100000000fdffffff0240e2010000000000160014810480bbaf62145abf945ebe5f657c665a3a3732462b060000000000160014a5103285eb519f826520a9f7d3227e1eaa7ec5f802473044022057a6f4b1ec63336c7d0ba233e785ec9f2e2d9c2d67617a50e069f4498ee6a3b7022032fb331e0bef06f46e9cb77bfe94413142653c4912516835e941fa7f170c1a53012103001b55f19541faaf7e6d57dd1bdb9fdc37725fc500e12f2418cc11e0aed4154978181e00",
                          tx_str)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_payto__confirmed_only(self, mock_save_db):
+    async def test_payto__confirmed_only(self):
         """test that payto respects 'confirmed_only' config var"""
         wallet = restore_wallet_from_text__for_unittest(
             'disagree rug lemon bean unaware square alone beach tennis exhibit fix mimic',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         # bootstrap wallet
         funding_tx = Transaction('0200000000010165806607dd458280cb57bf64a16cf4be85d053145227b98c28932e953076b8e20000000000fdffffff02ac150700000000001600147e3ddfe6232e448a8390f3073c7a3b2044fd17eb102908000000000016001427fbe3707bc57e5bb63d6f15733ec88626d8188a02473044022049ce9efbab88808720aa563e2d9bc40226389ab459c4390ea3e89465665d593502206c1c7c30a2f640af1e463e5107ee4cfc0ee22664cfae3f2606a95303b54cdef80121026269e54d06f7070c1f967eb2874ba60de550dfc327a945c98eb773672d9411fd77181e00')
@@ -364,11 +357,10 @@ class TestCommandsTestnet(ElectrumTestCase):
         txout = TxOutput.from_address_and_value("tb1qsyzgpwa0vg2940u5t6l97etuvedr5dejpf9tdy", 123456)
         self.assertTrue(txout in tx.outputs())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_paytomany_multiple_max_spends(self, mock_save_db):
+    async def test_paytomany_multiple_max_spends(self):
         wallet = restore_wallet_from_text__for_unittest(
             'kit virtual quantum festival fortune inform ladder saddle filter soldier start ghost',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         # bootstrap wallet
         funding_tx = Transaction('02000000000101f59876b1c65bbe3e182ccc7ea7224fe397bb9b70aadcbbf4f4074c75c8a074840000000000fdffffff021f351f00000000001600144eec851dd980cc36af1f629a32325f511604d6af56732d000000000016001439267bc7f3e3fabeae3bc3f73880de22d8b01ba50247304402207eac5f639806a00878488d58ca651d690292145bca5511531845ae21fab309d102207162708bd344840cc1bacff1092e426eb8484f83f5c068ba4ca579813de324540121020e0798c267ff06ee8b838cd465f3cfa6c843a122a04917364ce000c29ca205cae5f31f00')
@@ -391,19 +383,17 @@ class TestCommandsTestnet(ElectrumTestCase):
         self.assertEqual("0200000000010115de15adc19661582a948876fbff49fa5deee24a158f1bec847d859cbd77e9e80100000000fdffffff04400d030000000000160014b450f5942ea3b0bb085e45f568fe49e72d3f28b0e09304000000000016001484770005f3783adcaafdece4e536dded3fbf798e12190f00000000001600141fb2ce607fffe4b193bbd11568cd7bf856053ce19ca5160000000000160014e8ea4cd62b6a65a2527124da12f5b7829dc1298f02473044022079570c62352d7c462ee50851d27f829f7ea5757d258b6b38a6b377a4910ba597022056653f1b15a9693ba790e89ebac60e33b7a1d8357e05cd3d7ecc1ae00e9ab4a8012102eed460ead0cbaa71ad52b70899acf4ea12682ab237207b045c5cf9c6d11c2bcfe6f31f00",
                          tx_str)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_signtransaction_without_wallet(self, mock_save_db):
+    async def test_signtransaction_without_wallet(self):
         cmds = Commands(config=self.config)
         unsigned_tx = "70736274ff0100a0020000000221d3645ba44f33fff6fe2666dc080279bc34b531c66888729712a80b204a32a10100000000fdffffffdd7f90d51acf98dc45ad7489316a983868c75e16bf14ffeb9eae01603a7b4da40100000000fdffffff02e8030000000000001976a9149a9ec2b35a7660c80dae38dd806fdf9b0fde68fd88ac74c11000000000001976a914f0dc093f7fb1b76cfd06610d5359d6595676cc2b88aca79b1d00000100e102000000018ba8cf9f0ff0b44c389e4a1cd25c0770636d95ccef161e313542647d435a5fd0000000006a4730440220373b3989905177f2e36d7e3d02b967d03092747fe7bbd3ba7b2c24623a88538c02207be79ee1d981060c2be6783f4946ce1bda1f64671b349ef14a4a6fecc047a71e0121030de43c5ed4c6272d20ce3becf3fb7afd5c3ccfb5d58ddfdf3047981e0b005e0dfdffffff02c0010700000000001976a9141cd3eb65bce2cae9f54544b65e46b3ad1f0b187288ac40420f00000000001976a914f0dc093f7fb1b76cfd06610d5359d6595676cc2b88ac979b1d00000100e102000000014e39236158716e91b0b2170ebe9d6b359d139e9ebfff163f2bafd0bec9890d04000000006a473044022070340deb95ca25ef86c4c7a9539b5c8f7b8351941635450311f914cd9c2f45ea02203fa7576e032ab5ae4763c78f5c2124573213c956286fd766582d9462515dc6540121033f6737e40a3a6087bc58bc5b82b427f9ed26d710b8fe2f70bfdd3d62abebcf74fdffffff02e8030000000000001976a91490350959750b3b38e451df16bd5957b7649bf5d288acac840100000000001976a914f0dc093f7fb1b76cfd06610d5359d6595676cc2b88ac979b1d00000000"
         privkey = "cVtE728tULSA4gut4QWxo218q6PRsXHQAv84SXix83cuvScvGd1H"
         self.assertEqual("020000000221d3645ba44f33fff6fe2666dc080279bc34b531c66888729712a80b204a32a1010000006a47304402205b30e188e30c846f98dacc714c16b7cd3a58a3fa24973d289683c9d32813e24c0220153855a29e96fb083084417ba3e3873ccaeb08435dad93773ab60716f94a36160121033f6737e40a3a6087bc58bc5b82b427f9ed26d710b8fe2f70bfdd3d62abebcf74fdffffffdd7f90d51acf98dc45ad7489316a983868c75e16bf14ffeb9eae01603a7b4da4010000006a473044022010daa3dadf53bdcb071c6eff6b8787e3f675ed61feb4fef72d0bf9d99c0162f802200e73abd880b6f2ee5fe8c0abab731f1dddeb0f60df5e050a79c365bd718da1c80121033f6737e40a3a6087bc58bc5b82b427f9ed26d710b8fe2f70bfdd3d62abebcf74fdffffff02e8030000000000001976a9149a9ec2b35a7660c80dae38dd806fdf9b0fde68fd88ac74c11000000000001976a914f0dc093f7fb1b76cfd06610d5359d6595676cc2b88aca79b1d00",
                          await cmds.signtransaction_with_privkey(tx=unsigned_tx, privkey=privkey))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_signtransaction_with_wallet(self, mock_save_db):
+    async def test_signtransaction_with_wallet(self):
         wallet = restore_wallet_from_text__for_unittest(
             'bitter grass shiver impose acquire brush forget axis eager alone wine silver',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
 
         # bootstrap wallet1
@@ -420,11 +410,10 @@ class TestCommandsTestnet(ElectrumTestCase):
         self.assertEqual("020000000001010392c1940e2ec9f2372919ca3887327fe5b98b866022cc79bab5cbed5a53d2ad0000000000feffffff022823000000000000160014690b59a8140602fb23cc2904ece9cc4daf361052301b0f0000000000160014ac0e2d229200bffb2167ed6fd196aef9d687d8bb02473044022027e1e37172e52b2d84106663cff5bcf6e447dcb41f6483f99584cfb4de2785f4022005c72f6324ad130c78fca43fe5fc565526d1723f2c9dc3efea78f66d7ae9d4360121030faee9b4a25b7db82023ca989192712cdd4cb53d3d9338591c7909e581ae1c0c00000000",
                          await cmds.signtransaction(tx=unsigned_tx, wallet=wallet))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bumpfee(self, mock_save_db):
+    async def test_bumpfee(self):
         wallet = restore_wallet_from_text__for_unittest(
             'right nominee cheese afford exotic pilot mask illness rug fringe degree pottery',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']  # type: Abstract_Wallet
 
         funding_tx = Transaction("02000000000102789e8aa8caa79d87241ff9df0e3fd757a07c85a30195d76e8efced1d57c56b670000000000fdffffff7ee2b6abd52b332f797718ae582f8d3b979b83b1799e0a3bfb2c90c6e070c29e0100000000fdffffff020820000000000000160014c0eb720c93a61615d2d66542d381be8943ca553950c3000000000000160014d7dbd0196a2cbd76420f14a19377096cf6cddb75024730440220485b491ad8d3ce3b4da034a851882da84a06ec9800edff0d3fd6aa42eeba3b440220359ea85d32a05932ac417125e133fa54e54e7e9cd20ebc54b883576b8603fd65012103860f1fbf8a482b9d35d7d4d04be8fb33d856a514117cd8b73e372d36895feec60247304402206c2ca56cc030853fa59b4b3cb293f69a3378ead0f10cb76f640f8c2888773461022079b7055d0f6af6952a48e5b97218015b0723462d667765c142b41bd35e3d9c0a01210359e303f57647094a668d69e8ff0bd46c356d00aa7da6dc533c438e71c057f0793e721f00")
@@ -451,11 +440,10 @@ class TestCommandsTestnet(ElectrumTestCase):
         self.assertEqual("02000000000101b9723dfc69af058ef6613539a000d2cd098a2c8a74e802b6d8739db708ba8c9a0100000000fdffffff02a00f00000000000016001429e1fd187f0cac845946ae1b11dc136c536bfc0f84b2000000000000160014100611bcb3aee7aad176936cf4ed56ade03027aa0247304402203aa63539b673a3bd70a76482b17f35f8843974fab28f84143a00450789010bc40220779c2ce2d0217f973f1f6c9f718e19fc7ebd14dd8821a962f002437cda3082ec012102ee3f00141178006c78b0b458aab21588388335078c655459afe544211f15aee000000000",
                          await cmds.bumpfee(tx=orig_rawtx, new_fee_rate='1.6', from_coins="9a8cba08b79d73d8b602e8748a2c8a09cdd200a0393561f68e05af69fc3d72b9:1", wallet=wallet))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_importprivkey(self, mock_save_db):
+    async def test_importprivkey(self):
         wallet = restore_wallet_from_text__for_unittest(
             'p2wpkh:cQUdWZehnGDwGn7CSc911cJBcWTAcnyzpLoJYTsFNYW1w6iaq7Nw p2wpkh:cNHsDLo137ngrr2wGf3mwqpwTUvpuDVAZrqzan9heHcMTK4rP5JB',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
         self.assertEqual(2, len(wallet.get_addresses()))
@@ -490,11 +478,10 @@ class TestCommandsTestnet(ElectrumTestCase):
                          await cmds.importprivkey(privkeys2_str, wallet=wallet))
         self.assertEqual(10, len(wallet.get_addresses()))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_hold_invoice_commands(self, mock_save_db):
+    async def test_hold_invoice_commands(self):
         wallet: Abstract_Wallet = restore_wallet_from_text__for_unittest(
             'disagree rug lemon bean unaware square alone beach tennis exhibit fix mimic',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
 
         cmds = Commands(config=self.config)
@@ -667,11 +654,10 @@ class TestCommandsTestnet(ElectrumTestCase):
                 }
             )
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_get_submarine_swap_providers(self, *mock_args):
+    async def test_get_submarine_swap_providers(self):
         wallet = restore_wallet_from_text__for_unittest(
             'disagree rug lemon bean unaware square alone beach tennis exhibit fix mimic',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
 
         cmds = Commands(config=self.config)
@@ -733,11 +719,10 @@ class TestCommandsTestnet(ElectrumTestCase):
         }
         self.assertEqual(result, expected_result)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_export_lightning_preimage(self, *mock_args):
+    async def test_export_lightning_preimage(self):
         w = restore_wallet_from_text__for_unittest(
             'disagree rug lemon bean unaware square alone beach tennis exhibit fix mimic',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
 
@@ -748,12 +733,11 @@ class TestCommandsTestnet(ElectrumTestCase):
         assert await cmds.export_lightning_preimage(payment_hash=payment_hash.hex(), wallet=w) == preimage.hex()
         assert await cmds.export_lightning_preimage(payment_hash=os.urandom(32).hex(), wallet=w) is None
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
     @mock.patch('electrum.commands.LN_P2P_NETWORK_TIMEOUT', 0.001)
     async def test_add_peer(self, *mock_args):
         w = restore_wallet_from_text__for_unittest(
             'disagree rug lemon bean unaware square alone beach tennis exhibit fix mimic',
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']
         cmds = Commands(config=self.config)
 

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -6,7 +6,7 @@ from typing import Sequence
 import asyncio
 import copy
 
-from electrum import bitcoin, keystore, bip32, slip39, wallet
+from electrum import bitcoin, keystore, bip32, slip39
 from electrum.wallet_db import WalletDB
 from electrum.storage import WalletStorage
 from electrum import SimpleConfig
@@ -110,8 +110,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_standard(self, mock_save_db):
+    async def test_electrum_seed_standard(self):
         seed_words = 'cycle rocket west magnet parrot shuffle foot correct salt library feed song'
         self.assertEqual(calc_seed_type(seed_words), 'standard')
 
@@ -129,8 +128,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '1NNkttn1YvVGdqBW4PR6zvc3Zx3H5owKRf')
         self.assertEqual(w.get_change_addresses()[0], '1KSezYMhAJMWqFbVFB2JshYg69UpmEXR4D')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_segwit(self, mock_save_db):
+    async def test_electrum_seed_segwit(self):
         seed_words = 'bitter grass shiver impose acquire brush forget axis eager alone wine silver'
         self.assertEqual(calc_seed_type(seed_words), 'segwit')
 
@@ -151,8 +149,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual('zprvAabC4ncjU4qVMNbpYZ5G4XqmKJoJN3EA4TVCodaPwyvEatrZpVYmWVHfKwS1fdq2uCdPyCmbjAjQ5FzeqHFSGv9KUmUFptTMAcyKzHiUM6Q',
                          ks.get_lightning_xprv(None))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_segwit_passphrase(self, mock_save_db):
+    async def test_electrum_seed_segwit_passphrase(self):
         seed_words = 'bitter grass shiver impose acquire brush forget axis eager alone wine silver'
         self.assertEqual(calc_seed_type(seed_words), 'segwit')
 
@@ -173,8 +170,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual('zprvAaoTFrze53KLvVYL8yL5H4sxoBFto98dgfTxFxcBepBPaEWStxpsdYqvNGxskGMTgX11bUtPiVj3aCe2jXFkAJQMi9RmksGBgFVwFM85Gir',
                          ks.get_lightning_xprv(None))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_old(self, mock_save_db):
+    async def test_electrum_seed_old(self):
         seed_words = 'powerful random nobody notice nothing important anyway look away hidden message over'
         seed_hex = 'acb740e454c3134901d7c8f16497cc1c'
 
@@ -198,8 +194,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
                 self.assertEqual(w.get_receiving_addresses()[0], '1FJEEB8ihPMbzs2SkLmr37dHyRFzakqUmo')
                 self.assertEqual(w.get_change_addresses()[0], '1KRW8pH6HFHZh889VDq6fEKvmrsmApwNfe')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_2fa_legacy_pre27_25words(self, mock_save_db):
+    async def test_electrum_seed_2fa_legacy_pre27_25words(self):
         # pre-version-2.7 2fa seed, containing 25 words
         seed_words = 'bind clever room kidney crucial sausage spy edit canvas soul liquid ribbon slam open alpha suffer gate relax voice carpet law hill woman tonight abstract'
         assert len(seed_words.split()) == 25
@@ -234,8 +229,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '3Bw5jczNModhFAbvfwvUHbdGrC2Lh2qRQp')
         self.assertEqual(w.get_change_addresses()[0], '3Ke6pKrmtSyyQaMob1ES4pk8siAAkRmst9')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_2fa_legacy_pre27_24words(self, mock_save_db):
+    async def test_electrum_seed_2fa_legacy_pre27_24words(self):
         # pre-version-2.7 2fa seed, containing 24 words
         seed_words = 'sibling leg cable timber patient foot occur plate travel finger chef scale radio citizen promote immune must chef fluid sea sphere common acid lab'
         assert len(seed_words.split()) == 24
@@ -270,8 +264,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '39XK9VBGiK4bqNJYrajfKE8C1ky4gYA5Zy')
         self.assertEqual(w.get_change_addresses()[0], '3PKtHrjiKdsZ73ULZ4Sf1vDBnrUoAEtLDe')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_2fa_legacy_post27(self, mock_save_db):
+    async def test_electrum_seed_2fa_legacy_post27(self):
         # post-version-2.7 2fa seed
         seed_words = 'kiss live scene rude gate step hip quarter bunker oxygen motor glove'
         self.assertEqual(calc_seed_type(seed_words), '2fa')
@@ -305,8 +298,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '35L8XmCDoEBKeaWRjvmZvoZvhp8BXMMMPV')
         self.assertEqual(w.get_change_addresses()[0], '3PeZEcumRqHSPNN43hd4yskGEBdzXgY8Cy')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_seed_2fa_segwit(self, mock_save_db):
+    async def test_electrum_seed_2fa_segwit(self):
         seed_words = 'universe topic remind silver february ranch shine worth innocent cattle enhance wise'
         self.assertEqual(calc_seed_type(seed_words), '2fa_segwit')
 
@@ -339,8 +331,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], 'bc1qpmufh0zjp5prfsrk2yskcy82sa26srqkd97j0457andc6m0gh5asw7kqd2')
         self.assertEqual(w.get_change_addresses()[0], 'bc1qd4q50nft7kxm9yglfnpup9ed2ukj3tkxp793y0zya8dc9m39jcwq308dxz')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_seed_bip44_standard(self, mock_save_db):
+    async def test_bip39_seed_bip44_standard(self):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
@@ -358,8 +349,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '16j7Dqk3Z9DdTdBtHcCVLaNQy9MTgywUUo')
         self.assertEqual(w.get_change_addresses()[0], '1GG5bVeWgAp5XW7JLCphse14QaC4qiHyWn')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_seed_bip44_standard_passphrase(self, mock_save_db):
+    async def test_bip39_seed_bip44_standard_passphrase(self):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
@@ -377,8 +367,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '1F88g2naBMhDB7pYFttPWGQgryba3hPevM')
         self.assertEqual(w.get_change_addresses()[0], '1H4QD1rg2zQJ4UjuAVJr5eW1fEM8WMqyxh')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_seed_bip49_p2sh_segwit(self, mock_save_db):
+    async def test_bip39_seed_bip49_p2sh_segwit(self):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
@@ -396,8 +385,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '35ohQTdNykjkF1Mn9nAVEFjupyAtsPAK1W')
         self.assertEqual(w.get_change_addresses()[0], '3KaBTcviBLEJajTEMstsA2GWjYoPzPK7Y7')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_seed_bip84_native_segwit(self, mock_save_db):
+    async def test_bip39_seed_bip84_native_segwit(self):
         # test case from bip84
         seed_words = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
@@ -416,8 +404,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu')
         self.assertEqual(w.get_change_addresses()[0], 'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_multisig_seed_standard(self, mock_save_db):
+    async def test_electrum_multisig_seed_standard(self):
         seed_words = 'blast uniform dragon fiscal ensure vast young utility dinosaur abandon rookie sure'
         self.assertEqual(calc_seed_type(seed_words), 'standard')
 
@@ -438,8 +425,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '32ji3QkAgXNz6oFoRfakyD3ys1XXiERQYN')
         self.assertEqual(w.get_change_addresses()[0], '36XWwEHrrVCLnhjK5MrVVGmUHghr9oWTN1')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_electrum_multisig_seed_segwit(self, mock_save_db):
+    async def test_electrum_multisig_seed_segwit(self):
         seed_words = 'snow nest raise royal more walk demise rotate smooth spirit canyon gun'
         self.assertEqual(calc_seed_type(seed_words), 'segwit')
 
@@ -460,8 +446,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], 'bc1qvzezdcv6vs5h45ugkavp896e0nde5c5lg5h0fwe2xyfhnpkxq6gq7pnwlc')
         self.assertEqual(w.get_change_addresses()[0], 'bc1qxqf840dqswcmu7a8v82fj6ej0msx08flvuy6kngr7axstjcaq6us9hrehd')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_multisig_seed_bip45_standard(self, mock_save_db):
+    async def test_bip39_multisig_seed_bip45_standard(self):
         seed_words = 'treat dwarf wealth gasp brass outside high rent blood crowd make initial'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
 
@@ -483,8 +468,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '3JPTQ2nitVxXBJ1yhMeDwH6q417UifE3bN')
         self.assertEqual(w.get_change_addresses()[0], '3FGyDuxgUDn2pSZe5xAJH1yUwSdhzDMyEE')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_multisig_seed_p2sh_segwit(self, mock_save_db):
+    async def test_bip39_multisig_seed_p2sh_segwit(self):
         # bip39 seed: pulse mixture jazz invite dune enrich minor weapon mosquito flight fly vapor
         # der: m/49'/0'/0'
         # NOTE: there is currently no bip43 standard derivation path for p2wsh-p2sh
@@ -504,8 +488,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '35LeC45QgCVeRor1tJD6LiDgPbybBXisns')
         self.assertEqual(w.get_change_addresses()[0], '39RhtDchc6igmx5tyoimhojFL1ZbQBrXa6')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip32_extended_version_bytes(self, mock_save_db):
+    async def test_bip32_extended_version_bytes(self):
         seed_words = 'crouch dumb relax small truck age shine pink invite spatial object tenant'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
         bip32_seed = keystore.bip39_to_seed(seed_words, passphrase='')
@@ -563,8 +546,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], 'bc1q84x0yrztvcjg88qef4d6978zccxulcmc9y88xcg4ghjdau999x7q7zv2qe')
         self.assertEqual(w.get_change_addresses()[0], 'bc1q0fj5mra96hhnum80kllklc52zqn6kppt3hyzr49yhr3ecr42z3tsrkg3gs')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_non_extendable_basic_3of6_bip44_standard(self, mock_save_db):
+    async def test_slip39_non_extendable_basic_3of6_bip44_standard(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         xprv9s21ZrQH143K2pMWi8jrTawHaj16uKk4CSbvo4Zt61tcrmuUDMx2o1Byzcr3saXNGNvHP8zZgXVdJHsXVdzYFPavxvCyaGyGr1WkAYG83ce
@@ -590,8 +572,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '1NomKAUNnbASwbPuGHmkSVmnrJS5tZeVce')
         self.assertEqual(w.get_change_addresses()[0], '1Aw4wpXsAyEHSgMZqPdyewoAtJqH9Jaso3')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_non_extendable_basic_2of5_bip49_p2sh_segwit(self, mock_save_db):
+    async def test_slip39_non_extendable_basic_2of5_bip49_p2sh_segwit(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         xprv9s21ZrQH143K2o6EXEHpVy8TCYoMmkBnDCCESLdR2ieKwmcNG48ck2XJQY4waS7RUQcXqR9N7HnQbUVEDMWYyREdF1idQqxFHuCfK7fqFni
@@ -616,8 +597,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '3GCgNoWWVqVdhBxWxrnWQHgwLtffGSYn7D')
         self.assertEqual(w.get_change_addresses()[0], '3FVvdRhR7racZhmcvrGAqX9eJoP8Sw3ypp')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_non_extendable_groups_128bit_bip84_native_segwit(self, mock_save_db):
+    async def test_slip39_non_extendable_groups_128bit_bip84_native_segwit(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV
@@ -646,8 +626,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], 'bc1qaggygkqgqjjpt58zrmhvjz5m9dj8mjshw0lpgu')
         self.assertEqual(w.get_change_addresses()[0], 'bc1q8l6hcvlczu4mtjcnlwhczw7vdxnvwccpjl3cwz')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_non_extendable_groups_256bit_bip49_p2sh_segwit(self, mock_save_db):
+    async def test_slip39_non_extendable_groups_256bit_bip49_p2sh_segwit(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c
@@ -674,8 +653,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '3FoqkcrEHgkKQ3iXStantygCetRGSRMMNE')
         self.assertEqual(w.get_change_addresses()[0], '32tvTmBLfLofu8ps4SWpUJC4fS699jiWvC')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_extendable_basic_3of6_bip44_standard(self, mock_save_db):
+    async def test_slip39_extendable_basic_3of6_bip44_standard(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         xprv9yba7duYBT5g7SbaN1oCX43xeDtjKXNUZ2uSmJ3efHsWYaLkqzdjg2bjLYYzQ9rmXdNzDHYWXv5m9aBCqbFbZzAoGcAceH1K8cPYVDpsJLH
@@ -702,8 +680,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '1N4hqJRTVqUbwT5WCbbsQSwKRPPPzG1TSo')
         self.assertEqual(w.get_change_addresses()[0], '1FW3QQzbYRSUoNDDYGWPvSCoom8fBhPC9k')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_extendable_basic_2of5_bip49_p2sh_segwit(self, mock_save_db):
+    async def test_slip39_extendable_basic_2of5_bip49_p2sh_segwit(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         yprvAJP391MZiYGpkDnSkAfHBGrEKNxpkFVbx9hap59M2hxD1i7kmnaBUC2yo8tzz5AwxSv3ekJRrSGYWA8ec7XmQGLvX4xkWwCRqiadT5fuTfh
@@ -728,8 +705,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '38diDMcH7japAtpJjVKviBroQfTdvgpdqX')
         self.assertEqual(w.get_change_addresses()[0], '36Hd2PnEvJpN9pUdhpZWh3aQccbRp46FVc')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_extendable_groups_128bit_bip84_native_segwit(self, mock_save_db):
+    async def test_slip39_extendable_groups_128bit_bip84_native_segwit(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         zprvAe6okUFoH5tieuTJJxN84xjPCvWkhFiiP87myHqTNmfux4wY8XnLG7DxezL5Dt2jXu5FrsMc4wEPhAJovAGhH1cAPjmkhh3KcSCMRyuQghd
@@ -758,8 +734,7 @@ class TestWalletKeystoreAddressIntegrityForMainnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], 'bc1qs2svwhfz47qv9qju2waa6prxzv5f522fc4p06t')
         self.assertEqual(w.get_change_addresses()[0], 'bc1qmjq5nenac3vjwltldk5qsq4yd8mttw2dpkmx06')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_slip39_extendable_groups_256bit_bip49_p2sh_segwit(self, mock_save_db):
+    async def test_slip39_extendable_groups_256bit_bip49_p2sh_segwit(self):
         """
         BIP32 Root Key for passphrase "TREZOR":
         yprvAJbhup8ey3hmPhgVsXKySTS54BfywUZR6SvQ2jrjdsUgNd4P8B5HR7ute93zXVTXKUvrmvnav1spLzEkDuT7Cy3bf3hWtYoH6A5p8vNzbEC
@@ -793,8 +768,7 @@ class TestWalletKeystoreAddressIntegrityForTestnet(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip39_multisig_seed_p2sh_segwit_testnet(self, mock_save_db):
+    async def test_bip39_multisig_seed_p2sh_segwit_testnet(self):
         # bip39 seed: finish seminar arrange erosion sunny coil insane together pretty lunch lunch rose
         # der: m/49'/1'/0'
         # NOTE: there is currently no bip43 standard derivation path for p2wsh-p2sh
@@ -814,8 +788,7 @@ class TestWalletKeystoreAddressIntegrityForTestnet(ElectrumTestCase):
         self.assertEqual(w.get_receiving_addresses()[0], '2MzsfTfTGomPRne6TkctMmoDj6LwmVkDrMt')
         self.assertEqual(w.get_change_addresses()[0], '2NFp9w8tbYYP9Ze2xQpeYBJQjx3gbXymHX7')
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_bip32_extended_version_bytes(self, mock_save_db):
+    async def test_bip32_extended_version_bytes(self):
         seed_words = 'crouch dumb relax small truck age shine pink invite spatial object tenant'
         self.assertEqual(keystore.bip39_is_checksum_valid(seed_words), (True, True))
         bip32_seed = keystore.bip39_to_seed(seed_words, passphrase='')
@@ -887,8 +860,7 @@ class TestWalletSending(ElectrumTestCase):
         ks = keystore.from_seed(seed_words, passphrase='', for_multisig=False)
         return WalletIntegrityHelper.create_standard_wallet(ks, gap_limit=gap_limit, config=config)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_between_p2wpkh_and_compressed_p2pkh(self, mock_save_db):
+    async def test_sending_between_p2wpkh_and_compressed_p2pkh(self):
         wallet1 = self.create_standard_wallet_from_seed('bitter grass shiver impose acquire brush forget axis eager alone wine silver')
         wallet2 = self.create_standard_wallet_from_seed('cycle rocket west magnet parrot shuffle foot correct salt library feed song')
 
@@ -943,8 +915,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual((0, funding_output_value - 250000 - 5000 + 100000, 0), wallet1.get_balance())
         self.assertEqual((0, 250000 - 5000 - 100000, 0), wallet2.get_balance())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_between_p2sh_2of3_and_uncompressed_p2pkh(self, mock_save_db):
+    async def test_sending_between_p2sh_2of3_and_uncompressed_p2pkh(self):
         wallet1a = WalletIntegrityHelper.create_multisig_wallet(
             [
                 keystore.from_seed('blast uniform dragon fiscal ensure vast young utility dinosaur abandon rookie sure', passphrase='', for_multisig=True),
@@ -1026,8 +997,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual((0, funding_output_value - 370000 - 5000 + 100000, 0), wallet1a.get_balance())
         self.assertEqual((0, 370000 - 5000 - 100000, 0), wallet2.get_balance())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_between_p2wsh_2of3_and_p2wsh_p2sh_2of2(self, mock_save_db):
+    async def test_sending_between_p2wsh_2of3_and_p2wsh_p2sh_2of2(self):
         wallet1a = WalletIntegrityHelper.create_multisig_wallet(
             [
                 keystore.from_seed('bitter grass shiver impose acquire brush forget axis eager alone wine silver', passphrase='', for_multisig=True),
@@ -1146,8 +1116,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual((0, funding_output_value - 165000 - 5000 + 100000, 0), wallet1a.get_balance())
         self.assertEqual((0, 165000 - 5000 - 100000, 0), wallet2a.get_balance())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_between_p2sh_1of2_and_p2wpkh_p2sh(self, mock_save_db):
+    async def test_sending_between_p2sh_1of2_and_p2wpkh_p2sh(self):
         wallet1a = WalletIntegrityHelper.create_multisig_wallet(
             [
                 keystore.from_seed('phone guilt ancient scan defy gasp off rotate approve ill word exchange', passphrase='', for_multisig=True),
@@ -1215,8 +1184,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual((0, funding_output_value - 1000000 - 5000 + 300000, 0), wallet1a.get_balance())
         self.assertEqual((0, 1000000 - 5000 - 300000, 0), wallet2.get_balance())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_rbf(self, mock_save_db):
+    async def test_rbf(self):
         self.maxDiff = None
 
         class TmpConfig(tempfile.TemporaryDirectory):  # to avoid sub-tests side-effecting each other
@@ -1581,8 +1549,7 @@ class TestWalletSending(ElectrumTestCase):
         with self.assertRaises(CannotBumpFee):
             wallet.bump_fee(tx=tx_to_bump, new_fee_rate=tx_to_bump_feerate)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_cpfp_p2pkh(self, mock_save_db):
+    async def test_cpfp_p2pkh(self):
         wallet = self.create_standard_wallet_from_seed('fold object utility erase deputy output stadium feed stereo usage modify bean')
 
         # bootstrap wallet
@@ -2435,8 +2402,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual("70736274ff0100b902000000029264597cffcce8f0c17b16a02adca7a95ae90f2ea51bd4b4df60c76dfe86686e0000000000fdffffffa4c6da70097e1bfbbcba0edad4ba1143295300b60851aa6c4916a0b32381bf7f0000000000fdffffff03108c0400000000001600144e1b662f616fe134430054e29295ea6e5c18f173108c040000000000160014fac4435311276a6cfda5681cfb02252acdd14c3fe09304000000000016001458aee0f1201d1ae12dbd241209bbe92ed45e39b6c2ad26000001011f20a1070000000000160014542266519a44eb9b903761d40c6fe1055d33fa050100de02000000000101013548c9019890e27ce9e58766de05f18ea40ede70751fb6cd7a3a1715ece0a30100000000fdffffff0220a1070000000000160014542266519a44eb9b903761d40c6fe1055d33fa05485a080000000000160014bc69f7d82c403a9f35dfb6d1a4531d6b19cab0e3024730440220346b200f21c3024e1d51fb4ecddbdbd68bd24ae7b9dfd501519f6dcbeb7c052402200617e3ce7b0eb308e30caf23894fb0388b68fb1c15dd0681dd13ae5e735f148101210360d0c9ef15b8b6a16912d341ad218a4e4e4e07e9347f4a2dbc7ca8d974f8bc9ec1ad26002206029b1a61d66896486ab893741b38dbafb9673b91a82237d6e4ca0da3cda7cbeb7c101f1b48320000008000000000000000000001011f801a06000000000016001452af44a1e32754fd8d2e7c1c3cc1b305379f0b660100de020000000001018eeaf0cd7de0e0e117af1a7f2bab59b4ddfbd416ef7460b3fd42a1f7bc039cfd0000000000fdffffff02801a06000000000016001452af44a1e32754fd8d2e7c1c3cc1b305379f0b66909f0700000000001600140847a3685a3ce9911cdce3fbf33cb42edc8f6dd902473044022044d3485c09784f03cd648117ef2d4d0dabeeb2929b30f2e52c3bbd5efd1c0f820220346655235eb9fcb54b23bbf194217092cc8aa6dd33ecf018907626b90289be6801210304e06afd290a4e7a9eb008cf408a4f9b0640fd2688258b523aa3dbb236bb3f7eccad2600220602c1ed648e71f15643950b444b864ab784b9d0e31e6ca6ec7d849d3dda4d98da05101f1b483200000080000000000100000000220203db4846ec1841f48484590e67fcd7d1039f124a04410c5794f38ec8625329ea23101f1b483200000080010000000000000000220203aba60233db3aab45d0196cb70a22d667faa92124760700d20c953b0222ced96d101f1b48320000008001000000010000000000",
                          joined_tx.serialize_as_bytes().hex())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_cpfp_p2wpkh(self, mock_save_db):
+    async def test_cpfp_p2wpkh(self):
         wallet = self.create_standard_wallet_from_seed('frost repair depend effort salon ring foam oak cancel receive save usage')
 
         # bootstrap wallet
@@ -2618,8 +2584,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual('e02641928e5394332eec0a36c196f1e30e2b8645ebbeef89d6cc27bf237ae548', tx_copy.txid())
         self.assertEqual('b062d2e19880c66b36e80b823c2d00a2769658d1e574ff854dab15efd8fd7da8', tx_copy.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_coinjoin_between_two_p2wpkh_electrum_seeds(self, mock_save_db):
+    async def test_coinjoin_between_two_p2wpkh_electrum_seeds(self):
         wallet1 = WalletIntegrityHelper.create_standard_wallet(
             keystore.from_seed('humor argue expand gain goat shiver remove morning security casual leopard degree', passphrase=''),
             gap_limit=2,
@@ -2702,8 +2667,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual((0, 10995000, 0), wallet1.get_balance())
         self.assertEqual((0, 10495000, 0), wallet2.get_balance())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_standard_wallet_cannot_sign_multisig_input_even_if_cosigner(self, mock_save_db):
+    async def test_standard_wallet_cannot_sign_multisig_input_even_if_cosigner(self):
         """Just because our keystore recognizes the pubkeys in a txin, if the prevout does not belong to the wallet,
         then wallet.is_mine and wallet.can_sign should return False (e.g. multisig input for single-sig wallet).
         (see issue #5948)
@@ -2754,8 +2718,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertFalse(any([wallet_frost.is_mine(txin.address) for txin in tx.inputs()]))
         self.assertFalse(any([wallet_frost.is_mine(txout.address) for txout in tx.outputs()]))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_dscancel(self, mock_save_db):
+    async def test_dscancel(self):
         self.maxDiff = None
         config = SimpleConfig({'electrum_path': self.electrum_path})
         config.WALLET_COIN_CHOOSER_OUTPUT_ROUNDING = False
@@ -3044,8 +3007,7 @@ class TestWalletSending(ElectrumTestCase):
         with self.assertRaises(CannotDoubleSpendTx):
             wallet.dscancel(tx=tx_to_cancel, new_fee_rate=tx_to_cancel_feerate)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_wallet_history_chain_of_unsigned_transactions(self, mock_save_db):
+    async def test_wallet_history_chain_of_unsigned_transactions(self):
         wallet = self.create_standard_wallet_from_seed('cross end slow expose giraffe fuel track awake turtle capital ranch pulp',
                                                        config=self.config, gap_limit=3)
 
@@ -3086,10 +3048,10 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual("bf08206effded4126a95fbed375cedc0452b5e16a5d2025ac645dfae81addbe4:0",
                          coins[0].prevout.to_str())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_wallet_does_not_create_zero_input_tx(self, mock_save_db):
-        wallet = self.create_standard_wallet_from_seed('cross end slow expose giraffe fuel track awake turtle capital ranch pulp',
-                                                       config=self.config, gap_limit=3)
+    async def test_wallet_does_not_create_zero_input_tx(self):
+        wallet = self.create_standard_wallet_from_seed(
+            'cross end slow expose giraffe fuel track awake turtle capital ranch pulp',
+            config=self.config, gap_limit=3)
 
         with self.subTest(msg="no coins to use as inputs, max output value, zero fee"):
             outputs = [PartialTxOutput.from_address_and_value('tb1qsfcddwf7yytl62e3catwv8hpl2hs9e36g2cqxl', '!')]
@@ -3110,10 +3072,10 @@ class TestWalletSending(ElectrumTestCase):
             self.assertEqual(1, len(tx.inputs()))
             self.assertEqual(2, len(tx.outputs()))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_wallet_adb_gettxheight_treats_mempool_txid_as_local_if_missing_fulltx(self, mock_save_db):
-        wallet = self.create_standard_wallet_from_seed('dismiss smile transfer input market ten damage city duck dolphin entire because',
-                                                       config=self.config, gap_limit=2)
+    async def test_wallet_adb_gettxheight_treats_mempool_txid_as_local_if_missing_fulltx(self):
+        wallet = self.create_standard_wallet_from_seed(
+            'dismiss smile transfer input market ten damage city duck dolphin entire because',
+            config=self.config, gap_limit=2)
         self.assertEqual(0, len(wallet.get_spendable_coins()))
 
         # fund wallet with two utxos
@@ -3158,10 +3120,10 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual(2, len(wallet.get_spendable_coins(nonlocal_only=True)))
         self.assertEqual(2, len(wallet.get_spendable_coins(nonlocal_only=False)))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_wallet_adb_gettxheight_treats_future_txid_as_future_even_if_missing_fulltx(self, mock_save_db):
-        wallet = self.create_standard_wallet_from_seed('dismiss smile transfer input market ten damage city duck dolphin entire because',
-                                                       config=self.config, gap_limit=2)
+    async def test_wallet_adb_gettxheight_treats_future_txid_as_future_even_if_missing_fulltx(self):
+        wallet = self.create_standard_wallet_from_seed(
+            'dismiss smile transfer input market ten damage city duck dolphin entire because',
+            config=self.config, gap_limit=2)
         # fund wallet
         funding_tx1 = Transaction('02000000000101bf03f2d37ae084d729e5685d64988c92e8a98cb73062802646dfbb10d77e88410000000000fdffffff02a03007000000000016001443a24a730a7ddd2ce4da777a949a9e87c6ad870920a107000000000016001447597395323a834378d7577d848187684d0d70fe0247304402200e6f1898a0681c4ff1f5995b357c3388ca53fcf56760e0d14d4ea72c48d1134b0220683b8e5045743c087d488dfc5f8c5b7369ff92f611595eaba0dbb0c0009c816e0121021bd313412fad3802801f6c45321a10c7bf35603bf8571aa263ece764d1ab7ef1a2434300')
         wallet.adb.receive_tx_callback(funding_tx1, tx_height=TX_HEIGHT_UNCONFIRMED)
@@ -3178,11 +3140,10 @@ class TestWalletSending(ElectrumTestCase):
         wallet.adb.set_future_tx(payment_txid, wanted_height=300)
         self.assertEqual(TX_HEIGHT_FUTURE, wallet.adb.get_tx_height(payment_txid).height())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_imported_wallet_usechange_off(self, mock_save_db):
+    async def test_imported_wallet_usechange_off(self):
         wallet = restore_wallet_from_text__for_unittest(
             "p2wpkh:cVcwSp488C8Riguq55Tuktgi6TpzuyLdDwUxkBDBz3yzV7FW4af2 p2wpkh:cPWyoPvnv2hiyyxbhMkhX3gPEENzB6DqoP9bbR8SDTg5njK5SL9n",
-            path='if_this_exists_mocking_failed_648151893',
+            path=None, #'if_this_exists_mocking_failed_648151893',
             config=self.config)['wallet']  # type: Abstract_Wallet
 
         # bootstrap wallet
@@ -3214,11 +3175,10 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual('02000000000101ce010c0cab95cde544f713771916613a1a84c8787bbc95321854410b212aed9b0100000000fdffffff02cac00000000000001600147a65e09bb1da80abfc65d545388a2e61aab7c721eec100000000000016001405424089c64d39d9a498b6e1c8e646327431b240024730440220526eac6c56cba19842b67f6c9e45af113b1a2d44fb229335bdeaf08cb2cc164e0220087fba65619016fd3f62f6c8717070e48f94b45743b86d8e0517698d2b9c3afc012102d67eaa10463f5c786271feb9ae3456c27d35c3cf6c7d881617e915d1f32cb875c4951e00',
                          str(tx_copy))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_imported_wallet_usechange_on(self, mock_save_db):
+    async def test_imported_wallet_usechange_on(self):
         wallet = restore_wallet_from_text__for_unittest(
             "p2wpkh:cVcwSp488C8Riguq55Tuktgi6TpzuyLdDwUxkBDBz3yzV7FW4af2 p2wpkh:cPWyoPvnv2hiyyxbhMkhX3gPEENzB6DqoP9bbR8SDTg5njK5SL9n",
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']  # type: Abstract_Wallet
 
         # bootstrap wallet
@@ -3249,11 +3209,10 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual('02000000000101ce010c0cab95cde544f713771916613a1a84c8787bbc95321854410b212aed9b0100000000fdffffff02cac0000000000000160014caf086bb82f85b35d13b118cd0e052bf5a27eb04eec100000000000016001405424089c64d39d9a498b6e1c8e646327431b24002473044022006dfe30f851b0174e5c920fd5b2e294a25fe5d449b17b422f3fda485d514c39b022047a6760f9d6ddfac5273094bed1f640fc1622a42938ebfb0b5f61cce7b161a00012102d67eaa10463f5c786271feb9ae3456c27d35c3cf6c7d881617e915d1f32cb875c4951e00',
                          str(tx_copy))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_imported_wallet_usechange_on__no_more_unused_addresses(self, mock_save_db):
+    async def test_imported_wallet_usechange_on__no_more_unused_addresses(self):
         wallet = restore_wallet_from_text__for_unittest(
             "p2wpkh:cVcwSp488C8Riguq55Tuktgi6TpzuyLdDwUxkBDBz3yzV7FW4af2 p2wpkh:cPWyoPvnv2hiyyxbhMkhX3gPEENzB6DqoP9bbR8SDTg5njK5SL9n",
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']  # type: Abstract_Wallet
 
         # bootstrap wallet
@@ -3294,10 +3253,10 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual('02000000000101ce010c0cab95cde544f713771916613a1a84c8787bbc95321854410b212aed9b0100000000fdffffff02cac00000000000001600147a65e09bb1da80abfc65d545388a2e61aab7c721eec100000000000016001405424089c64d39d9a498b6e1c8e646327431b240024730440220526eac6c56cba19842b67f6c9e45af113b1a2d44fb229335bdeaf08cb2cc164e0220087fba65619016fd3f62f6c8717070e48f94b45743b86d8e0517698d2b9c3afc012102d67eaa10463f5c786271feb9ae3456c27d35c3cf6c7d881617e915d1f32cb875c4951e00',
                          str(tx_copy))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_get_spendable_coins(self, mock_save_db):
-        wallet = self.create_standard_wallet_from_seed('frost repair depend effort salon ring foam oak cancel receive save usage',
-                                                       config=self.config)
+    async def test_get_spendable_coins(self):
+        wallet = self.create_standard_wallet_from_seed(
+            'frost repair depend effort salon ring foam oak cancel receive save usage',
+            config=self.config)
 
         # bootstrap wallet (incoming funding_tx1)
         funding_tx1 = Transaction('01000000000102acd6459dec7c3c51048eb112630da756f5d4cb4752b8d39aa325407ae0885cba020000001716001455c7f5e0631d8e6f5f05dddb9f676cec48845532fdffffffd146691ef6a207b682b13da5f2388b1f0d2a2022c8cfb8dc27b65434ec9ec8f701000000171600147b3be8a7ceaf15f57d7df2a3d216bc3c259e3225fdffffff02a9875b000000000017a914ea5a99f83e71d1c1dfc5d0370e9755567fe4a141878096980000000000160014d4ca56fcbad98fb4dcafdc573a75d6a6fffb09b702483045022100dde1ba0c9a2862a65791b8d91295a6603207fb79635935a67890506c214dd96d022046c6616642ef5971103c1db07ac014e63fa3b0e15c5729eacdd3e77fcb7d2086012103a72410f185401bb5b10aaa30989c272b554dc6d53bda6da85a76f662723421af024730440220033d0be8f74e782fbcec2b396647c7715d2356076b442423f23552b617062312022063c95cafdc6d52ccf55c8ee0f9ceb0f57afb41ea9076eb74fe633f59c50c6377012103b96a4954d834fbcfb2bbf8cf7de7dc2b28bc3d661c1557d1fd1db1bfc123a94abb391400')
@@ -3353,8 +3312,7 @@ class TestWalletSending(ElectrumTestCase):
             wallet.set_frozen_state_of_coins([utxo1], freeze=None)
             self.assertTrue(utxo1 not in wallet._frozen_coins)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_export_psbt_with_xpubs__multisig(self, mock_save_db):
+    async def test_export_psbt_with_xpubs__multisig(self):
         """When exporting a PSBT to be signed by a hw device, test that we populate
         the PSBT_GLOBAL_XPUB field with wallet xpubs.
         """
@@ -3433,8 +3391,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual("70736274ff01007d020000000122c3730eb6314cf59e11988c41bfdd73f70cb55b294ec6f2eda828b5c939c0980100000000fdffffff0240e20100000000001600147e45d43294b0ff2b08a5f45232649815e516cff058ab05000000000022002014d2823afee4d75f0f83b91a9d625972df41be222c1373d28e068c3eaae9e00a7b4a24004f01043587cf04b5faa014800000021044dcc4a72f0084f25ca3b7927abd5596715a515e2a59004ce10a51a17cf4b403a5b8b89c28c5a51832be51bb184749ac2ea6c561259bfc5bf58b852ad60f6fe41430cf1be5300000800100008000000080020000804f01043587cf019559fbd18000270f1b7a7db8a20f23be687941c8bcc8b330fd8823f19eea6ad5cb4af09b00cf6fd802db662ac8cf00e16cebe67e4d9f88b266eddbe0dfbb24b884bf3002b68ade721b089559fbd10f2700800001012b20a10700000000002200207f50b9d6eb4d899c710d8c48903de33d966ff52445d5a57b5210d02a5dd7e3bf0100fd7e0102000000000102deab5844de4aadc177d992696fda2aa6e4692403633d31a4b4073710594d2fca0000000000fdffffffdeab5844de4aadc177d992696fda2aa6e4692403633d31a4b4073710594d2fca0100000000fdffffff02f49f070000000000160014473b34b7da0aa9f7add803019f649e0729fd39d220a10700000000002200207f50b9d6eb4d899c710d8c48903de33d966ff52445d5a57b5210d02a5dd7e3bf0247304402202a4ec3df7bf2b82505bcd4833eeb32875784b4e93d09ac3cf4a8981dc89a049b02205239bad290877fb810a12538a275d5467f3f6afc88d1e0be3d8f6dc4876e6793012103e48cae7f140e15440f4ad6b3d96cb0deb471bbb45daf527e6eb4d5f6c5e26ec802473044022031028192a8307e52829ad1428941000629de73726306ca71d18c5bcfcb98a4a602205ad0240f7dd6c83686ea257f3146ba595b787d7f68b514569962fd5d3692b07c0121033c8af340bd9abf4a56c7cf7554f52e84a1128e5206ffe5da166ca18a57a260077b4a24000105475221022c4338968f87a09b0fefd0aaac36f1b983bab237565d521944c60fdc482750492103cf9a6ac058d36a6dc325b19715a2223c6416e1cef13bc047a99bded8c99463ca52ae2206022c4338968f87a09b0fefd0aaac36f1b983bab237565d521944c60fdc48275049109559fbd10f2700800000000000000000220603cf9a6ac058d36a6dc325b19715a2223c6416e1cef13bc047a99bded8c99463ca1c30cf1be530000080010000800000008002000080000000000000000000000101475221027f7f2eaf9a44316c2cd98b67584d1e71ccaced29a347673f3364efe16f5919e221028d9b8ff374e0f60fbc698c5a494c12d9a31a3ce364b1f81ae4a46f48ae45acdd52ae2202027f7f2eaf9a44316c2cd98b67584d1e71ccaced29a347673f3364efe16f5919e2109559fbd10f27008001000000000000002202028d9b8ff374e0f60fbc698c5a494c12d9a31a3ce364b1f81ae4a46f48ae45acdd1c30cf1be530000080010000800000008002000080010000000000000000",
                          tx.serialize_as_bytes().hex())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_export_psbt_with_xpubs__singlesig(self, mock_save_db):
+    async def test_export_psbt_with_xpubs__singlesig(self):
         """When exporting a PSBT to be signed by a hw device, test that we populate
         the PSBT_GLOBAL_XPUB field with wallet xpubs.
         """
@@ -3468,8 +3425,7 @@ class TestWalletSending(ElectrumTestCase):
         self.assertEqual("70736274ff0100710200000001916fa04d7080ae0cb19bd08671d37dbe3dc925be383737bb34b3097d82830dc70000000000fdffffff0240e20100000000001600147e45d43294b0ff2b08a5f45232649815e516cff0ceaa05000000000016001456ec9cad206160ab578fa1dfbe13311b3be4a3107f4a24000001011f96a007000000000016001413ce91db66299806c4f35b2b4f8426b0bd4f2cd70100fd2e010200000000010122c3730eb6314cf59e11988c41bfdd73f70cb55b294ec6f2eda828b5c939c0980100000000fdffffff0196a007000000000016001413ce91db66299806c4f35b2b4f8426b0bd4f2cd704004730440220112840ce5486c6b2d15bc3b12e45c2a4518828e1b34f9bb0b3a78220c0cec52f02205b146a1f683289909ecbd3f53932d5acc321444101d8002e435b38a54adbf47201473044022058dfb4c75de119595119f35dcd7b1b2c28c40d7e2e746baeae83f09396c6bb9e02201c3c40fb684253638f12392af3934a90a6c6a512441aac861022f927473c952001475221022c4338968f87a09b0fefd0aaac36f1b983bab237565d521944c60fdc482750492103cf9a6ac058d36a6dc325b19715a2223c6416e1cef13bc047a99bded8c99463ca52ae4a4a24002206029e65093d22877cbfcc27cb754c58d144ec96635af1fcc63e5a7b90b23bb6acb81830cf1be5540000800100008000000080000000000000000000002202031503b2e74b21d4583b7f0d9e65b2c0ef19fd6e8aae7d0524fc770a1d2b2127501830cf1be5540000800100008000000080010000000000000000",
                          tx.serialize_as_bytes().hex())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_export_psbt__rm_witness_utxo_from_non_segwit_input(self, mock_save_db):
+    async def test_export_psbt__rm_witness_utxo_from_non_segwit_input(self):
         """We sometimes convert full utxo to witness_utxo in psbt inputs when using QR codes, to save space,
         even for non-segwit inputs (which goes against the spec).
         This tests that upon scanning the QR code, if we can add the full utxo to the input (e.g. via network),
@@ -3577,8 +3533,7 @@ class TestWalletSending(ElectrumTestCase):
                         except TransactionPotentiallyDangerousException:
                             self.assertTrue(uses_qr_code2)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_we_dont_sign_tx_including_dummy_address(self, mock_save_db):
+    async def test_we_dont_sign_tx_including_dummy_address(self):
         wallet1 = self.create_standard_wallet_from_seed('bitter grass shiver impose acquire brush forget axis eager alone wine silver')
 
         # bootstrap wallet1
@@ -3599,8 +3554,7 @@ class TestWalletSending(ElectrumTestCase):
         with self.assertRaises(bitcoin.DummyAddressUsedInTxException):
             wallet1.sign_transaction(tx, password=None)
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sighash_warnings(self, mock_save_db):
+    async def test_sighash_warnings(self):
         wallet1 = self.create_standard_wallet_from_seed('bitter grass shiver impose acquire brush forget axis eager alone wine silver')
 
         # bootstrap wallet1
@@ -3651,8 +3605,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_old_electrum_seed_online_mpk(self, mock_save_db):
+    async def test_sending_offline_old_electrum_seed_online_mpk(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             keystore.from_seed('alone body father children lead goodbye phone twist exist grass kick join', passphrase='', for_multisig=False),
             gap_limit=4,
@@ -3698,8 +3651,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('06032230d0bf6a277bc4f8c39e3311a712e0e614626d0dea7cc9f592abfae5d8', tx.txid())
         self.assertEqual('06032230d0bf6a277bc4f8c39e3311a712e0e614626d0dea7cc9f592abfae5d8', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_xprv_online_xpub_p2pkh(self, mock_save_db):
+    async def test_sending_offline_xprv_online_xpub_p2pkh(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/44'/1'/0'
             keystore.from_xprv('tprv8gfKwjuAaqtHgqxMh1tosAQ28XvBMkcY5NeFRA3pZMpz6MR4H4YZ3MJM4fvNPnRKeXR1Td2vQGgjorNXfo94WvT5CYDsPAqjHxSn436G1Eu'),
@@ -3753,8 +3705,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
                 self.assertEqual('d9c21696eca80321933e7444ca928aaf25eeda81aaa2f4e5c085d4d0a9cf7aa7', tx.txid())
                 self.assertEqual('d9c21696eca80321933e7444ca928aaf25eeda81aaa2f4e5c085d4d0a9cf7aa7', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_xprv_online_xpub_p2wpkh_p2sh(self, mock_save_db):
+    async def test_sending_offline_xprv_online_xpub_p2wpkh_p2sh(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/49'/1'/0'
             keystore.from_xprv('uprv8zHHrMQMQ26utWwNJ5MK2SXpB9hbmy7pbPaneii69xT8cZTyFpxQFxkknGWKP8dxBTZhzy7yP6cCnLrRCQjzJDk3G61SjZpxhFQuB2NR8a5'),
@@ -3798,8 +3749,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('3f0d188519237478258ad2bf881643618635d11c2bb95512e830fcf2eda3c522', tx.txid())
         self.assertEqual('27b78ec072a403b0545258e7a1a8d494e4b6fd48bf77f4251a12160c92207cbc', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_xprv_online_xpub_p2wpkh(self, mock_save_db):
+    async def test_sending_offline_xprv_online_xpub_p2wpkh(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/84'/1'/0'
             keystore.from_xprv('vprv9K9hbuA23Bidgj1KRSHUZMa59jJLeZBpXPVn4RP7sBLArNhZxJjw4AX7aQmVTErDt4YFC11ptMLjbwxgrsH8GLQ1cx77KggWeVPeDBjr9xM'),
@@ -3856,8 +3806,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
                 self.assertEqual('ee76c0c6da87f0eb5ab4d1ae05d3942512dcd3c4c42518f9d3619e74400cfc1f', tx.txid())
                 self.assertEqual('484e350beaa722a744bb3e2aa38de005baa8526d86536d6143e5814355acf775', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_offline_signing_beyond_gap_limit(self, mock_save_db):
+    async def test_offline_signing_beyond_gap_limit(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/84'/1'/0'
             keystore.from_xprv('vprv9K9hbuA23Bidgj1KRSHUZMa59jJLeZBpXPVn4RP7sBLArNhZxJjw4AX7aQmVTErDt4YFC11ptMLjbwxgrsH8GLQ1cx77KggWeVPeDBjr9xM'),
@@ -3901,8 +3850,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('ee76c0c6da87f0eb5ab4d1ae05d3942512dcd3c4c42518f9d3619e74400cfc1f', tx.txid())
         self.assertEqual('484e350beaa722a744bb3e2aa38de005baa8526d86536d6143e5814355acf775', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_signing_where_offline_ks_does_not_have_keyorigin_but_psbt_contains_it(self, mock_save_db):
+    async def test_signing_where_offline_ks_does_not_have_keyorigin_but_psbt_contains_it(self):
         # keystore has intermediate xprv without root fp; tx contains root fp and full path.
         # tx has input with key beyond gap limit
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
@@ -3922,8 +3870,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('020000000001017b748828553b1127b86674e71ad0cd4a2e5e8baeab8792a3c3263f7ea0ba86500000000000fdffffff01ad16010000000000160014d74b54300bc0d4b6e8f506fe540b47ce0da38b4a0247304402203098741bf4d4f956e96f2706a517a1c0a63f67a242a50d155fbc56ad0bbac8b102207e535391c03bdab641f3205762311c1e6648b3459681e53d68fa44e63604a7f6012102d137f257a96cbc58c7e60f2085cd65a311e242459e23d1efbed77dd8f372513808f21c00',
                          str(tx))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_wif_online_addr_p2pkh(self, mock_save_db):  # compressed pubkey
+    async def test_sending_offline_wif_online_addr_p2pkh(self):  # compressed pubkey
         wallet_offline = WalletIntegrityHelper.create_imported_wallet(privkeys=True, config=self.config)
         wallet_offline.import_private_key('p2pkh:cQDxbmQfwRV3vP1mdnVHq37nJekHLsuD3wdSQseBRA2ct4MFk5Pq', password=None)
         wallet_online = WalletIntegrityHelper.create_imported_wallet(privkeys=False, config=self.config)
@@ -3959,8 +3906,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('e56da664631b8c666c6df38ec80c954c4ac3c4f56f040faf0070e4681e937fc4', tx.txid())
         self.assertEqual('e56da664631b8c666c6df38ec80c954c4ac3c4f56f040faf0070e4681e937fc4', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_wif_online_addr_p2wpkh_p2sh(self, mock_save_db):
+    async def test_sending_offline_wif_online_addr_p2wpkh_p2sh(self):
         wallet_offline = WalletIntegrityHelper.create_imported_wallet(privkeys=True, config=self.config)
         wallet_offline.import_private_key('p2wpkh-p2sh:cU9hVzhpvfn91u2zTVn8uqF2ymS7ucYH8V5TmsTDmuyMHgRk9WsJ', password=None)
         wallet_online = WalletIntegrityHelper.create_imported_wallet(privkeys=False, config=self.config)
@@ -3999,8 +3945,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('7642816d051aa3b333b6564bb6e44fe3a5885bfe7db9860dfbc9973a5c9a6562', tx.txid())
         self.assertEqual('9bb9949974954613945756c48ca5525cd5cba1b667ccb10c7a53e1ed076a1117', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_wif_online_addr_p2wpkh(self, mock_save_db):
+    async def test_sending_offline_wif_online_addr_p2wpkh(self):
         wallet_offline = WalletIntegrityHelper.create_imported_wallet(privkeys=True, config=self.config)
         wallet_offline.import_private_key('p2wpkh:cPuQzcNEgbeYZ5at9VdGkCwkPA9r34gvEVJjuoz384rTfYpahfe7', password=None)
         wallet_online = WalletIntegrityHelper.create_imported_wallet(privkeys=False, config=self.config)
@@ -4036,8 +3981,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('f8039bd85279f2b5698f15d47f2e338d067d09af391bd8a19467aa94d03f280c', tx.txid())
         self.assertEqual('3b7cc3c3352bbb43ddc086487ac696e09f2863c3d9e8636721851b8008a83ffa', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_signing_mixed_input_script_types(self, mock_save_db):
+    async def test_signing_mixed_input_script_types(self):
         """Create a tx that spends mixed non-segwit and segwit UTXOs, and try to offline-sign that."""
         wallet_offline = WalletIntegrityHelper.create_imported_wallet(privkeys=True, config=self.config)
         wallet_offline.import_private_key('p2pkh:cRd5PRVPgArr1eyrcGLKUAULM3EY3Zhseo5Xs8afkeA9UrtMdEFk', password=None)
@@ -4082,8 +4026,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('08b4283f230ffbb72b001eef01e267b310fa6f9d3800d2000474787e13c98ae7', tx.txid())
         self.assertEqual('24c32d0a7370ca664023a9a1305ae1554731f400723f119e6f11b54332e950c9', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_xprv_online_addr_p2pkh(self, mock_save_db):  # compressed pubkey
+    async def test_sending_offline_xprv_online_addr_p2pkh(self):  # compressed pubkey
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/44'/1'/0'
             keystore.from_xprv('tprv8gfKwjuAaqtHgqxMh1tosAQ28XvBMkcY5NeFRA3pZMpz6MR4H4YZ3MJM4fvNPnRKeXR1Td2vQGgjorNXfo94WvT5CYDsPAqjHxSn436G1Eu'),
@@ -4126,8 +4069,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('e56da664631b8c666c6df38ec80c954c4ac3c4f56f040faf0070e4681e937fc4', tx.txid())
         self.assertEqual('e56da664631b8c666c6df38ec80c954c4ac3c4f56f040faf0070e4681e937fc4', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_xprv_online_addr_p2wpkh_p2sh(self, mock_save_db):
+    async def test_sending_offline_xprv_online_addr_p2wpkh_p2sh(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/49'/1'/0'
             keystore.from_xprv('uprv8zHHrMQMQ26utWwNJ5MK2SXpB9hbmy7pbPaneii69xT8cZTyFpxQFxkknGWKP8dxBTZhzy7yP6cCnLrRCQjzJDk3G61SjZpxhFQuB2NR8a5'),
@@ -4167,8 +4109,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('7642816d051aa3b333b6564bb6e44fe3a5885bfe7db9860dfbc9973a5c9a6562', tx.txid())
         self.assertEqual('9bb9949974954613945756c48ca5525cd5cba1b667ccb10c7a53e1ed076a1117', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_xprv_online_addr_p2wpkh(self, mock_save_db):
+    async def test_sending_offline_xprv_online_addr_p2wpkh(self):
         wallet_offline = WalletIntegrityHelper.create_standard_wallet(
             # bip39: "qwe", der: m/84'/1'/0'
             keystore.from_xprv('vprv9K9hbuA23Bidgj1KRSHUZMa59jJLeZBpXPVn4RP7sBLArNhZxJjw4AX7aQmVTErDt4YFC11ptMLjbwxgrsH8GLQ1cx77KggWeVPeDBjr9xM'),
@@ -4208,8 +4149,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('f8039bd85279f2b5698f15d47f2e338d067d09af391bd8a19467aa94d03f280c', tx.txid())
         self.assertEqual('3b7cc3c3352bbb43ddc086487ac696e09f2863c3d9e8636721851b8008a83ffa', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_hd_multisig_online_addr_p2sh(self, mock_save_db):
+    async def test_sending_offline_hd_multisig_online_addr_p2sh(self):
         # 2-of-3 legacy p2sh multisig
         wallet_offline1 = WalletIntegrityHelper.create_multisig_wallet(
             [
@@ -4275,8 +4215,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('0e8fdc8257a85ebe7eeab14a53c2c258c61a511f64176b7f8fc016bc2263d307', tx.txid())
         self.assertEqual('0e8fdc8257a85ebe7eeab14a53c2c258c61a511f64176b7f8fc016bc2263d307', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_hd_multisig_online_addr_p2wsh_p2sh(self, mock_save_db):
+    async def test_sending_offline_hd_multisig_online_addr_p2wsh_p2sh(self):
         # 2-of-2 p2sh-embedded segwit multisig
         wallet_offline1 = WalletIntegrityHelper.create_multisig_wallet(
             [
@@ -4344,8 +4283,7 @@ class TestWalletOfflineSigning(ElectrumTestCase):
         self.assertEqual('6a58a51591142429203b62b6ddf6b799a6926882efac229998c51bee6c3573eb', tx.txid())
         self.assertEqual('96d0bca1001778c54e4c3a07929fab5562c5b5a23fd1ca3aa3870cc5df2bf97d', tx.wtxid())
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_sending_offline_hd_multisig_online_addr_p2wsh(self, mock_save_db):
+    async def test_sending_offline_hd_multisig_online_addr_p2wsh(self):
         # 2-of-3 p2wsh multisig
         wallet_offline1 = WalletIntegrityHelper.create_multisig_wallet(
             [
@@ -4419,8 +4357,7 @@ class TestWalletCreationChecks(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_duplicate_masterkeys_in_multisig(self, mock_save_db):
+    async def test_duplicate_masterkeys_in_multisig(self):
         # ks1 (seed) and ks2 have same xpub
         with self.assertRaises(Exception) as ctx1:
             w1 = WalletIntegrityHelper.create_multisig_wallet(
@@ -4456,8 +4393,7 @@ class TestWalletCreationChecks(ElectrumTestCase):
             config=self.config
         )
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_heterogeneous_xpub_types_in_multisig(self, mock_save_db):
+    async def test_heterogeneous_xpub_types_in_multisig(self):
         # tpub + vpub
         with self.assertRaises(Exception) as ctx1:
             w1 = WalletIntegrityHelper.create_multisig_wallet(
@@ -4541,24 +4477,21 @@ class TestWalletHistory_SimpleRandomOrder(ElectrumTestCase):
         w.create_new_address(for_change=True)
         return w
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_restoring_old_wallet_txorder1(self, mock_save_db):
+    async def test_restoring_old_wallet_txorder1(self):
         w = self.create_old_wallet()
         for i in [2, 12, 7, 9, 11, 10, 16, 6, 17, 1, 13, 15, 5, 8, 4, 0, 14, 18, 3]:
             tx = Transaction(self.transactions[self.txid_list[i]])
             w.adb.receive_tx_callback(tx, tx_height=TX_HEIGHT_UNCONFIRMED)
         self.assertEqual(27633300, sum(w.get_balance()))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_restoring_old_wallet_txorder2(self, mock_save_db):
+    async def test_restoring_old_wallet_txorder2(self):
         w = self.create_old_wallet()
         for i in [9, 18, 2, 0, 13, 3, 1, 11, 4, 17, 7, 14, 12, 15, 10, 8, 5, 6, 16]:
             tx = Transaction(self.transactions[self.txid_list[i]])
             w.adb.receive_tx_callback(tx, tx_height=TX_HEIGHT_UNCONFIRMED)
         self.assertEqual(27633300, sum(w.get_balance()))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_restoring_old_wallet_txorder3(self, mock_save_db):
+    async def test_restoring_old_wallet_txorder3(self):
         w = self.create_old_wallet()
         for i in [5, 8, 17, 0, 9, 10, 12, 3, 15, 18, 2, 11, 14, 7, 16, 1, 4, 6, 13]:
             tx = Transaction(self.transactions[self.txid_list[i]])
@@ -4590,8 +4523,7 @@ class TestWalletHistory_EvilGapLimit(ElectrumTestCase):
         w = WalletIntegrityHelper.create_standard_wallet(ks, gap_limit=20, config=self.config)
         return w
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_restoring_wallet_txorder1(self, mock_save_db):
+    async def test_restoring_wallet_txorder1(self):
         w = self.create_wallet()
         w.db.put('stored_height', 1316917 + 100)
         for txid in self.transactions:
@@ -4639,11 +4571,10 @@ class TestWalletHistory_DoubleSpend(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_restoring_wallet_without_manual_delete(self, mock_save_db):
+    async def test_restoring_wallet_without_manual_delete(self):
         w = restore_wallet_from_text__for_unittest(
             "small rapid pattern language comic denial donate extend tide fever burden barrel",
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             gap_limit=5,
             config=self.config)['wallet']  # type: Abstract_Wallet
         for txid in self.transactions:
@@ -4654,11 +4585,10 @@ class TestWalletHistory_DoubleSpend(ElectrumTestCase):
         # txn C is double-spending txn B, to a wallet address
         self.assertEqual(999890, sum(w.get_balance()))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_restoring_wallet_with_manual_delete(self, mock_save_db):
+    async def test_restoring_wallet_with_manual_delete(self):
         w = restore_wallet_from_text__for_unittest(
             "small rapid pattern language comic denial donate extend tide fever burden barrel",
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             gap_limit=5,
             config=self.config)['wallet']  # type: Abstract_Wallet
         # txn A is an external incoming txn funding the wallet
@@ -4684,8 +4614,7 @@ class TestWalletHistory_HelperFns(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_get_tx_status_feerate_for_local_2of3_multisig_partial_tx(self, mock_save_db):
+    async def test_get_tx_status_feerate_for_local_2of3_multisig_partial_tx(self):
         wallet1 = WalletIntegrityHelper.create_multisig_wallet(
             [
                 keystore.from_seed('bitter grass shiver impose acquire brush forget axis eager alone wine silver', passphrase='', for_multisig=True),
@@ -4717,8 +4646,7 @@ class TestWalletHistory_HelperFns(ElectrumTestCase):
         self.assertEqual((3, 'Local [26.3 sat/vB]'),
                          wallet1.get_tx_status(tx.txid(), TxMinedInfo(_height=TX_HEIGHT_LOCAL, conf=0)))
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_get_tx_status_feerate_for_local_2of3_multisig_signed_tx(self, mock_save_db):
+    async def test_get_tx_status_feerate_for_local_2of3_multisig_signed_tx(self):
         wallet1 = WalletIntegrityHelper.create_multisig_wallet(
             [
                 keystore.from_seed('bitter grass shiver impose acquire brush forget axis eager alone wine silver', passphrase='', for_multisig=True),
@@ -4756,11 +4684,10 @@ class TestImportedWallet(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-    @mock.patch.object(wallet.Abstract_Wallet, 'save_db')
-    async def test_importing_and_deleting_addresses(self, mock_save_db):
+    async def test_importing_and_deleting_addresses(self):
         w = restore_wallet_from_text__for_unittest(
             "tb1q7648a2pm2se425lvun0g3vlf4ahmflcthegz63",
-            path='if_this_exists_mocking_failed_648151893',
+            path=None,
             config=self.config)['wallet']  # type: Abstract_Wallet
         self.assertEqual(1, len(w.get_addresses()))
         w.adb.add_transaction(Transaction(self.transactions["0e350564ee7ed4ffce24a998b538f7f3ebbab6fcb4bb331f8bb6b9d86d86fcd8"]))


### PR DESCRIPTION
Create in-memory wallets instead.

The logic of calling save_db() at specific places is specific to the current JsonDB backend, and it does not generalize well.