### PR TITLE
add Iroh P2P transport for Electrum

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -467,14 +467,21 @@ class ServerAddr:
             protocol = 's'
         if not host:
             raise ValueError('host must not be empty')
+        if protocol not in KNOWN_ELEC_PROTOCOL_TRANSPORTS:
+            raise ValueError(f"invalid network protocol: {protocol}")
+        if protocol == 'i':
+            # Iroh: host is a Node ID (hex string), not a network address
+            self.host = host
+            self.port = int(port)
+            self.protocol = protocol
+            self._net_addr_str = f"{host}:{port}"
+            return
         if host[0] == '[' and host[-1] == ']':  # IPv6
             host = host[1:-1]
         try:
             net_addr = NetAddress(host, port)  # this validates host and port
         except Exception as e:
             raise ValueError(f"cannot construct ServerAddr: invalid host or port (host={host}, port={port})") from e
-        if protocol not in KNOWN_ELEC_PROTOCOL_TRANSPORTS:
-            raise ValueError(f"invalid network protocol: {protocol}")
         self.host = str(net_addr.host)  # canonical form (if e.g. IPv6 address)
         self.port = int(net_addr.port)
         self.protocol = protocol
@@ -994,9 +1001,9 @@ class Interface(Logger):
             if not _IROH_AVAILABLE:
                 raise ConnectError("iroh package not installed. Run: pip install iroh")
             iroh_transport = await _open_iroh_connection(self.host)
-            session = session_factory(framer=NewlineFramer())
-            iroh_transport.set_protocol(session)
-            session.connection_made(iroh_transport)
+            session = NotificationSession(iroh_transport, interface=self)
+            framer = NewlineFramer()
+            iroh_transport.connection_made_with_framer(session, framer)
             iroh_transport.start_reader()
             await self._run_electrum_session(session, exit_early=exit_early)
             return

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -66,6 +66,13 @@ from .transaction import Transaction
 from .fee_policy import FEE_ETA_TARGETS
 from .lrucache import LRUCache
 
+# Iroh P2P transport (optional, requires: pip install iroh)
+try:
+    from .iroh_transport import open_iroh_connection as _open_iroh_connection
+    _IROH_AVAILABLE = True
+except ImportError:
+    _IROH_AVAILABLE = False
+
 if TYPE_CHECKING:
     from .network import Network
     from .simple_config import SimpleConfig
@@ -75,7 +82,7 @@ ca_path = certifi.where()
 
 BUCKET_NAME_OF_ONION_SERVERS = 'onion'
 
-KNOWN_ELEC_PROTOCOL_TRANSPORTS = {'t', 's'}
+KNOWN_ELEC_PROTOCOL_TRANSPORTS = {'t', 's', 'i'}
 PREFERRED_NETWORK_PROTOCOL = 's'
 assert PREFERRED_NETWORK_PROTOCOL in KNOWN_ELEC_PROTOCOL_TRANSPORTS
 
@@ -983,6 +990,16 @@ class Interface(Logger):
         exit_early: bool = False,
     ):
         session_factory = lambda *args, iface=self, **kwargs: NotificationSession(*args, **kwargs, interface=iface)
+        if self.server.protocol == 'i':
+            if not _IROH_AVAILABLE:
+                raise ConnectError("iroh package not installed. Run: pip install iroh")
+            iroh_transport = await _open_iroh_connection(self.host)
+            session = session_factory(framer=NewlineFramer())
+            iroh_transport.set_protocol(session)
+            session.connection_made(iroh_transport)
+            iroh_transport.start_reader()
+            await self._run_electrum_session(session, exit_early=exit_early)
+            return
         async with _RSClient(
             session_factory=session_factory,
             host=self.host, port=self.port,
@@ -990,53 +1007,55 @@ class Interface(Logger):
             proxy=self.proxy,
             transport=PaddedRSTransport,
         ) as session:
