### PR TITLE
lnpeer: add some rate-limiting against ping flood

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -386,7 +386,8 @@ class Peer(Logger, EventListener):
             await asyncio.sleep(min_delay - elapsed_since_last)
         self._last_ping_recv_time = time.monotonic()
         l = payload['num_pong_bytes']
-        self.send_message('pong', byteslen=l)
+        raw_msg = encode_msg('pong', byteslen=l)
+        await self.transport.send_bytes_and_drain(raw_msg)
 
     def on_pong(self, payload):
         self.pong_event.set()

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -140,6 +140,7 @@ class Peer(Logger, EventListener):
         self._num_gossip_messages_forwarded = 0
         self._processed_onion_cache = LRUCache(maxsize=100)  # type: LRUCache[bytes, ProcessedOnionPacket]
         self._last_commitsig_sent_time = time.monotonic()
+        self._last_ping_recv_time = min(0, time.monotonic())
 
     def send_message(self, message_name: str, **kwargs):
         assert util.get_running_loop() == util.get_asyncio_loop(), f"this must be run on the asyncio thread!"
@@ -372,7 +373,18 @@ class Peer(Logger, EventListener):
                     self.schedule_force_closing(cid)
         raise GracefulDisconnect
 
-    def on_ping(self, payload):
+    async def on_ping(self, payload):
+        elapsed_since_last = time.monotonic() - self._last_ping_recv_time
+        min_delay = 1.0  # seconds
+        if elapsed_since_last < min_delay:
+            self.logger.debug("remote sending PINGs too often, sleeping a bit")
+            # note: This rate-limiting helps limit our outbound traffic usage.
+            #       (max inc msg size 65 KB, max out msg size 65 KB, decoupled)
+            #       Does not really help for inbound traffic-usage:
+            #       there are many other ways for the peer to flood us, e.g. unknown 'odd' message types.
+            # note: this blocks processing *any* further incoming message from this peer
+            await asyncio.sleep(min_delay - elapsed_since_last)
+        self._last_ping_recv_time = time.monotonic()
         l = payload['num_pong_bytes']
         self.send_message('pong', byteslen=l)
 

--- a/tests/lnhelpers.py
+++ b/tests/lnhelpers.py
@@ -214,6 +214,10 @@ class PutIntoOthersQueueTransport(MockTransport):
     def send_bytes(self, data):
         self.other_mock_transport.queue.put_nowait(data)
 
+    async def send_bytes_and_drain(self, data):
+        self.send_bytes(data)
+
+
 def transport_pair(k1, k2, name1, name2):
     t1 = PutIntoOthersQueueTransport(k1, name1)
     t2 = PutIntoOthersQueueTransport(k2, name2)


### PR DESCRIPTION
A remote peer could send us lots of small ping messages, requesting large pong responses. This is cheap for them but potentially expensive for us. Does not seem too serious, but I think we could add some rate-limiting.

note: There are many ways for a remote peer to inflate our incoming traffic usage, but the cost of that is usually shared between them and us (they need to send the data, we receive it).