### PR TITLE
refactor change-to-swap and submarine-payment parts from GUI to backend 

### DIFF
--- a/electrum/gui/common_qt/swaps.py
+++ b/electrum/gui/common_qt/swaps.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2026 The Electrum Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from concurrent.futures import Future
+from typing import Optional, Callable, TYPE_CHECKING
+
+from PyQt6.QtCore import pyqtSignal, pyqtProperty
+
+from electrum import get_logger
+from electrum.gui.common_qt.util import qt_event_listener, QtEventListener
+from electrum.submarine_swaps import SwapServerTransport
+
+if TYPE_CHECKING:
+    from electrum.wallet import Abstract_Wallet
+
+
+class SubmarineSwapMixin(QtEventListener):
+
+    _swaps_logger = get_logger(__name__)
+    swapAvailabilityChanged = pyqtSignal()
+    swapOffersChanged = pyqtSignal()
+
+    def __init__(self, create_sm_transport: Callable = None):
+        self.swap_wallet = None
+        self.config = None
+        self.create_sm_transport = create_sm_transport
+        self.swap_manager = None
+        self.swap_transport = None  # type: Optional[SwapServerTransport]
+
+    def set_wallet_for_swap(self, wallet: 'Abstract_Wallet'):
+        self.swap_wallet = wallet
+        self.config = wallet.config
+        self.swap_manager = wallet.lnworker.swap_manager if wallet.has_lightning() else None
+
+    # --- Shared functionality for submarine swaps (change to ln and submarine payments) ---
+    def prepare_swap_transport(self):
+        if not self.swap_manager:
+            return  # no swaps possible, lightning disabled
+        if self.swap_transport is not None:
+            if self.swap_transport.is_connected.is_set():
+                # we already have a connected transport, no need to create a new one
+                return
+            if self.swap_transport.ongoing_connection_attempt:
+                # another task is currently trying to connect
+                return
+
+        # there should only be a connected transport.
+        # a useless transport should get cleaned up and not stored.
+        assert self.swap_transport is None, "swap transport wasn't cleaned up properly"
+
+        self.swap_transport = self.create_sm_transport() if self.create_sm_transport \
+            else self.swap_manager.create_transport()
+
+        if not self.swap_transport:
+            # could not create transport, e.g. user declined to enable Nostr and has no http server configured
+            self._swaps_logger.debug('could not create swap transport')
+            self.swapAvailabilityChanged.emit()
+            return
+
+        def transport_initialize_done(future: Future):
+            if future.cancelled() or future.exception() is not None:
+                self.swap_transport = None
+            self.swapAvailabilityChanged.emit()
+
+        self.swap_transport.initialize(transport_initialize_done)
+
+    def swap_transport_cleanup(self):
+        self.unregister_callbacks()
+        if self.swap_transport is not None:
+            self.swap_transport.destroy()
+            self.swap_transport = None
+
+    @qt_event_listener
+    def on_event_swap_provider_changed(self):
+        self.swapAvailabilityChanged.emit()
+
+    @qt_event_listener
+    def on_event_channel(self, wallet, _channel):
+        # useful e.g. if the user quickly opens the tab after startup before the channels are initialized
+        if wallet == self.swap_wallet and self.swap_manager and self.swap_manager.is_initialized.is_set():
+            self.swapAvailabilityChanged.emit()
+
+    @qt_event_listener
+    def on_event_swap_offers_changed(self, _):
+        if self.swap_transport and self.swap_transport.ongoing_connection_attempt:
+            return
+        self.swapOffersChanged.emit()

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -23,31 +23,30 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import asyncio
 from decimal import Decimal
 from functools import partial
 from typing import TYPE_CHECKING, Optional, Union, Sequence
-from concurrent.futures import Future
 from enum import Enum, auto
 