-            start = time.perf_counter()
-            self.session = session  # type: NotificationSession
-            self.session.set_default_timeout(self.network.get_network_timeout_seconds(NetworkTimeout.Generic))
-            client_prange = [version.PROTOCOL_VERSION_MIN, version.PROTOCOL_VERSION_MAX]
-            try:
-                ver = await session.send_request('server.version', [self.client_name(), client_prange])
-            except aiorpcx.jsonrpc.RPCError as e:
-                raise GracefulDisconnect(e)  # probably 'unsupported protocol version'
-            if exit_early:
-                return
-            self.active_protocol_tuple = protocol_tuple(ver[1])
-            client_pmin = protocol_tuple(client_prange[0])
-            client_pmax = protocol_tuple(client_prange[1])
-            if not (client_pmin <= self.active_protocol_tuple <= client_pmax):
-                raise GracefulDisconnect(f'server violated protocol-version-negotiation. '
-                                         f'we asked for {client_prange!r}, they sent {ver[1]!r}')
-            if not self.network.check_interface_against_healthy_spread_of_connected_servers(self):
-                raise GracefulDisconnect(f'too many connected servers already '
-                                         f'in bucket {self.bucket_based_on_ipaddress()}')
+            await self._run_electrum_session(session, exit_early=exit_early)
 
-            try:
-                features = await session.send_request('server.features')
-                server_genesis_hash = assert_dict_contains_field(features, field_name='genesis_hash')
-            except (aiorpcx.jsonrpc.RPCError, RequestCorrupted) as e:
-                raise GracefulDisconnect(e)
-            if server_genesis_hash != constants.net.GENESIS:
-                raise GracefulDisconnect(f'server on different chain: {server_genesis_hash=}. ours: {constants.net.GENESIS}')
-            self.logger.info(f"connection established. version: {ver}, handshake duration: {(time.perf_counter() - start) * 1000:.2f} ms")
-
-            try:
-                async with self.taskgroup as group:
-                    await group.spawn(self.ping)
-                    await group.spawn(self.request_fee_estimates)
-                    await group.spawn(self.run_fetch_blocks)
-                    await group.spawn(self.monitor_connection)
-            except aiorpcx.jsonrpc.RPCError as e:
-                if e.code in (
-                    JSONRPC.EXCESSIVE_RESOURCE_USAGE,
-                    JSONRPC.SERVER_BUSY,
-                    JSONRPC.METHOD_NOT_FOUND,
-                    JSONRPC.INTERNAL_ERROR,
-                ):
-                    log_level = logging.WARNING if self.is_main_server() else logging.INFO
-                    raise GracefulDisconnect(e, log_level=log_level) from e
-                raise
-            finally:
-                self.got_disconnected.set()  # set this ASAP, ideally before any awaits
+    async def _run_electrum_session(self, session, *, exit_early: bool) -> None:
+        """Shared session logic for both TCP and Iroh connections."""
+        start = time.perf_counter()
+        self.session = session
+        self.session.set_default_timeout(self.network.get_network_timeout_seconds(NetworkTimeout.Generic))
+        client_prange = [version.PROTOCOL_VERSION_MIN, version.PROTOCOL_VERSION_MAX]
+        try:
+            ver = await session.send_request('server.version', [self.client_name(), client_prange])
+        except aiorpcx.jsonrpc.RPCError as e:
+            raise GracefulDisconnect(e)
+        if exit_early:
+            return
+        self.active_protocol_tuple = protocol_tuple(ver[1])
+        client_pmin = protocol_tuple(client_prange[0])
+        client_pmax = protocol_tuple(client_prange[1])
+        if not (client_pmin <= self.active_protocol_tuple <= client_pmax):
+            raise GracefulDisconnect(f'server violated protocol-version-negotiation. '
+                                     f'we asked for {client_prange!r}, they sent {ver[1]!r}')
+        if not self.network.check_interface_against_healthy_spread_of_connected_servers(self):
+            raise GracefulDisconnect(f'too many connected servers already '
+                                     f'in bucket {self.bucket_based_on_ipaddress()}')
+        try:
+            features = await session.send_request('server.features')
+            server_genesis_hash = assert_dict_contains_field(features, field_name='genesis_hash')
+        except (aiorpcx.jsonrpc.RPCError, RequestCorrupted) as e:
+            raise GracefulDisconnect(e)
+        if server_genesis_hash != constants.net.GENESIS:
+            raise GracefulDisconnect(f'server on different chain: {server_genesis_hash=}. ours: {constants.net.GENESIS}')
+        self.logger.info(f"connection established. version: {ver}, handshake duration: {(time.perf_counter() - start) * 1000:.2f} ms")
+        try:
+            async with self.taskgroup as group:
+                await group.spawn(self.ping)
+                await group.spawn(self.request_fee_estimates)
+                await group.spawn(self.run_fetch_blocks)
+                await group.spawn(self.monitor_connection)
+        except aiorpcx.jsonrpc.RPCError as e:
+            if e.code in (
+                JSONRPC.EXCESSIVE_RESOURCE_USAGE,
+                JSONRPC.SERVER_BUSY,
+                JSONRPC.METHOD_NOT_FOUND,
+                JSONRPC.INTERNAL_ERROR,
+            ):
+                log_level = logging.WARNING if self.is_main_server() else logging.INFO
+                raise GracefulDisconnect(e, log_level=log_level) from e
+            raise
+        finally:
+            self.got_disconnected.set()
 
     async def monitor_connection(self):
         while True:

