### PR TITLE
mpp_split: stop returning splits without amounts

### DIFF
--- a/electrum/mpp_split.py
+++ b/electrum/mpp_split.py
@@ -143,11 +143,10 @@ def suggest_splits(
                 random.shuffle(channel_keys)
                 # we check each channel and try to put the funds inside, break if we succeed
                 for c in channel_keys:
-                    if c not in config:
-                        config[c] = []
+                    amounts = config.get(c, [])
                     channel_funds, channel_slots = channels_with_funds[c]
-                    if sum(config[c]) + amount <= channel_funds and len(config[c]) < channel_slots:
-                        config[c].append(amount)
+                    if sum(amounts) + amount <= channel_funds and len(amounts) < channel_slots:
+                        config.setdefault(c, []).append(amount)
                         break
                 # if we don't succeed to put the amount anywhere,
                 # we try to fill up channels and put the rest somewhere else
@@ -155,15 +154,17 @@ def suggest_splits(
                     distribute_amount = amount
                     for c in channel_keys:
                         channel_funds, channel_slots = channels_with_funds[c]
-                        slots_left = channel_slots - len(config[c])
+                        amounts = config.get(c, [])
+                        slots_left = channel_slots - len(amounts)
                         if slots_left == 0:
                             # no slot left in that channel
                             continue
-                        funds_left = channel_funds - sum(config[c])
+                        funds_left = channel_funds - sum(amounts)
                         # it would be good to not fill the full channel if possible
                         add_amount = min(funds_left, distribute_amount)
-                        config[c].append(add_amount)
-                        distribute_amount -= add_amount
+                        if add_amount:
+                            config.setdefault(c, []).append(add_amount)
+                            distribute_amount -= add_amount
                         if distribute_amount == 0:
                             break
             if config.total_config_amount() != amount_msat:

--- a/tests/test_mpp_split.py
+++ b/tests/test_mpp_split.py
@@ -31,9 +31,7 @@ class TestMppSplit(ElectrumTestCase):
             splits = mpp_split.suggest_splits(1_000_000_000, self.channels_with_funds, exclude_single_part_payments=True)
             self.assertEqual({
                 (b"0", b"0"): [671_020_676],
-                (b"1", b"1"): [328_979_324],
-                (b"2", b"0"): [],
-                (b"3", b"2"): []},
+                (b"1", b"1"): [328_979_324]},
                 splits[0].config
             )
 


### PR DESCRIPTION
`mpp_split.suggest_splits()` would return payment split configurations with no split amounts like:
`{(channel_id, node_id): []}`.

This is unintuitive and introduced two bugs:

1. `LNWallet.create_routes_for_payment()` evaluates `is_multichan_mpp = len(sc.config.items()) > 1`. So even if the actual payment amount gets split onto a single channel this would falsely evaluate `True` if there is an empty, additional split.

2. `is_direct_path = all(node_id == paysession.invoice_pubkey for (chan_id, node_id) in sc.config.keys())` similarly might incorrectly evaluates `False` if the split contains an empty split for another `node_id`.