### PR TITLE
qml/2fa: partially reverse #10543

### DIFF
--- a/electrum/plugins/trustedcoin/qml/ShowConfirmOTP.qml
+++ b/electrum/plugins/trustedcoin/qml/ShowConfirmOTP.qml
@@ -42,12 +42,16 @@ WizardComponent {
             render: plugin.otpSecret
             onClicked: {
                 if (plugin.otpSecret) {
-                    if (AppController.isAndroid()) {
-                        Qt.openUrlExternally(qrdata)
-                    } else {
-                        AppController.textToClipboard(plugin.otpSecret)
-                        toaster.show(this, qsTr('Copied!'))
-                    }
+                    AppController.textToClipboard(plugin.otpSecret)
+                    toaster.show(this, qsTr('Copied!'))
+                    // On Android the app will get killed when switching to the authenticator app,
+                    // losing the wizard state. TODO: re-enable once we have means to keep app alive in background.
+                    // if (AppController.isAndroid()) {
+                    //     Qt.openUrlExternally(qrdata)
+                    // } else {
+                    //     AppController.textToClipboard(plugin.otpSecret)
+                    //     toaster.show(this, qsTr('Copied!'))
+                    // }
                 }
             }
         }
@@ -78,7 +82,7 @@ WizardComponent {
             Layout.fillWidth: true
             visible: !otpVerified && plugin.otpSecret
             wrapMode: Text.Wrap
-            text: qsTr('Tap the QR code to open in your authenticator app, or scan it manually. Then authenticate below')
+            text: qsTr('Enter or scan into authenticator app. Then authenticate below')
         }
 
         Label {


### PR DESCRIPTION
When opening the 2fa app on an android phone the Electrum app gets killed, causing the user to lose the wizard state. This is quite annoying, so we should prevent this until there is a proper mechanism to keep the app alive.