--- a/electrum/iroh_transport.py
+++ b/electrum/iroh_transport.py
@@ -50,52 +50,75 @@ class IrohTransport(asyncio.Transport):
         self._protocol = None
         self._reader_task = None
         self._write_lock = asyncio.Lock()
+        self._framer = None
 
     def set_protocol(self, protocol):
         self._protocol = protocol
+
+    def connection_made_with_framer(self, session, framer):
+        """Set up framer and start aiorpcx message processing loop."""
+        self._protocol = session
+        self._framer = framer
+        self._loop.create_task(session.process_messages(framer.receive_message))
 
     def get_protocol(self):
         return self._protocol
 
     def start_reader(self):
+        _logger.info('start_reader called')
         self._reader_task = self._loop.create_task(
             self._reader_loop(), name=f"iroh-reader-{self._node_id[:12]}"
         )
 
     async def _reader_loop(self):
+        _logger.info('_reader_loop started')
         try:
             while not self._closing:
+                _logger.info('waiting for data...')
                 data = await self._recv.read(65536)
+                _logger.info(f'got {len(data)}b')
                 if not data:
                     break
-                if self._protocol is not None:
-                    self._protocol.data_received(data)
+                if self._framer is not None:
+                    _logger.info(f'feeding {len(data)}b to framer')
+                    self._framer.received_bytes(data)
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            if not self._closing:
-                _logger.warning(f"Iroh reader error ({self._node_id[:12]}): {e}")
+            import traceback
+            _logger.warning(f"Iroh reader error ({self._node_id[:12]}): {e}")
+            _logger.warning(traceback.format_exc())
         finally:
             if not self._closing:
                 self._closing = True
                 if self._protocol is not None:
                     self._protocol.connection_lost(None)
 
-    def write(self, data):
+    async def write(self, data):
+        # Ensure newline termination for Electrum JSON-RPC protocol
+        if data and not data.endswith(b'\n'):
+            data = data + b'\n'
+        _logger.info(f'write {len(data)}b: {data[:60]}')
         if self._closing:
+            _logger.warning('write called but closing!')
             return
-        self._loop.create_task(self._write_async(data))
+        await self._write_async(data)
 
     async def _write_async(self, data):
         async with self._write_lock:
             try:
+                _logger.info(f'_write_async sending {len(data)}b')
                 await self._send.write_all(data)
+                _logger.info(f'_write_async sent OK')
             except Exception as e:
                 if not self._closing:
                     _logger.warning(f"Iroh write error: {e}")
                     self.close()
 
-    def close(self):
+    async def close(self, *args):
+        import traceback
+        _logger.warning(f'close() called, args={args}')
+        _logger.warning(''.join(traceback.format_stack()[-5:]))
         if self._closing:
             return
         self._closing = True
@@ -112,11 +135,16 @@ class IrohTransport(asyncio.Transport):
     def is_closing(self):
         return self._closing
 
+    # aiorpcx expects these attributes on the transport
+    kind = 'SSL'  # pretend to be SSL so aiorpcx does not try to use TLS
+    
     def get_extra_info(self, name, default=None):
         if name == 'peername':
             return (self._node_id, 0)
         if name == 'sockname':
             return ('iroh-local', 0)
+        if name == 'ssl_object':
+            return None
         return default
 
 async def open_iroh_connection(node_id_str):
@@ -129,12 +157,16 @@ async def open_iroh_connection(node_id_str):
     node_addr = iroh.NodeAddr(node_id=public_key, derp_url="https://use1-1.relay.iroh.network./", addresses=[])
     conn = await endpoint.connect(node_addr, alpn=ALPN)
     bistream = await conn.open_bi()
+    send_stream = bistream.send()
+    recv_stream = bistream.recv()
     loop = asyncio.get_event_loop()
     transport = IrohTransport(
-        send_stream=bistream.send(),
-        recv_stream=bistream.recv(),
+        send_stream=send_stream,
+        recv_stream=recv_stream,
         node_id=node_id_str,
         loop=loop,
     )
