### PR TITLE
New storage api

### DIFF
--- a/electrum/__init__.py
+++ b/electrum/__init__.py
@@ -17,7 +17,7 @@ class GuiImportError(ImportError):
 from .version import ELECTRUM_VERSION
 from .util import format_satoshis
 from .wallet import Wallet
-from .storage import WalletStorage
+from .stored_dict import WalletStorage
 from .coinchooser import COIN_CHOOSERS
 from .network import Network, pick_random_server
 from .interface import Interface

--- a/electrum/__init__.py
+++ b/electrum/__init__.py
@@ -17,7 +17,7 @@ class GuiImportError(ImportError):
 from .version import ELECTRUM_VERSION
 from .util import format_satoshis
 from .wallet import Wallet
-from .stored_dict import WalletStorage
+from .stored_dict import DictStorage
 from .coinchooser import COIN_CHOOSERS
 from .network import Network, pick_random_server
 from .interface import Interface

--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -47,7 +47,7 @@ from .util import (
     log_exceptions, randrange, OldTaskGroup, UserFacingException, JsonRPCError, os_chmod
 )
 from .wallet import Wallet, Abstract_Wallet
-from .stored_dict import WalletStorage
+from .stored_dict import DictStorage
 from .wallet_db import WalletDB, WalletUnfinished
 from .commands import known_commands, Commands
 from .simple_config import SimpleConfig
@@ -544,7 +544,7 @@ class Daemon(Logger):
             force_check_password: bool = False,  # if set, always validate password
     ) -> Optional[Abstract_Wallet]:
         path = standardize_path(path)
-        storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
+        storage = DictStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
         if not storage.file_exists():
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
         if storage.is_encrypted():

--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -47,7 +47,7 @@ from .util import (
     log_exceptions, randrange, OldTaskGroup, UserFacingException, JsonRPCError, os_chmod
 )
 from .wallet import Wallet, Abstract_Wallet
-from .storage import WalletStorage
+from .stored_dict import WalletStorage
 from .wallet_db import WalletDB, WalletUnfinished
 from .commands import known_commands, Commands
 from .simple_config import SimpleConfig
@@ -551,8 +551,7 @@ class Daemon(Logger):
             if not password:
                 raise InvalidPassword('No password given')
             storage.decrypt(password)
-        # read data, pass it to db
-        db = WalletDB(storage.read(), storage=storage, upgrade=upgrade)
+        db = WalletDB(storage, upgrade=upgrade)
         if db.get_action():
             raise WalletUnfinished(db)
         wallet = Wallet(db, config=config)

--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -544,9 +544,9 @@ class Daemon(Logger):
             force_check_password: bool = False,  # if set, always validate password
     ) -> Optional[Abstract_Wallet]:
         path = standardize_path(path)
-        storage = DictStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
-        if not storage.file_exists():
+        if not os.path.exists(path):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+        storage = DictStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
         if storage.is_encrypted():
             if not password:
                 raise InvalidPassword('No password given')

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -13,7 +13,7 @@ from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.bitcoin import is_address
 from electrum.bitcoin import verify_usermessage_with_address
-from electrum.stored_dict import StorageReadWriteError, WalletStorage
+from electrum.stored_dict import StorageReadWriteError, DictStorage
 
 from .auth import AuthMixin, auth_protect
 from .qefx import QEFX
@@ -333,7 +333,7 @@ class QEDaemon(AuthMixin, QObject):
         wallet_path = self.wallet_path_from_wallet_name(wallet_name)
         # validate that the path looks sane to the filesystem:
         try:
-            temp_storage = WalletStorage(wallet_path, init_db=False)
+            temp_storage = DictStorage(wallet_path, init_db=False)
         except (StorageReadWriteError, WalletFileException):
             return False
         except Exception:

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -13,7 +13,7 @@ from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.bitcoin import is_address
 from electrum.bitcoin import verify_usermessage_with_address
-from electrum.storage import StorageReadWriteError, WalletStorage
+from electrum.stored_dict import StorageReadWriteError, WalletStorage
 
 from .auth import AuthMixin, auth_protect
 from .qefx import QEFX
@@ -333,7 +333,7 @@ class QEDaemon(AuthMixin, QObject):
         wallet_path = self.wallet_path_from_wallet_name(wallet_name)
         # validate that the path looks sane to the filesystem:
         try:
-            temp_storage = WalletStorage(wallet_path)
+            temp_storage = WalletStorage(wallet_path, init_db=False)
         except (StorageReadWriteError, WalletFileException):
             return False
         except Exception:

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -754,7 +754,8 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
 
         try:
             self._logger.info('setting new password')
-            self.wallet.update_password(current_password, password, encrypt_storage=True)
+            encrypt_storage = self.wallet.storage.supports_file_encryption()
+            self.wallet.update_password(current_password, password, encrypt_storage=encrypt_storage)
             # restore the invariant that all loaded wallets in qml must be unlocked:
             self.wallet.unlock(password)
             return True

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -507,7 +507,7 @@ class ElectrumGui(BaseElectrumGui, Logger):
                 self.logger.info('wizard dialog cancelled by user')
                 return
             db.put('x3', wizard.get_wizard_data()['x3'])
-            db.write_and_force_consolidation()  # TODO API for db is a bit weird: there should be a close method
+            db.storage.write()  # TODO API for db is a bit weird: there should be a close method
 
         wallet = self.daemon.load_wallet(wallet_file, password, upgrade=True)
         return wallet

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1748,7 +1748,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
     def update_console(self):
         console = self.console