-from PyQt6.QtCore import Qt, QTimer, pyqtSlot, pyqtSignal
+from PyQt6.QtCore import Qt, QTimer, pyqtSlot
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import (QHBoxLayout, QVBoxLayout, QLabel, QGridLayout, QPushButton, QToolButton,
                              QComboBox, QTabWidget, QWidget, QStackedWidget)
 
 from electrum.i18n import _
 from electrum.util import (UserCancelled, quantize_feerate, profiler, NotEnoughFunds, NoDynamicFeeEstimates,
-                           get_asyncio_loop, wait_for2, UserFacingException)
+                           UserFacingException)
 from electrum.plugin import run_hook
 from electrum.transaction import PartialTransaction, PartialTxOutput, Transaction
 from electrum.wallet import InternalAddressCorruption
 from electrum.bitcoin import DummyAddress
 from electrum.fee_policy import FeePolicy, FixedFeePolicy, FeeMethod
 from electrum.logging import Logger
-from electrum.submarine_swaps import NostrTransport, HttpTransport, SwapServerTransport, SwapServerError
+from electrum.submarine_swaps import NostrTransport, SwapServerError
 from electrum.gui.messages import MSG_SUBMARINE_PAYMENT_HELP_TEXT
 
-from electrum.gui.common_qt.util import QtEventListener, qt_event_listener
+from electrum.gui.common_qt.util import qt_event_listener
+from electrum.gui.common_qt.swaps import SubmarineSwapMixin
 
 from .util import (WindowModalDialog, ColorScheme, HelpLabel, Buttons, CancelButton, WWLabel,
                    read_QIcon, IconLabel, HelpButton, RunCoroutineDialog)
@@ -71,9 +70,7 @@ class TxEditorContext(Enum):
     CHANNEL_FUNDING = auto()
 
 
