### PR TITLE
regtest: make extract_preimage less flaky

### DIFF
--- a/tests/regtest/regtest.sh
+++ b/tests/regtest/regtest.sh
@@ -566,6 +566,7 @@ if [[ $1 == "extract_preimage" ]]; then
     new_blocks 1
     wait_until_preimage alice $rhash1
     wait_until_preimage bob $rhash2
+    while screen -ls | grep -q _payment; do sleep 1; done  # wait until lnpay return before checking logs
     # check both "lnpay" commands succeeded
     success=$(cat /tmp/alice/screen1.log | jq -r ".success")
     if [[ "$success" != "true" ]]; then echo "alice payment failed"; exit 1; fi


### PR DESCRIPTION
Wait until the lnpay screen commands in the `extract_preimage` regtest return before checking their log output to prevent a race where the preimage becomes available but the log doesn't yet contain the success string.

```
***** test_extract_preimage ******
initializing alice
funding alice
a6f8f660a3bab3c4af636849dae55f4c7d5d483289a5812c7efce19f4c701753
initializing bob
funding bob
b51eae095f875c7a796e74d87d6e4c21d42348272159ee30bd81ce7d9f18defe
mining 1 blocks
starting daemon (PID 5040)
/tmp/alice/regtest/wallets/default_wallet
true
starting daemon (PID 5060)
/tmp/bob/regtest/wallets/default_wallet
true

alice opens channel
7cde6dcba2a0d033ecd40c1c7cb8eec4c554acb1a09099eb1206ba39a93728ae:1
mining 3 blocks
wait until alice sees channel open.
wait until alice sees channel open..
wait until alice sees channel open...
0caecfe64e319771d60f6f1e488f28d64667783432a15fccab534dfffb2096a4
mining 1 blocks
wait until alice has preimage for c217931809c870a8032d536e59ccf2399a5d96b937818c64ae60c7e7d5363728.
wait until alice has preimage for c217931809c870a8032d536e59ccf2399a5d96b937818c64ae60c7e7d5363728..
wait until alice has preimage for c217931809c870a8032d536e59ccf2399a5d96b937818c64ae60c7e7d5363728...
wait until bob has preimage for c53556db6fcffcb2dd7c6b215e94d1af9c96e42c7170ae11e47b03a929917f28.
bob payment failed
Daemon stopped
Daemon stopped
......F
======================================================================
FAIL: test_extract_preimage (tests.regtest.TestLightningAB)
```