-        console.history = self.wallet.db.get_stored_item("qt-console-history", [])
+        console.history = self.wallet.db.get_list("qt-console-history")
         console.history_index = len(console.history)
 
         console.updateNamespace({
@@ -1950,8 +1950,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.update_lock_menu()
 
     def _update_wallet_password(self, *, old_password, new_password, xpub_encrypt=False):
+        encrypt_storage = self.wallet.storage.supports_file_encryption()
         try:
-            self.wallet.update_password(old_password, new_password, encrypt_storage=True, xpub_encrypt=xpub_encrypt)
+            self.wallet.update_password(
+                old_password, new_password,
+                encrypt_storage=encrypt_storage,
+                xpub_encrypt=xpub_encrypt)
         except InvalidPassword as e:
             self.show_error(str(e))
             return

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -21,7 +21,7 @@ from electrum.util import is_subpath, ChoiceItem, multisig_type, UserCancelled, 
 from electrum.wallet import wallet_types
 from .wizard import QEAbstractWizard, WizardComponent
 from electrum.logging import get_logger, Logger
-from electrum import WalletStorage, mnemonic, keystore
+from electrum import DictStorage, mnemonic, keystore
 from electrum.wallet_db import WalletDB
 from electrum.wizard import NewWalletWizard, KeystoreWizard, WizardViewState
 
@@ -176,7 +176,7 @@ class QENewWalletWizard(NewWalletWizard, QEAbstractWizard, MessageBoxMixin):
 
         wallet_file = wizard_data['wallet_name']
 
-        storage = WalletStorage(wallet_file)
+        storage = DictStorage(wallet_file)
         assert storage.file_exists(), f"file {wallet_file!r} does not exist"
         if not storage.is_encrypted_with_user_pw() and not storage.is_encrypted_with_hw_device():
             return True
@@ -280,7 +280,7 @@ class WCWalletName(WalletWizardComponent, Logger):
         self.layout().addLayout(hbox2)
         self.layout().addStretch(1)
 
-        temp_storage = None  # type: Optional[WalletStorage]
+        temp_storage = None  # type: Optional[DictStorage]
         datadir_wallet_folder = self.wizard.config.get_datadir_wallet_path()
 
         def relative_path(path):
@@ -313,10 +313,10 @@ class WCWalletName(WalletWizardComponent, Logger):
                 wallet_from_memory = self.wizard._daemon.get_wallet(_path)
                 try:
                     if wallet_from_memory:
-                        temp_storage = wallet_from_memory.storage  # type: Optional[WalletStorage]
+                        temp_storage = wallet_from_memory.storage  # type: Optional[DictStorage]
                         self.wallet_is_open = True
                     else:
-                        temp_storage = WalletStorage(_path, init_db=False)
+                        temp_storage = DictStorage(_path, init_db=False)
                     self.wallet_exists = temp_storage.file_exists()
                 except (StorageReadWriteError, WalletFileException) as e:
                     msg = _('Cannot read file') + f'\n{repr(e)}'
@@ -1376,7 +1376,7 @@ class WCHWUnlock(WalletWizardComponent, Logger):
     def check_hw_decrypt(self):
         wallet_file = self.wizard_data['wallet_name']
 
-        storage = WalletStorage(wallet_file)
+        storage = DictStorage(wallet_file)
         if not storage.is_encrypted_with_hw_device():
             return True
 

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -316,7 +316,7 @@ class WCWalletName(WalletWizardComponent, Logger):
                         temp_storage = wallet_from_memory.storage  # type: Optional[WalletStorage]
                         self.wallet_is_open = True
                     else:
-                        temp_storage = WalletStorage(_path)
+                        temp_storage = WalletStorage(_path, init_db=False)
                     self.wallet_exists = temp_storage.file_exists()
                 except (StorageReadWriteError, WalletFileException) as e:
                     msg = _('Cannot read file') + f'\n{repr(e)}'
@@ -327,7 +327,7 @@ class WCWalletName(WalletWizardComponent, Logger):
                 msg = ""
             self.valid = temp_storage is not None
             user_needs_to_enter_password = False
-            if temp_storage:
+            if temp_storage is not None:
                 if not temp_storage.file_exists():
                     msg = _("This file does not exist.") + '\n' \
                           + _("Press 'Next' to create this wallet, or choose another file.")

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from electrum.gui import BaseElectrumGui
 from electrum import util
-from electrum import WalletStorage, Wallet
+from electrum import DictStorage, Wallet
 from electrum.wallet import Abstract_Wallet
 from electrum.wallet_db import WalletDB
 from electrum.util import format_satoshis, EventListener, event_listener
@@ -26,7 +26,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
     def __init__(self, *, config, daemon, plugins):
         BaseElectrumGui.__init__(self, config=config, daemon=daemon, plugins=plugins)
         self.network = daemon.network
-        storage = WalletStorage(config.get_wallet_path())
+        storage = DictStorage(config.get_wallet_path())
         password = None
         if not storage.file_exists():
             print("Wallet not found. try 'electrum create'")

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -21,7 +21,7 @@ from electrum.bitcoin import is_address, address_to_script
 from electrum.transaction import PartialTxOutput
 from electrum.wallet import Wallet, Abstract_Wallet
 from electrum.wallet_db import WalletDB
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.network import NetworkParameters, TxBroadcastError, BestEffortRequestFailed, ProxySettings
 from electrum.interface import ServerAddr
 from electrum.invoices import Invoice
@@ -62,7 +62,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
     def __init__(self, *, config: 'SimpleConfig', daemon: 'Daemon', plugins: 'Plugins'):
         BaseElectrumGui.__init__(self, config=config, daemon=daemon, plugins=plugins)
         self.network = daemon.network
-        storage = WalletStorage(config.get_wallet_path())
+        storage = DictStorage(config.get_wallet_path())
         password = None
         if not storage.file_exists():
             print("Wallet not found. try 'electrum create'")

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -21,7 +21,7 @@ from electrum.bitcoin import is_address, address_to_script
 from electrum.transaction import PartialTxOutput
 from electrum.wallet import Wallet, Abstract_Wallet
 from electrum.wallet_db import WalletDB
-from electrum.storage import WalletStorage
+from electrum.stored_dict import WalletStorage
 from electrum.network import NetworkParameters, TxBroadcastError, BestEffortRequestFailed, ProxySettings
 from electrum.interface import ServerAddr
 from electrum.invoices import Invoice

--- a/electrum/invoices.py
+++ b/electrum/invoices.py
@@ -236,7 +236,7 @@ class BaseInvoice(StoredObject):
         else:  # on-chain
             return get_id_from_onchain_outputs(outputs=self.get_outputs(), timestamp=self.time)
 
-    def as_dict(self, status):
+    def export(self, status):
         d = {
             'is_lightning': self.is_lightning(),
             'amount_BTC': format_satoshis(self.get_amount_sat()),
@@ -298,7 +298,7 @@ class Invoice(BaseInvoice):
             return True
 
     def to_debug_json(self) -> Dict[str, Any]:
-        d = self.to_json()
+        d = self.as_dict()
         d["lnaddr"] = self._lnaddr.to_debug_json()
         return d
 

--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -30,9 +30,9 @@ from typing import TYPE_CHECKING, Optional, Sequence, List, Union, Dict, Any
 import jsonpatch
 import jsonpointer
 
-from .util import WalletFileException, profiler, sticky_property, MyEncoder
+from .util import WalletFileException, profiler, sticky_property
 from .logging import Logger
-from .stored_dict import _FLEX_KEY, BaseDB, _convert_dict_key, _convert_dict_value
+from .stored_dict import _FLEX_KEY, BaseDB
 from .storage import FileStorage
 
 
@@ -89,12 +89,10 @@ class JsonDB(BaseDB):
             *,
             allow_partial_writes = True,
             init_db = True,
-            encoder = MyEncoder,
     ):
         BaseDB.__init__(self, path)
         self._is_closed = True
         self.lock = threading.RLock()
-        self.encoder = encoder
         self.pending_changes = []  # type: List[str]
         self._modified = False
         if self.path:
@@ -105,18 +103,17 @@ class JsonDB(BaseDB):
                 self.init_db()
         else:
             self.storage = None
-            self.set_data('{}')
+            self.json_data = {}
             self._is_closed = False
 
     def set_data(self, json_str):
-        data = self.load_data(json_str)
-        self.json_data = self._convert_dict([], data)
+        self.json_data = self.load_data(json_str)
 
     def init_db(self):
         if self.storage.is_encrypted():
             assert self.storage.is_past_initial_decryption()
         json_str = self.storage.read()
-        self.set_data(json_str)
+        self.json_data = self.load_data(json_str)
         # write file in case there was a db upgrade
         self.write_and_force_consolidation()
         self._is_closed = False
@@ -286,7 +283,7 @@ class JsonDB(BaseDB):
 
     @locked
     def add_patch(self, patch):
-        self.pending_changes.append(json.dumps(patch, cls=self.encoder))
+        self.pending_changes.append(json.dumps(patch))
         self.set_modified(True)
 
     def db_add(self, path, key: _FLEX_KEY, value) -> None:
@@ -310,28 +307,7 @@ class JsonDB(BaseDB):
             self.json_data,
             indent=4 if human_readable else None,
             sort_keys=bool(human_readable),
-            cls=self.encoder,
         )
-
-    def _convert_dict_key(self, path: List[str], key: str) -> _FLEX_KEY:
-        return _convert_dict_key(path, key)
-
-    def _convert_dict_value(self, path: List[str], v) -> Any:
-        v = _convert_dict_value(path, v)
-        if isinstance(v, dict):
-            v = self._convert_dict(path, v)
-        return v
-
-    def _convert_dict(self, path: List[str], data: dict):
-        # recursively convert json dict to StoredDict
-        assert all(isinstance(x, str) for x in path), repr(path)
-        d = {}
-        for k, v in list(data.items()):
-            child_path = path + [k]
-            k = self._convert_dict_key(path, k)
-            v = self._convert_dict_value(child_path, v)
-            d[k] = v
-        return d
 
     @locked
     def write(self):

--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -30,14 +30,11 @@ from typing import TYPE_CHECKING, Optional, Sequence, List, Union, Dict, Any
 import jsonpatch
 import jsonpointer
 
-from . import util
-from .util import WalletFileException, profiler, sticky_property
+from .util import WalletFileException, profiler, sticky_property, MyEncoder
 from .logging import Logger
-from .stored_dict import StoredDict, _FLEX_KEY, registered_names, registered_keys, _convert_dict_key, _convert_dict_value
+from .stored_dict import _FLEX_KEY, BaseDB, _convert_dict_key, _convert_dict_value
+from .storage import FileStorage
 
-
-if TYPE_CHECKING:
-    from .storage import WalletStorage
 
 
 # We monkeypatch exceptions in the jsonpatch package to ensure they do not contain secrets from the DB.
@@ -84,36 +81,154 @@ def locked(func):
 
 
 
-
-class JsonDB(Logger):
+class JsonDB(BaseDB):
 
     def __init__(
-        self,
-        s: str,
-        *,
-        storage: Optional['WalletStorage'] = None,
-        encoder=None,
-        upgrader=None,
+            self,
+            path: Optional[str],
+            *,
+            allow_partial_writes = True,
+            init_db = True,
+            encoder = MyEncoder,
     ):
-        Logger.__init__(self)
+        BaseDB.__init__(self, path)
+        self._is_closed = True
         self.lock = threading.RLock()
-        self.storage = storage
         self.encoder = encoder
         self.pending_changes = []  # type: List[str]
         self._modified = False
-        # load data
-        data = self.load_data(s)
-        if upgrader:
-            data, was_upgraded = upgrader(data)
-            self._modified |= was_upgraded
-        # convert json to python objects
-        data = self._convert_dict([], data)
-        # convert dict to StoredDict
-        self.data = StoredDict(data, self)
-        self.data.set_parent(key='', parent=None)
+        if self.path:
+            self.storage = FileStorage(path, allow_partial_writes=allow_partial_writes)
+            if init_db and not self.is_encrypted():
+                # open DB if file is not encrypted
+                # otherwise, this will be called in self.decrypt
+                self.init_db()
+        else:
+            self.storage = None
+            self.set_data('{}')
+            self._is_closed = False
+
+    def set_data(self, json_str):
+        data = self.load_data(json_str)
+        self.json_data = self._convert_dict([], data)
+
+    def init_db(self):
+        if self.storage.is_encrypted():
+            assert self.storage.is_past_initial_decryption()
+        json_str = self.storage.read()
+        self.set_data(json_str)
         # write file in case there was a db upgrade
-        if self.storage and self.storage.file_exists():
-            self.write_and_force_consolidation()
+        self.write_and_force_consolidation()
+        self._is_closed = False
+
+    def decrypt(self, password: str):
+        self.storage.decrypt(password)
+        json_str = self.storage.read()
+        self.set_data(json_str)
+        self._is_closed = False
+
+    def check_password(self, password):
+        self.storage.check_password(password)
+
+    def supports_file_encryption(self):
+        return bool(self.storage)
+
+    def get_encryption_version(self):
+        return self.storage.get_encryption_version()
+
+    def is_encrypted(self):
+        return self.storage and self.storage.is_encrypted()
+
+    def is_encrypted_with_user_pw(self) -> bool:
+        return self.storage and self.storage.is_encrypted_with_user_pw()
+
+    def is_encrypted_with_hw_device(self) -> bool:
+        return self.storage and self.storage.is_encrypted_with_hw_device()
+
+    def set_password(self, password: str, enc_version=None):
+        self.storage.set_password(password, enc_version=enc_version)
+
+    def file_exists(self):
+        return self.storage and self.storage.file_exists()
+
+    def _subdict(self, path):
+        d = self.json_data
+        for k in path[1:]:
+            d = d[k]
+        return d
+
+    def iter_keys(self, path):
+        d = self._subdict(path)
+        return d.__iter__()
+
+    def dict_len(self, path):
+        d = self._subdict(path)
+        return len(d)
+
+    def contains(self, path, key):
+        d = self._subdict(path)
+        return key in d
+
+    def replace(self, path, key, value):
+        # called by setattr
+        self.put(path, key, value)
+
+    @modifier
+    def put(self, path, key, value):
+        d = self._subdict(path)
+        is_new = key not in d
+        if not is_new and d[key] == value:
+            return
+        d[key] = value
+        self.db_add(path, key, value) if is_new else self.db_replace(path, key, value)
+
+    @modifier
+    def clear(self, path):
+        d = self._subdict(path)
+        d.clear()
+        path, key = path[:-1], path[-1]
+        self.db_replace(path, key, {})
+
+    def get(self, hint, key):
+        return hint[key]
+
+    def get_hint(self, path):
+        return self._subdict(path)
+
+    @modifier
+    def remove(self, path, key):
+        d = self._subdict(path)
+        d.pop(key)
+        self.db_remove(path, key)
+
+    @modifier
+    def list_append(self, path, item):
+        _list = self._subdict(path)
+        n = len(_list)
+        _list.append(item)
+        self.db_add(path, str(n), item)
+
+    def list_index(self, path, item):
+        _list = self._subdict(path)
+        return _list.index(item)
+
+    def list_len(self, path):
+        _list = self._subdict(path)
+        return len(_list)
+
+    @modifier
+    def list_clear(self, path):
+        _list = self._subdict(path)
+        _list.clear()
+        self.db_remove(path[:-1], path[-1])
+        self.db_add(path[:-1], path[-1], [])
+
+    @modifier
+    def list_remove(self, path, item):
+        _list = self._subdict(path)
+        n = _list.index(item)
+        _list.remove(item)
+        self.db_remove(path, str(n)) # fixme: keys
 
     def load_data(self, s: str) -> Dict[str, Any]:
         if s == '':
@@ -185,55 +300,17 @@ class JsonDB(Logger):
         self.pending_changes.append(json.dumps(patch, cls=self.encoder))
         self.set_modified(True)
 
-    def add(self, path, key: _FLEX_KEY, value) -> None:
+    def db_add(self, path, key: _FLEX_KEY, value) -> None:
         assert isinstance(key, _FLEX_KEY), repr(key)
         self.add_patch({'op': 'add', 'path': key_path(path, key), 'value': value})
 
-    def replace(self, path, key: _FLEX_KEY, value) -> None:
+    def db_replace(self, path, key: _FLEX_KEY, value) -> None:
         assert isinstance(key, _FLEX_KEY), repr(key)
         self.add_patch({'op': 'replace', 'path': key_path(path, key), 'value': value})
 
-    def remove(self, path, key: _FLEX_KEY) -> None:
+    def db_remove(self, path, key: _FLEX_KEY) -> None:
         assert isinstance(key, _FLEX_KEY), repr(key)
         self.add_patch({'op': 'remove', 'path': key_path(path, key)})
-
-    @locked
-    def get(self, key, default=None):
-        v = self.data.get(key)
-        if v is None:
-            v = default
-        return v
-
-    @modifier
-    def put(self, key, value):
-        try:
-            json.dumps(key, cls=self.encoder)
-            json.dumps(value, cls=self.encoder)
-        except Exception:
-            self.logger.info(f"json error: cannot save {repr(key)} ({repr(value)})")
-            return False
-        if value is not None:
-            if self.data.get(key) != value:
-                self.data[key] = copy.deepcopy(value)
-                return True
-        elif key in self.data:
-            self.data.pop(key)
-            return True
-        return False
-
-    @locked
-    def get_dict(self, name) -> dict:
-        # Warning: interacts un-intuitively with 'put': certain parts
-        # of 'data' will have pointers saved as separate variables.
-        if name not in self.data:
-            self.data[name] = {}
-        return self.data[name]
-
-    @locked
-    def get_stored_item(self, key, default) -> dict:
-        if key not in self.data:
-            self.data[key] = default
-        return self.data[key]
 
     @locked
     def dump(self, *, human_readable: bool = True) -> str:
@@ -241,14 +318,11 @@ class JsonDB(Logger):
         'human_readable': makes the json indented and sorted, but this is ~2x slower
         """
         return json.dumps(
-            self.data,
+            self.json_data,
             indent=4 if human_readable else None,
             sort_keys=bool(human_readable),
             cls=self.encoder,
         )
-
-    def _should_convert_to_stored_dict(self, key) -> bool:
-        return True
 
     def _convert_dict_key(self, path: List[str], key: str) -> _FLEX_KEY:
         return _convert_dict_key(path, key)
@@ -272,10 +346,19 @@ class JsonDB(Logger):
 
     @locked
     def write(self):
+        if not self.storage:
+            return
         if self.storage.should_do_full_write_next():
             self.write_and_force_consolidation()
         else:
             self._append_pending_changes()
+
+    def close(self):
+        # do not call write
+        self._is_closed = True
+
+    def is_closed(self):
+        return self._is_closed
 
     @locked
     def _append_pending_changes(self):

--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -26,6 +26,7 @@ import threading
 import copy
 import json
 from typing import TYPE_CHECKING, Optional, Sequence, List, Union, Dict, Any
+from contextlib import contextmanager
 
 import jsonpatch
 import jsonpointer
@@ -94,6 +95,7 @@ class JsonDB(BaseDB):
         self._is_closed = True
         self.lock = threading.RLock()
         self.pending_changes = []  # type: List[str]
+        self._write_batch = False
         self._modified = False
         if self.path:
             self.storage = FileStorage(path, allow_partial_writes=allow_partial_writes)
@@ -309,8 +311,22 @@ class JsonDB(BaseDB):
             sort_keys=bool(human_readable),
         )
 
+    @contextmanager
+    def write_batch(self):
+        assert self._write_batch is False
+        self._write_batch = True
+        try:
+            yield
+        finally:
+            # FIXME: if an exception is raised here, changes will not be
+            # written to disk, but they will be added to the in-memory dict.
+            self._write_batch = False
+        if self.storage:
+            self.write()
+
     @locked
     def write(self):
+        assert self._write_batch is False
         if not self.storage:
             return
         if self.storage.should_do_full_write_next():
@@ -319,7 +335,7 @@ class JsonDB(BaseDB):
             self._append_pending_changes()
 
     def close(self):
-        # do not call write
+        # do not call write, because we may need to close the DB after an exception was raised during a batch write
         self._is_closed = True
 
     def is_closed(self):

--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -157,25 +157,21 @@ class JsonDB(BaseDB):
             d = d[k]
         return d
 
-    def iter_keys(self, path):
-        d = self._subdict(path)
+    def iter_keys(self, d, path):
         return d.__iter__()
 
-    def dict_len(self, path):
-        d = self._subdict(path)
+    def dict_len(self, d, path):
         return len(d)
 
-    def contains(self, path, key):
-        d = self._subdict(path)
+    def dict_contains(self, d, path, key):
         return key in d
 
-    def replace(self, path, key, value):
+    def replace(self, d, path, key, value):
         # called by setattr
-        self.put(path, key, value)
+        self.put(d, path, key, value)
 
     @modifier
-    def put(self, path, key, value):
-        d = self._subdict(path)
+    def put(self, d, path, key, value):
         is_new = key not in d
         if not is_new and d[key] == value:
             return
@@ -183,49 +179,42 @@ class JsonDB(BaseDB):
         self.db_add(path, key, value) if is_new else self.db_replace(path, key, value)
 
     @modifier
-    def clear(self, path):
-        d = self._subdict(path)
+    def clear(self, d, path):
         d.clear()
         path, key = path[:-1], path[-1]
         self.db_replace(path, key, {})
 
-    def get(self, hint, key):
-        return hint[key]
+    def get(self, d, key):
+        return d[key]
 
     def get_hint(self, path):
         return self._subdict(path)
 
     @modifier
-    def remove(self, path, key):
-        d = self._subdict(path)
+    def remove(self, d, path, key):
         d.pop(key)
         self.db_remove(path, key)
 
     @modifier
-    def list_append(self, path, item):
-        _list = self._subdict(path)
+    def list_append(self, _list, path, item):
         n = len(_list)
         _list.append(item)
         self.db_add(path, str(n), item)
 
-    def list_index(self, path, item):
-        _list = self._subdict(path)
+    def list_index(self, _list, path, item):
         return _list.index(item)
 
-    def list_len(self, path):
-        _list = self._subdict(path)
+    def list_len(self, _list, path):
         return len(_list)
 
     @modifier
-    def list_clear(self, path):
-        _list = self._subdict(path)
+    def list_clear(self, _list, path):
         _list.clear()
         self.db_remove(path[:-1], path[-1])
         self.db_add(path[:-1], path[-1], [])
 
     @modifier
-    def list_remove(self, path, item):
-        _list = self._subdict(path)
+    def list_remove(self, _list, path, item):
         n = _list.index(item)
         _list.remove(item)
         self.db_remove(path, str(n)) # fixme: keys

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -1123,14 +1123,12 @@ def hardware_keystore(d) -> Hardware_KeyStore:
                               f'hw_keystores: {list(hw_keystores)}')
 
 def load_keystore(db: 'WalletDB', name: str) -> KeyStore:
-    # deepcopy object to avoid keeping a pointer to db.data
-    # note: this is needed as type(wallet.db.get("keystore")) != StoredDict
-    d = copy.deepcopy(db.get(name, {}))
+    d = db.get(name)
+    if d is None:
+        raise WalletFileException('Cannot find keystore for name {}'.format(name))
     t = d.get('type')
     if not t:
-        raise WalletFileException(
-            'Wallet format requires update.\n'
-            'Cannot find keystore for name {}'.format(name))
+        raise WalletFileException('Cannot find keystore for name {}'.format(name))
     keystore_constructors = {ks.type: ks for ks in [Old_KeyStore, Imported_KeyStore, BIP32_KeyStore]}
     keystore_constructors['hardware'] = hardware_keystore
     try:

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -62,6 +62,7 @@ from .lnutil import CHANNEL_OPENING_TIMEOUT_BLOCKS, CHANNEL_OPENING_TIMEOUT_SEC
 from .lnutil import ChannelBackupStorage, ImportedChannelBackupStorage, OnchainChannelBackupStorage
 from .lnutil import format_short_channel_id
 from .fee_policy import FEERATE_PER_KW_MIN_RELAY_LIGHTNING
+from .stored_dict import stored_at
 
 if TYPE_CHECKING:
     from .lnworker import LNWallet

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -65,7 +65,7 @@ from .fee_policy import FEERATE_PER_KW_MIN_RELAY_LIGHTNING
 
 if TYPE_CHECKING:
     from .lnworker import LNWallet
-    from .json_db import StoredDict
+    from .stored_dict import StoredDict
 
 
 # channel flags

--- a/electrum/lnhtlc.py
+++ b/electrum/lnhtlc.py
@@ -6,7 +6,7 @@ from .lnutil import SENT, RECEIVED, LOCAL, REMOTE, HTLCOwner, UpdateAddHtlc, Dir
 from .util import bfh, with_lock
 
 if TYPE_CHECKING:
-    from .json_db import StoredDict
+    from .stored_dict import StoredDict
 
 LOG_TEMPLATE = {
     'adds': {},              # "side who offered htlc" -> htlc_id -> htlc

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1191,7 +1191,7 @@ class Peer(Logger, EventListener):
             lnworker=self.lnworker,
             initial_feerate=feerate
         )
-        temp_chan.storage['funding_inputs'] = [txin.prevout.to_json() for txin in funding_tx.inputs()]
+        temp_chan.storage['funding_inputs'] = [txin.prevout for txin in funding_tx.inputs()]
         temp_chan.storage['has_onchain_backup'] = has_onchain_backup
         temp_chan.storage['init_height'] = self.lnworker.network.get_local_height()
         temp_chan.storage['init_timestamp'] = int(time.time())

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1942,7 +1942,7 @@ class UpdateAddHtlc:
             htlc_id=htlc_id,
             timestamp=timestamp)
 
-    def to_json(self):
+    def as_tuple(self):
         self._validate()
         return dataclasses.astuple(self)
 

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -3654,7 +3654,7 @@ class LNWallet(Logger):
         assert chan.can_be_deleted()
         with self.lock:
             self._channels.pop(chan_id)
-            self.db.get('channels').pop(chan_id.hex())
+            self.db.get_dict('channels').pop(chan_id.hex())
         self.wallet.set_reserved_addresses_for_chan(chan, reserved=False)
 
         util.trigger_callback('channels_updated', self.wallet)

--- a/electrum/plugins/watchtower/watchtower.py
+++ b/electrum/plugins/watchtower/watchtower.py
@@ -36,6 +36,7 @@ from electrum.transaction import Transaction, match_script_against_template
 from electrum.network import Network
 from electrum.address_synchronizer import AddressSynchronizer, TX_HEIGHT_LOCAL
 from electrum.wallet_db import WalletDB
+from electrum.stored_dict import WalletStorage
 from electrum.lnutil import WITNESS_TEMPLATE_RECEIVED_HTLC, WITNESS_TEMPLATE_OFFERED_HTLC
 from electrum.logging import Logger
 from electrum.util import EventListener, event_listener
@@ -67,7 +68,8 @@ class WatchTower(Logger, EventListener):
     def __init__(self, network: 'Network'):
         Logger.__init__(self)
         self.config = network.config
-        wallet_db = WalletDB('', storage=None, upgrade=True)
+        storage = WalletStorage(None)
+        wallet_db = WalletDB(storage)
         self.adb = AddressSynchronizer(wallet_db, self.config, name=self.diagnostic_name())
         self.adb.start_network(network)
         self.callbacks = {}  # address -> lambda function

--- a/electrum/plugins/watchtower/watchtower.py
+++ b/electrum/plugins/watchtower/watchtower.py
@@ -36,7 +36,7 @@ from electrum.transaction import Transaction, match_script_against_template
 from electrum.network import Network
 from electrum.address_synchronizer import AddressSynchronizer, TX_HEIGHT_LOCAL
 from electrum.wallet_db import WalletDB
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.lnutil import WITNESS_TEMPLATE_RECEIVED_HTLC, WITNESS_TEMPLATE_OFFERED_HTLC
 from electrum.logging import Logger
 from electrum.util import EventListener, event_listener
@@ -68,7 +68,7 @@ class WatchTower(Logger, EventListener):
     def __init__(self, network: 'Network'):
         Logger.__init__(self)
         self.config = network.config
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
         wallet_db = WalletDB(storage)
         self.adb = AddressSynchronizer(wallet_db, self.config, name=self.diagnostic_name())
         self.adb.start_network(network)

--- a/electrum/scripts/bruteforce_pw.py
+++ b/electrum/scripts/bruteforce_pw.py
@@ -29,7 +29,7 @@ from typing import Callable
 from functools import partial
 
 from electrum.wallet import Wallet, Abstract_Wallet
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.wallet_db import WalletDB
 from electrum.simple_config import SimpleConfig
 from electrum.util import InvalidPassword
@@ -39,7 +39,7 @@ ALLOWED_CHARS = digits + ascii_uppercase + ascii_lowercase
 MAX_PASSWORD_LEN = 12
 
 
-def test_password_for_storage_encryption(storage: WalletStorage, password: str) -> bool:
+def test_password_for_storage_encryption(storage: DictStorage, password: str) -> bool:
     try:
         storage.decrypt(password)
     except InvalidPassword:
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     path = sys.argv[1]
 
     config = SimpleConfig()
-    storage = WalletStorage(path)
+    storage = DictStorage(path)
     if not storage.file_exists():
         print(f"ERROR. wallet file not found at path: {path}")
         sys.exit(1)

--- a/electrum/scripts/bruteforce_pw.py
+++ b/electrum/scripts/bruteforce_pw.py
@@ -29,7 +29,7 @@ from typing import Callable
 from functools import partial
 
 from electrum.wallet import Wallet, Abstract_Wallet
-from electrum.storage import WalletStorage
+from electrum.stored_dict import WalletStorage
 from electrum.wallet_db import WalletDB
 from electrum.simple_config import SimpleConfig
 from electrum.util import InvalidPassword
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         test_password = partial(test_password_for_storage_encryption, storage)
         print(f"wallet found: with storage encryption.")
     else:
-        db = WalletDB(storage.read(), storage=storage, upgrade=False)
+        db = WalletDB(storage, upgrade=False)
         wallet = Wallet(db, config=config)
         if not wallet.has_password():
             print("wallet found but it is not encrypted.")

--- a/electrum/scripts/quick_start.py
+++ b/electrum/scripts/quick_start.py
@@ -6,7 +6,6 @@ import asyncio
 from electrum.simple_config import SimpleConfig
 from electrum import constants
 from electrum.daemon import Daemon
-from electrum.stored_dict import WalletStorage
 from electrum.wallet import Wallet, create_new_wallet
 from electrum.wallet_db import WalletDB
 from electrum.commands import Commands

--- a/electrum/scripts/quick_start.py
+++ b/electrum/scripts/quick_start.py
@@ -6,7 +6,7 @@ import asyncio
 from electrum.simple_config import SimpleConfig
 from electrum import constants
 from electrum.daemon import Daemon
-from electrum.storage import WalletStorage
+from electrum.stored_dict import WalletStorage
 from electrum.wallet import Wallet, create_new_wallet
 from electrum.wallet_db import WalletDB
 from electrum.commands import Commands

--- a/electrum/storage.py
+++ b/electrum/storage.py
@@ -53,8 +53,7 @@ from .stored_dict import StorageEncryptionVersion, StorageReadWriteError
 class StorageOnDiskUnexpectedlyChanged(Exception): pass
 
 
-# TODO: Rename to Storage
-class WalletStorage(Logger):
+class FileStorage(Logger):
 
     # TODO maybe split this into separate create() and open() classmethods, to prevent some bugs.
     #      Until then, the onus is on the caller to check file_exists().
@@ -68,6 +67,7 @@ class WalletStorage(Logger):
         self.path = standardize_path(path)
         self._file_exists = bool(self.path and os.path.exists(self.path))
         self.logger.info(f"wallet path {self.path}")
+
         self._allow_partial_writes = allow_partial_writes
         self.pubkey = None
         self.decrypted = ''
@@ -254,7 +254,4 @@ class WalletStorage(Logger):
         else:
             self.pubkey = None
             self._encryption_version = StorageEncryptionVersion.PLAINTEXT
-
-    def basename(self) -> str:
-        return os.path.basename(self.path)
 

--- a/electrum/stored_dict.py
+++ b/electrum/stored_dict.py
@@ -296,6 +296,9 @@ class StoredDict(BaseStoredObject):
     def should_convert(self):
         return self._db._should_convert
 
+    def write_batch(self):
+        return self._db.write_batch()
+
     def dump(self) -> dict:
         data = {}
         for k, v in self.items():

--- a/electrum/stored_dict.py
+++ b/electrum/stored_dict.py
@@ -151,6 +151,7 @@ class BaseStoredObject:
     _parent: Optional['BaseStoredObject'] = None
     _lock: threading.RLock = None
     _path = None
+    _hint = None
 
     def set_db(self, db):
         self._db = db
@@ -182,8 +183,15 @@ class BaseStoredObject:
         #    value = tuple(value[:]) # do not expose StoredTuple to callers
         return value
 
+    @property
+    def hint(self):
+        # cached object returned by the db (performance optimization)
+        if self._hint is None:
+            self._hint = self._db.get_hint(self._path)
+        return self._hint
+
     def db_get(self, key):
-        value = self._db.get(key)
+        value = self._db.get(self.hint, key)
         value = self._to_stored_dict_or_list(key, value)
         # set db for StoredObject, because it is not set in the constructor
         if isinstance(value, StoredObject):
@@ -237,7 +245,7 @@ class StoredObject(BaseStoredObject):
         assert isinstance(key, str), repr(key)
         if not key.startswith('_') and self._path:
             if value != getattr(self, key):
-                self._db.replace(self._path, key, value)
+                self._db.replace(self.hint, self._path, key, value)
         object.__setattr__(self, key, value)
 
     def to_json(self):
@@ -287,32 +295,32 @@ class StoredDict(BaseStoredObject):
             value.set_parent(key=key, parent=self)
         if isinstance(value, (StoredList, StoredDict)):
             value = value.dump()
-        self._db.put(self._path, key, value)
+        self._db.put(self.hint, self._path, key, value)
 
     def __delitem__(self, key: _FLEX_KEY) -> None:
-        self._db.remove(self._path, key)
+        self._db.remove(self.hint, self._path, key)
 
     def __iter__(self) -> Iterator[str]:
-        return self._db.iter_keys(self._path)
+        return self._db.iter_keys(self.hint, self._path)
 
     def __len__(self) -> int:
-        return self._db.dict_len(self._path)
+        return self._db.dict_len(self.hint, self._path)
 
     # ---- Dict-like extras ----
 
     def __contains__(self, key: object) -> bool:
-        return self._db.contains(self._path, key)
+        return self._db.dict_contains(self.hint, self._path, key)
 
     def keys(self) -> Iterable[str]:
-        for k in self._db.iter_keys(self._path):
+        for k in self._db.iter_keys(self.hint, self._path):
             yield k
 
     def values(self) -> Iterator[Any]:
-        for k in self._db.iter_keys(self._path):
+        for k in self._db.iter_keys(self.hint, self._path):
             yield self[k]
 
     def items(self) -> Iterator[Tuple[str, Any]]:
-        for k in self._db.iter_keys(self._path):
+        for k in self._db.iter_keys(self.hint, self._path):
             yield (k, self[k])
 
     def get(self, key: _FLEX_KEY, default: Any = None, add_if_missing=False) -> Any:
@@ -327,7 +335,7 @@ class StoredDict(BaseStoredObject):
             return default
 
     def clear(self) -> None:
-        self._db.clear(self._path)
+        self._db.clear(self.hint, self._path)
 
     def pop(self, key: _FLEX_KEY, default: Any = _RaiseKeyError) -> Any:
         # This will return dict/list
@@ -380,7 +388,7 @@ class StoredList(BaseStoredObject):
         return self.db_get(key)
 
     def __getitem__(self, s: slice) -> Any:
-        n = self._db.list_len(self._path)
+        n = self._db.list_len(self.hint, self._path)
         if type(s) is int:
             s = n + s if s < 0 else s
             return self._get_list_item(s)
@@ -393,24 +401,24 @@ class StoredList(BaseStoredObject):
             raise Exception()
 
     def __len__(self):
-        return self._db.list_len(self._path)
+        return self._db.list_len(self.hint, self._path)
 
     def __iter__(self) -> Iterator[str]:
-        for i in range(self._db.list_len(self._path)):
+        for i in range(self._db.list_len(self.hint, self._path)):
             yield self._get_list_item(i)
 
     def append(self, value):
-        self._db.list_append(self._path, value)
+        self._db.list_append(self.hint, self._path, value)
 
     def clear(self):
-        self._db.list_clear(self._path)
+        self._db.list_clear(self.hint, self._path)
         assert len(self) == 0
 
     def index(self, item) -> int:
-        return self._db.list_index(self._path, item)
+        return self._db.list_index(self.hint, self._path, item)
 
     def remove(self, item):
-        self._db.list_remove(self._path, item)
+        self._db.list_remove(self.hint, self._path, item)
 
     def dump(self) -> list:
         data = []

--- a/electrum/stored_dict.py
+++ b/electrum/stored_dict.py
@@ -89,39 +89,29 @@ def stored_at(path, _type=dict):
     return decorator
 
 
-def _walk_path(d, path):
-    for k in path:
-        if k in d:
-            d = d[k]
-        elif '*' in d:
-            d = d['*']
-        else:
-            return None
-    return d
-
-def _convert_dict_key(path: List[str], key: str) -> _FLEX_KEY:
-    """Maybe convert key from str to python type (typically int or IntEnum)"""
-    assert all(isinstance(x, str) for x in path), repr(path)
-    r = _walk_path(registered_keys, path)
-    if r:
-        if func := r.get('self'):
-            key = func(key)
-    assert isinstance(key, _FLEX_KEY), f"unexpected type for {key=!r} at {path=}"
-    return key
-
-def _convert_dict_value(path: List[str], v) -> Any:
-    assert all(isinstance(x, str) for x in path), repr(path)
-    r = _walk_path(registered_names, path)
-    if r and type(r) is tuple:
-        _type, constructor = r
-        if _type == dict:
-            v = constructor(**v)
-        elif _type == tuple:
-            v = constructor(*v)
-        else:
-            v = constructor(v)
-    return v
-
+def to_default(obj):
+    """Convert user-defined classes to python built-in types.
+    Also convert bytes to hex, so that the result is json serializable.
+    """
+    if obj is None or isinstance(obj, (str, int, float)):
+        return obj
+    if isinstance(obj, bytes):
+        return obj.hex()
+    if hasattr(obj, 'as_str') and callable(obj.as_str):
+        return obj.as_str()
+    if hasattr(obj, 'as_dict') and callable(obj.as_dict):
+        obj = obj.as_dict()
+    if hasattr(obj, 'as_tuple') and callable(obj.as_tuple):
+        obj = obj.as_tuple()
+    if isinstance(obj, (set, frozenset)):
+        return [to_default(x) for x in list(obj)]
+    if isinstance(obj, dict):
+        return dict([(key_to_str(k), to_default(v)) for k, v in obj.items()])
+    if isinstance(obj, list):
+        return [to_default(x) for x in obj]
+    if isinstance(obj, tuple):
+        return tuple([to_default(x) for x in list(obj)])
+    raise Exception('unsupported type', type(obj))
 
 
 
@@ -131,6 +121,7 @@ class BaseDB(Logger):
         Logger.__init__(self)
         self._write_batch = None
         self.path = path
+        self._should_convert = True
 
     def file_exists(self):
         raise NotImplementedError()
@@ -178,9 +169,9 @@ class BaseStoredObject:
             value = StoredList(self._db, key=key, parent=self)
         elif isinstance(value, dict):
             value = StoredDict(self._db, key=key, parent=self)
-        #elif isinstance(value, tuple):
-        #    value = StoredList(self._db, key=key, parent=self)
-        #    value = tuple(value[:]) # do not expose StoredTuple to callers
+        elif isinstance(value, tuple):
+            value = StoredList(self._db, key=key, parent=self)
+            value = tuple(value[:]) # do not expose StoredTuple to callers
         return value
 
     @property
@@ -193,11 +184,36 @@ class BaseStoredObject:
     def db_get(self, key):
         value = self._db.get(self.hint, key)
         value = self._to_stored_dict_or_list(key, value)
+        if not self.should_convert():
+            return value
+        value = self._convert_value(key, value)
         # set db for StoredObject, because it is not set in the constructor
         if isinstance(value, StoredObject):
             value.set_db(self._db)
             value.set_parent(key=key, parent=self)
         return value
+
+    def _convert_key(self, key: str) -> _FLEX_KEY:
+        """Maybe convert key from str to python type (typically int or IntEnum)"""
+        if self._key_converters:
+            if func := self._key_converters.get('self'):
+                key = func(key)
+        assert isinstance(key, _FLEX_KEY), f"unexpected type for {key=!r} at {self._path}"
+        return key
+
+    def _convert_value(self, key, v) -> Any:
+        reg = self.get_constructor(key)
+        if reg:
+            if isinstance(v, (StoredDict, StoredList)):
+                v = v.dump()
+            _type, constructor = reg
+            if _type == dict:
+                v = constructor(**v)
+            elif _type == tuple:
+                v = constructor(*v)
+            else:
+                v = constructor(v)
+        return v
 
     def get_constructor(self, key):
         if self._constructor:
@@ -245,10 +261,10 @@ class StoredObject(BaseStoredObject):
         assert isinstance(key, str), repr(key)
         if not key.startswith('_') and self._path:
             if value != getattr(self, key):
-                self._db.replace(self.hint, self._path, key, value)
+                self._db.replace(self.hint, self._path, key, to_default(value))
         object.__setattr__(self, key, value)
 
-    def to_json(self):
+    def as_dict(self):
         d = dict(vars(self))
         # don't expose/store private stuff
         d = {k: v for k, v in d.items()
@@ -277,6 +293,9 @@ class StoredDict(BaseStoredObject):
         self.init_constructor()
         self.init_key_converters()
 
+    def should_convert(self):
+        return self._db._should_convert
+
     def dump(self) -> dict:
         data = {}
         for k, v in self.items():
@@ -286,18 +305,23 @@ class StoredDict(BaseStoredObject):
         return data
 
     def __getitem__(self, key: _FLEX_KEY) -> Any:
+        key = key_to_str(key)
         return self.db_get(key)
 
     def __setitem__(self, key: _FLEX_KEY, value: Any) -> None:
+        key = key_to_str(key)
         if isinstance(value, StoredObject):
             # side effect
             value.set_db(self._db)
             value.set_parent(key=key, parent=self)
         if isinstance(value, (StoredList, StoredDict)):
             value = value.dump()
+        # convert to python
+        value = to_default(value)
         self._db.put(self.hint, self._path, key, value)
 
     def __delitem__(self, key: _FLEX_KEY) -> None:
+        key = key_to_str(key)
         self._db.remove(self.hint, self._path, key)
 
     def __iter__(self) -> Iterator[str]:
@@ -309,11 +333,12 @@ class StoredDict(BaseStoredObject):
     # ---- Dict-like extras ----
 
     def __contains__(self, key: object) -> bool:
+        key = key_to_str(key)
         return self._db.dict_contains(self.hint, self._path, key)
 
     def keys(self) -> Iterable[str]:
         for k in self._db.iter_keys(self.hint, self._path):
-            yield k
+            yield self._convert_key(k)
 
     def values(self) -> Iterator[Any]:
         for k in self._db.iter_keys(self.hint, self._path):
@@ -321,7 +346,7 @@ class StoredDict(BaseStoredObject):
 
     def items(self) -> Iterator[Tuple[str, Any]]:
         for k in self._db.iter_keys(self.hint, self._path):
-            yield (k, self[k])
+            yield (self._convert_key(k), self[k])
 
     def get(self, key: _FLEX_KEY, default: Any = None, add_if_missing=False) -> Any:
         # If add_if_missing is True, create DB entry if it does not exist.
@@ -383,6 +408,9 @@ class StoredList(BaseStoredObject):
         self.init_constructor()
         self.init_key_converters()
 
+    def should_convert(self):
+        return self._db._should_convert
+
     def _get_list_item(self, key: int):
         key = int(key)
         return self.db_get(key)
@@ -408,6 +436,7 @@ class StoredList(BaseStoredObject):
             yield self._get_list_item(i)
 
     def append(self, value):
+        value = to_default(value)
         self._db.list_append(self.hint, self._path, value)
 
     def clear(self):
@@ -415,9 +444,11 @@ class StoredList(BaseStoredObject):
         assert len(self) == 0
 
     def index(self, item) -> int:
+        item = to_default(item)
         return self._db.list_index(self.hint, self._path, item)
 
     def remove(self, item):
+        item = to_default(item)
         self._db.list_remove(self.hint, self._path, item)
 
     def dump(self) -> list:

--- a/electrum/stored_dict.py
+++ b/electrum/stored_dict.py
@@ -24,16 +24,16 @@
 # SOFTWARE.
 
 import threading
-import json
+import os
 from enum import IntEnum
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, Sequence, List, Union, Any
+from typing import Any, Optional, Tuple, Union, Iterator, Iterable, List, Sequence
+from .logging import Logger
 
 
-if TYPE_CHECKING:
-    from .json_db import JsonDB
-    from .storage import WalletStorage
+_FLEX_KEY = str | int | None
 
+_RaiseKeyError = object() # singleton for no-default behavior
 
 class StorageReadWriteError(Exception): pass
 
@@ -43,11 +43,21 @@ class StorageEncryptionVersion(IntEnum):
     XPUB_PASSWORD = 2
 
 
-def locked(func):
-    def wrapper(self, *args, **kwargs):
-        with self.lock:
-            return func(self, *args, **kwargs)
-    return wrapper
+def normalize_key(x: _FLEX_KEY) -> str:
+    if isinstance(x, int):
+        return int(x)
+    elif isinstance(x, str):
+        return x
+    else:
+        raise Exception(f"key {x=}")
+
+def key_to_str(x: _FLEX_KEY) -> str:
+    if isinstance(x, int):
+        return str(int(x))
+    elif isinstance(x, str):
+        return x
+    else:
+        raise Exception(f"key {x=}")
 
 
 registered_names = {}
@@ -78,7 +88,6 @@ def stored_at(path, _type=dict):
         return func
     return decorator
 
-_FLEX_KEY = str | int | None
 
 def _walk_path(d, path):
     for k in path:
@@ -115,12 +124,33 @@ def _convert_dict_value(path: List[str], v) -> Any:
 
 
 
+
+class BaseDB(Logger):
+
+    def __init__(self, path):
+        Logger.__init__(self)
+        self._write_batch = None
+        self.path = path
+
+    def file_exists(self):
+        raise NotImplementedError()
+
+    def get_path(self):
+        return self.path
+
+    def set_password(self, password:str):
+        raise NotImplementedError()
+
+
+
+
 class BaseStoredObject:
 
-    _db: 'JsonDB' = None
+    _db: BaseDB = None
     _key: _FLEX_KEY = None
     _parent: Optional['BaseStoredObject'] = None
     _lock: threading.RLock = None
+    _path = None
 
     def set_db(self, db):
         self._db = db
@@ -131,6 +161,7 @@ class BaseStoredObject:
         assert isinstance(key, _FLEX_KEY), repr(key)
         self._key = key
         self._parent = parent
+        self._path = self._parent._path + [key] if parent else ['']
 
     @property
     def lock(self):
@@ -138,31 +169,65 @@ class BaseStoredObject:
 
     @property
     def path(self) -> Sequence[_FLEX_KEY] | None:
-        # return None iff we are pruned from root
-        x = self
-        s = [x._key]
-        while x._parent is not None:
-            x = x._parent
-            s = [x._key] + s
-        if x._key != '':
-            return None
-        assert self._db is not None
-        return s
+        return self._path
 
-    def db_add(self, key: _FLEX_KEY, value) -> None:
-        assert isinstance(key, _FLEX_KEY), repr(key)
-        if self.path:
-            self._db.add(self.path, key, value)
+    def _to_stored_dict_or_list(self, key, value):
+        """convert list to StoredList, dict to StoredDict"""
+        if isinstance(value, list):
+            value = StoredList(self._db, key=key, parent=self)
+        elif isinstance(value, dict):
+            value = StoredDict(self._db, key=key, parent=self)
+        #elif isinstance(value, tuple):
+        #    value = StoredList(self._db, key=key, parent=self)
+        #    value = tuple(value[:]) # do not expose StoredTuple to callers
+        return value
 
-    def db_replace(self, key: _FLEX_KEY, value) -> None:
-        assert isinstance(key, _FLEX_KEY), repr(key)
-        if self.path:
-            self._db.replace(self.path, key, value)
+    def db_get(self, key):
+        value = self._db.get(key)
+        value = self._to_stored_dict_or_list(key, value)
+        # set db for StoredObject, because it is not set in the constructor
+        if isinstance(value, StoredObject):
+            value.set_db(self._db)
+            value.set_parent(key=key, parent=self)
+        return value
 
-    def db_remove(self, key: _FLEX_KEY) -> None:
-        assert isinstance(key, _FLEX_KEY), repr(key)
-        if self.path:
-            self._db.remove(self.path, key)
+    def get_constructor(self, key):
+        if self._constructor:
+            r = self._constructor.get(key, self._constructor.get('*', None))
+            if type(r) is tuple:
+                return r
+
+    def init_constructor(self):
+        if self._parent is None:
+            self._constructor = registered_names
+        else:
+            d = self._parent._constructor
+            if d is None:
+                return
+            if self._key in d:
+                d = d[self._key]
+            elif '*' in d:
+                d = d['*']
+            else:
+                d = None
+            if d and type(d) is dict:
+                self._constructor = d
+
+    def init_key_converters(self):
+        if self._parent is None:
+            self._key_converters = registered_keys
+        else:
+            d = self._parent._key_converters
+            if d is None:
+                return
+            if self._key in d:
+                d = d[self._key]
+            elif '*' in d:
+                d = d['*']
+            else:
+                d = None
+            if d and type(d) is dict:
+                self._key_converters = d
 
 
 class StoredObject(BaseStoredObject):
@@ -170,9 +235,9 @@ class StoredObject(BaseStoredObject):
 
     def __setattr__(self, key: str, value):
         assert isinstance(key, str), repr(key)
-        if self.path and not key.startswith('_'):
+        if not key.startswith('_') and self._path:
             if value != getattr(self, key):
-                self.db_replace(key, value)
+                self._db.replace(self._path, key, value)
         object.__setattr__(self, key, value)
 
     def to_json(self):
@@ -183,66 +248,112 @@ class StoredObject(BaseStoredObject):
         return d
 
 
+class StoredDict(BaseStoredObject):
+    """
+    dict-like object that queries the DB
+    type conversions are performed here
 
-_RaiseKeyError = object() # singleton for no-default behavior
+    the DB object returns simple python objects: list or dict
+    this class converts them
+    """
 
+    def __init__(self, db: BaseDB, key: _FLEX_KEY, parent):
+        BaseStoredObject.__init__(self)
+        self._db = db
+        self._lock = db.lock
+        self._parent = parent
+        self._key = normalize_key(key)
+        self._path = self._parent._path + [self._key] if parent else ['']
+        self._constructor = None # func or Dict[str, func]
+        self._key_converters = None
+        self.init_constructor()
+        self.init_key_converters()
 
-class StoredDict(dict, BaseStoredObject):
+    def dump(self) -> dict:
+        data = {}
+        for k, v in self.items():
+            if isinstance(v, (StoredDict, StoredList)):
+                v = v.dump()
+            data[k] = v
+        return data
 
-    def __init__(self, data: dict, db: 'JsonDB'):
-        self.set_db(db)
-        # recursively convert dicts to StoredDict
-        for k, v in list(data.items()):
-            self.__setitem__(k, v)
+    def __getitem__(self, key: _FLEX_KEY) -> Any:
+        return self.db_get(key)
 
-    @locked
-    def __setitem__(self, key: _FLEX_KEY, v) -> None:
-        assert isinstance(key, _FLEX_KEY), repr(key)
-        is_new = key not in self
-        # early return to prevent unnecessary disk writes
-        if not is_new and self._db and json.dumps(v, cls=self._db.encoder) == json.dumps(self[key], cls=self._db.encoder):
-            return
-        # convert dict to StoredDict.
-        if type(v) == dict and (self._db is None or self._db._should_convert_to_stored_dict(key)):
-            v = StoredDict(v, self._db)
-        # convert list to StoredList
-        elif type(v) == list:
-            v = StoredList(v, self._db)
-        # reject sets. they do not work well with jsonpatch
-        elif isinstance(v, set):
-            raise Exception(f"Do not store sets inside jsondb. path={self.path!r}")
-        # set db for StoredObject, because it is not set in the constructor
-        if isinstance(v, StoredObject):
-            v.set_db(self._db)
-        # set parent
-        if isinstance(v, BaseStoredObject):
-            v.set_parent(key=key, parent=self)
-        # set item
-        dict.__setitem__(self, key, v)
-        self.db_add(key, v) if is_new else self.db_replace(key, v)
+    def __setitem__(self, key: _FLEX_KEY, value: Any) -> None:
+        if isinstance(value, StoredObject):
+            # side effect
+            value.set_db(self._db)
+            value.set_parent(key=key, parent=self)
+        if isinstance(value, (StoredList, StoredDict)):
+            value = value.dump()
+        self._db.put(self._path, key, value)
 
-    @locked
     def __delitem__(self, key: _FLEX_KEY) -> None:
-        assert isinstance(key, _FLEX_KEY), repr(key)
-        r  = self.get(key, None)
-        dict.__delitem__(self, key)
-        self.db_remove(key)
-        if isinstance(r, BaseStoredObject):
-            r._parent = None
+        self._db.remove(self._path, key)
 
-    @locked
-    def pop(self, key: _FLEX_KEY, v=_RaiseKeyError) -> Any:
-        assert isinstance(key, _FLEX_KEY), repr(key)
-        if key not in self:
-            if v is _RaiseKeyError:
-                raise KeyError(key)
-            else:
-                return v
-        r = dict.pop(self, key)
-        self.db_remove(key)
-        if isinstance(r, BaseStoredObject):
-            r._parent = None
-        return r
+    def __iter__(self) -> Iterator[str]:
+        return self._db.iter_keys(self._path)
+
+    def __len__(self) -> int:
+        return self._db.dict_len(self._path)
+
+    # ---- Dict-like extras ----
+
+    def __contains__(self, key: object) -> bool:
+        return self._db.contains(self._path, key)
+
+    def keys(self) -> Iterable[str]:
+        for k in self._db.iter_keys(self._path):
+            yield k
+
+    def values(self) -> Iterator[Any]:
+        for k in self._db.iter_keys(self._path):
+            yield self[k]
+
+    def items(self) -> Iterator[Tuple[str, Any]]:
+        for k in self._db.iter_keys(self._path):
+            yield (k, self[k])
+
+    def get(self, key: _FLEX_KEY, default: Any = None, add_if_missing=False) -> Any:
+        # If add_if_missing is True, create DB entry if it does not exist.
+        # This will return StoredDict/StoredList if default is dict/list
+        try:
+            return self[key]
+        except KeyError:
+            if add_if_missing:
+                self[key] = default
+                return self[key]
+            return default
+
+    def clear(self) -> None:
+        self._db.clear(self._path)
+
+    def pop(self, key: _FLEX_KEY, default: Any = _RaiseKeyError) -> Any:
+        # This will return dict/list
+        try:
+            v = self[key]
+        except KeyError:
+            if default is _RaiseKeyError:
+                raise
+            return default
+        if isinstance(v, (StoredList, StoredDict)):
+            v = v.dump()
+        del self[key]
+        return v
+
+    def update(self, other=(), /, **kwargs) -> None:
+        if isinstance(other, dict):
+            pairs = list(other.items())
+        else:
+            pairs = list(other)
+        pairs.extend(kwargs.items())
+        for k, v in pairs:
+            self[k] = v
+
+    def as_dict(self) -> dict:
+        """used by keystore"""
+        return self.dump()
 
     def setdefault(self, key: _FLEX_KEY, default = None, /):
         assert isinstance(key, _FLEX_KEY), repr(key)
@@ -251,28 +362,124 @@ class StoredDict(dict, BaseStoredObject):
         return self[key]
 
 
-class StoredList(list, BaseStoredObject):
+class StoredList(BaseStoredObject):
 
-    def __init__(self, data, db: 'JsonDB'):
-        list.__init__(self, data)
-        self.set_db(db)
+    def __init__(self, db: BaseDB, key: _FLEX_KEY, parent):
+        self._db = db
+        self._lock = db.lock
+        self._parent = parent
+        self._key = normalize_key(key)
+        self._path = self._parent._path + [self._key]
+        self._constructor = None
+        self._key_converters = None
+        self.init_constructor()
+        self.init_key_converters()
 
-    @locked
-    def append(self, item):
-        n = len(self)
-        list.append(self, item)
-        self.db_add('%d'%n, item)
+    def _get_list_item(self, key: int):
+        key = int(key)
+        return self.db_get(key)
 
-    @locked
-    def remove(self, item):
-        n = self.index(item)
-        list.remove(self, item)
-        self.db_remove('%d'%n)
+    def __getitem__(self, s: slice) -> Any:
+        n = self._db.list_len(self._path)
+        if type(s) is int:
+            s = n + s if s < 0 else s
+            return self._get_list_item(s)
+        elif type(s) is slice:
+            start = 0 if s.start is None else s.start if s.start >= 0 else n + s.start
+            stop = n if s.stop is None else s.stop if s.stop >= 0 else n + s.stop
+            step = 1 if s.step is None else s.step
+            return [self._get_list_item(i) for i in range(start, stop, step)]
+        else:
+            raise Exception()
 
-    @locked
+    def __len__(self):
+        return self._db.list_len(self._path)
+
+    def __iter__(self) -> Iterator[str]:
+        for i in range(self._db.list_len(self._path)):
+            yield self._get_list_item(i)
+
+    def append(self, value):
+        self._db.list_append(self._path, value)
+
     def clear(self):
-        list.clear(self)
-        self.db_replace(None, [])
+        self._db.list_clear(self._path)
+        assert len(self) == 0
+
+    def index(self, item) -> int:
+        return self._db.list_index(self._path, item)
+
+    def remove(self, item):
+        self._db.list_remove(self._path, item)
+
+    def dump(self) -> list:
+        data = []
+        for v in self:
+            if isinstance(v, (dict, list)):
+                raise Exception()
+            if isinstance(v, (StoredDict, StoredList)):
+                v = v.dump()
+            data.append(v)
+        return data
 
 
 
+class WalletStorage(StoredDict):
+    """ stored dict at the root of the file """
+
+    def __init__(self, path: str, init_db: bool = True, allow_partial_writes: bool = True):
+        from .json_db import JsonDB
+        db = JsonDB(path=path, init_db=init_db, allow_partial_writes=allow_partial_writes)
+        StoredDict.__init__(self, db, key='', parent=None)
+
+    def file_exists(self):
+        return self._db.file_exists()
+
+    def is_encrypted(self):
+        return self._db.is_encrypted()
+
+    def decrypt(self, pw:str):
+        return self._db.decrypt(pw)
+
+    def get_path(self):
+        return self._db.get_path()
+
+    def set_password(self, password:str, enc_version=None):
+        return self._db.set_password(password, enc_version)
+
+    def set_data(self, data:str):
+        return self._db.set_data(data)
+
+    def set_modified(self, b: bool):
+        return self._db.set_modified(b)
+
+    def write_and_force_consolidation(self):
+        self._db.write_and_force_consolidation()
+
+    def get_encryption_version(self) -> StorageEncryptionVersion:
+        return self._db.get_encryption_version()
+
+    def check_password(self, password):
+        self._db.check_password(password)
+
+    def supports_file_encryption(self):
+        return self._db.supports_file_encryption()
+
+    def is_encrypted_with_hw_device(self):
+        return self._db.is_encrypted_with_hw_device()
+
+    def is_encrypted_with_user_pw(self):
+        return self._db.is_encrypted_with_user_pw()
+
+    def write(self):
+        return self._db.write()
+
+    def close(self):
+        return self._db.close()
+
+    def is_closed(self):
+        return self._db.is_closed()
+
+    def basename(self) -> str:
+        path = self.get_path()
+        return os.path.basename(path) if path else 'no name'

--- a/electrum/stored_dict.py
+++ b/electrum/stored_dict.py
@@ -432,7 +432,7 @@ class StoredList(BaseStoredObject):
 
 
 
-class WalletStorage(StoredDict):
+class DictStorage(StoredDict):
     """ stored dict at the root of the file """
 
     def __init__(self, path: str, init_db: bool = True, allow_partial_writes: bool = True):

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -40,6 +40,7 @@ from .util import (
 )
 from . import lnutil
 from .lnutil import hex_to_bytes, REDEEM_AFTER_DOUBLE_SPENT_DELAY, Keypair
+
 from .bolt11 import decode_bolt11_invoice
 from .stored_dict import StoredObject, stored_at
 from . import constants
@@ -290,6 +291,7 @@ class SwapManager(Logger):
         for k, swap in swaps_items:
             if swap.is_redeemed:
                 continue
+            swap._payment_hash = bytes.fromhex(k)
             self.add_lnwatcher_callback(swap)
         asyncio.run_coroutine_threadsafe(self.main_loop(), self.network.asyncio_loop)
 

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -164,6 +164,9 @@ class TxOutput:
             return TYPE_ADDRESS, self.address, self.value
         return TYPE_SCRIPT, self.scriptpubkey.hex(), self.value
 
+    def as_tuple(self):
+        return self.to_legacy_tuple()
+
     @classmethod
     def from_legacy_tuple(cls, _type: int, addr: str, val: Union[int, str]) -> Union['TxOutput', 'PartialTxOutput']:
         if _type == TYPE_ADDRESS:
@@ -305,8 +308,8 @@ class TxOutpoint(NamedTuple):
     def to_str(self) -> str:
         return f"{self.txid.hex()}:{self.out_idx}"
 
-    def to_json(self):
-        return [self.txid.hex(), self.out_idx]
+    def as_tuple(self):
+        return (self.txid.hex(), self.out_idx)
 
     def serialize_to_network(self) -> bytes:
         return self.txid[::-1] + int.to_bytes(self.out_idx, length=4, byteorder="little", signed=False)
@@ -906,6 +909,9 @@ class Transaction:
 
     def __str__(self):
         return self.serialize()
+
+    def as_str(self):
+        return str(self)
 
     def __init__(self, raw):
         if raw is None:

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -70,6 +70,7 @@ import dns.asyncresolver
 
 from .i18n import _
 from .logging import get_logger, Logger
+from .stored_dict import stored_at
 
 if TYPE_CHECKING:
     from .network import Network, ProxySettings
@@ -342,6 +343,12 @@ class MyEncoder(json.JSONEncoder):
             return obj.hex()
         if hasattr(obj, 'to_json') and callable(obj.to_json):
             return obj.to_json()
+        if hasattr(obj, 'to_str') and callable(obj.to_str):
+            return obj.to_str()
+        if hasattr(obj, 'as_tuple') and callable(obj.as_tuple):
+            return obj.as_tuple()
+        if hasattr(obj, 'as_dict') and callable(obj.as_dict):
+            return obj.as_dict()
         return super(MyEncoder, self).default(obj)
 
 
@@ -1258,6 +1265,19 @@ class TxMinedInfo:
     txpos: Optional[int] = None        # position of tx in serialized block
     header_hash: Optional[str] = None  # hash of block that mined tx
     wanted_height: Optional[int] = None  # in case of timelock, min abs block height
+
+    def as_tuple(self):
+        return (self._height, self.timestamp, self.txpos, self.header_hash)
+
+    @staticmethod
+    @stored_at('/verified_tx3/*', tuple)
+    def from_tuple(height, timestamp, txpos, header_hash):
+        return TxMinedInfo(
+            _height=height,
+            timestamp=timestamp,
+            txpos=txpos,
+            header_hash=header_hash,
+        )
 
     def height(self) -> int:
         """Treat unverified heights as unconfirmed."""

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -500,7 +500,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def save_backup(self, backup_dir):
         import json
-        from .util import MyEncoder
+        from .stored_dict import to_default
         # create data
         data = self.storage.dump()
         if self.lnworker:
@@ -511,10 +511,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             data.pop('channels', None)
             data.pop('lightning_privkey2', None)
         json_str = json.dumps(
-            data,
+            to_default(data),
             indent=4,
             sort_keys=True,
-            cls=MyEncoder,
         )
         new_path = os.path.join(backup_dir, self.basename() + '.backup')
         new_storage = DictStorage(path=new_path)
@@ -2962,7 +2961,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     def export_request(self, x: Request) -> Dict[str, Any]:
         key = x.get_id()
         status = self.get_invoice_status(x)
-        d = x.as_dict(status)
+        d = x.export(status)
         d['request_id'] = d.pop('id')
         if x.is_lightning():
             d['rhash'] = x.rhash
@@ -2988,7 +2987,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     def export_invoice(self, x: Invoice) -> Dict[str, Any]:
         key = x.get_id()
         status = self.get_invoice_status(x)
-        d = x.as_dict(status)
+        d = x.export(status)
         d['invoice_id'] = d.pop('id')
         if x.is_lightning():
             d['lightning_invoice'] = x.lightning_invoice
@@ -4539,6 +4538,8 @@ def restore_wallet_from_text(
         if gap_limit_for_change is not None:
             db.put('gap_limit_for_change', gap_limit_for_change)
         wallet = wallet_factory(db, config=config)
+    if storage:
+        assert not storage.file_exists(), "file was created too soon! plaintext keys might have been written to disk"
     wallet.synchronize()
     msg = ("This wallet was restored offline. It may contain more addresses than displayed. "
            "Start a daemon and use load_wallet to sync its history.")

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -4538,8 +4538,6 @@ def restore_wallet_from_text(
         if gap_limit_for_change is not None:
             db.put('gap_limit_for_change', gap_limit_for_change)
         wallet = wallet_factory(db, config=config)
-    if storage:
-        assert not storage.file_exists(), "file was created too soon! plaintext keys might have been written to disk"
     wallet.synchronize()
     msg = ("This wallet was restored offline. It may contain more addresses than displayed. "
            "Start a daemon and use load_wallet to sync its history.")

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -55,7 +55,7 @@ from .util import (
     WalletFileException, BitcoinException, InvalidPassword, format_time, timestamp_to_datetime,
     Satoshis, Fiat, TxMinedInfo, quantize_feerate, OrderedDictWithIndex, multisig_type, parse_max_spend,
     OnchainHistoryItem, read_json_file, write_json_file, UserFacingException, FileImportFailed, EventListener,
-    event_listener
+    event_listener, standardize_path
 )
 from .bitcoin import COIN, is_address, is_minikey, relayfee, dust_threshold, DummyAddress, DummyAddressUsedInTxException
 from .keystore import (
@@ -63,8 +63,6 @@ from .keystore import (
 )
 from .simple_config import SimpleConfig
 from .fee_policy import FeePolicy, FixedFeePolicy, FEE_RATIO_HIGH_WARNING, FEERATE_WARNING_HIGH_FEE
-from .stored_dict import StorageEncryptionVersion
-from .storage import  WalletStorage
 from .wallet_db import WalletDB
 from .transaction import (
     Transaction, TxInput, TxOutput, PartialTransaction, PartialTxInput, PartialTxOutput, TxOutpoint, Sighash
@@ -83,6 +81,7 @@ from .lntransport import extract_nodeid
 from .descriptor import Descriptor
 from .txbatcher import TxBatcher
 from .submarine_swaps import MIN_SWAP_AMOUNT_SAT
+from .stored_dict import WalletStorage, StorageEncryptionVersion
 
 if TYPE_CHECKING:
     from .network import Network
@@ -408,7 +407,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self.config = config
         assert self.config is not None, "config must not be None"
         self.db = db
-        self.storage = db.storage  # type: Optional[WalletStorage]
+        self.storage = db.storage  # type: StoredDict
         # load addresses needs to be called before constructor for sanity checks
         db.load_addresses(self.wallet_type)
         self.keystore = None  # type: Optional[KeyStore]  # will be set by load_keystore
@@ -460,7 +459,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self.up_to_date_changed_event = asyncio.Event()
 
         assert self.db.get('genesis_blockhash') == constants.net.GENESIS, self.db.get('genesis_blockhash')
-        if self.storage and self.has_storage_encryption():
+        if self.has_storage_encryption():
             if (se := self.storage.get_encryption_version()) not in (ae := self.get_available_storage_encryption_versions()):
                 raise WalletFileException(f"unexpected storage encryption type. found: {se!r}. allowed: {ae!r}")
 
@@ -496,24 +495,35 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             await run_in_thread(self.synchronize)
 
     def save_db(self):
-        if self.db.storage:
-            self.db.write()
+        if self.storage:
+            self.storage.write()
 
     def save_backup(self, backup_dir):
-        new_path = os.path.join(backup_dir, self.basename() + '.backup')
-        new_storage = WalletStorage(new_path)
-        new_storage._encryption_version = self.storage._encryption_version
-        new_storage.pubkey = self.storage.pubkey
-
-        new_db = WalletDB(self.db.dump(), storage=new_storage, upgrade=True)
+        import json
+        from .util import MyEncoder
+        # create data
+        data = self.storage.dump()
         if self.lnworker:
-            channel_backups = new_db.get_dict('imported_channel_backups')
+            channel_backups = data.get('imported_channel_backups', {})
             for chan_id, chan in self.lnworker.channels.items():
                 channel_backups[chan_id.hex()] = self.lnworker.create_channel_backup(chan_id)
-            new_db.put('channels', None)
-            new_db.put('lightning_privkey2', None)
-        new_db.set_modified(True)
-        new_db.write()
+            data['imported_channel_backups'] = channel_backups
+            data.pop('channels', None)
+            data.pop('lightning_privkey2', None)
+        json_str = json.dumps(
+            data,
+            indent=4,
+            sort_keys=True,
+            cls=MyEncoder,
+        )
+        new_path = os.path.join(backup_dir, self.basename() + '.backup')
+        new_storage = WalletStorage(path=new_path)
+        if self.storage.is_encrypted():
+            new_storage._db.storage._encryption_version = self.storage._db.storage._encryption_version
+            new_storage._db.storage.pubkey = self.storage._db.storage.pubkey
+        new_storage.set_data(json_str)
+        new_storage.set_modified(True)
+        new_storage.write_and_force_consolidation()
         return new_path
 
     def has_lightning(self) -> bool:
@@ -582,6 +592,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 self.save_keystore()
             self.db.prune_uninstalled_plugin_data(self.config.get_installed_plugins())
             self.save_db()
+            if self.storage:
+                self.storage.close()
 
     def is_up_to_date(self) -> bool:
         if self.taskgroup and self.taskgroup.joined:  # either stop() was called, or the taskgroup died
@@ -690,7 +702,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         assert self.lnworker.network is None, 'lnworker network already initialized'
         self.lnworker.start_network(self.network)
         # only start gossiping when we already have channels
-        if self.db.get('channels'):
+        if len(self.db.get_dict('channels')) > 0:
             self.network.start_gossip()
 
     @abstractmethod
@@ -710,7 +722,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         return []
 
     def basename(self) -> str:
-        return self.storage.basename() if self.storage else 'no_name'
+        return self.storage.basename()
 
     def check_returned_address_for_corruption(func):
         def wrapper(self, *args, **kwargs):
@@ -1759,7 +1771,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def get_all_labels(self) -> Dict[str, str]:
         with self.lock:
-            return copy.copy(self._labels)
+            return self._labels.dump()
 
     def get_tx_status(self, tx_hash: str, tx_mined_info: TxMinedInfo):
         extra = []
@@ -3183,7 +3195,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def has_storage_encryption(self) -> bool:
         """Returns whether encryption is enabled for the wallet file on disk."""
-        return bool(self.storage) and self.storage.is_encrypted()
+        return self.storage.is_encrypted()
 
     @classmethod
     def may_have_password(cls):
@@ -3204,7 +3216,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if old_pw is None and self.has_password():
             raise InvalidPassword()
         self.check_password(old_pw)
-        if self.storage:
+        if encrypt_storage:
+            assert self.storage.supports_file_encryption()
+        if self.storage.supports_file_encryption():
             if encrypt_storage:
                 enc_version = StorageEncryptionVersion.XPUB_PASSWORD if xpub_encrypt else StorageEncryptionVersion.USER_PASSWORD
                 assert enc_version in self.get_available_storage_encryption_versions()
@@ -3212,7 +3226,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 enc_version = StorageEncryptionVersion.PLAINTEXT
             self.storage.set_password(new_pw, enc_version)
         # make sure next storage.write() saves changes
-        self.db.set_modified(True)
+        self.storage.set_modified(True)
 
         # note: Encrypting storage with a hw device is currently only
         #       allowed for non-multisig wallets. Further,
@@ -3223,8 +3237,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         encrypt_keystore = self.can_have_keystore_encryption()
         self.db.set_keystore_encryption(bool(new_pw) and encrypt_keystore)
         # save changes. force full rewrite to rm remnants of old password
-        if self.storage and self.storage.file_exists():
-            self.db.write_and_force_consolidation()
+        if self.storage.file_exists():
+            self.storage.write_and_force_consolidation()
         # if wallet was previously unlocked, reset password_in_memory
         self.lock_wallet()
 
@@ -4435,12 +4449,12 @@ def create_new_wallet(
     gap_limit_for_change: Optional[int] = None,
 ) -> dict:
     """Create a new wallet"""
-    storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
-    if storage.file_exists():
+    if os.path.exists(standardize_path(path)):
         raise UserFacingException("Remove the existing wallet first!")
+    storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
     if encrypt_file:
         storage.set_password(password, StorageEncryptionVersion.USER_PASSWORD)
-    db = WalletDB('', storage=storage, upgrade=True)
+    db = WalletDB(storage)
     seed = Mnemonic('en').make_seed(seed_type=seed_type)
     k = keystore.from_seed(seed, passphrase=passphrase)
     k.update_password(None, password)
@@ -4478,14 +4492,15 @@ def restore_wallet_from_text(
     if encrypt_file is None:
         encrypt_file = True
     if path is None:  # create wallet in-memory
-        storage = None
+        storage = WalletStorage(None)
     else:
-        storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
-        if storage.file_exists():
+        if os.path.exists(standardize_path(path)):
             raise UserFacingException("Remove the existing wallet first!")
+        storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
         if encrypt_file:
             storage.set_password(password, StorageEncryptionVersion.USER_PASSWORD)
-    db = WalletDB('', storage=storage, upgrade=True)
+
+    db = WalletDB(storage)
     db.set_keystore_encryption(bool(password))
     text = text.strip()
     if keystore.is_address_list(text):
@@ -4524,8 +4539,6 @@ def restore_wallet_from_text(
         if gap_limit_for_change is not None:
             db.put('gap_limit_for_change', gap_limit_for_change)
         wallet = wallet_factory(db, config=config)
-    if db.storage:
-        assert not db.storage.file_exists(), "file was created too soon! plaintext keys might have been written to disk"
     wallet.synchronize()
     msg = ("This wallet was restored offline. It may contain more addresses than displayed. "
            "Start a daemon and use load_wallet to sync its history.")

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -81,7 +81,7 @@ from .lntransport import extract_nodeid
 from .descriptor import Descriptor
 from .txbatcher import TxBatcher
 from .submarine_swaps import MIN_SWAP_AMOUNT_SAT
-from .stored_dict import WalletStorage, StorageEncryptionVersion
+from .stored_dict import DictStorage, StorageEncryptionVersion
 
 if TYPE_CHECKING:
     from .network import Network
@@ -517,7 +517,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             cls=MyEncoder,
         )
         new_path = os.path.join(backup_dir, self.basename() + '.backup')
-        new_storage = WalletStorage(path=new_path)
+        new_storage = DictStorage(path=new_path)
         if self.storage.is_encrypted():
             new_storage._db.storage._encryption_version = self.storage._db.storage._encryption_version
             new_storage._db.storage.pubkey = self.storage._db.storage.pubkey
@@ -4420,7 +4420,7 @@ def register_constructor(wallet_type, constructor):
 class Wallet(object):
     """The main wallet "entry point".
     This class is actually a factory that will return a wallet of the correct
-    type when passed a WalletStorage instance."""
+    type when passed a WalletDB instance."""
 
     def __new__(cls, db: 'WalletDB', *, config: SimpleConfig) -> Abstract_Wallet:
         wallet_type = db.get('wallet_type')
@@ -4451,7 +4451,7 @@ def create_new_wallet(
     """Create a new wallet"""
     if os.path.exists(standardize_path(path)):
         raise UserFacingException("Remove the existing wallet first!")
-    storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
+    storage = DictStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
     if encrypt_file:
         storage.set_password(password, StorageEncryptionVersion.USER_PASSWORD)
     db = WalletDB(storage)
@@ -4492,11 +4492,11 @@ def restore_wallet_from_text(
     if encrypt_file is None:
         encrypt_file = True
     if path is None:  # create wallet in-memory
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
     else:
         if os.path.exists(standardize_path(path)):
             raise UserFacingException("Remove the existing wallet first!")
-        storage = WalletStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
+        storage = DictStorage(path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
         if encrypt_file:
             storage.set_password(password, StorageEncryptionVersion.USER_PASSWORD)
 

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -27,7 +27,7 @@ import json
 import copy
 from collections import defaultdict
 from typing import (Dict, Optional, List, Tuple, Set, Iterable, NamedTuple, Sequence, TYPE_CHECKING,
-                    Union, AbstractSet)
+                    Union, AbstractSet, Any)
 import time
 from functools import partial
 
@@ -35,21 +35,18 @@ import attr
 
 from . import bitcoin
 from . import constants
-from .util import profiler, WalletFileException, multisig_type, TxMinedInfo, MyEncoder
+from .util import with_lock as locked
+from .util import profiler, WalletFileException, multisig_type, TxMinedInfo
 from .keystore import bip44_derivation
 from .transaction import Transaction, TxOutpoint, tx_from_any, PartialTransaction, PartialTxOutput, BadHeaderMagic
 from .logging import Logger
 
 from .lnutil import HTLCOwner, ChannelType, RecvMPPResolution
-from .json_db import JsonDB, locked, modifier
-from . import stored_dict
-from .stored_dict import StoredObject, stored_at, register_key, register_name
+from .stored_dict import register_name, register_key
+from .stored_dict import StoredObject, StoredDict, StoredList, stored_at
 from .plugin import run_hook, plugin_loaders
 from .version import ELECTRUM_VERSION
 from .i18n import _
-
-if TYPE_CHECKING:
-    from .storage import WalletStorage
 
 
 class WalletRequiresUpgrade(WalletFileException):
@@ -685,6 +682,7 @@ class WalletDBUpgrader(Logger):
         invoices = self.data.get('invoices', {})
         for d in [invoices, requests]:
             for key, r in list(d.items()):
+                r = r.dump() # convert StoredDict/List to dict/list
                 _type = r.get('type', 0)
                 item = {
                     'type': _type,
@@ -928,6 +926,7 @@ class WalletDBUpgrader(Logger):
         for name in ['invoices', 'payment_requests']:
             invoices = self.data.get(name, {})
             for key, item in invoices.items():
+                item = item.dump() # convert StoredDict/List to dict/list
                 is_lightning = item['type'] == 2
                 lightning_invoice = item['invoice'] if is_lightning else None
                 outputs = item['outputs'] if not is_lightning else None
@@ -967,6 +966,7 @@ class WalletDBUpgrader(Logger):
             outputs_str = "\n".join(f"{txout.scriptpubkey.hex()}, {txout.value}" for txout in outputs)
             return sha256d(outputs_str + "%d" % timestamp).hex()[0:10]
         for key, item in list(invoices.items()):
+            item = item.dump() # convert StoredDict/List to dict/list
             is_lightning = item['lightning_invoice'] is not None
             if is_lightning:
                 continue
@@ -1532,7 +1532,7 @@ class WalletDBUpgrader(Logger):
         raise WalletFileException(msg)
 
 
-def upgrade_wallet_db(data: dict, do_upgrade: bool) -> Tuple[dict, bool]:
+def upgrade_wallet_db(data: dict, do_upgrade: bool=True) -> Tuple[dict, bool]:
     was_upgraded = False
 
     if len(data) == 0:
@@ -1566,26 +1566,53 @@ def upgrade_wallet_db(data: dict, do_upgrade: bool) -> Tuple[dict, bool]:
     return dbu.data, was_upgraded
 
 
-class WalletDB(JsonDB):
 
-    def __init__(
-        self,
-        s: str,
-        *,
-        storage: Optional['WalletStorage'] = None,
-        upgrade: bool = False,
-    ):
-        JsonDB.__init__(
-            self,
-            s,
-            storage=storage,
-            encoder=MyEncoder,
-            upgrader=partial(upgrade_wallet_db, do_upgrade=upgrade),
-        )
+
+
+class WalletDB(Logger):
+
+    def __init__(self, data: 'StoredDict', upgrade: bool = True):
+        Logger.__init__(self)
+        self.storage = data
+        self.lock = self.storage.lock
+        # we must perform db upgrades on the storeddict
+        #was_upgraded = upgrade_wallet_db(self.storage, upgrade)
+        #self._modified |= was_upgraded
+
         # create pointers
         self.load_transactions()
         # load plugins that are conditional on wallet type
         self.load_plugins()
+
+    @locked
+    def put(self, key, value):
+        # raises if value cannot be serialized by db
+        if value is not None:
+            if self.storage.get(key) != value:
+                self.storage[key] = copy.deepcopy(value)
+                return True
+        elif key in self.storage:
+            self.storage.pop(key)
+            return True
+        return False
+
+    @locked
+    def get(self, key, default=None) -> Any:
+        # returns dict or list in place of StoredDict/StoredList
+        v = self.storage.get(key, default)
+        if isinstance(v, (StoredDict, StoredList)):
+            v = v.dump()
+        return v
+
+    @locked
+    def get_dict(self, name) -> StoredDict:
+        # side effect: creates DB entry
+        return self.storage.get(name, {}, add_if_missing=True)
+
+    @locked
+    def get_list(self, name) -> StoredList:
+        # side effect: creates DB entry
+        return self.storage.get(name, [], add_if_missing=True)
 
     @locked
     def get_seed_version(self):
@@ -1623,7 +1650,7 @@ class WalletDB(JsonDB):
         d = self.txo.get(tx_hash, {}).get(address, {})
         return {int(n): (v, cb) for (n, (v, cb)) in d.items()}
 
-    @modifier
+    @locked
     def add_txi_addr(self, tx_hash: str, addr: str, ser: str, v: int) -> None:
         assert isinstance(tx_hash, str)
         assert isinstance(addr, str)
@@ -1636,7 +1663,7 @@ class WalletDB(JsonDB):
             d[addr] = {}
         d[addr][ser] = v
 
-    @modifier
+    @locked
     def add_txo_addr(self, tx_hash: str, addr: str, n: Union[int, str], v: int, is_coinbase: bool) -> None:
         n = str(n)
         assert isinstance(tx_hash, str)
@@ -1659,12 +1686,12 @@ class WalletDB(JsonDB):
     def list_txo(self) -> Sequence[str]:
         return list(self.txo.keys())
 
-    @modifier
+    @locked
     def remove_txi(self, tx_hash: str) -> None:
         assert isinstance(tx_hash, str)
         self.txi.pop(tx_hash, None)
 
-    @modifier
+    @locked
     def remove_txo(self, tx_hash: str) -> None:
         assert isinstance(tx_hash, str)
         self.txo.pop(tx_hash, None)
@@ -1687,7 +1714,7 @@ class WalletDB(JsonDB):
         prevout_n = str(prevout_n)
         return self.spent_outpoints.get(prevout_hash, {}).get(prevout_n)
 
-    @modifier
+    @locked
     def remove_spent_outpoint(self, prevout_hash: str, prevout_n: Union[int, str]) -> None:
         assert isinstance(prevout_hash, str)
         prevout_n = str(prevout_n)
@@ -1695,7 +1722,7 @@ class WalletDB(JsonDB):
         if not self.spent_outpoints[prevout_hash]:
             self.spent_outpoints.pop(prevout_hash)
 
-    @modifier
+    @locked
     def set_spent_outpoint(self, prevout_hash: str, prevout_n: Union[int, str], tx_hash: str) -> None:
         assert isinstance(prevout_hash, str)
         assert isinstance(tx_hash, str)
@@ -1704,7 +1731,7 @@ class WalletDB(JsonDB):
             self.spent_outpoints[prevout_hash] = {}
         self.spent_outpoints[prevout_hash][prevout_n] = tx_hash
 
-    @modifier
+    @locked
     def add_prevout_by_scripthash(self, scripthash: str, *, prevout: TxOutpoint, value: int) -> None:
         assert isinstance(scripthash, str)
         assert isinstance(prevout, TxOutpoint)
@@ -1713,7 +1740,7 @@ class WalletDB(JsonDB):
             self._prevouts_by_scripthash[scripthash] = dict()
         self._prevouts_by_scripthash[scripthash][prevout.to_str()] = value
 
-    @modifier
+    @locked
     def remove_prevout_by_scripthash(self, scripthash: str, *, prevout: TxOutpoint, value: int) -> None:
         assert isinstance(scripthash, str)
         assert isinstance(prevout, TxOutpoint)
@@ -1728,7 +1755,7 @@ class WalletDB(JsonDB):
         prevouts_and_values = self._prevouts_by_scripthash.get(scripthash, {})
         return {(TxOutpoint.from_str(prevout), value) for prevout, value in prevouts_and_values.items()}
 
-    @modifier
+    @locked
     def add_transaction(self, tx_hash: str, tx: Transaction) -> None:
         assert isinstance(tx_hash, str)
         assert isinstance(tx, Transaction), tx
@@ -1744,7 +1771,7 @@ class WalletDB(JsonDB):
         if tx_we_already_have is None or isinstance(tx_we_already_have, PartialTransaction):
             self.transactions[tx_hash] = tx
 
-    @modifier
+    @locked
     def remove_transaction(self, tx_hash: str) -> Optional[Transaction]:
         assert isinstance(tx_hash, str)
         return self.transactions.pop(tx_hash, None)
@@ -1774,12 +1801,12 @@ class WalletDB(JsonDB):
         assert isinstance(addr, str)
         return self.history.get(addr, [])
 
-    @modifier
+    @locked
     def set_addr_history(self, addr: str, hist) -> None:
         assert isinstance(addr, str)
         self.history[addr] = hist
 
-    @modifier
+    @locked
     def remove_addr_history(self, addr: str) -> None:
         assert isinstance(addr, str)
         self.history.pop(addr, None)
@@ -1800,7 +1827,7 @@ class WalletDB(JsonDB):
                            txpos=txpos,
                            header_hash=header_hash)
 
-    @modifier
+    @locked
     def add_verified_tx(self, txid: str, info: TxMinedInfo):
         assert isinstance(txid, str)
         assert isinstance(info, TxMinedInfo)
@@ -1808,7 +1835,7 @@ class WalletDB(JsonDB):
         assert height > 0, height
         self.verified_tx[txid] = (height, info.timestamp, info.txpos, info.header_hash)
 
-    @modifier
+    @locked
     def remove_verified_tx(self, txid: str):
         assert isinstance(txid, str)
         self.verified_tx.pop(txid, None)
@@ -1817,7 +1844,7 @@ class WalletDB(JsonDB):
         assert isinstance(txid, str)
         return txid in self.verified_tx
 
-    @modifier
+    @locked
     def add_tx_fee_from_server(self, txid: str, fee_sat: Optional[int]) -> None:
         assert isinstance(txid, str)
         assert fee_sat is None or isinstance(fee_sat, int)
@@ -1829,7 +1856,7 @@ class WalletDB(JsonDB):
             return
         self.tx_fees[txid] = tx_fees_value._replace(fee=fee_sat, is_calculated_by_us=False)
 
-    @modifier
+    @locked
     def add_tx_fee_we_calculated(self, txid: str, fee_sat: Optional[int]) -> None:
         assert isinstance(txid, str)
         if fee_sat is None:
@@ -1850,7 +1877,7 @@ class WalletDB(JsonDB):
             return None
         return tx_fees_value.fee
 
-    @modifier
+    @locked
     def add_num_inputs_to_tx(self, txid: str, num_inputs: int) -> None:
         assert isinstance(txid, str)
         assert isinstance(num_inputs, int)
@@ -1872,7 +1899,7 @@ class WalletDB(JsonDB):
         txins = self.txi.get(txid, {})
         return sum([len(tupls) for addr, tupls in txins.items()])
 
-    @modifier
+    @locked
     def remove_tx_fee(self, txid: str) -> None:
         assert isinstance(txid, str)
         self.tx_fees.pop(txid, None)
@@ -1895,13 +1922,13 @@ class WalletDB(JsonDB):
         # note: slicing makes a shallow copy
         return self.receiving_addresses[slice_start:slice_stop]
 
-    @modifier
+    @locked
     def add_change_address(self, addr: str) -> None:
         assert isinstance(addr, str)
         self._addr_to_addr_index[addr] = (1, len(self.change_addresses))
         self.change_addresses.append(addr)
 
-    @modifier
+    @locked
     def add_receiving_address(self, addr: str) -> None:
         assert isinstance(addr, str)
         self._addr_to_addr_index[addr] = (0, len(self.receiving_addresses))
@@ -1912,12 +1939,12 @@ class WalletDB(JsonDB):
         assert isinstance(address, str)
         return self._addr_to_addr_index.get(address)
 
-    @modifier
+    @locked
     def add_imported_address(self, addr: str, d: dict) -> None:
         assert isinstance(addr, str)
         self.imported_addresses[addr] = d
 
-    @modifier
+    @locked
     def remove_imported_address(self, addr: str) -> None:
         assert isinstance(addr, str)
         self.imported_addresses.pop(addr)
@@ -1941,12 +1968,12 @@ class WalletDB(JsonDB):
         if wallet_type == 'imported':
             self.imported_addresses = self.get_dict('addresses')  # type: Dict[str, dict]
         else:
-            self.get_dict('addresses')
+            addresses = self.get_dict('addresses')
             for name in ['receiving', 'change']:
-                if name not in self.data['addresses']:
-                    self.data['addresses'][name] = []
-            self.change_addresses = self.data['addresses']['change']
-            self.receiving_addresses = self.data['addresses']['receiving']
+                if name not in addresses:
+                    addresses[name] = []
+            self.change_addresses = self.storage['addresses']['change']
+            self.receiving_addresses = self.storage['addresses']['receiving']
             self._addr_to_addr_index = {}  # type: Dict[str, Sequence[int]]  # key: address, value: (is_change, index)
             for i, addr in enumerate(self.receiving_addresses):
                 self._addr_to_addr_index[addr] = (0, i)
@@ -1955,7 +1982,7 @@ class WalletDB(JsonDB):
 
     @profiler
     def load_transactions(self):
-        # references in self.data
+        # references in self.storage
         # TODO make all these private
         # txid -> address -> prev_outpoint -> value
         self.txi = self.get_dict('txi')                          # type: Dict[str, Dict[str, Dict[str, int]]]
@@ -1981,7 +2008,7 @@ class WalletDB(JsonDB):
                     self.logger.info("removing unreferenced spent outpoint")
                     d.pop(prevout_n)
 
-    @modifier
+    @locked
     def clear_history(self):
         self.txi.clear()
         self.txo.clear()
@@ -1992,23 +2019,17 @@ class WalletDB(JsonDB):
         self.tx_fees.clear()
         self._prevouts_by_scripthash.clear()
 
-    def _should_convert_to_stored_dict(self, key) -> bool:
-        if key == 'keystore':
-            return False
-        multisig_keystore_names = [('x%d' % i) for i in range(1, 16)]
-        if key in multisig_keystore_names:
-            return False
-        return True
-
     @classmethod
     def split_accounts(klass, root_path, split_data):
-        from .storage import WalletStorage
+        # not covered by tests
+        from .stored_dict import WalletStorage
         file_list = []
         for data in split_data:
             path = root_path + '.' + data['suffix']
-            item_storage = WalletStorage(path)
-            db = WalletDB(json.dumps(data), storage=item_storage, upgrade=True)
-            db.write()
+            storage = WalletStorage(path)
+            storage.set_data(json.dumps(data))
+            db = WalletDB(storage, upgrade=True)
+            storage.write()
             file_list.append(path)
         return file_list
 

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -1570,14 +1570,15 @@ def upgrade_wallet_db(data: 'StoredDict', do_upgrade: bool) -> Tuple[dict, bool]
         )
 
     data._db._should_convert = False
-    dbu = WalletDBUpgrader(data)
-    if dbu.requires_split():
-        raise WalletRequiresSplit(dbu.get_split_accounts())
-    if dbu.requires_upgrade() and do_upgrade:
-        dbu.upgrade()
-        was_upgraded = True
-    if dbu.requires_upgrade():
-        raise WalletRequiresUpgrade()
+    with data.write_batch():
+        dbu = WalletDBUpgrader(data)
+        if dbu.requires_split():
+            raise WalletRequiresSplit(dbu.get_split_accounts())
+        if dbu.requires_upgrade() and do_upgrade:
+            dbu.upgrade()
+            was_upgraded = True
+        if dbu.requires_upgrade():
+            raise WalletRequiresUpgrade()
     data._db._should_convert = True
     return was_upgraded
 

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -104,8 +104,14 @@ class WalletFileExceptionVersion51(WalletFileException): pass
 register_name('/transactions/*', None, lambda x: tx_from_any(x, deserialize=False, sanitize=False))
 register_name('/channels/*/data_loss_protect_remote_pcp/*', None, lambda x: bytes.fromhex(x))
 # register tuples, otherwise they will default to StoredList
+register_name('/channels/*/closing_height', None, tuple)
+register_name('/channels/*/funding_height', None, tuple)
+register_name('/forwarding_failures/*', None, tuple)
+register_name('/lightning_payments/*', None, tuple)
 register_name('/contacts/*', None, tuple)
 register_name('/lightning_preimages/*', None, tuple)
+register_name('/addr_history/*/*', None, tuple)
+register_name('/channels/*/funding_inputs/*', None, tuple)
 # register dicts that require key conversion
 for key in [
         '/channels/*/log/*/adds',
@@ -127,12 +133,9 @@ for key in [
 
 
 class WalletDBUpgrader(Logger):
-    def __init__(self, data: dict):
+    def __init__(self, data: StoredDict):
         Logger.__init__(self)
         self.data = data
-        # self.data must be in-memory dict (not a StoredDict or similar),
-        # so a failed, partial upgrade won't get commited to disk
-        assert type(self.data) == dict, type(self.data)
 
     def get(self, key, default=None):
         return self.data.get(key, default)
@@ -156,11 +159,11 @@ class WalletDBUpgrader(Logger):
         wallet_type = self.get('wallet_type')
         if wallet_type == 'old':
             assert len(d) == 2
-            data1 = copy.deepcopy(self.data)
-            data1['accounts'] = {'0': d['0']}
+            data1 = copy.deepcopy(self.data.as_dict())
+            data1['accounts'] = {'0': d['0'].as_dict()}
             data1['suffix'] = 'deterministic'
-            data2 = copy.deepcopy(self.data)
-            data2['accounts'] = {'/x': d['/x']}
+            data2 = copy.deepcopy(self.data.as_dict())
+            data2['accounts'] = {'/x': d['/x'].as_dict()}
             data2['seed'] = None
             data2['seed_version'] = None
             data2['master_public_key'] = None
@@ -173,11 +176,11 @@ class WalletDBUpgrader(Logger):
             mpk = self.get('master_public_keys')
             for k in d.keys():
                 i = int(k)
-                x = d[k]
+                x = d[k].as_dict()
                 if x.get("pending"):
                     continue
                 xpub = mpk["x/%d'"%i]
-                new_data = copy.deepcopy(self.data)
+                new_data = copy.deepcopy(self.data.as_dict())
                 # save account, derivation and xpub at index 0
                 new_data['accounts'] = {'0': x}
                 new_data['master_public_keys'] = {"x/0'": xpub}
@@ -193,6 +196,7 @@ class WalletDBUpgrader(Logger):
 
     @profiler
     def upgrade(self):
+        assert self.data.should_convert() is False
         self.logger.info('upgrading wallet format')
         self._convert_imported()
         self._convert_wallet_type()
@@ -273,6 +277,8 @@ class WalletDBUpgrader(Logger):
         xprvs = self.get('master_private_keys', {})
         mpk = self.get('master_public_key')
         keypairs = self.get('keypairs')
+        if keypairs:
+            keypairs = keypairs.as_dict()
         key_type = self.get('key_type')
         if seed_version == OLD_SEED_VERSION or wallet_type == 'old':
             d = {
@@ -374,14 +380,14 @@ class WalletDBUpgrader(Logger):
 
         if self.get('wallet_type') =='imported':
             addresses = self.get('addresses')
-            if type(addresses) is list:
+            if type(addresses) is StoredList:
                 addresses = dict([(x, None) for x in addresses])
                 self.put('addresses', addresses)
         elif self.get('wallet_type') == 'standard':
             if self.get('keystore').get('type')=='imported':
                 addresses = set(self.get('addresses').get('receiving'))
                 pubkeys = self.get('keystore').get('keypairs').keys()
-                assert len(addresses) == len(pubkeys)
+                assert len(addresses) == len(list(pubkeys))
                 d = {}
                 for pubkey in pubkeys:
                     addr = bitcoin.pubkey_to_address('p2pkh', pubkey)
@@ -433,7 +439,7 @@ class WalletDBUpgrader(Logger):
 
         if self.get('wallet_type') == 'imported':
             addresses = self.get('addresses')
-            assert isinstance(addresses, dict)
+            assert isinstance(addresses, StoredDict)
             addresses_new = dict()
             for address, details in addresses.items():
                 if not bitcoin.is_address(address):
@@ -494,6 +500,7 @@ class WalletDBUpgrader(Logger):
         for ks_name in ('keystore', *['x{}/'.format(i) for i in range(1, 16)]):
             ks = self.get(ks_name, None)
             if ks is None: continue
+            assert isinstance(ks, StoredDict)
             xpub = ks.get('xpub', None)
             if xpub is None: continue
             bip32node = BIP32Node.from_xkey(xpub)
@@ -518,7 +525,6 @@ class WalletDBUpgrader(Logger):
                     root_fingerprint = bip32node.fingerprint.hex()
             ks['root_fingerprint'] = root_fingerprint
             ks.pop('ckcc_xfp', None)
-            self.put(ks_name, ks)
 
         self.put('seed_version', 20)
 
@@ -593,7 +599,7 @@ class WalletDBUpgrader(Logger):
         # convert channels to dict
         self.data['channels'] = {x['channel_id']: x for x in channels}
         # convert txi & txo
-        txi = self.get('txi', {})
+        txi = self.data.get('txi', {})
         for tx_hash, d in list(txi.items()):
             d2 = {}
             for addr, l in d.items():
@@ -601,8 +607,7 @@ class WalletDBUpgrader(Logger):
                 for ser, v in l:
                     d2[addr][ser] = v
             txi[tx_hash] = d2
-        self.data['txi'] = txi
-        txo = self.get('txo', {})
+        txo = self.data.get('txo', {})
         for tx_hash, d in list(txo.items()):
             d2 = {}
             for addr, l in d.items():
@@ -610,7 +615,6 @@ class WalletDBUpgrader(Logger):
                 for n, v, cb in l:
                     d2[addr][str(n)] = (v, cb)
             txo[tx_hash] = d2
-        self.data['txo'] = txo
 
         self.data['seed_version'] = 24
 
@@ -786,10 +790,12 @@ class WalletDBUpgrader(Logger):
         if not self._is_upgrade_method_needed(34, 34):
             return
         PR_TYPE_ONCHAIN = 0
-        requests_old = self.data.get('payment_requests', {})
-        requests_new = {k: item for k, item in requests_old.items()
-                        if not (item['type'] == PR_TYPE_ONCHAIN and item['outputs'] is None)}
-        self.data['payment_requests'] = requests_new
+        payment_requests = self.data.get('payment_requests', {})
+        for k in list(payment_requests.keys()):
+            item = payment_requests[k]
+            if (item['type'] == PR_TYPE_ONCHAIN and item['outputs'] is None):
+                payment_requests.pop(k)
+
         self.data['seed_version'] = 35
 
     def _convert_version_36(self):
@@ -892,13 +898,12 @@ class WalletDBUpgrader(Logger):
     def _convert_version_43(self):
         if not self._is_upgrade_method_needed(42, 42):
             return
-        channels = self.data.pop('channels', {})
+        channels = self.data.get('channels', {})
         for k, c in channels.items():
             log = c['log']
             c['fail_htlc_reasons'] = log.pop('fail_htlc_reasons', {})
             c['unfulfilled_htlcs'] = log.pop('unfulfilled_htlcs', {})
             log["1"]['unacked_updates'] = log.pop('unacked_local_updates2', {})
-        self.data['channels'] = channels
         self.data['seed_version'] = 43
 
     def _convert_version_44(self):
@@ -965,6 +970,7 @@ class WalletDBUpgrader(Logger):
             outputs = [PartialTxOutput.from_legacy_tuple(*output) for output in raw_outputs]
             outputs_str = "\n".join(f"{txout.scriptpubkey.hex()}, {txout.value}" for txout in outputs)
             return sha256d(outputs_str + "%d" % timestamp).hex()[0:10]
+        assert isinstance(invoices, StoredDict)
         for key, item in list(invoices.items()):
             item = item.dump() # convert StoredDict/List to dict/list
             is_lightning = item['lightning_invoice'] is not None
@@ -981,8 +987,9 @@ class WalletDBUpgrader(Logger):
     def _convert_version_46(self):
         if not self._is_upgrade_method_needed(45, 45):
             return
-        invoices = self.data.get('invoices', {})
-        self._convert_invoices_keys(invoices)
+        invoices = self.data.get('invoices')
+        if invoices:
+            self._convert_invoices_keys(invoices)
         self.data['seed_version'] = 46
 
     def _convert_version_47(self):
@@ -1030,8 +1037,9 @@ class WalletDBUpgrader(Logger):
     def _convert_version_50(self):
         if not self._is_upgrade_method_needed(49, 49):
             return
-        requests = self.data.get('payment_requests', {})
-        self._convert_invoices_keys(requests)
+        requests = self.data.get('payment_requests')
+        if requests:
+            self._convert_invoices_keys(requests)
         self.data['seed_version'] = 50
 
     def _convert_version_51(self):
@@ -1113,7 +1121,9 @@ class WalletDBUpgrader(Logger):
         # do not use '/' in dict keys
         for key in list(self.data.keys()):
             if key.endswith('/'):
-                self.data[key[:-1]] = self.data.pop(key)
+                item = self.data.get(key)
+                self.data[key[:-1]] = item.as_dict()
+                self.data.pop(key)
         self.data['seed_version'] = 55
 
     def _convert_version_56(self):
@@ -1168,7 +1178,6 @@ class WalletDBUpgrader(Logger):
             for htlc_id, (local_ctn, remote_ctn, onion_packet_hex, forwarding_key) in chan['unfulfilled_htlcs'].items():
                 unfulfilled_htlcs[htlc_id] = (onion_packet_hex, forwarding_key or None)
             chan['unfulfilled_htlcs'] = unfulfilled_htlcs
-        self.data['channels'] = channels
         self.data['seed_version'] = 59
 
     def _convert_version_60(self):
@@ -1238,14 +1247,17 @@ class WalletDBUpgrader(Logger):
                 htlc_data = unfulfilled_htlcs_.get(str(htlc_id))
                 if htlc_data is None:
                     return None
+                htlc_data = htlc_data.dump() # StoredList -> list
                 stored_onion_packet, htlc_forwarding_key = htlc_data
                 if stored_onion_packet is not None:
                     htlc_data[0] = None  # overwrite the onion so it is not processed again in htlc_switch
+                    unfulfilled_htlcs_[str(htlc_id)] = htlc_data
                     return stored_onion_packet, htlc_forwarding_key
             return None
 
         mpp_sets = self.data.get('received_mpp_htlcs', {})
         for payment_key, recv_mpp_status in list(mpp_sets.items()):
+            recv_mpp_status = recv_mpp_status.dump() # StoredList -> list
             assert isinstance(recv_mpp_status, list), f"{recv_mpp_status=}"
             del recv_mpp_status[1]  # remove expected_msat
 
@@ -1280,6 +1292,7 @@ class WalletDBUpgrader(Logger):
                     # as the htlcs won't get failed due to the new SETTLING state
                     # unless a forwarding error is set.
                     recv_mpp_status[0] = 4  # RecvMPPResolution.SETTLING
+                    mpp_sets[payment_key] = recv_mpp_status
 
         # replace Tuple[onion, forwarding_key] with just the onion in chan['unfulfilled_htlcs']
         for chan in channels.values():
@@ -1326,6 +1339,7 @@ class WalletDBUpgrader(Logger):
         mpp_sets = self.data.get('received_mpp_htlcs', {})
         new_mpp_sets = {}
         for payment_key, mpp_set in mpp_sets.items():
+            mpp_set = mpp_set.dump() # StoredList -> list
             if len(mpp_set) == 2:
                 # if the db has received_mpp_htlcs pre version 65 we cannot assume they have parent_set_key
                 # as _convert_version_63 doesn't set it
@@ -1368,7 +1382,7 @@ class WalletDBUpgrader(Logger):
             key = '-1' if is_initiator else '1'
             assert len(chan['log'][key]['fee_updates']) == 1, chan['log'][key]['fee_updates']
             chan['log'][key]['fee_updates'] = {}
-        self.data['channels'] = channels
+        #self.data['channels'] = channels
         self.data['seed_version'] = 67
 
     def _convert_version_68(self):
@@ -1532,7 +1546,7 @@ class WalletDBUpgrader(Logger):
         raise WalletFileException(msg)
 
 
-def upgrade_wallet_db(data: dict, do_upgrade: bool=True) -> Tuple[dict, bool]:
+def upgrade_wallet_db(data: 'StoredDict', do_upgrade: bool) -> Tuple[dict, bool]:
     was_upgraded = False
 
     if len(data) == 0:
@@ -1545,7 +1559,7 @@ def upgrade_wallet_db(data: dict, do_upgrade: bool=True) -> Tuple[dict, bool]:
             first_electrum_version_used=ELECTRUM_VERSION,
         )
         assert data.get("db_metadata", None) is None
-        data["db_metadata"] = v.to_json()
+        data["db_metadata"] = v.as_dict()
         was_upgraded = True
     # Test mainnet/testnet mixup. Do this before DB upgrades, as those might assume
     # network magic bytes (e.g. if they parse an address or an xpub).
@@ -1555,6 +1569,7 @@ def upgrade_wallet_db(data: dict, do_upgrade: bool=True) -> Tuple[dict, bool]:
               "Current chain: {}").format(constants.net.NET_NAME)
         )
 
+    data._db._should_convert = False
     dbu = WalletDBUpgrader(data)
     if dbu.requires_split():
         raise WalletRequiresSplit(dbu.get_split_accounts())
@@ -1563,10 +1578,15 @@ def upgrade_wallet_db(data: dict, do_upgrade: bool=True) -> Tuple[dict, bool]:
         was_upgraded = True
     if dbu.requires_upgrade():
         raise WalletRequiresUpgrade()
-    return dbu.data, was_upgraded
+    data._db._should_convert = True
+    return was_upgraded
 
 
 
+@stored_at('/txo/*/*/*', tuple)
+class TxoValue(NamedTuple):
+    value: int
+    is_coinbase: bool
 
 
 class WalletDB(Logger):
@@ -1576,7 +1596,7 @@ class WalletDB(Logger):
         self.storage = data
         self.lock = self.storage.lock
         # we must perform db upgrades on the storeddict
-        #was_upgraded = upgrade_wallet_db(self.storage, upgrade)
+        was_upgraded = upgrade_wallet_db(self.storage, upgrade)
         #self._modified |= was_upgraded
 
         # create pointers
@@ -1648,7 +1668,7 @@ class WalletDB(Logger):
         assert isinstance(tx_hash, str)
         assert isinstance(address, str)
         d = self.txo.get(tx_hash, {}).get(address, {})
-        return {int(n): (v, cb) for (n, (v, cb)) in d.items()}
+        return {int(n): (item.value, item.is_coinbase) for (n, item) in d.items()}
 
     @locked
     def add_txi_addr(self, tx_hash: str, addr: str, ser: str, v: int) -> None:
@@ -1676,7 +1696,7 @@ class WalletDB(Logger):
         d = self.txo[tx_hash]
         if addr not in d:
             d[addr] = {}
-        d[addr][n] = (v, is_coinbase)
+        d[addr][n] = TxoValue(v, is_coinbase)
 
     @locked
     def list_txi(self) -> Sequence[str]:
@@ -1820,12 +1840,7 @@ class WalletDB(Logger):
         assert isinstance(txid, str)
         if txid not in self.verified_tx:
             return None
-        height, timestamp, txpos, header_hash = self.verified_tx[txid]
-        return TxMinedInfo(_height=height,
-                           conf=None,
-                           timestamp=timestamp,
-                           txpos=txpos,
-                           header_hash=header_hash)
+        return self.verified_tx[txid]
 
     @locked
     def add_verified_tx(self, txid: str, info: TxMinedInfo):
@@ -1833,7 +1848,7 @@ class WalletDB(Logger):
         assert isinstance(info, TxMinedInfo)
         height = info._height  # number of conf is dynamic and might not be set here
         assert height > 0, height
-        self.verified_tx[txid] = (height, info.timestamp, info.txpos, info.header_hash)
+        self.verified_tx[txid] = info
 
     @locked
     def remove_verified_tx(self, txid: str):

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -2022,11 +2022,11 @@ class WalletDB(Logger):
     @classmethod
     def split_accounts(klass, root_path, split_data):
         # not covered by tests
-        from .stored_dict import WalletStorage
+        from .stored_dict import DictStorage
         file_list = []
         for data in split_data:
             path = root_path + '.' + data['suffix']
-            storage = WalletStorage(path)
+            storage = DictStorage(path)
             storage.set_data(json.dumps(data))
             db = WalletDB(storage, upgrade=True)
             storage.write()

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -13,7 +13,7 @@ from electrum.network import ProxySettings
 from electrum.plugin import run_hook
 from electrum.slip39 import EncryptedSeed
 from electrum.storage import StorageEncryptionVersion, StorageReadWriteError
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.util import UserFacingException
 from electrum.wallet_db import WalletDB
 from electrum.bip32 import normalize_bip32_derivation, xpub_type
@@ -688,7 +688,7 @@ class NewWalletWizard(KeystoreWizard):
         if os.path.exists(path):
             raise UserFacingException(_('File already exists at path: {}').format(path))
         try:
-            storage = WalletStorage(path)
+            storage = DictStorage(path)
         except StorageReadWriteError as e:
             raise UserFacingException(e)
 

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -12,7 +12,8 @@ from electrum.logging import get_logger
 from electrum.network import ProxySettings
 from electrum.plugin import run_hook
 from electrum.slip39 import EncryptedSeed
-from electrum.storage import WalletStorage, StorageEncryptionVersion, StorageReadWriteError
+from electrum.storage import StorageEncryptionVersion, StorageReadWriteError
+from electrum.stored_dict import WalletStorage
 from electrum.util import UserFacingException
 from electrum.wallet_db import WalletDB
 from electrum.bip32 import normalize_bip32_derivation, xpub_type
@@ -780,7 +781,7 @@ class NewWalletWizard(KeystoreWizard):
                 enc_version = StorageEncryptionVersion.USER_PASSWORD
             storage.set_password(data['password'], enc_version=enc_version)
 
-        db = WalletDB('', storage=storage, upgrade=True)
+        db = WalletDB(storage)
         db.set_keystore_encryption(bool(data['password']))
 
         db.put('wallet_type', data['wallet_type'])
@@ -823,7 +824,8 @@ class NewWalletWizard(KeystoreWizard):
             db.put('lightning_xprv', k.get_lightning_xprv(data['password']))
 
         db.load_plugins()
-        db.write()
+        storage.write()
+        storage.close()
 
 
 class ServerConnectWizard(AbstractWizard):

--- a/run_electrum
+++ b/run_electrum
@@ -124,7 +124,7 @@ from electrum.payment_identifier import PaymentIdentifier
 from electrum import SimpleConfig
 from electrum.wallet_db import WalletDB
 from electrum.wallet import Wallet
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.util import print_msg, print_stderr, json_encode, json_decode, UserCancelled
 from electrum.util import InvalidPassword
 from electrum.plugin import Plugins
@@ -168,7 +168,7 @@ def init_cmdline(config_options, wallet_path, *, rpcserver: bool, config: 'Simpl
         sys_exit(1)
 
     # instantiate storage without opening the DB, so that we can check if it is encrypted
-    storage = WalletStorage(wallet_path, init_db=False) if wallet_path else None
+    storage = DictStorage(wallet_path, init_db=False) if wallet_path else None
 
     if cmd.requires_wallet and not storage.file_exists():
         print_msg("Error: Wallet file not found.")
@@ -250,7 +250,7 @@ async def run_offline_command(config: 'SimpleConfig', config_options: dict, wall
     if 'wallet_path' in cmd.options and config_options.get('wallet_path') is None:
         config_options['wallet_path'] = wallet_path
     if cmd.requires_wallet:
-        storage = WalletStorage(wallet_path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
+        storage = DictStorage(wallet_path, allow_partial_writes=config.WALLET_PARTIAL_WRITES)
         if storage.is_encrypted():
             if storage.is_encrypted_with_hw_device():
                 password = get_password_for_hw_device_encrypted_storage(plugins)

--- a/run_electrum
+++ b/run_electrum
@@ -124,7 +124,7 @@ from electrum.payment_identifier import PaymentIdentifier
 from electrum import SimpleConfig
 from electrum.wallet_db import WalletDB
 from electrum.wallet import Wallet
-from electrum.storage import WalletStorage
+from electrum.stored_dict import WalletStorage
 from electrum.util import print_msg, print_stderr, json_encode, json_decode, UserCancelled
 from electrum.util import InvalidPassword
 from electrum.plugin import Plugins
@@ -167,8 +167,8 @@ def init_cmdline(config_options, wallet_path, *, rpcserver: bool, config: 'Simpl
         print_msg("wallet path not provided.")
         sys_exit(1)
 
-    # instantiate wallet for command-line
-    storage = WalletStorage(wallet_path, allow_partial_writes=config.WALLET_PARTIAL_WRITES) if wallet_path else None
+    # instantiate storage without opening the DB, so that we can check if it is encrypted
+    storage = WalletStorage(wallet_path, init_db=False) if wallet_path else None
 
     if cmd.requires_wallet and not storage.file_exists():
         print_msg("Error: Wallet file not found.")
@@ -256,7 +256,7 @@ async def run_offline_command(config: 'SimpleConfig', config_options: dict, wall
                 password = get_password_for_hw_device_encrypted_storage(plugins)
                 config_options['password'] = password
             storage.decrypt(password)
-        db = WalletDB(storage.read(), storage=storage, upgrade=True)
+        db = WalletDB(storage)
         wallet = Wallet(db, config=config)
         config_options['wallet'] = wallet
     else:

--- a/tests/plugins/test_timelock_recovery.py
+++ b/tests/plugins/test_timelock_recovery.py
@@ -6,7 +6,7 @@ from electrum.bitcoin import address_to_script
 from electrum.fee_policy import FixedFeePolicy
 from electrum.simple_config import SimpleConfig
 from electrum.transaction import PartialTxOutput
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.wallet import Wallet
 from electrum.wallet_db import WalletDB
 
@@ -36,7 +36,7 @@ class TestTimelockRecovery(ElectrumTestCase):
     def _create_default_wallet(self):
         with open(os.path.join(os.path.dirname(__file__), "test_timelock_recovery", "default_wallet"), "r") as f:
             wallet_str = f.read()
-        storage = WalletStorage(self.wallet_path)
+        storage = DictStorage(self.wallet_path)
         storage.set_data(wallet_str)
         db = WalletDB(storage, upgrade=True)
         wallet = Wallet(db, config=self.config)

--- a/tests/plugins/test_timelock_recovery.py
+++ b/tests/plugins/test_timelock_recovery.py
@@ -5,8 +5,8 @@ import sys
 from electrum.bitcoin import address_to_script
 from electrum.fee_policy import FixedFeePolicy
 from electrum.simple_config import SimpleConfig
-from electrum.storage import WalletStorage
 from electrum.transaction import PartialTxOutput
+from electrum.stored_dict import WalletStorage
 from electrum.wallet import Wallet
 from electrum.wallet_db import WalletDB
 
@@ -37,7 +37,8 @@ class TestTimelockRecovery(ElectrumTestCase):
         with open(os.path.join(os.path.dirname(__file__), "test_timelock_recovery", "default_wallet"), "r") as f:
             wallet_str = f.read()
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        storage.set_data(wallet_str)
+        db = WalletDB(storage, upgrade=True)
         wallet = Wallet(db, config=self.config)
         return wallet
 

--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -28,7 +28,7 @@ from electrum.bip32 import (BIP32Node, convert_bip32_intpath_to_strpath,
 from electrum.crypto import sha256d, SUPPORTED_PW_HASH_VERSIONS
 from electrum import crypto, constants
 from electrum.util import bfh, InvalidPassword, randrange
-from electrum.storage import WalletStorage
+from electrum.storage import FileStorage
 from electrum.keystore import xtype_from_derivation
 
 from . import ElectrumTestCase
@@ -270,7 +270,7 @@ class Test_bitcoin(ElectrumTestCase):
 
     @needs_test_with_all_aes_implementations
     def test_decrypt_message(self):
-        key = WalletStorage.get_eckey_from_password('pw123')
+        key = FileStorage.get_eckey_from_password('pw123')
         self.assertEqual(b'me<(s_s)>age', crypto.ecies_decrypt_message(
             key, b'QklFMQMDFtgT3zWSQsa+Uie8H/WvfUjlu9UN9OJtTt3KlgKeSTi6SQfuhcg1uIz9hp3WIUOFGTLr4RNQBdjPNqzXwhkcPi2Xsbiw6UCNJncVPJ6QBg=='))
         self.assertEqual(b'me<(s_s)>age', crypto.ecies_decrypt_message(
@@ -280,7 +280,7 @@ class Test_bitcoin(ElectrumTestCase):
 
     @needs_test_with_all_aes_implementations
     def test_encrypt_message(self):
-        key = WalletStorage.get_eckey_from_password('secret_password77')
+        key = FileStorage.get_eckey_from_password('secret_password77')
         msgs = [
             bytes([0] * 555),
             b'cannot think of anything funny'

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,6 +12,7 @@ import electrum
 from electrum.commands import Commands, eval_bool
 from electrum import storage, wallet
 from electrum.lnutil import RECEIVED, channel_id_from_funding_tx
+from electrum.lnutil import ReceivedMPPStatus, UpdateAddHtlc, ReceivedMPPHtlc
 from electrum.lnworker import RecvMPPResolution
 from electrum.wallet import Abstract_Wallet
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED
@@ -536,16 +537,28 @@ class TestCommandsTestnet(ElectrumTestCase):
                 wallet=wallet,
             )
 
-        mock_htlc1 = mock.Mock()
-        mock_htlc1.htlc.cltv_abs = 800_000
-        mock_htlc1.htlc.amount_msat = 4_500_000
-        mock_htlc2 = mock.Mock()
-        mock_htlc2.htlc.cltv_abs = 800_144
-        mock_htlc2.htlc.amount_msat = 5_500_000
-        mock_htlc_status = mock.Mock()
-        mock_htlc_status.htlcs = [mock_htlc1, mock_htlc2]
-        mock_htlc_status.resolution = RecvMPPResolution.COMPLETE
-
+        mock_htlc1 = ReceivedMPPHtlc(
+            channel_id='',
+            htlc = UpdateAddHtlc(
+                cltv_abs = 800_000,
+                amount_msat = 4_500_000,
+                payment_hash=bytes(32),
+            ),
+            unprocessed_onion='',
+        )
+        mock_htlc2 = ReceivedMPPHtlc(
+            channel_id = '',
+            htlc = UpdateAddHtlc(
+                cltv_abs = 800_144,
+                amount_msat = 5_500_000,
+                payment_hash=bytes(32),
+            ),
+            unprocessed_onion = '',
+        )
+        mock_htlc_status = ReceivedMPPStatus(
+            htlcs = [mock_htlc1, mock_htlc2],
+            resolution = RecvMPPResolution.COMPLETE,
+        )
         payment_key = wallet.lnworker._get_payment_key(bytes.fromhex(payment_hash)).hex()
         with mock.patch.dict(wallet.lnworker.received_mpp_htlcs, {payment_key: mock_htlc_status}):
             status: dict = await cmds.check_hold_invoice(payment_hash=payment_hash, wallet=wallet)
@@ -574,8 +587,8 @@ class TestCommandsTestnet(ElectrumTestCase):
             # cancelling a settled invoice should raise
             await cmds.cancel_hold_invoice(payment_hash=payment_hash, wallet=wallet)
 
-    @mock.patch.object(storage.WalletStorage, 'write')
-    @mock.patch.object(storage.WalletStorage, 'append')
+    @mock.patch.object(storage.FileStorage, 'write')
+    @mock.patch.object(storage.FileStorage, 'append')
     async def test_onchain_history(self, *mock_args):
         cmds = Commands(config=self.config, daemon=self.daemon)
         wallet_path = self.get_wallet_file_path("client_3_3_8_xpub_with_realistic_history")

--- a/tests/test_jsondb.py
+++ b/tests/test_jsondb.py
@@ -2,6 +2,7 @@ import contextlib
 import copy
 import traceback
 import json
+import os
 from typing import Any
 
 import jsonpatch
@@ -10,7 +11,7 @@ from jsonpointer import JsonPointerException
 
 from . import ElectrumTestCase
 
-from electrum.json_db import JsonDB
+from electrum.stored_dict import WalletStorage
 
 class TestJsonpatch(ElectrumTestCase):
 
@@ -89,16 +90,6 @@ class TestJsonpatch(ElectrumTestCase):
             fail_if_leaking_secret(ctx)
 
 
-def pop1_from_dict(d: dict, key: str) -> Any:
-    return d.pop(key)
-
-
-def pop2_from_dict(d: dict, key: str) -> Any:
-    val = d[key]
-    del d[key]
-    return val
-
-
 class TestJsonDB(ElectrumTestCase):
 
     async def test_jsonpatch_replace_after_remove(self):
@@ -119,36 +110,22 @@ class TestJsonDB(ElectrumTestCase):
         with self.assertRaises(JsonPatchException):
             data = jpatch.apply(data)
 
-    async def test_jsondb_replace_after_remove(self):
-        for pop_from_dict in [pop1_from_dict, pop2_from_dict]:
-            with self.subTest(pop_from_dict):
-                data = { 'a': {'b': {'c': 0}}, 'd': 3}
-                db = JsonDB(repr(data))
-                a = db.get_dict('a')
-                # remove
-                b = pop_from_dict(a, 'b')
-                self.assertEqual(len(db.pending_changes), 1)
-                # replace item. this must not been written to db
-                b['c'] = 42
-                self.assertEqual(len(db.pending_changes), 1)
-                patches = json.loads('[' + ','.join(db.pending_changes) + ']')
-                jpatch = jsonpatch.JsonPatch(patches)
-                data = jpatch.apply(data)
-                self.assertEqual(data, {'a': {}, 'd': 3})
+    async def test_jsondb_partial_write_round_test(self):
+        wallet_path = os.path.join(self.electrum_path, "somewallet")
+        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        storage['a'] = [1, 2, 3]
+        storage._db.write_and_force_consolidation()
+        storage['a'].append(4)
+        storage._db._append_pending_changes()
+        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        self.assertEqual(len(storage['a']), 4)
 
-    async def test_jsondb_replace_after_remove_nested(self):
-        for pop_from_dict in [pop1_from_dict, pop2_from_dict]:
-            with self.subTest(pop_from_dict):
-                data = { 'a': {'b': {'c': 0}}, 'd': 3}
-                db = JsonDB(repr(data))
-                # remove
-                a = pop_from_dict(db.data, "a")
-                self.assertEqual(len(db.pending_changes), 1)
-                b = a['b']
-                # replace item. this must not be written to db
-                b['c'] = 42
-                self.assertEqual(len(db.pending_changes), 1)
-                patches = json.loads('[' + ','.join(db.pending_changes) + ']')
-                jpatch = jsonpatch.JsonPatch(patches)
-                data = jpatch.apply(data)
-                self.assertEqual(data, {'d': 3})
+    async def test_jsondb_list_clear(self):
+        wallet_path = os.path.join(self.electrum_path, "somewallet")
+        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        storage['a'] = [1, 2, 3]
+        storage._db.write()
+        storage['a'].clear()
+        storage._db.write()
+        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        self.assertEqual(len(storage['a']), 0)

--- a/tests/test_jsondb.py
+++ b/tests/test_jsondb.py
@@ -11,7 +11,7 @@ from jsonpointer import JsonPointerException
 
 from . import ElectrumTestCase
 
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 
 class TestJsonpatch(ElectrumTestCase):
 
@@ -112,20 +112,20 @@ class TestJsonDB(ElectrumTestCase):
 
     async def test_jsondb_partial_write_round_test(self):
         wallet_path = os.path.join(self.electrum_path, "somewallet")
-        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        storage = DictStorage(wallet_path, allow_partial_writes=True)
         storage['a'] = [1, 2, 3]
         storage._db.write_and_force_consolidation()
         storage['a'].append(4)
         storage._db._append_pending_changes()
-        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        storage = DictStorage(wallet_path, allow_partial_writes=True)
         self.assertEqual(len(storage['a']), 4)
 
     async def test_jsondb_list_clear(self):
         wallet_path = os.path.join(self.electrum_path, "somewallet")
-        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        storage = DictStorage(wallet_path, allow_partial_writes=True)
         storage['a'] = [1, 2, 3]
         storage._db.write()
         storage['a'].clear()
         storage._db.write()
-        storage = WalletStorage(wallet_path, allow_partial_writes=True)
+        storage = DictStorage(wallet_path, allow_partial_writes=True)
         self.assertEqual(len(storage['a']), 0)

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -40,6 +40,7 @@ from electrum.lnutil import (
 )
 from electrum.logging import console_stderr_handler
 from electrum.lnchannel import ChannelState, Channel
+from electrum.coinchooser import PRNG
 
 from . import ElectrumTestCase
 from .lnhelpers import create_test_channels
@@ -589,7 +590,7 @@ class TestChannel(ElectrumTestCase):
         self.assertTrue(chan.is_zeroconf())
         # add channel to lnwallet/db
         bob._channels[chan.channel_id] = chan
-        bob.db.get('channels')[chan.channel_id.hex()] = "something"
+        bob.db.get_dict('channels')[chan.channel_id.hex()] = "something"
         self.assertIsNotNone(bob.get_channel_by_id(chan.channel_id))
         chan.storage['init_height'] = 0  # checked by has_funding_timed_out
         chan.storage['init_timestamp'] = int(time.time())
@@ -601,7 +602,7 @@ class TestChannel(ElectrumTestCase):
 
         # assert nothing happened
         self.assertIsNotNone(bob.get_channel_by_id(chan.channel_id))
-        self.assertIsNotNone(bob.db.get('channels').get(chan.channel_id.hex()))
+        self.assertIsNotNone(bob.db.get_dict('channels').get(chan.channel_id.hex()))
         self.assertEqual(chan.get_state(), ChannelState.OPEN)
         self.assertEqual(bob.config.ZEROCONF_TRUSTED_NODE, trusted_node)
 
@@ -613,7 +614,7 @@ class TestChannel(ElectrumTestCase):
 
         # assert nothing happened again
         self.assertIsNotNone(bob.get_channel_by_id(chan.channel_id))
-        self.assertIsNotNone(bob.db.get('channels').get(chan.channel_id.hex()))
+        self.assertIsNotNone(bob.db.get_dict('channels').get(chan.channel_id.hex()))
         self.assertEqual(chan.get_state(), ChannelState.OPEN)
         self.assertEqual(bob.config.ZEROCONF_TRUSTED_NODE, trusted_node)
         self.assertFalse(chan.is_frozen_for_receiving())
@@ -636,7 +637,7 @@ class TestChannel(ElectrumTestCase):
 
         # check that channel got removed, now that funding has timed out
         self.assertIsNone(self.alice_lnwallet.get_channel_by_id(chan.channel_id))
-        self.assertIsNone(self.alice_lnwallet.db.get('channels').get(chan.channel_id.hex()))
+        self.assertIsNone(self.alice_lnwallet.db.get_dict('channels').get(chan.channel_id.hex()))
 
     async def test_should_be_closed_due_to_expiring_htlcs_offered_htlcs(self):
         alice_lnwallet = self.create_mock_lnwallet(name="alice")

--- a/tests/test_lnhtlc.py
+++ b/tests/test_lnhtlc.py
@@ -4,7 +4,6 @@ from typing import NamedTuple
 
 from electrum.lnutil import RECEIVED, LOCAL, REMOTE, SENT, HTLCOwner, Direction
 from electrum.lnhtlc import HTLCManager
-from electrum.json_db import StoredDict
 
 from . import ElectrumTestCase
 
@@ -14,8 +13,8 @@ class H(NamedTuple):
 
 class TestHTLCManager(ElectrumTestCase):
     def test_adding_htlcs_race(self):
-        A = HTLCManager(StoredDict({}, None))
-        B = HTLCManager(StoredDict({}, None))
+        A = HTLCManager({})
+        B = HTLCManager({})
         A.channel_open_finished()
         B.channel_open_finished()
         ah0, bh0 = H('A', 0), H('B', 0)
@@ -61,8 +60,8 @@ class TestHTLCManager(ElectrumTestCase):
 
     def test_single_htlc_full_lifecycle(self):
         def htlc_lifecycle(htlc_success: bool):
-            A = HTLCManager(StoredDict({}, None))
-            B = HTLCManager(StoredDict({}, None))
+            A = HTLCManager({})
+            B = HTLCManager({})
             A.channel_open_finished()
             B.channel_open_finished()
             B.recv_htlc(A.send_htlc(H('A', 0)))
@@ -134,8 +133,8 @@ class TestHTLCManager(ElectrumTestCase):
 
     def test_remove_htlc_while_owing_commitment(self):
         def htlc_lifecycle(htlc_success: bool):
-            A = HTLCManager(StoredDict({}, None))
-            B = HTLCManager(StoredDict({}, None))
+            A = HTLCManager({})
+            B = HTLCManager({})
             A.channel_open_finished()
             B.channel_open_finished()
             ah0 = H('A', 0)
@@ -171,8 +170,8 @@ class TestHTLCManager(ElectrumTestCase):
         htlc_lifecycle(htlc_success=False)
 
     def test_adding_htlc_between_send_ctx_and_recv_rev(self):
-        A = HTLCManager(StoredDict({}, None))
-        B = HTLCManager(StoredDict({}, None))
+        A = HTLCManager({})
+        B = HTLCManager({})
         A.channel_open_finished()
         B.channel_open_finished()
         A.send_ctx()
@@ -217,8 +216,8 @@ class TestHTLCManager(ElectrumTestCase):
         self.assertEqual([(Direction.RECEIVED, ah0)], A.get_htlcs_in_next_ctx(REMOTE))
 
     def test_unacked_local_updates(self):
-        A = HTLCManager(StoredDict({}, None))
-        B = HTLCManager(StoredDict({}, None))
+        A = HTLCManager({})
+        B = HTLCManager({})
         A.channel_open_finished()
         B.channel_open_finished()
         self.assertEqual({}, A.get_unacked_local_updates())

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -3,7 +3,6 @@ import json
 from typing import Dict, List
 
 from electrum import bitcoin
-from electrum.json_db import StoredDict
 from electrum.lnutil import (
     RevocationStore, get_per_commitment_secret_from_seed, make_offered_htlc, make_received_htlc, make_commitment,
     make_htlc_tx_witness, make_htlc_tx_output, make_htlc_tx_inputs, secret_to_pubkey, derive_blinded_pubkey,
@@ -13,6 +12,7 @@ from electrum.lnutil import (
     ImportedChannelBackupStorage, list_enabled_ln_feature_bits, PaymentFeeBudget, LnFeatureContexts
 )
 from electrum.util import bfh, MyEncoder
+from electrum.stored_dict import WalletStorage
 from electrum.transaction import Transaction, PartialTransaction, Sighash
 from electrum.lnworker import LNWallet
 from electrum.wallet import Standard_Wallet
@@ -474,10 +474,11 @@ class TestLNUtil(ElectrumTestCase):
         ]
 
         for test in tests:
-            receiver = RevocationStore(StoredDict({}, None))
+            storage = WalletStorage(None)
+            storage.set_data(json.dumps({"channels": {"0": { "revocation_store": {}}}}))
+            receiver = RevocationStore(storage["channels"]["0"]["revocation_store"])
             for insert in test["inserts"]:
                 secret = bytes.fromhex(insert["secret"])
-
                 try:
                     receiver.add_next_entry(secret)
                 except Exception as e:
@@ -497,7 +498,9 @@ class TestLNUtil(ElectrumTestCase):
 
     def test_shachain_produce_consume(self):
         seed = bitcoin.sha256(b"shachaintest")
-        consumer = RevocationStore(StoredDict({}, None))
+        storage = WalletStorage(None)
+        storage.set_data(json.dumps({"channels": {"0": { "revocation_store": {}}}}))
+        consumer = RevocationStore(storage["channels"]["0"]["revocation_store"])
         for i in range(10000):
             secret = get_per_commitment_secret_from_seed(seed, RevocationStore.START_INDEX - i)
             try:
@@ -506,9 +509,11 @@ class TestLNUtil(ElectrumTestCase):
                 raise Exception("iteration " + str(i) + ": " + str(e))
             if i % 1000 == 0:
                 c1 = consumer
-                s1 = json.dumps(c1.storage, cls=MyEncoder)
-                c2 = RevocationStore(StoredDict(json.loads(s1), None))
-                s2 = json.dumps(c2.storage, cls=MyEncoder)
+                s1 = json.dumps(storage._db.json_data, cls=MyEncoder)
+                storage2 = WalletStorage(None)
+                storage2.set_data(s1)
+                c2 = RevocationStore(storage2["channels"]["0"]["revocation_store"])
+                s2 = json.dumps(storage2._db.json_data, cls=MyEncoder)
                 self.assertEqual(s1, s2)
 
     def test_commitment_tx_with_all_five_HTLCs_untrimmed_minimum_feerate(self):

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -12,7 +12,7 @@ from electrum.lnutil import (
     ImportedChannelBackupStorage, list_enabled_ln_feature_bits, PaymentFeeBudget, LnFeatureContexts
 )
 from electrum.util import bfh, MyEncoder
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.transaction import Transaction, PartialTransaction, Sighash
 from electrum.lnworker import LNWallet
 from electrum.wallet import Standard_Wallet
@@ -474,7 +474,7 @@ class TestLNUtil(ElectrumTestCase):
         ]
 
         for test in tests:
-            storage = WalletStorage(None)
+            storage = DictStorage(None)
             storage.set_data(json.dumps({"channels": {"0": { "revocation_store": {}}}}))
             receiver = RevocationStore(storage["channels"]["0"]["revocation_store"])
             for insert in test["inserts"]:
@@ -498,7 +498,7 @@ class TestLNUtil(ElectrumTestCase):
 
     def test_shachain_produce_consume(self):
         seed = bitcoin.sha256(b"shachaintest")
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
         storage.set_data(json.dumps({"channels": {"0": { "revocation_store": {}}}}))
         consumer = RevocationStore(storage["channels"]["0"]["revocation_store"])
         for i in range(10000):
@@ -510,7 +510,7 @@ class TestLNUtil(ElectrumTestCase):
             if i % 1000 == 0:
                 c1 = consumer
                 s1 = json.dumps(storage._db.json_data, cls=MyEncoder)
-                storage2 = WalletStorage(None)
+                storage2 = DictStorage(None)
                 storage2.set_data(s1)
                 c2 = RevocationStore(storage2["channels"]["0"]["revocation_store"])
                 s2 = json.dumps(storage2._db.json_data, cls=MyEncoder)

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -11,8 +11,8 @@ from electrum.lnutil import (
     IncompatibleLightningFeatures, ChannelType, offered_htlc_trim_threshold_sat, received_htlc_trim_threshold_sat,
     ImportedChannelBackupStorage, list_enabled_ln_feature_bits, PaymentFeeBudget, LnFeatureContexts
 )
-from electrum.util import bfh, MyEncoder
-from electrum.stored_dict import DictStorage
+from electrum.util import bfh
+from electrum.stored_dict import to_default, DictStorage
 from electrum.transaction import Transaction, PartialTransaction, Sighash
 from electrum.lnworker import LNWallet
 from electrum.wallet import Standard_Wallet
@@ -509,11 +509,11 @@ class TestLNUtil(ElectrumTestCase):
                 raise Exception("iteration " + str(i) + ": " + str(e))
             if i % 1000 == 0:
                 c1 = consumer
-                s1 = json.dumps(storage._db.json_data, cls=MyEncoder)
+                s1 = json.dumps(storage._db.json_data, default=to_default)
                 storage2 = DictStorage(None)
                 storage2.set_data(s1)
                 c2 = RevocationStore(storage2["channels"]["0"]["revocation_store"])
-                s2 = json.dumps(storage2._db.json_data, cls=MyEncoder)
+                s2 = json.dumps(storage2._db.json_data, default=to_default)
                 self.assertEqual(s1, s2)
 
     def test_commitment_tx_with_all_five_HTLCs_untrimmed_minimum_feerate(self):

--- a/tests/test_storage_upgrade.py
+++ b/tests/test_storage_upgrade.py
@@ -7,6 +7,8 @@ import asyncio
 import inspect
 
 import electrum
+from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import StoredDict
 from electrum.wallet_db import WalletDBUpgrader, WalletDB, WalletRequiresUpgrade, WalletRequiresSplit
 from electrum.wallet import Wallet
 from electrum import constants
@@ -369,7 +371,9 @@ class TestStorageUpgrade(WalletTestCase):
                 self.assertEqual(accounts, len(split_data))
                 for item in split_data:
                     data = json.dumps(item)
-                    new_db = WalletDB(data, storage=None, upgrade=True)
+                    storage = WalletStorage(None)
+                    storage.set_data(data)
+                    new_db = WalletDB(storage, upgrade=True)
                     await self._sanity_check_upgraded_db(new_db)
 
     async def _sanity_check_upgraded_db(self, db):
@@ -378,5 +382,7 @@ class TestStorageUpgrade(WalletTestCase):
 
     @staticmethod
     def _load_db_from_json_string(*, wallet_json, upgrade):
-        db = WalletDB(wallet_json, storage=None, upgrade=upgrade)
+        storage = WalletStorage(None)
+        storage.set_data(wallet_json)
+        db = WalletDB(storage, upgrade=upgrade)
         return db

--- a/tests/test_storage_upgrade.py
+++ b/tests/test_storage_upgrade.py
@@ -7,7 +7,7 @@ import asyncio
 import inspect
 
 import electrum
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.stored_dict import StoredDict
 from electrum.wallet_db import WalletDBUpgrader, WalletDB, WalletRequiresUpgrade, WalletRequiresSplit
 from electrum.wallet import Wallet
@@ -371,7 +371,7 @@ class TestStorageUpgrade(WalletTestCase):
                 self.assertEqual(accounts, len(split_data))
                 for item in split_data:
                     data = json.dumps(item)
-                    storage = WalletStorage(None)
+                    storage = DictStorage(None)
                     storage.set_data(data)
                     new_db = WalletDB(storage, upgrade=True)
                     await self._sanity_check_upgraded_db(new_db)
@@ -382,7 +382,7 @@ class TestStorageUpgrade(WalletTestCase):
 
     @staticmethod
     def _load_db_from_json_string(*, wallet_json, upgrade):
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
         storage.set_data(wallet_json)
         db = WalletDB(storage, upgrade=upgrade)
         return db

--- a/tests/test_stored_dict.py
+++ b/tests/test_stored_dict.py
@@ -1,0 +1,75 @@
+import tempfile
+import sys
+import os
+import json
+import time
+from io import StringIO
+import asyncio
+from pathlib import Path
+
+from electrum.stored_dict import WalletStorage, StoredDict
+
+
+
+from . import ElectrumTestCase
+
+
+class TestStorage(ElectrumTestCase):
+
+    def setUp(self):
+        super(TestStorage, self).setUp()
+        self.path = os.path.join(self.electrum_path, "somewallet")
+
+        self._saved_stdout = sys.stdout
+        self._stdout_buffer = StringIO()
+        sys.stdout = self._stdout_buffer
+
+    def tearDown(self):
+        super(TestStorage, self).tearDown()
+        # Restore the "real" stdout
+        sys.stdout = self._saved_stdout
+
+    def test_db_roundtrip(self):
+        sd = WalletStorage(self.path)
+        # list containing list and dict
+        some_list = [[1, 2], {"c": "d"} ]
+        sd['1'] = some_list
+        self.assertEqual(sd['1'].dump(), some_list)
+        # dict containing list and dict
+        some_dict = {"a": [1, 2], "b": {"c":"d"} }
+        sd['2'] = some_dict
+        self.assertEqual(sd['2'].dump(), some_dict)
+        # simple tuple.
+        some_tuple = (1, 2, 3)
+        sd['3'] = some_tuple
+        self.assertEqual(sd['3'], some_tuple)
+        # complex tuple
+        complex_tuple = (1, 2, [3, 4])
+        sd['4'] = complex_tuple
+        self.assertEqual(sd['4'], complex_tuple)
+
+    def test_db_iterators(self):
+        sd = WalletStorage(self.path)
+        sd['a'] = [0, 1, 2, 3, 4]
+        sl = sd.get('a')
+        self.assertEqual(len(sl), 5)
+        for i, v in enumerate(sl):
+            self.assertEqual(i, v)
+
+    async def test_dangling_dict(self):
+        storage = WalletStorage(self.path)
+        storage['a'] = {'b': {'c': 0}}
+        storage.write()
+        a = storage.get('a')
+        b = a['b']
+        self.assertEqual(type(b), StoredDict)
+        b2 = a.pop('b')
+        self.assertEqual(type(b2), dict)
+        # replace item. this must not been written to db
+        with self.assertRaises(KeyError):
+            b['c'] = 42
+        storage.write()
+        storage.close()
+        storage = WalletStorage(self.path)
+        self.assertEqual(storage.dump(), {'a':{}})
+

--- a/tests/test_stored_dict.py
+++ b/tests/test_stored_dict.py
@@ -7,7 +7,7 @@ from io import StringIO
 import asyncio
 from pathlib import Path
 
-from electrum.stored_dict import WalletStorage, StoredDict
+from electrum.stored_dict import DictStorage, StoredDict
 
 
 
@@ -30,7 +30,7 @@ class TestStorage(ElectrumTestCase):
         sys.stdout = self._saved_stdout
 
     def test_db_roundtrip(self):
-        sd = WalletStorage(self.path)
+        sd = DictStorage(self.path)
         # list containing list and dict
         some_list = [[1, 2], {"c": "d"} ]
         sd['1'] = some_list
@@ -49,7 +49,7 @@ class TestStorage(ElectrumTestCase):
         self.assertEqual(sd['4'], complex_tuple)
 
     def test_db_iterators(self):
-        sd = WalletStorage(self.path)
+        sd = DictStorage(self.path)
         sd['a'] = [0, 1, 2, 3, 4]
         sl = sd.get('a')
         self.assertEqual(len(sl), 5)
@@ -57,7 +57,7 @@ class TestStorage(ElectrumTestCase):
             self.assertEqual(i, v)
 
     async def test_dangling_dict(self):
-        storage = WalletStorage(self.path)
+        storage = DictStorage(self.path)
         storage['a'] = {'b': {'c': 0}}
         storage.write()
         a = storage.get('a')
@@ -70,6 +70,6 @@ class TestStorage(ElectrumTestCase):
             b['c'] = 42
         storage.write()
         storage.close()
-        storage = WalletStorage(self.path)
+        storage = DictStorage(self.path)
         self.assertEqual(storage.dump(), {'a':{}})
 

--- a/tests/test_stored_dict.py
+++ b/tests/test_stored_dict.py
@@ -58,6 +58,29 @@ class TestStorage(ElectrumTestCase):
         for i, v in enumerate(sl):
             self.assertEqual(i, v)
 
+    def test_write_batch(self):
+        # test that batches are written atomically
+        sd = DictStorage(self.path)
+        with sd.write_batch():
+            sd['a'] = 0
+        self.assertEqual(len(sd), 1)
+        with sd.write_batch():
+            sd['a'] = 1
+        self.assertEqual(len(sd), 1)
+        try:
+            with sd.write_batch():
+                sd['b'] = 1
+                raise Exception('blah')
+        except Exception as e:
+            pass
+        self.assertEqual(sd._db._write_batch, False)
+        # at this point, the StoredDict length is 2
+        self.assertEqual(len(sd), 2)
+        sd.close()
+        # check that changes have not been written to disk
+        sd = DictStorage(self.path)
+        self.assertEqual(len(sd), 1)
+
     async def test_dangling_dict(self):
         storage = DictStorage(self.path)
         storage['a'] = {'b': {'c': 0}}

--- a/tests/test_stored_dict.py
+++ b/tests/test_stored_dict.py
@@ -43,10 +43,12 @@ class TestStorage(ElectrumTestCase):
         some_tuple = (1, 2, 3)
         sd['3'] = some_tuple
         self.assertEqual(sd['3'], some_tuple)
-        # complex tuple
+        # complex tuple: the third element is a StoredDict
         complex_tuple = (1, 2, [3, 4])
         sd['4'] = complex_tuple
-        self.assertEqual(sd['4'], complex_tuple)
+        with self.assertRaises(AssertionError):
+            self.assertEqual(sd['4'], complex_tuple)
+        self.assertEqual(sd['4'][2].dump(), complex_tuple[2])
 
     def test_db_iterators(self):
         sd = DictStorage(self.path)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -10,14 +10,14 @@ import asyncio
 from unittest import mock
 from pathlib import Path
 
-from electrum.storage import WalletStorage
 from electrum.wallet_db import FINAL_SEED_VERSION
 from electrum.wallet import (Abstract_Wallet, Standard_Wallet, create_new_wallet,
                              Imported_Wallet, Wallet)
 from electrum.exchange_rate import ExchangeBase, FxThread
 from electrum.util import TxMinedInfo, InvalidPassword
 from electrum.bitcoin import COIN
-from electrum.wallet_db import WalletDB, JsonDB
+from electrum.wallet_db import WalletDB
+from electrum.stored_dict import WalletStorage
 from electrum.simple_config import SimpleConfig
 from electrum import util, storage
 from electrum.daemon import Daemon
@@ -66,15 +66,13 @@ class TestWalletStorage(WalletTestCase):
         with open(self.wallet_path, "w") as f:
             contents = f.write(contents)
 
-        storage = WalletStorage(self.wallet_path)
-        db = JsonDB(storage.read(), storage=storage)
+        db = WalletStorage(self.wallet_path)
         self.assertEqual("b", db.get("a"))
         self.assertEqual("d", db.get("c"))
 
     def test_write_dictionary_to_file(self):
 
-        storage = WalletStorage(self.wallet_path)
-        db = JsonDB('', storage=storage)
+        db = WalletStorage(self.wallet_path)
 
         some_dict = {
             u"a": u"b",
@@ -82,7 +80,7 @@ class TestWalletStorage(WalletTestCase):
             u"seed_version": FINAL_SEED_VERSION}
 
         for key, value in some_dict.items():
-            db.put(key, value)
+            db[key] = value
         db.write()
 
         with open(self.wallet_path, "r") as f:
@@ -172,7 +170,8 @@ class FakeWallet:
     def __init__(self, fiat_value):
         super().__init__()
         self.fiat_value = fiat_value
-        self.db = WalletDB('', storage=None, upgrade=False)
+        storage = WalletStorage(None)
+        self.db = WalletDB(storage)
         self.adb = FakeADB()
         self.db.transactions = self.db.verified_tx = {'abc':'Tx'}
 
@@ -234,8 +233,8 @@ class TestHistoryExport(ElectrumTestCase):
         time.tzset()
 
     @mock.patch('electrum.wallet.run_hook')
-    @mock.patch.object(storage.WalletStorage, 'write')
-    @mock.patch.object(storage.WalletStorage, 'append')
+    @mock.patch.object(storage.FileStorage, 'write')
+    @mock.patch.object(storage.FileStorage, 'append')
     async def test_export_history_to_file(self, _mock_append, _mock_write, mock_run_hook):
         # prepare wallet with realistic history
         c = self.config
@@ -325,7 +324,7 @@ class TestCreateRestoreWallet(WalletTestCase):
             config=self.config,
         )
         wallet = d['wallet']  # type: Standard_Wallet
-        self.assertEqual(None, wallet.storage)
+        self.assertEqual(None, wallet.storage._db.storage)
         self.assertEqual(text, wallet.keystore.get_seed(None))
         self.assertEqual('bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af', wallet.get_receiving_addresses()[0])
 
@@ -379,7 +378,8 @@ class TestWalletPassword(WalletTestCase):
     async def test_update_password_of_imported_wallet(self):
         wallet_str = '{"addr_history":{"1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr":[],"15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA":[],"1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6":[]},"addresses":{"change":[],"receiving":["1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr","1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6","15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA"]},"keystore":{"keypairs":{"0344b1588589958b0bcab03435061539e9bcf54677c104904044e4f8901f4ebdf5":"L2sED74axVXC4H8szBJ4rQJrkfem7UMc6usLCPUoEWxDCFGUaGUM","0389508c13999d08ffae0f434a085f4185922d64765c0bff2f66e36ad7f745cc5f":"L3Gi6EQLvYw8gEEUckmqawkevfj9s8hxoQDFveQJGZHTfyWnbk1U","04575f52b82f159fa649d2a4c353eb7435f30206f0a6cb9674fbd659f45082c37d559ffd19bea9c0d3b7dcc07a7b79f4cffb76026d5d4dff35341efe99056e22d2":"5JyVyXU1LiRXATvRTQvR9Kp8Rx1X84j2x49iGkjSsXipydtByUq"},"type":"imported"},"pruned_txo":{},"seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[100,100,840,405]}'
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        storage.set_data(wallet_str)
+        db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
 
         wallet.check_password(None)
@@ -394,8 +394,9 @@ class TestWalletPassword(WalletTestCase):
 
     async def test_update_password_of_standard_wallet(self):
         wallet_str = '''{"addr_history":{"12ECgkzK6gHouKAZ7QiooYBuk1CgJLJxes":[],"12iR43FPb5M7sw4Mcrr5y1nHKepg9EtZP1":[],"13HT1pfWctsSXVFzF76uYuVdQvcAQ2MAgB":[],"13kG9WH9JqS7hyCcVL1ssLdNv4aXocQY9c":[],"14Tf3qiiHJXStSU4KmienAhHfHq7FHpBpz":[],"14gmBxYV97mzYwWdJSJ3MTLbTHVegaKrcA":[],"15FGuHvRssu1r8fCw98vrbpfc3M4xs5FAV":[],"17oJzweA2gn6SDjsKgA9vUD5ocT1sSnr2Z":[],"18hNcSjZzRcRP6J2bfFRxp9UfpMoC4hGTv":[],"18n9PFxBjmKCGhd4PCDEEqYsi2CsnEfn2B":[],"19a98ZfEezDNbCwidVigV5PAJwrR2kw4Jz":[],"19z3j2ELqbg2pR87byCCt3BCyKR7rc3q8G":[],"1A3XSmvLQvePmvm7yctsGkBMX9ZKKXLrVq":[],"1CmhFe2BN1h9jheFpJf4v39XNPj8F9U6d":[],"1DuphhHUayKzbkdvjVjf5dtjn2ACkz4zEs":[],"1E4ygSNJpWL2uPXZHBptmU2LqwZTqb1Ado":[],"1GTDSjkVc9vaaBBBGNVqTANHJBcoT5VW9z":[],"1GWqgpThAuSq3tDg6uCoLQxPXQNnU8jZ52":[],"1GhmpwqSF5cqNgdr9oJMZx8dKxPRo4pYPP":[],"1J5TTUQKhwehEACw6Jjte1E22FVrbeDmpv":[],"1JWySzjzJhsETUUcqVZHuvQLA7pfFfmesb":[],"1KQHxcy3QUHAWMHKUtJjqD9cMKXcY2RTwZ":[],"1KoxZfc2KsgovjGDxwqanbFEA76uxgYH4G":[],"1KqVEPXdpbYvEbwsZcEKkrA4A2jsgj9hYN":[],"1N16yDSYe76c5A3CoVoWAKxHeAUc8Jhf9J":[],"1Pm8JBhzUJDqeQQKrmnop1Frr4phe1jbTt":[]},"addresses":{"change":["1GhmpwqSF5cqNgdr9oJMZx8dKxPRo4pYPP","1GTDSjkVc9vaaBBBGNVqTANHJBcoT5VW9z","15FGuHvRssu1r8fCw98vrbpfc3M4xs5FAV","1A3XSmvLQvePmvm7yctsGkBMX9ZKKXLrVq","19z3j2ELqbg2pR87byCCt3BCyKR7rc3q8G","1JWySzjzJhsETUUcqVZHuvQLA7pfFfmesb"],"receiving":["14gmBxYV97mzYwWdJSJ3MTLbTHVegaKrcA","13HT1pfWctsSXVFzF76uYuVdQvcAQ2MAgB","19a98ZfEezDNbCwidVigV5PAJwrR2kw4Jz","1J5TTUQKhwehEACw6Jjte1E22FVrbeDmpv","1Pm8JBhzUJDqeQQKrmnop1Frr4phe1jbTt","13kG9WH9JqS7hyCcVL1ssLdNv4aXocQY9c","1KQHxcy3QUHAWMHKUtJjqD9cMKXcY2RTwZ","12ECgkzK6gHouKAZ7QiooYBuk1CgJLJxes","12iR43FPb5M7sw4Mcrr5y1nHKepg9EtZP1","14Tf3qiiHJXStSU4KmienAhHfHq7FHpBpz","1KqVEPXdpbYvEbwsZcEKkrA4A2jsgj9hYN","17oJzweA2gn6SDjsKgA9vUD5ocT1sSnr2Z","1E4ygSNJpWL2uPXZHBptmU2LqwZTqb1Ado","18hNcSjZzRcRP6J2bfFRxp9UfpMoC4hGTv","1KoxZfc2KsgovjGDxwqanbFEA76uxgYH4G","18n9PFxBjmKCGhd4PCDEEqYsi2CsnEfn2B","1CmhFe2BN1h9jheFpJf4v39XNPj8F9U6d","1DuphhHUayKzbkdvjVjf5dtjn2ACkz4zEs","1GWqgpThAuSq3tDg6uCoLQxPXQNnU8jZ52","1N16yDSYe76c5A3CoVoWAKxHeAUc8Jhf9J"]},"keystore":{"seed":"cereal wise two govern top pet frog nut rule sketch bundle logic","type":"bip32","xprv":"xprv9s21ZrQH143K29XjRjUs6MnDB9wXjXbJP2kG1fnRk8zjdDYWqVkQYUqaDtgZp5zPSrH5PZQJs8sU25HrUgT1WdgsPU8GbifKurtMYg37d4v","xpub":"xpub661MyMwAqRbcEdcCXm1sTViwjBn28zK9kFfrp4C3JUXiW1sfP34f6HA45B9yr7EH5XGzWuTfMTdqpt9XPrVQVUdgiYb5NW9m8ij1FSZgGBF"},"pruned_txo":{},"seed_type":"standard","seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[619,310,840,405]}'''
-        storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        storage = WalletStorage(path=self.wallet_path)
+        storage.set_data(wallet_str)
+        db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
 
         wallet.check_password(None)
@@ -424,14 +425,15 @@ class TestWalletPassword(WalletTestCase):
     async def test_update_password_with_app_restarts(self):
         wallet_str = '{"addr_history":{"1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr":[],"15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA":[],"1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6":[]},"addresses":{"change":[],"receiving":["1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr","1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6","15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA"]},"keystore":{"keypairs":{"0344b1588589958b0bcab03435061539e9bcf54677c104904044e4f8901f4ebdf5":"L2sED74axVXC4H8szBJ4rQJrkfem7UMc6usLCPUoEWxDCFGUaGUM","0389508c13999d08ffae0f434a085f4185922d64765c0bff2f66e36ad7f745cc5f":"L3Gi6EQLvYw8gEEUckmqawkevfj9s8hxoQDFveQJGZHTfyWnbk1U","04575f52b82f159fa649d2a4c353eb7435f30206f0a6cb9674fbd659f45082c37d559ffd19bea9c0d3b7dcc07a7b79f4cffb76026d5d4dff35341efe99056e22d2":"5JyVyXU1LiRXATvRTQvR9Kp8Rx1X84j2x49iGkjSsXipydtByUq"},"type":"imported"},"pruned_txo":{},"seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[100,100,840,405]}'
         storage = WalletStorage(self.wallet_path)
-        db = WalletDB(wallet_str, storage=storage, upgrade=True)
+        storage.set_data(wallet_str)
+        db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
         await wallet.stop()
 
         storage = WalletStorage(self.wallet_path)
         # if storage.is_encrypted():
         #     storage.decrypt(password)
-        db = WalletDB(storage.read(), storage=storage, upgrade=True)
+        db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
 
         wallet.check_password(None)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -17,7 +17,7 @@ from electrum.exchange_rate import ExchangeBase, FxThread
 from electrum.util import TxMinedInfo, InvalidPassword
 from electrum.bitcoin import COIN
 from electrum.wallet_db import WalletDB
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum.simple_config import SimpleConfig
 from electrum import util, storage
 from electrum.daemon import Daemon
@@ -66,13 +66,13 @@ class TestWalletStorage(WalletTestCase):
         with open(self.wallet_path, "w") as f:
             contents = f.write(contents)
 
-        db = WalletStorage(self.wallet_path)
+        db = DictStorage(self.wallet_path)
         self.assertEqual("b", db.get("a"))
         self.assertEqual("d", db.get("c"))
 
     def test_write_dictionary_to_file(self):
 
-        db = WalletStorage(self.wallet_path)
+        db = DictStorage(self.wallet_path)
 
         some_dict = {
             u"a": u"b",
@@ -170,7 +170,7 @@ class FakeWallet:
     def __init__(self, fiat_value):
         super().__init__()
         self.fiat_value = fiat_value
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
         self.db = WalletDB(storage)
         self.adb = FakeADB()
         self.db.transactions = self.db.verified_tx = {'abc':'Tx'}
@@ -377,7 +377,7 @@ class TestWalletPassword(WalletTestCase):
 
     async def test_update_password_of_imported_wallet(self):
         wallet_str = '{"addr_history":{"1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr":[],"15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA":[],"1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6":[]},"addresses":{"change":[],"receiving":["1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr","1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6","15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA"]},"keystore":{"keypairs":{"0344b1588589958b0bcab03435061539e9bcf54677c104904044e4f8901f4ebdf5":"L2sED74axVXC4H8szBJ4rQJrkfem7UMc6usLCPUoEWxDCFGUaGUM","0389508c13999d08ffae0f434a085f4185922d64765c0bff2f66e36ad7f745cc5f":"L3Gi6EQLvYw8gEEUckmqawkevfj9s8hxoQDFveQJGZHTfyWnbk1U","04575f52b82f159fa649d2a4c353eb7435f30206f0a6cb9674fbd659f45082c37d559ffd19bea9c0d3b7dcc07a7b79f4cffb76026d5d4dff35341efe99056e22d2":"5JyVyXU1LiRXATvRTQvR9Kp8Rx1X84j2x49iGkjSsXipydtByUq"},"type":"imported"},"pruned_txo":{},"seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[100,100,840,405]}'
-        storage = WalletStorage(self.wallet_path)
+        storage = DictStorage(self.wallet_path)
         storage.set_data(wallet_str)
         db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
@@ -394,7 +394,7 @@ class TestWalletPassword(WalletTestCase):
 
     async def test_update_password_of_standard_wallet(self):
         wallet_str = '''{"addr_history":{"12ECgkzK6gHouKAZ7QiooYBuk1CgJLJxes":[],"12iR43FPb5M7sw4Mcrr5y1nHKepg9EtZP1":[],"13HT1pfWctsSXVFzF76uYuVdQvcAQ2MAgB":[],"13kG9WH9JqS7hyCcVL1ssLdNv4aXocQY9c":[],"14Tf3qiiHJXStSU4KmienAhHfHq7FHpBpz":[],"14gmBxYV97mzYwWdJSJ3MTLbTHVegaKrcA":[],"15FGuHvRssu1r8fCw98vrbpfc3M4xs5FAV":[],"17oJzweA2gn6SDjsKgA9vUD5ocT1sSnr2Z":[],"18hNcSjZzRcRP6J2bfFRxp9UfpMoC4hGTv":[],"18n9PFxBjmKCGhd4PCDEEqYsi2CsnEfn2B":[],"19a98ZfEezDNbCwidVigV5PAJwrR2kw4Jz":[],"19z3j2ELqbg2pR87byCCt3BCyKR7rc3q8G":[],"1A3XSmvLQvePmvm7yctsGkBMX9ZKKXLrVq":[],"1CmhFe2BN1h9jheFpJf4v39XNPj8F9U6d":[],"1DuphhHUayKzbkdvjVjf5dtjn2ACkz4zEs":[],"1E4ygSNJpWL2uPXZHBptmU2LqwZTqb1Ado":[],"1GTDSjkVc9vaaBBBGNVqTANHJBcoT5VW9z":[],"1GWqgpThAuSq3tDg6uCoLQxPXQNnU8jZ52":[],"1GhmpwqSF5cqNgdr9oJMZx8dKxPRo4pYPP":[],"1J5TTUQKhwehEACw6Jjte1E22FVrbeDmpv":[],"1JWySzjzJhsETUUcqVZHuvQLA7pfFfmesb":[],"1KQHxcy3QUHAWMHKUtJjqD9cMKXcY2RTwZ":[],"1KoxZfc2KsgovjGDxwqanbFEA76uxgYH4G":[],"1KqVEPXdpbYvEbwsZcEKkrA4A2jsgj9hYN":[],"1N16yDSYe76c5A3CoVoWAKxHeAUc8Jhf9J":[],"1Pm8JBhzUJDqeQQKrmnop1Frr4phe1jbTt":[]},"addresses":{"change":["1GhmpwqSF5cqNgdr9oJMZx8dKxPRo4pYPP","1GTDSjkVc9vaaBBBGNVqTANHJBcoT5VW9z","15FGuHvRssu1r8fCw98vrbpfc3M4xs5FAV","1A3XSmvLQvePmvm7yctsGkBMX9ZKKXLrVq","19z3j2ELqbg2pR87byCCt3BCyKR7rc3q8G","1JWySzjzJhsETUUcqVZHuvQLA7pfFfmesb"],"receiving":["14gmBxYV97mzYwWdJSJ3MTLbTHVegaKrcA","13HT1pfWctsSXVFzF76uYuVdQvcAQ2MAgB","19a98ZfEezDNbCwidVigV5PAJwrR2kw4Jz","1J5TTUQKhwehEACw6Jjte1E22FVrbeDmpv","1Pm8JBhzUJDqeQQKrmnop1Frr4phe1jbTt","13kG9WH9JqS7hyCcVL1ssLdNv4aXocQY9c","1KQHxcy3QUHAWMHKUtJjqD9cMKXcY2RTwZ","12ECgkzK6gHouKAZ7QiooYBuk1CgJLJxes","12iR43FPb5M7sw4Mcrr5y1nHKepg9EtZP1","14Tf3qiiHJXStSU4KmienAhHfHq7FHpBpz","1KqVEPXdpbYvEbwsZcEKkrA4A2jsgj9hYN","17oJzweA2gn6SDjsKgA9vUD5ocT1sSnr2Z","1E4ygSNJpWL2uPXZHBptmU2LqwZTqb1Ado","18hNcSjZzRcRP6J2bfFRxp9UfpMoC4hGTv","1KoxZfc2KsgovjGDxwqanbFEA76uxgYH4G","18n9PFxBjmKCGhd4PCDEEqYsi2CsnEfn2B","1CmhFe2BN1h9jheFpJf4v39XNPj8F9U6d","1DuphhHUayKzbkdvjVjf5dtjn2ACkz4zEs","1GWqgpThAuSq3tDg6uCoLQxPXQNnU8jZ52","1N16yDSYe76c5A3CoVoWAKxHeAUc8Jhf9J"]},"keystore":{"seed":"cereal wise two govern top pet frog nut rule sketch bundle logic","type":"bip32","xprv":"xprv9s21ZrQH143K29XjRjUs6MnDB9wXjXbJP2kG1fnRk8zjdDYWqVkQYUqaDtgZp5zPSrH5PZQJs8sU25HrUgT1WdgsPU8GbifKurtMYg37d4v","xpub":"xpub661MyMwAqRbcEdcCXm1sTViwjBn28zK9kFfrp4C3JUXiW1sfP34f6HA45B9yr7EH5XGzWuTfMTdqpt9XPrVQVUdgiYb5NW9m8ij1FSZgGBF"},"pruned_txo":{},"seed_type":"standard","seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[619,310,840,405]}'''
-        storage = WalletStorage(path=self.wallet_path)
+        storage = DictStorage(path=self.wallet_path)
         storage.set_data(wallet_str)
         db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
@@ -424,13 +424,13 @@ class TestWalletPassword(WalletTestCase):
 
     async def test_update_password_with_app_restarts(self):
         wallet_str = '{"addr_history":{"1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr":[],"15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA":[],"1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6":[]},"addresses":{"change":[],"receiving":["1364Js2VG66BwRdkaoxAaFtdPb1eQgn8Dr","1Exet2BhHsFxKTwhnfdsBMkPYLGvobxuW6","15CyDgLffJsJgQrhcyooFH4gnVDG82pUrA"]},"keystore":{"keypairs":{"0344b1588589958b0bcab03435061539e9bcf54677c104904044e4f8901f4ebdf5":"L2sED74axVXC4H8szBJ4rQJrkfem7UMc6usLCPUoEWxDCFGUaGUM","0389508c13999d08ffae0f434a085f4185922d64765c0bff2f66e36ad7f745cc5f":"L3Gi6EQLvYw8gEEUckmqawkevfj9s8hxoQDFveQJGZHTfyWnbk1U","04575f52b82f159fa649d2a4c353eb7435f30206f0a6cb9674fbd659f45082c37d559ffd19bea9c0d3b7dcc07a7b79f4cffb76026d5d4dff35341efe99056e22d2":"5JyVyXU1LiRXATvRTQvR9Kp8Rx1X84j2x49iGkjSsXipydtByUq"},"type":"imported"},"pruned_txo":{},"seed_version":13,"stored_height":-1,"transactions":{},"tx_fees":{},"txi":{},"txo":{},"use_encryption":false,"verified_tx3":{},"wallet_type":"standard","winpos-qt":[100,100,840,405]}'
-        storage = WalletStorage(self.wallet_path)
+        storage = DictStorage(self.wallet_path)
         storage.set_data(wallet_str)
         db = WalletDB(storage)
         wallet = Wallet(db, config=self.config)
         await wallet.stop()
 
-        storage = WalletStorage(self.wallet_path)
+        storage = DictStorage(self.wallet_path)
         # if storage.is_encrypted():
         #     storage.decrypt(password)
         db = WalletDB(storage)

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -8,7 +8,7 @@ import copy
 
 from electrum import bitcoin, keystore, bip32, slip39
 from electrum.wallet_db import WalletDB
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 from electrum import SimpleConfig
 from electrum import util
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCONF_PARENT, TX_HEIGHT_LOCAL, TX_HEIGHT_FUTURE
@@ -55,7 +55,7 @@ class WalletIntegrityHelper:
 
     @classmethod
     def create_standard_wallet(cls, ks, *, config: SimpleConfig, gap_limit=None, gap_limit_for_change=None):
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
         db = WalletDB(storage)
         db.put('keystore', ks.dump())
         db.put('gap_limit', gap_limit or cls.gap_limit)
@@ -66,7 +66,7 @@ class WalletIntegrityHelper:
 
     @classmethod
     def create_imported_wallet(cls, *, config: SimpleConfig, privkeys: bool):
-        storage = WalletStorage(None)
+        storage = DictStorage(None)
         db = WalletDB(storage)
         if privkeys:
             k = keystore.Imported_KeyStore({})
@@ -81,13 +81,13 @@ class WalletIntegrityHelper:
         multisig_type: str,
         *,
         config: SimpleConfig,
-        storage: WalletStorage | None = None,
+        storage: DictStorage | None = None,
         gap_limit=None,
         gap_limit_for_change=None,
     ):
         """Creates a multisig wallet."""
         if storage is None:
-            storage = WalletStorage(None)
+            storage = DictStorage(None)
         db = WalletDB(storage)
         for i, ks in enumerate(keystores):
             cosigner_index = i + 1

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -8,7 +8,7 @@ import copy
 
 from electrum import bitcoin, keystore, bip32, slip39
 from electrum.wallet_db import WalletDB
-from electrum.storage import WalletStorage
+from electrum.stored_dict import WalletStorage
 from electrum import SimpleConfig
 from electrum import util
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCONF_PARENT, TX_HEIGHT_LOCAL, TX_HEIGHT_FUTURE
@@ -55,7 +55,8 @@ class WalletIntegrityHelper:
 
     @classmethod
     def create_standard_wallet(cls, ks, *, config: SimpleConfig, gap_limit=None, gap_limit_for_change=None):
-        db = WalletDB('', storage=None, upgrade=True)
+        storage = WalletStorage(None)
+        db = WalletDB(storage)
         db.put('keystore', ks.dump())
         db.put('gap_limit', gap_limit or cls.gap_limit)
         db.put('gap_limit_for_change', gap_limit_for_change or cls.gap_limit_for_change)
@@ -65,7 +66,8 @@ class WalletIntegrityHelper:
 
     @classmethod
     def create_imported_wallet(cls, *, config: SimpleConfig, privkeys: bool):
-        db = WalletDB('', storage=None, upgrade=True)
+        storage = WalletStorage(None)
+        db = WalletDB(storage)
         if privkeys:
             k = keystore.Imported_KeyStore({})
             db.put('keystore', k.dump())
@@ -84,7 +86,9 @@ class WalletIntegrityHelper:
         gap_limit_for_change=None,
     ):
         """Creates a multisig wallet."""
-        db = WalletDB('', storage=storage, upgrade=False)
+        if storage is None:
+            storage = WalletStorage(None)
+        db = WalletDB(storage)
         for i, ks in enumerate(keystores):
             cosigner_index = i + 1
             db.put('x%d' % cosigner_index, ks.dump())

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -12,7 +12,7 @@ from electrum import util
 from electrum import slip39
 from electrum.bip32 import KeyOriginInfo
 from electrum import keystore
-from electrum.storage import WalletStorage
+from electrum.stored_dict import WalletStorage
 
 from . import ElectrumTestCase
 from .test_wallet_vertical import UNICODE_HORROR, WalletIntegrityHelper

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -12,7 +12,7 @@ from electrum import util
 from electrum import slip39
 from electrum.bip32 import KeyOriginInfo
 from electrum import keystore
-from electrum.stored_dict import WalletStorage
+from electrum.stored_dict import DictStorage
 
 from . import ElectrumTestCase
 from .test_wallet_vertical import UNICODE_HORROR, WalletIntegrityHelper
@@ -403,7 +403,7 @@ class KeystoreWizardTestCase(WizardTestCase):
             ],
             '2of2',
             config=self.config,
-            storage=WalletStorage(self.wallet_path),
+            storage=DictStorage(self.wallet_path),
         )
 
         w, v = self._wizard_for(wallet_type=wallet.wallet_type)


### PR DESCRIPTION
I am marking this as ready because it is advanced enough that it could use some review.

My hope was to make the first commit pass all the tests, but that seems to be impossible. Commit 4 (types conversions) restores functionality. Note that commit 2 (perf optimization) and 3 (rename) are	trivial, and they could	potentially be reordered after commit 4.

There are 3 remaining design issues:

   1. should `StoredDict`.get() return `dict`/`list` instead of `StoredList`/`StoredDict`	?
       - pro: `get`() would be consistent with `pop`()
       - con: `get`() would be inconsistent with `__getitem__` , which must return `StoredList`/`StoredDict`
       - pro: in order to access/create `StoredDict`/`StoredList`, we would move `get_dict`, `get_list` from `wallet_db` to `stored_dict`. This would make the returned types more explicit.
       - pro: this would simplify DB upgrades, and code in general
      	
   2. should we remove the `init_db` parameter in the constructor, and use an explicit `DictStorage.open`() call instead?
       - probably cleaner, there is already a `close`() method
       - `open` would take the password as parameter, and behave as `decrypt`(). Howver, it would need to be called even for non-encrypted wallets.

   3.  currently if an exception is raised during a batch write, memory and disk become inconsistent (see FIXME)
       - ideally, we should get rid of `save_db`, and always write to disk if we are not in a batch.
       - this would be easy if we had partial writes always enabled (not implemented yet with encrypted wallets)

EDIT: point 3 is now fixed in #10339 