-class TxEditor(WindowModalDialog, QtEventListener, Logger):
-
-    swap_availability_changed = pyqtSignal()
+class TxEditor(WindowModalDialog, SubmarineSwapMixin, Logger):
 
     def __init__(
             self, *, title='',
@@ -87,6 +84,7 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
 
         WindowModalDialog.__init__(self, window, title=title)
         Logger.__init__(self)
+        SubmarineSwapMixin.__init__(self, window.create_sm_transport)
         self.main_window = window
         self.make_tx = make_tx
         self.output_value = output_value
@@ -109,9 +107,9 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
         self._base_tx = None  # type: Optional[Transaction]  # for batching
         self.batching_candidates = batching_candidates
 
-        self.swap_manager = self.wallet.lnworker.swap_manager if self.wallet.has_lightning() else None
-        self.swap_transport = None  # type: Optional[SwapServerTransport]
-        self.swap_availability_changed.connect(self.on_swap_availability_changed, Qt.ConnectionType.QueuedConnection)
+        self.swapAvailabilityChanged.connect(self.on_swap_availability_changed, Qt.ConnectionType.QueuedConnection)
+        self.swapOffersChanged.connect(self.on_swap_offers_changed, Qt.ConnectionType.QueuedConnection)
+        self.set_wallet_for_swap(window.wallet)
         self.did_swap = False  # used to clear the PI on send tab
 
         self.locktime_e = LockTimeEdit(self)
@@ -168,24 +166,16 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
         # debug_widget_layouts(self)  # enable to show red lines around all elements
 
     def accept(self):
-        self._cleanup()
+        self.swap_transport_cleanup()
         super().accept()
 
     def reject(self):
-        self._cleanup()
+        self.swap_transport_cleanup()
         super().reject()
 
     def closeEvent(self, event):
-        self._cleanup()
+        self.swap_transport_cleanup()
         super().closeEvent(event)
-
-    def _cleanup(self):
-        self.unregister_callbacks()
-        if self.swap_transport and self.swap_transport.ongoing_connection_attempt:
-            self.swap_transport.ongoing_connection_attempt.cancel()
-        if isinstance(self.swap_transport, NostrTransport):
-            asyncio.run_coroutine_threadsafe(self.swap_transport.stop(), get_asyncio_loop())
-        self.swap_transport = None  # HTTPTransport doesn't need to be closed
 
     def on_tab_changed(self, index):
         if self.tab_widget.widget(index) == self.submarine_payment_tab:
@@ -742,67 +732,10 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
     def can_pay_assuming_zero_fees(self, confirmed_only: bool) -> bool:
         raise NotImplementedError
 
-    ### --- Shared functionality for submarine swaps (change to ln and submarine payments) ---
-    def prepare_swap_transport(self):
-        if not self.swap_manager:
-            return  # no swaps possible, lightning disabled
-        if self.swap_transport is not None:
-            if self.swap_transport.is_connected.is_set():
-                # we already have a connected transport, no need to create a new one
-                return
-            if self.swap_transport.ongoing_connection_attempt:
-                # another task is currently trying to connect
-                return
-
-        # there should only be a connected transport.
-        # a useless transport should get cleaned up and not stored.
-        assert self.swap_transport is None, "swap transport wasn't cleaned up properly"
-
-        new_swap_transport = self.main_window.create_sm_transport()
-        if not new_swap_transport:
-            # user declined to enable Nostr and has no http server configured
-            self.swap_availability_changed.emit()
-            return
-
-        async def _initialize_transport(transport):
-            try:
-                if isinstance(transport, NostrTransport):
-                    asyncio.create_task(transport.main_loop())
-                else:
-                    assert isinstance(transport, HttpTransport)
-                    asyncio.create_task(transport.get_pairs_just_once())
-                if not await self.swap_manager.wait_for_swap_transport(transport):
-                    return
-                self.swap_transport = transport
-            except Exception:
-                self.logger.exception("failed to create swap transport")
-            finally:
-                self.swap_transport.ongoing_connection_attempt = None
-                self.swap_availability_changed.emit()
-
-        # this task will get cancelled if the TxEditor gets closed
-        self.swap_transport.ongoing_connection_attempt = asyncio.run_coroutine_threadsafe(
-            _initialize_transport(new_swap_transport),
-            get_asyncio_loop(),
-        )
-
-    @qt_event_listener
-    def on_event_swap_provider_changed(self):
-        self.swap_availability_changed.emit()
-
-    @qt_event_listener
-    def on_event_channel(self, wallet, _channel):
-        # useful e.g. if the user quickly opens the tab after startup before the channels are initialized
-        if wallet == self.wallet and self.swap_manager and self.swap_manager.is_initialized.is_set():
-            self.swap_availability_changed.emit()
-
-    @qt_event_listener
-    def on_event_swap_offers_changed(self, _):
+    @pyqtSlot()
+    def on_swap_offers_changed(self):
         self.change_to_ln_swap_providers_button.update()
         self.submarine_payment_provider_button.update()
-        if self.swap_transport and self.swap_transport.ongoing_connection_attempt:
-            return
-        self.swap_availability_changed.emit()
 
     @pyqtSlot()
     def on_swap_availability_changed(self):

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -683,39 +683,11 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
                 messages.append(long_warning)
         if self.no_dynfee_estimates:
             self.error = _('Fee estimates not available. Please set a fixed fee or feerate.')
-        if dummy_output := self.tx.get_dummy_output(DummyAddress.SWAP):
-            swap_msg = _('Will send change to lightning')
-            swap_fee_msg = "."
-            if self.swap_manager and self.swap_manager.is_initialized.is_set() and isinstance(dummy_output.value, int):
-                ln_amount_we_recv = self.swap_manager.get_recv_amount(send_amount=dummy_output.value, is_reverse=False)
-                if ln_amount_we_recv:
-                    swap_fees = dummy_output.value - ln_amount_we_recv
-                    swap_fee_msg = " [" + _("Swap fees:") + " " + self.main_window.format_amount_and_units(swap_fees) + "]."
-            messages.append(swap_msg + swap_fee_msg)
-        elif self.config.WALLET_SEND_CHANGE_TO_LIGHTNING \
-                and not (self.swap_transport and self.swap_transport.ongoing_connection_attempt) \
-                and self.tx.has_change():
-            swap_msg = _('Will not send change to Lightning')
-            swap_msg_reason = None
-            change_amount = sum(c.value for c in self.tx.get_change_outputs() if isinstance(c.value, int))
-            if not self.wallet.has_lightning():
-                swap_msg_reason = _('Lightning is not enabled.')
-            elif change_amount > int(self.wallet.lnworker.num_sats_can_receive()):
-                swap_msg_reason = _("Your channels cannot receive this amount.")
-            elif self.wallet.lnworker.swap_manager.is_initialized.is_set():
-                min_amount = self.wallet.lnworker.swap_manager.get_min_amount()
-                max_amount = self.wallet.lnworker.swap_manager.get_provider_max_reverse_amount()
-                if change_amount < min_amount:
-                    swap_msg_reason = _("Below the swap providers minimum value of {}.").format(
-                        self.main_window.format_amount_and_units(min_amount)
-                    )
-                else:
-                    swap_msg_reason = _('Change amount exceeds the swap providers maximum value of {}.').format(
-                        self.main_window.format_amount_and_units(max_amount)
-                    )
-            messages.append(swap_msg + (f": {swap_msg_reason}" if swap_msg_reason else '.'))
-        elif self.swap_transport and self.swap_transport.ongoing_connection_attempt:
-            messages.append(_("Fetching submarine swap providers..."))
+        if self.config.WALLET_SEND_CHANGE_TO_LIGHTNING:
+            if not self.swap_manager:
+                messages.append(_("Lightning is not enabled."))
+            elif swap_msg := self.swap_manager.get_message_for_swap_change(self.swap_transport, self.tx):
+                messages.append(swap_msg)
         # warn if spending unconf
         if any((txin.block_height is not None and txin.block_height<=0) for txin in self.tx.inputs()):
             messages.append(_('This transaction will spend unconfirmed coins.'))

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -798,7 +798,7 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
                 else:
                     assert isinstance(transport, HttpTransport)
                     asyncio.create_task(transport.get_pairs_just_once())
-                if not await self.wait_for_swap_transport(transport):
+                if not await self.swap_manager.wait_for_swap_transport(transport):
                     return
                 self.swap_transport = transport
             except Exception:
@@ -812,36 +812,6 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
             _initialize_transport(new_swap_transport),
             get_asyncio_loop(),
         )
