### PR TITLE
lnonion/trampoline: stop double counting HMAC size

### DIFF
--- a/electrum/lnonion.py
+++ b/electrum/lnonion.py
@@ -228,7 +228,7 @@ def new_onion_packet(
     payload_size = 0
     for i in range(num_hops):
         # FIXME: serializing here and again below. cache bytes in OnionHopsDataSingle? _raw_bytes_payload?
-        payload_size += PER_HOP_HMAC_SIZE + len(hops_data[i].to_bytes())
+        payload_size += len(hops_data[i].to_bytes())
     if trampoline:
         data_size = payload_size
     elif onion_message:

--- a/electrum/trampoline.py
+++ b/electrum/trampoline.py
@@ -10,7 +10,7 @@ import electrum_ecc as ecc
 
 from .lnutil import LnFeatures, PaymentFeeBudget, FeeBudgetExceeded
 from .lnonion import (
-    calc_hops_data_for_payment, new_onion_packet, OnionPacket, PER_HOP_HMAC_SIZE
+    calc_hops_data_for_payment, new_onion_packet, OnionPacket
 )
 from .lnrouter import TrampolineEdge, is_route_within_budget, LNPaymentTRoute
 from .lnutil import NoPathFound
@@ -418,8 +418,7 @@ def create_trampoline_onion(
         payload = dict(hops_data[index].payload)
         # try different r_tag order on each attempt
         invoice_routing_info = random_shuffled_copy(route[index].invoice_routing_info)
-        remaining_payload_space = TRAMPOLINE_HOPS_MAX_DATA_SIZE \
-                                  - sum(len(hop.to_bytes()) + PER_HOP_HMAC_SIZE for hop in hops_data)
+        remaining_payload_space = TRAMPOLINE_HOPS_MAX_DATA_SIZE - sum(len(hop.to_bytes()) for hop in hops_data)
         routing_info_to_use = []
         for encoded_r_tag in invoice_routing_info:
             if remaining_payload_space < 50:


### PR DESCRIPTION
`OnionHopsDataSingle.to_bytes()` already accounts for the onions hmac internally, 
it seems incorrect that we were additionally adding `PER_HOP_HMAC_SIZE` to the payload 
size of the payload returned by `.to_bytes()`.

https://github.com/spesmilo/electrum/blob/8e96fef1e1d6859204d918685e41c0d002b718a6/electrum/lnonion.py#L76-L92