### PR TITLE
chore: improve electrum maintenance path

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -74,7 +74,7 @@ class ElectrumTestCase(unittest.IsolatedAsyncioTestCase, Logger):
         self.electrum_path = os.path.join(self.unittest_base_path, "electrum")
         util.make_dir(self.electrum_path)
         assert util._asyncio_event_loop is None, "global event loop already set?!"
-        self._lnworkers_created = []  # type: List[MockLNWallet]
+        self._lnworkers_created: List[MockLNWallet] = []
 
     async def asyncSetUp(self):
         await super().asyncSetUp()

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -2,14 +2,14 @@ import os
 import sys
 import unittest
 import subprocess
-from typing import Mapping, Any
+from typing import Mapping, Any, List
 
 
 class TestLightning(unittest.TestCase):
     agents: Mapping[str, Mapping[str, Any]]
 
     @staticmethod
-    def run_shell(args, timeout=30):
+    def run_shell(args: List[str], timeout: int = 30) -> None:
         process = subprocess.Popen(['tests/regtest/regtest.sh'] + args, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, universal_newlines=True)
         for line in iter(process.stdout.readline, ''):
             sys.stdout.write(line)


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/regtest.py, tests/__init__.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.