-
-    async def wait_for_swap_transport(self, new_swap_transport: Union[HttpTransport, NostrTransport]) -> bool:
-        """
-        Wait until we found the announcement event of the configured swap server.
-        If it is not found but the relay connection is established return True anyway,
-        the user will then need to select a different swap server.
-        """
-        timeout = new_swap_transport.connect_timeout + 1
-        try:
-            # swap_manager.is_initialized gets set once we got pairs of the configured swap server
-            await wait_for2(self.swap_manager.is_initialized.wait(), timeout)
-        except asyncio.TimeoutError:
-            self.logger.debug(f"swap transport initialization timed out after {timeout} sec")
-
-        if self.swap_manager.is_initialized.is_set():
-            return True
-
-        # timed out above
-        if self.config.SWAPSERVER_URL:
-            # http swapserver didn't return pairs
-            self.logger.error(f"couldn't request pairs from {self.config.SWAPSERVER_URL=}")
-            return False
-        elif new_swap_transport.is_connected.is_set():
-            assert isinstance(new_swap_transport, NostrTransport)
-            # couldn't find announcement of configured swapserver, maybe it is gone.
-            # update_submarine_payment_tab will tell the user to select a different swap server.
-            return True
-
-        # we couldn't even connect to the relays, this transport is useless. maybe network issues.
-        return False
 
     @qt_event_listener
     def on_event_swap_provider_changed(self):

