### PR TITLE
lnurl: fail lnurl-pay flow on successAction field

### DIFF
--- a/electrum/lnurl.py
+++ b/electrum/lnurl.py
@@ -248,6 +248,9 @@ async def callback_lnurl(url: str, params: dict) -> dict:
     status = response.get("status")
     if status and status == "ERROR":
         raise UntrustedLNURLError(f"LNURL request encountered an error: {response.get('reason', '<missing reason>')}")
+    # TODO: implement LUD-09 (https://github.com/lnurl/luds/blob/luds/09.md), e.g. useful for paying offline devices
+    if 'successAction' in response:
+        raise LNURLError("successAction are not yet supported by Electrum.")
     # TODO: handling of specific errors (validate fields, e.g. for lnurl6)
     return response
 


### PR DESCRIPTION
Fail the lnurl flow if a `successAction` field is present in the lnurl callback response.
This prevents users from losing their payment until we properly implement showing LUD-09 responses in the GUI.
See https://github.com/lnurl/luds/blob/luds/09.md.

Related: https://github.com/spesmilo/electrum/issues/10269

Tested against a temporary lnbits instance from https://lnbits.com/ with the lnurlp extension.