+    transport._conn = conn
+    transport._bistream = bistream
     _logger.info(f"Iroh: connected to {node_id_str[:12]}")
     return transport

--- a/electrum/iroh_transport.py
+++ b/electrum/iroh_transport.py
@@ -1,0 +1,140 @@
+"""
+iroh_transport.py — Iroh P2P transport for Electrum
+"""
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+import iroh
+
+_logger = logging.getLogger(__name__)
+ALPN = b"electrs/electrum/0"
+_iroh_node = None
+_endpoint = None
+_endpoint_lock = asyncio.Lock()
+
+def _load_or_create_secret_key():
+    key_path = Path.home() / ".electrum" / "iroh_secret_key.bin"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    if key_path.exists():
+        key_bytes = key_path.read_bytes()
+        if len(key_bytes) == 32:
+            return key_bytes
+    key_bytes = os.urandom(32)
+    key_path.write_bytes(key_bytes)
+    _logger.info(f"New Iroh secret key saved to {key_path}")
+    return key_bytes
+
+async def get_shared_endpoint():
+    global _iroh_node, _endpoint
+    async with _endpoint_lock:
+        if _endpoint is None:
+            iroh.iroh_ffi.uniffi_set_event_loop(asyncio.get_event_loop())
+            secret_key = _load_or_create_secret_key()
+            options = iroh.NodeOptions(secret_key=secret_key)
+            _iroh_node = await iroh.Iroh.memory_with_options(options)
+            _endpoint = _iroh_node.node().endpoint()
+            _logger.info(f"Iroh endpoint ready. Node ID: {_endpoint.node_id()}")
+            await asyncio.sleep(3)
+        return _endpoint
+
+class IrohTransport(asyncio.Transport):
+    def __init__(self, send_stream, recv_stream, node_id, loop):
+        super().__init__()
+        self._send = send_stream
+        self._recv = recv_stream
+        self._node_id = node_id
+        self._loop = loop
+        self._closing = False
+        self._protocol = None
+        self._reader_task = None
+        self._write_lock = asyncio.Lock()
+
+    def set_protocol(self, protocol):
+        self._protocol = protocol
+
+    def get_protocol(self):
+        return self._protocol
+
+    def start_reader(self):
+        self._reader_task = self._loop.create_task(
+            self._reader_loop(), name=f"iroh-reader-{self._node_id[:12]}"
+        )
+
+    async def _reader_loop(self):
+        try:
+            while not self._closing:
+                data = await self._recv.read(65536)
+                if not data:
+                    break
+                if self._protocol is not None:
+                    self._protocol.data_received(data)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            if not self._closing:
+                _logger.warning(f"Iroh reader error ({self._node_id[:12]}): {e}")
+        finally:
+            if not self._closing:
+                self._closing = True
+                if self._protocol is not None:
+                    self._protocol.connection_lost(None)
+
+    def write(self, data):
+        if self._closing:
+            return
+        self._loop.create_task(self._write_async(data))
+
+    async def _write_async(self, data):
+        async with self._write_lock:
+            try:
+                await self._send.write_all(data)
+            except Exception as e:
+                if not self._closing:
+                    _logger.warning(f"Iroh write error: {e}")
+                    self.close()
+
+    def close(self):
+        if self._closing:
+            return
+        self._closing = True
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+        self._loop.create_task(self._close_streams())
+
+    async def _close_streams(self):
+        try:
+            await self._send.finish()
+        except Exception:
+            pass
+
+    def is_closing(self):
+        return self._closing
+
+    def get_extra_info(self, name, default=None):
+        if name == 'peername':
+            return (self._node_id, 0)
+        if name == 'sockname':
+            return ('iroh-local', 0)
+        return default
+
+async def open_iroh_connection(node_id_str):
+    _logger.info(f"Iroh: connecting to {node_id_str[:12]}...")
+    endpoint = await get_shared_endpoint()
+    try:
+        public_key = iroh.PublicKey.from_string(node_id_str)
+    except Exception as e:
+        raise Exception(f"Invalid Iroh Node ID '{node_id_str}': {e}") from e
+    node_addr = iroh.NodeAddr(node_id=public_key, derp_url="https://use1-1.relay.iroh.network./", addresses=[])
+    conn = await endpoint.connect(node_addr, alpn=ALPN)
+    bistream = await conn.open_bi()
+    loop = asyncio.get_event_loop()
+    transport = IrohTransport(
+        send_stream=bistream.send(),
+        recv_stream=bistream.recv(),
+        node_id=node_id_str,
+        loop=loop,
+    )
+    _logger.info(f"Iroh: connected to {node_id_str[:12]}")
+    return transport