--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -112,7 +112,6 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
         self.swap_manager = self.wallet.lnworker.swap_manager if self.wallet.has_lightning() else None
         self.swap_transport = None  # type: Optional[SwapServerTransport]
         self.swap_availability_changed.connect(self.on_swap_availability_changed, Qt.ConnectionType.QueuedConnection)
-        self.ongoing_swap_transport_connection_attempt = None  # type: Optional[Future]
         self.did_swap = False  # used to clear the PI on send tab
 
         self.locktime_e = LockTimeEdit(self)
@@ -182,8 +181,8 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
 
     def _cleanup(self):
         self.unregister_callbacks()
-        if self.ongoing_swap_transport_connection_attempt:
-            self.ongoing_swap_transport_connection_attempt.cancel()
+        if self.swap_transport and self.swap_transport.ongoing_connection_attempt:
+            self.swap_transport.ongoing_connection_attempt.cancel()
         if isinstance(self.swap_transport, NostrTransport):
             asyncio.run_coroutine_threadsafe(self.swap_transport.stop(), get_asyncio_loop())
         self.swap_transport = None  # HTTPTransport doesn't need to be closed
@@ -658,7 +657,8 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
 
         if self.config.WALLET_SEND_CHANGE_TO_LIGHTNING:
             self.change_to_ln_swap_providers_button.setVisible(True)
-            self.change_to_ln_swap_providers_button.fetching = bool(self.ongoing_swap_transport_connection_attempt)
+            self.change_to_ln_swap_providers_button.fetching = \
+                bool(self.swap_transport and self.swap_transport.ongoing_connection_attempt)
             self.change_to_ln_swap_providers_button.update()
         else:
             self.change_to_ln_swap_providers_button.setVisible(False)
@@ -693,7 +693,7 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
                     swap_fee_msg = " [" + _("Swap fees:") + " " + self.main_window.format_amount_and_units(swap_fees) + "]."
             messages.append(swap_msg + swap_fee_msg)
         elif self.config.WALLET_SEND_CHANGE_TO_LIGHTNING \
-                and not self.ongoing_swap_transport_connection_attempt \
+                and not (self.swap_transport and self.swap_transport.ongoing_connection_attempt) \
                 and self.tx.has_change():
             swap_msg = _('Will not send change to Lightning')
             swap_msg_reason = None
@@ -714,7 +714,7 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
                         self.main_window.format_amount_and_units(max_amount)
                     )
             messages.append(swap_msg + (f": {swap_msg_reason}" if swap_msg_reason else '.'))
-        elif self.ongoing_swap_transport_connection_attempt:
+        elif self.swap_transport and self.swap_transport.ongoing_connection_attempt:
             messages.append(_("Fetching submarine swap providers..."))
         # warn if spending unconf
         if any((txin.block_height is not None and txin.block_height<=0) for txin in self.tx.inputs()):
@@ -774,12 +774,13 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
     def prepare_swap_transport(self):
         if not self.swap_manager:
             return  # no swaps possible, lightning disabled
-        if self.swap_transport is not None and self.swap_transport.is_connected.is_set():
-            # we already have a connected transport, no need to create a new one
-            return
-        if self.ongoing_swap_transport_connection_attempt:
-            # another task is currently trying to connect
-            return
+        if self.swap_transport is not None:
+            if self.swap_transport.is_connected.is_set():
+                # we already have a connected transport, no need to create a new one
+                return
+            if self.swap_transport.ongoing_connection_attempt:
+                # another task is currently trying to connect
+                return
 
         # there should only be a connected transport.
         # a useless transport should get cleaned up and not stored.
@@ -804,11 +805,11 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
             except Exception:
                 self.logger.exception("failed to create swap transport")
             finally:
-                self.ongoing_swap_transport_connection_attempt = None
+                self.swap_transport.ongoing_connection_attempt = None
                 self.swap_availability_changed.emit()
 
         # this task will get cancelled if the TxEditor gets closed
