### PR TITLE
plugin: nwc: change default relay used for new NWC connections

### DIFF
--- a/electrum/plugins/nwc/__init__.py
+++ b/electrum/plugins/nwc/__init__.py
@@ -37,7 +37,7 @@ plugin_name = "nwc"
 # This relay will be used as the first relay in the connection string.
 SimpleConfig.NWC_RELAY = ConfigVar(
     key='plugins.nwc.relay',
-    default='wss://relay.getalby.com/v1',
+    default='wss://relay.primal.net',
     type_=str,
     plugin=plugin_name
 )


### PR DESCRIPTION
The default relay is the one that is positioned first in a NWC connection string. This matters because most clients only use the first relay and ignore the subsequent ones.

We set the Alby relay as default because they operate it specifically for NWC.
However it doesn't seem to work anymore, client requests time out (for weeks now). I suspect they drop NIP-04 encrypted events to push wallets to implement the newer NIP-44 encryption.
We should eventually implement this, but for now changing the default relay makes the connection reliable again for users who don't know about relays.
The primal relay happily accepts NIP-04 encrypted NWC events so lets use this as default.