### PR TITLE
qml: disallow wallet names starting with '.'

### DIFF
--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -325,6 +325,9 @@ class QEDaemon(AuthMixin, QObject):
         for forbidden_char in ("/", "\\", ):
             if forbidden_char in wallet_name:
                 return False
+        if wallet_name.startswith('.'):  # not shown in wallet list
+            # TODO: allow wallets starting with '.' as hidden wallets, opened e.g. through wallet creation wizard
+            return False
         if os.path.basename(wallet_name) != wallet_name:  # '/foo/bar/' returns 'bar'
             return False
         wallet_path = self.wallet_path_from_wallet_name(wallet_name)


### PR DESCRIPTION
Prevent qml users from creating or renaming wallet files starting with a `.` as those files are not listed in the wallet list, making it impossible to access the wallet.
Later we could allow this again and implement opening such a "hidden" wallet file e.g. through the wizard.

Related https://github.com/spesmilo/electrum/issues/10688