-        self.ongoing_swap_transport_connection_attempt = asyncio.run_coroutine_threadsafe(
+        self.swap_transport.ongoing_connection_attempt = asyncio.run_coroutine_threadsafe(
             _initialize_transport(new_swap_transport),
             get_asyncio_loop(),
         )
@@ -827,7 +828,7 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
     def on_event_swap_offers_changed(self, _):
         self.change_to_ln_swap_providers_button.update()
         self.submarine_payment_provider_button.update()
-        if self.ongoing_swap_transport_connection_attempt:
+        if self.swap_transport and self.swap_transport.ongoing_connection_attempt:
             return
         self.swap_availability_changed.emit()
 
@@ -951,7 +952,7 @@ class TxEditor(WindowModalDialog, QtEventListener, Logger):
             self.set_submarine_payment_tab_warning(_("Enable Lightning in the 'Channels' tab to use Submarine Swaps."))
             return
         if not self.swap_manager.is_initialized.is_set() \
-                and self.ongoing_swap_transport_connection_attempt:
+                and self.swap_transport and self.swap_transport.ongoing_connection_attempt:
             self.show_swap_transport_connection_message()
             return
         if not self.swap_transport:

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -372,6 +372,41 @@ class SwapManager(Logger):
         # we couldn't even connect to the relays, this transport is useless. maybe network issues.
         return False
 
+    def get_message_for_swap_change(self, swap_transport, tx):
+        """ UI support for send-change-to-lightning.
+        """
+        msg = ''
+        if swap_transport is not None and swap_transport.ongoing_connection_attempt:
+            msg = _("Fetching submarine swap providers...")
+        elif dummy_output := tx.get_dummy_output(DummyAddress.SWAP):
+            msg = _('Will send change to lightning')
+            if self.is_initialized.is_set() and isinstance(dummy_output.value, int):
+                ln_amount_we_recv = self.get_recv_amount(send_amount=dummy_output.value,
+                                                         is_reverse=False)
+                if ln_amount_we_recv:
+                    swap_fees = dummy_output.value - ln_amount_we_recv
+                    msg += " [" + _("Swap fees:") + " " + self.config.format_amount_and_units(swap_fees) + "]."
+        elif not tx.has_change():
+            msg = _('No change output, so no need for swap')
+        else:
+            change_amount = sum(c.value for c in tx.get_change_outputs() if isinstance(c.value, int))
+            if change_amount > int(self.wallet.lnworker.num_sats_can_receive()):
+                msg = _("Your channels cannot receive this amount.")
+            elif self.is_initialized.is_set():
+                min_amount = self.get_min_amount()
+                max_amount = self.get_provider_max_reverse_amount()
+                if change_amount < min_amount:
+                    msg = _("Below the swap providers minimum value of {}.").format(
+                        self.config.format_amount_and_units(min_amount)
+                    )
+                elif change_amount > max_amount:
+                    msg = _('Change amount exceeds the swap providers maximum value of {}.').format(
+                        self.config.format_amount_and_units(max_amount)
+                    )
+            else:
+                msg = _('Will not send change to Lightning')
+        return msg
+
     async def set_nostr_proof_of_work(self) -> None:
         current_pow = get_nostr_ann_pow_amount(
             self.lnworker.nostr_keypair.pubkey[1:],

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -3,6 +3,7 @@ import json
 import os
 import ssl
 import threading
+from concurrent.futures import Future
 from typing import TYPE_CHECKING, Optional, Dict, Sequence, Tuple, Iterable, List
 from decimal import Decimal
 import math
@@ -1600,6 +1601,7 @@ class SwapServerTransport(Logger):
         self.config = config
         self.is_connected = asyncio.Event()
         self.connect_timeout = 10 if self.uses_proxy else 5
+        self.ongoing_connection_attempt: Future = None
 
     def __enter__(self):
         pass

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -4,7 +4,7 @@ import os
 import ssl
 import threading
 from concurrent.futures import Future
-from typing import TYPE_CHECKING, Optional, Dict, Sequence, Tuple, Iterable, List
+from typing import TYPE_CHECKING, Optional, Dict, Sequence, Tuple, Iterable, List, Callable
 from decimal import Decimal
 import math
 import time
@@ -1658,6 +1658,31 @@ class SwapServerTransport(Logger):
     def uses_proxy(self):
         return self.network.proxy and self.network.proxy.enabled
 
+    def initialize(self, done_callback: Optional[Callable[[Future], None]] = None):
+        async def _initialize_transport(transport):
+            try:
+                if isinstance(transport, NostrTransport):
+                    asyncio.create_task(transport.main_loop())
+                else:
+                    assert isinstance(transport, HttpTransport)
+                    asyncio.create_task(transport.get_pairs_just_once())
+                if not await self.sm.wait_for_swap_transport(transport):
+                    raise Exception(_('Swap transport failed.'))
+                return True
+            finally:
+                self.ongoing_connection_attempt = None
+
+        self.ongoing_connection_attempt = asyncio.run_coroutine_threadsafe(
+            _initialize_transport(self),
+            self.network.asyncio_loop,
+        )
+        if done_callback:
+            self.ongoing_connection_attempt.add_done_callback(done_callback)
+
+    def destroy(self):
+        if self.ongoing_connection_attempt:
+            self.ongoing_connection_attempt.cancel()
+
 
 class HttpTransport(SwapServerTransport):
 
@@ -1758,6 +1783,10 @@ class NostrTransport(SwapServerTransport):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await wait_for2(self.stop(), timeout=5)
+
+    def destroy(self):
+        super().destroy()
+        asyncio.run_coroutine_threadsafe(self.stop(), self.network.asyncio_loop)
 
     @log_exceptions
     async def main_loop(self):

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -341,6 +341,36 @@ class SwapManager(Logger):
             keypair = self.lnworker.nostr_keypair if self.is_server else generate_random_keypair()
             return NostrTransport(self.config, self, keypair)
 
+    async def wait_for_swap_transport(self, new_swap_transport: 'SwapServerTransport') -> bool:
+        """
+        Wait until we found the announcement event of the configured swap server.
+        If it is not found but the relay connection is established return True anyway,
+        the user will then need to select a different swap server.
+        """
+        timeout = new_swap_transport.connect_timeout + 1
+        try:
+            # swap_manager.is_initialized gets set once we got pairs of the configured swap server
+            await wait_for2(self.is_initialized.wait(), timeout)
+        except asyncio.TimeoutError:
+            self.logger.debug(f"swap transport initialization timed out after {timeout} sec")
+
+        if self.is_initialized.is_set():
+            return True
+
+        # timed out above
+        if self.config.SWAPSERVER_URL:
+            # http swapserver didn't return pairs
+            self.logger.error(f"couldn't request pairs from {self.config.SWAPSERVER_URL=}")
+            return False
+        elif new_swap_transport.is_connected.is_set():
+            assert isinstance(new_swap_transport, NostrTransport)
+            # couldn't find announcement of configured swapserver, maybe it is gone.
+            # update_submarine_payment_tab will tell the user to select a different swap server.
+            return True
+
+        # we couldn't even connect to the relays, this transport is useless. maybe network issues.
+        return False
+
     async def set_nostr_proof_of_work(self) -> None:
         current_pow = get_nostr_ann_pow_amount(
             self.lnworker.nostr_keypair.pubkey[1:],


### PR DESCRIPTION
Move submarine swap support code from qt gui to backend and common_qt, where applicable.
    
This covers the functionality for swap use during payments (so, change-to-ln and
submarine-payments) present in `gui/qt/confirm_tx_dialog`, not the 'standalone' swap.

This is in preparation for adding the same functionality to qml.

- move backend code present in GUI to backend
- move common Qt GUI swap support code from `TxEditor` to `SubmarineSwapMixin`
