### PR TITLE
ci: builds: android: fix cache key

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: packages
-          key: android-packages-${{ env.APK_ARCH }}-${{ hashFiles('contrib/deterministic-build/requirements.txt', 'contrib/make_packages.sh', 'contrib/android/**') }}
+          key: android-packages-${{ env.APK_ARCH }}-${{ hashFiles('contrib/deterministic-build/**', 'contrib/make_packages.sh', 'contrib/android/**', '!contrib/android/.cache') }}
 
       - name: Cache buildozer (p4a)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -109,8 +109,7 @@ jobs:
           path: |
             .buildozer_qml/android/platform/build-${{ env.APK_ARCH }}/packages
             .buildozer_qml/android/platform/build-${{ env.APK_ARCH }}/build
-          # note: should *at least* depend on Dockerfile and p4a_recipes/, but contrib/android/ is simplest
-          key: android-buildozer-${{ env.APK_ARCH }}-${{ hashFiles('contrib/android/**') }}
+          key: android-buildozer-${{ env.APK_ARCH }}-${{ hashFiles('contrib/android/**', '!contrib/android/.cache') }}
 
       - name: Build APK (debug)
         run: ./contrib/android/build.sh qml "$APK_ARCH" debug


### PR DESCRIPTION
Fix the cache key of the scheduled Android CI build which failed at the `Cache buildozer (p4a)` step with the following error:
```
Error: The template is not valid. .github/workflows/builds.yml (Line: 113, Col: 16): hashFiles('contrib/android/**') failed. Fail to hash files under directory '/home/runner/work/electrum/electrum'
```

Probably it failed because the `contrib/android/.cache` directory got included in the cache key, which worked on Cirrus. This specifies the cache key hash inputs explicitly.