### PR TITLE
hw_wallet/qt: reuse message dialog to fix lag between device prompts

### DIFF
--- a/electrum/hw_wallet/qt.py
+++ b/electrum/hw_wallet/qt.py
@@ -84,6 +84,8 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
         self.win = win
         self.device = device
         self.dialog = None
+        self.dialog_label = None
+        self._dialog_on_cancel = None
         self.done = threading.Event()
 
     def top_level_window(self):
@@ -174,12 +176,22 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
 
     MESSAGE_DIALOG_TITLE = None  # type: Optional[str]
     def message_dialog(self, msg, on_cancel=None):
+        # If a dialog is already open, update its text instead of rebuilding it.
+        # A device emits one button request per output, and rebuilding the
+        # window-modal dialog each time is slow and visibly janky on macOS
+        # (the modal "sheet" animates closed/open between outputs). See #10718.
+        if self.dialog is not None and self._dialog_on_cancel == on_cancel:
+            self.dialog_label.setText(msg)
+            if not self.dialog.isVisible():  # e.g. was hidden by a user "cancel"
+                self.dialog.show()
+            return
         self.clear_dialog()
         title = self.MESSAGE_DIALOG_TITLE
         if title is None:
             title = _('Please check your {} device').format(self.device)
         self.dialog = dialog = WindowModalDialog(self.top_level_window(), title)
-        label = QLabel(msg)
+        self._dialog_on_cancel = on_cancel
+        self.dialog_label = label = QLabel(msg)
         label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         vbox = QVBoxLayout(dialog)
         vbox.addWidget(label)
@@ -197,6 +209,8 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
         if self.dialog:
             self.dialog.accept()
             self.dialog = None
+            self.dialog_label = None
+            self._dialog_on_cancel = None
 
     def win_query_choice(self, msg: str, choices: Sequence[ChoiceItem]):
         try:

--- a/electrum/hw_wallet/qt.py
+++ b/electrum/hw_wallet/qt.py
@@ -84,7 +84,7 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
         self.win = win
         self.device = device
         self.dialog = None
-        self.dialog_label = None
+        self._dialog_label = None
         self._dialog_on_cancel = None
         self.done = threading.Event()
 
@@ -181,7 +181,7 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
         # window-modal dialog each time is slow and visibly janky on macOS
         # (the modal "sheet" animates closed/open between outputs). See #10718.
         if self.dialog is not None and self._dialog_on_cancel == on_cancel:
-            self.dialog_label.setText(msg)
+            self._dialog_label.setText(msg)
             if not self.dialog.isVisible():  # e.g. was hidden by a user "cancel"
                 self.dialog.show()
             return
@@ -191,7 +191,7 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
             title = _('Please check your {} device').format(self.device)
         self.dialog = dialog = WindowModalDialog(self.top_level_window(), title)
         self._dialog_on_cancel = on_cancel
-        self.dialog_label = label = QLabel(msg)
+        self._dialog_label = label = QLabel(msg)
         label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         vbox = QVBoxLayout(dialog)
         vbox.addWidget(label)
@@ -209,7 +209,7 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
         if self.dialog:
             self.dialog.accept()
             self.dialog = None
-            self.dialog_label = None
+            self._dialog_label = None
             self._dialog_on_cancel = None
 
     def win_query_choice(self, msg: str, choices: Sequence[ChoiceItem]):


### PR DESCRIPTION
Signing a transaction with many outputs on a Trezor is noticeably laggy: after I confirm one output on the device, there's a short pause before the next output shows up on the device screen.

What pointed me at Electrum's GUI rather than the device or the library: I have an Android signer ([welldone-tech/satoshi-signer](https://github.com/welldone-tech/satoshi-signer)) built on the same `trezorlib`, and it has no such delay — confirming an output brings up the next one instantly. Same library, same device, so the bottleneck is on Electrum's host/UI side.

## Symptom

When signing a tx with many outputs, each output confirmation on the device is preceded by a visible pause. On macOS you can see why: the "check your device" popup slides closed and a brand-new one slides open for *every* output, instead of staying put.

## Root cause

`QtHandlerBase.message_dialog()` tore down the current dialog (`clear_dialog()` → `QDialog.accept()`) and built a fresh `WindowModalDialog` on every device button request. A device emits one button request per output, so signing a tx with N outputs rebuilds the dialog N times. A window-modal `QDialog` is rendered as an animated "sheet" on macOS, so the popup visibly slides closed and reopens on each request. That GUI churn also competes with the (single) hardware-comms thread for the GIL, adding latency between device prompts.

## Fix

Reuse the already-open dialog and just update its label text when one is showing, instead of tearing it down and rebuilding. The window title and `on_cancel` handler are stable within a signing flow, so the only thing that changes between requests is the message text. If a new request comes in with a different `on_cancel`, we still rebuild (the existing dialog's cancel wiring would otherwise be wrong).

This also smooths Ledger's repeated progress messages (`Signing transaction... (phase2, i/N)`), which update the label text on each call.

## Testing

Tested on macOS with a Trezor: signing a many-output transaction no longer slides the popup closed/open between outputs, and the lag between prompts is gone — outputs now appear back-to-back.

(I also have a small headless unit test for the dialog-reuse logic if you'd like the suite to start covering this — left out by default, since it would be the first `QtWidgets`-based test in the tree and pulls in a new `QT_QPA_PLATFORM=offscreen` setup.)