--- a/electrum/iroh_transport.py
+++ b/electrum/iroh_transport.py
@@ -23,7 +23,7 @@ def _load_or_create_secret_key():
             return key_bytes
     key_bytes = os.urandom(32)
     key_path.write_bytes(key_bytes)
-    _logger.info(f"New Iroh secret key saved to {key_path}")
+    _logger.info(f"Iroh: new secret key saved to {key_path}")
     return key_bytes
 
 async def get_shared_endpoint():
@@ -65,29 +65,22 @@ class IrohTransport(asyncio.Transport):
         return self._protocol
 
     def start_reader(self):
-        _logger.info('start_reader called')
         self._reader_task = self._loop.create_task(
             self._reader_loop(), name=f"iroh-reader-{self._node_id[:12]}"
         )
 
     async def _reader_loop(self):
-        _logger.info('_reader_loop started')
         try:
             while not self._closing:
-                _logger.info('waiting for data...')
                 data = await self._recv.read(65536)
-                _logger.info(f'got {len(data)}b')
                 if not data:
                     break
                 if self._framer is not None:
-                    _logger.info(f'feeding {len(data)}b to framer')
                     self._framer.received_bytes(data)
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            import traceback
             _logger.warning(f"Iroh reader error ({self._node_id[:12]}): {e}")
-            _logger.warning(traceback.format_exc())
         finally:
             if not self._closing:
                 self._closing = True
@@ -98,27 +91,20 @@ class IrohTransport(asyncio.Transport):
         # Ensure newline termination for Electrum JSON-RPC protocol
         if data and not data.endswith(b'\n'):
             data = data + b'\n'
-        _logger.info(f'write {len(data)}b: {data[:60]}')
         if self._closing:
-            _logger.warning('write called but closing!')
             return
         await self._write_async(data)
 
     async def _write_async(self, data):
         async with self._write_lock:
             try:
-                _logger.info(f'_write_async sending {len(data)}b')
                 await self._send.write_all(data)
-                _logger.info(f'_write_async sent OK')
             except Exception as e:
                 if not self._closing:
                     _logger.warning(f"Iroh write error: {e}")
                     self.close()
 
     async def close(self, *args):
-        import traceback
-        _logger.warning(f'close() called, args={args}')
-        _logger.warning(''.join(traceback.format_stack()[-5:]))
         if self._closing:
             return
         self._closing = True

--- a/electrum/iroh_transport.py
+++ b/electrum/iroh_transport.py
@@ -124,6 +124,9 @@ class IrohTransport(asyncio.Transport):
     # aiorpcx expects these attributes on the transport
     kind = 'SSL'  # pretend to be SSL so aiorpcx does not try to use TLS
     
+    def remote_address(self):
+        return None
+
     def get_extra_info(self, name, default=None):
         if name == 'peername':
             return (self._node_id, 0)


### PR DESCRIPTION
Adds Iroh QUIC-based P2P transport as an alternative to TCP/SSL/Tor.

## What this does
- Adds `electrum/iroh_transport.py` — asyncio Transport over Iroh QUIC streams
- Adds `i` as a valid protocol in `KNOWN_ELEC_PROTOCOL_TRANSPORTS`
- `ServerAddr` bypasses NetAddress validation for protocol `i`
- Iroh connection path in `open_session()` before `_RSClient`
- Persistent secret key in `~/.electrum/iroh_secret_key.bin`
- `remote_address()` stub for compatibility with `interface.py`

## How to connect
Server address: `<NODE_ID>:1:i`

## Dependencies
- `iroh` Python package (0.35.0): `pip install iroh`

## Tested with
- electrs with Iroh listener (rueckwaerts/electrs, branch iroh-test)
- StartOS 0.4.0-beta.9 (x86_64)
- End-to-end: wallet sync, transaction history, real-time block updates
- Handshake duration: ~165ms over relay, ~4ms direct LAN

## Notes
- Uses iroh 0.35.0 (latest version with Python bindings)
- ALPN: `electrs/electrum/0`
- Relay: `https://use1-1.relay.iroh.network./`
- No changes to existing TCP/SSL/Tor transports