### PR TITLE
lightning: rate-limit incoming channels

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1257,7 +1257,14 @@ class Peer(Logger, EventListener):
         return chan_dict
 
     @non_blocking_msg_handler
-    async def on_open_channel(self, payload):
+    async def on_open_channel(self, payload: dict):
+        try:
+            with self.lnworker.incoming_channel_rate_limiter.rate_limit(self.pubkey):
+                await self._on_open_channel(payload)
+        except lnutil.IncomingChannelRateLimiter.ChannelOpeningRateLimited as e:
+            self.send_warning(payload["temporary_channel_id"], message=str(e), close_connection=False)
+
+    async def _on_open_channel(self, payload):
         """Implements the channel acceptance flow.
 
         <- open_channel message

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -5,11 +5,13 @@ from enum import IntFlag, IntEnum
 import enum
 from typing import (
     NamedTuple, List, Tuple, Mapping, Optional, TYPE_CHECKING, Union, Dict, Set, Sequence, FrozenSet,
-    TypedDict,
+    TypedDict, Iterable
 )
 import sys
 import time
 from functools import lru_cache
+from collections import defaultdict
+from contextlib import contextmanager
 
 import electrum_ecc as ecc
 from electrum_ecc import CURVE_ORDER, ecdsa_sig64_from_der_sig
@@ -39,6 +41,7 @@ if TYPE_CHECKING:
     from .lnchannel import Channel, AbstractChannel
     from .lnrouter import LNPaymentRoute
     from .lnonion import OnionRoutingFailure
+    from .lnworker import LNPeerManager
     from .simple_config import SimpleConfig
 
 
@@ -1806,6 +1809,64 @@ class GossipForwardingMessage:
         except KeyError:
             return None
         return cls(msg, scid, timestamp, sender_node_id)
+
+
+class IncomingChannelRateLimiter:
+    """
+    Rate limiting for new incoming channels.
+    If there previously was an active channel with the given peer before we allow it to bypass the global pending limit.
+    """
+    MAX_UNFUNDED_INCOMING_CHANNELS_PER_PEER = 2
+    MAX_UNFUNDED_INCOMING_CHANNELS_GLOBAL = 20
+
+    class ChannelOpeningRateLimited(Exception): pass
+
+    def __init__(self, lnpeermgr: 'LNPeerManager'):
+        self._lnpeermgr = lnpeermgr
+        # stores the pending opening flows as they are not yet part of lnworker.channels
+        self._pending_channel_openings = defaultdict(int)  # type: dict[bytes, int]
+
+    @contextmanager
+    def rate_limit(self, node_id: bytes):
+        self._try_acquire(node_id)
+        try:
+            yield
+        finally:
+            self._release(node_id)
+
+    def _try_acquire(self, node_id: bytes):
+        if self._count_unfunded_channels_with_peer(node_id) >= self.MAX_UNFUNDED_INCOMING_CHANNELS_PER_PEER:
+            raise self.ChannelOpeningRateLimited(f"per-peer rate limit ({self.MAX_UNFUNDED_INCOMING_CHANNELS_PER_PEER}) exceeded")
+        if not self._is_trusted_peer(node_id) \
+                and self._count_unfunded_channels_global() >= self.MAX_UNFUNDED_INCOMING_CHANNELS_GLOBAL:
+            raise self.ChannelOpeningRateLimited(f"global rate limit ({self.MAX_UNFUNDED_INCOMING_CHANNELS_GLOBAL}) exceeded")
+        self._pending_channel_openings[node_id] += 1
+
+    def _release(self, node_id: bytes):
+        self._pending_channel_openings[node_id] -= 1
+        if self._pending_channel_openings[node_id] <= 0:
+            del self._pending_channel_openings[node_id]
+
+    @staticmethod
+    def _count_unfunded_channels(channels: Iterable['Channel']) -> int:
+        # count zeroconf as unfunded, flag gets dropped after 3 confirmations by LNWatcher.
+        # zeroconf channels aren't unbounded here as the LSP might even have an incentive
+        # to DOS us so we are unable to broadcast a fraud proof/preimage onchain?
+        return sum(1 for c in channels if (not c.is_funded() or c.is_zeroconf()) and not c.is_initiator())
+
+    def _is_trusted_peer(self, node_id: bytes) -> bool:
+        return any(c.get_latest_ctn(HTLCOwner.LOCAL) > 0 for c in self._lnpeermgr.channels_for_peer(node_id).values())
+
+    def _count_unfunded_channels_with_peer(self, node_id: bytes) -> int:
+        channels_with_peer = self._lnpeermgr.channels_for_peer(node_id).values()
+        count_unfunded_channels = self._count_unfunded_channels(channels_with_peer)
+        count_pending_channel_openings = self._pending_channel_openings.get(node_id, 0)
+        return count_unfunded_channels + count_pending_channel_openings
+
+    def _count_unfunded_channels_global(self) -> int:
+        global_channels = self._lnpeermgr._lnwallet_or_lngossip.channels.values()
+        count_global_channels = self._count_unfunded_channels(global_channels)
+        return count_global_channels + sum(self._pending_channel_openings.values())
 
 
 def list_enabled_ln_feature_bits(features: int) -> tuple[int, ...]:

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1048,6 +1048,7 @@ class LNWallet(Logger):
         for channel_id, c in random_shuffled_copy(channels.items()):
             self._channels[bfh(channel_id)] = chan = Channel(c, lnworker=self)
             self.wallet.set_reserved_addresses_for_chan(chan, reserved=True)
+        self.incoming_channel_rate_limiter = lnutil.IncomingChannelRateLimiter(self.lnpeermgr)
 
         self._channel_backups = {}  # type: Dict[bytes, ChannelBackup]
         # order is important: imported should overwrite onchain

--- a/tests/lnhelpers.py
+++ b/tests/lnhelpers.py
@@ -26,7 +26,9 @@ from electrum.channel_db import ChannelDB
 from electrum.lnworker import LNWallet, PaySession, PaymentInfo
 from electrum.simple_config import SimpleConfig
 from electrum.fee_policy import FeeTimeEstimates, FEE_ETA_TARGETS
-from electrum.wallet import  Standard_Wallet
+from electrum.wallet import Standard_Wallet, Abstract_Wallet
+from electrum.transaction import PartialTransaction, PartialTxInput, PartialTxOutput, TxOutpoint
+from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED
 
 from . import restore_wallet_from_text__for_unittest
 
@@ -167,6 +169,9 @@ class MockNetwork:
         self._blockchain = MockBlockchain()
 
     def get_local_height(self):
+        return self.blockchain().height()
+
+    def get_server_height(self):
         return self.blockchain().height()
 
     def blockchain(self):
@@ -405,6 +410,26 @@ def prepare_lnwallets(elec_test_case: 'ElectrumTestCase', graph_definition) -> M
     for a, definition in graph_definition.items():
         workers[a] = elec_test_case.create_mock_lnwallet(name=a)
     return workers
+
+
+def fund_wallet(wallet: 'Abstract_Wallet', *, value_sat: int) -> PartialTransaction:
+    """Give a mock wallet a spendable on-chain UTXO."""
+    txin = PartialTxInput(prevout=TxOutpoint(txid=bytes(32), out_idx=0))
+    txin._trusted_value_sats = value_sat
+    txin.script_type = 'p2wpkh'
+    txout = PartialTxOutput.from_address_and_value(wallet.get_receiving_address(), value_sat)
+    tx = PartialTransaction.from_io([txin], [txout], version=2)
+    wallet.adb.receive_tx_callback(tx, tx_height=TX_HEIGHT_UNCONFIRMED)
+    return tx
+
+
+def force_state_transition(chanA: Channel, chanB: Channel) -> None:
+    chanB.receive_new_commitment(*chanA.sign_next_commitment())
+    rev = chanB.revoke_current_commitment()
+    bob_sig, bob_htlc_sigs = chanB.sign_next_commitment()
+    chanA.receive_revocation(rev)
+    chanA.receive_new_commitment(bob_sig, bob_htlc_sigs)
+    chanB.receive_revocation(chanA.revoke_current_commitment())
 
 
 def prepare_chans_and_peers_in_graph(
@@ -703,3 +728,9 @@ def create_test_channels(
     assert alice.channel_id == bob.channel_id
 
     return alice, bob
+
+
+class PaymentDone(Exception): pass
+class PaymentTimeout(Exception): pass
+class SuccessfulTest(Exception): pass
+

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -42,7 +42,7 @@ from electrum.logging import console_stderr_handler
 from electrum.lnchannel import ChannelState, Channel
 
 from . import ElectrumTestCase
-from .lnhelpers import create_test_channels
+from .lnhelpers import create_test_channels, force_state_transition
 
 
 one_bitcoin_in_msat = bitcoin.COIN * 1000
@@ -1051,10 +1051,3 @@ class TestDustNoAnchors(TestDust):
     TEST_ANCHOR_CHANNELS = False
 
 
-def force_state_transition(chanA: Channel, chanB: Channel) -> None:
-    chanB.receive_new_commitment(*chanA.sign_next_commitment())
-    rev = chanB.revoke_current_commitment()
-    bob_sig, bob_htlc_sigs = chanB.sign_next_commitment()
-    chanA.receive_revocation(rev)
-    chanA.receive_new_commitment(bob_sig, bob_htlc_sigs)
-    chanB.receive_revocation(chanA.revoke_current_commitment())

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -1,65 +1,48 @@
 import asyncio
 import dataclasses
-import shutil
 import copy
-import tempfile
 import os
-from contextlib import contextmanager
-from collections import defaultdict
 import logging
-import concurrent
-from concurrent import futures
-from functools import lru_cache
 from unittest import mock
-from typing import Iterable, NamedTuple, Tuple, List, Dict, Sequence, Mapping, Optional
+from typing import List, Mapping, Optional
 from types import MappingProxyType
 import time
 import statistics
 
-from aiorpcx import timeout_after, TaskTimeout
-from electrum_ecc import ECPrivkey
 import electrum_ecc as ecc
 
 import electrum
 import electrum.trampoline
 from electrum import bitcoin
 from electrum import util
-from electrum import constants
-from electrum import bip32
-from electrum.network import Network, ProxySettings
-from electrum import simple_config, lnutil
+from electrum import lnutil
 from electrum.bolt11 import encode_bolt11_invoice, BOLT11Addr
 from electrum.bitcoin import sha256
 from electrum.transaction import Transaction
-from electrum.util import NetworkRetryManager, bfh, OldTaskGroup, EventListener, InvoiceError
+from electrum.util import OldTaskGroup, InvoiceError
 from electrum.lnpeer import Peer
 from electrum.lnpeer import CoopCloseFailure
 from electrum.lntransport import LNPeerAddr
 from electrum.crypto import privkey_to_pubkey
-from electrum.lnutil import Keypair, PaymentFailure, LnFeatures, HTLCOwner, PaymentFeeBudget, RECEIVED
+from electrum.lnutil import PaymentFailure, LnFeatures, HTLCOwner, RECEIVED, PaymentFeeBudget
 from electrum.lnchannel import ChannelState, PeerState, Channel
-from electrum.lnrouter import LNPathFinder, PathEdge, LNPathInconsistent
+from electrum.lnrouter import PathEdge, LNPathInconsistent
 from electrum.channel_db import ChannelDB, InvalidGossipMsg
-from electrum.lnworker import LNWallet, NoPathFound, SentHtlcInfo, PaySession, LNPeerManager
+from electrum.lnworker import LNWallet, NoPathFound, SentHtlcInfo
 from electrum.lnmsg import encode_msg, decode_msg
 from electrum import lnmsg
-from electrum.logging import console_stderr_handler, Logger
+from electrum.logging import console_stderr_handler
 from electrum.lnonion import OnionFailureCode, OnionRoutingFailure, OnionHopsDataSingle, OnionPacket
 from electrum.lnutil import LOCAL, REMOTE, UpdateAddHtlc, RecvMPPResolution, RevocationStore
 from electrum.invoices import PR_PAID, PR_UNPAID, Invoice
 from electrum.interface import GracefulDisconnect
-from electrum.fee_policy import FeeTimeEstimates, FEE_ETA_TARGETS
 from electrum.mpp_split import split_amount_normal
-from electrum.wallet import Abstract_Wallet, Standard_Wallet
 
-from .test_bitcoin import needs_test_with_all_chacha20_implementations
-from . import ElectrumTestCase, restore_wallet_from_text__for_unittest, lnhelpers
-from .lnhelpers import Graph, MockLNWallet, create_test_channels, low_fee_channel, depleted_channel
-
-
-class PaymentDone(Exception): pass
-class PaymentTimeout(Exception): pass
-class SuccessfulTest(Exception): pass
+from . import ElectrumTestCase, lnhelpers
+from .lnhelpers import (
+    Graph, MockLNWallet, create_test_channels, low_fee_channel, depleted_channel, SuccessfulTest,
+    PaymentDone, PaymentTimeout,
+)
 
 
 def inject_chan_into_gossipdb(
@@ -1380,6 +1363,26 @@ class TestPeerDirect(TestPeer):
             p1.send_warning(alice_channel.channel_id, 'be warned!', close_connection=True)
         gath = asyncio.gather(action(), p1._message_loop(), p2._message_loop(), p1.htlc_switch(), p2.htlc_switch())
         with self.assertRaises(GracefulDisconnect):
+            await gath
+
+    async def test_channel_close_after_previous_warning(self):
+        """We receive a warning, and later a shutdown.
+        We shouldn't fail the shutdown due to some unconsumed warning message in the queue."""
+        graph = self.prepare_chans_and_peers_in_graph(self.GRAPH_DEFINITIONS['single_chan'])
+        p1, p2 = graph.peers.values()
+        alice_channel = graph.channels[('alice', 'bob')][0]
+
+        async def action():
+            await util.wait_for2(p1.initialized, 1)
+            await util.wait_for2(p2.initialized, 1)
+            p1.send_warning(alice_channel.channel_id, 'be warned!', close_connection=False)
+            await asyncio.sleep(0.05)
+            # one hour later peer tries to close, close_channel depends on a message response
+            await p1.close_channel(alice_channel.channel_id)
+            self.assertTrue(alice_channel.is_closed_or_closing())
+            raise SuccessfulTest
+        gath = asyncio.gather(action(), p1._message_loop(), p2._message_loop(), p1.htlc_switch(), p2.htlc_switch())
+        with self.assertRaises(SuccessfulTest):
             await gath
 
     async def test_error(self):

--- a/tests/test_lnwallet.py
+++ b/tests/test_lnwallet.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Optional, Sequence
 
 from electrum.address_synchronizer import TX_HEIGHT_LOCAL
-from electrum import bitcoin
+from electrum import lnutil
 import electrum.trampoline
 from electrum.channel_db import UpdateStatus
 from electrum.lnutil import RECEIVED, MIN_FINAL_CLTV_DELTA_ACCEPTED, serialize_htlc_key, LnFeatures, HTLCOwner
@@ -22,9 +22,10 @@ from electrum.lnonion import OnionPacket, OnionRoutingFailure, OnionFailureCode
 from electrum.mpp_split import SplitConfig, SplitConfigRating
 from electrum.crypto import sha256
 from electrum.simple_config import SimpleConfig
+from electrum.util import OldTaskGroup
 
 from . import ElectrumTestCase, lnhelpers
-from .lnhelpers import create_test_channels
+from .lnhelpers import create_test_channels, SuccessfulTest, force_state_transition
 
 
 class TestLNWallet(ElectrumTestCase):
@@ -584,3 +585,69 @@ class TestLNWallet(ElectrumTestCase):
         pubkey_b = graph.workers['bob'].node_keypair.pubkey
         pubkey_d = graph.workers['dave'].node_keypair.pubkey
         self.assertEqual(amount_msat, hint_bd.cannot_send(pubkey_b < pubkey_d))
+
+    async def test_channel_open_rate_limit(self):
+        alice = self.create_mock_lnwallet(name="alice")
+        bob = self.create_mock_lnwallet(name="bob")
+        carol = self.create_mock_lnwallet(name="carol")
+        dave = self.create_mock_lnwallet(name="dave")
+        alice.config.LIGHTNING_USE_RECOVERABLE_CHANNELS = False
+        bob.config.LIGHTNING_USE_RECOVERABLE_CHANNELS = False
+        alice.incoming_channel_rate_limiter.MAX_UNFUNDED_INCOMING_CHANNELS_GLOBAL = 3
+        for lnw in (alice, bob, carol, dave):
+            lnhelpers.fund_wallet(lnw.wallet, value_sat=10_000_000)
+
+        peer_loops = []
+        def connect(w1, w2):
+            t1, t2 = lnhelpers.transport_pair(w1.node_keypair, w2.node_keypair, w1.name, w2.name)
+            peer_1 = lnhelpers.PeerInTests(w1, w2.node_keypair.pubkey, t1)
+            peer_2 = lnhelpers.PeerInTests(w2, w1.node_keypair.pubkey, t2)
+            w1.lnpeermgr._peers[w2.node_keypair.pubkey] = peer_1
+            w2.lnpeermgr._peers[w1.node_keypair.pubkey] = peer_2
+            peer_loops.extend([peer_1, peer_2])
+            return peer_1, peer_2
+
+        bob_alice_peer, alice_bob_peer = connect(bob, alice)
+        carol_alice_peer, _ = connect(carol, alice)
+        dave_alice_peer, _ = connect(dave, alice)
+
+        async def open_channel(initiator_peer, funding_sat=lnutil.MIN_FUNDING_SAT):
+            initiator_peer.lnworker.network._blockchain._height += 1
+            return await initiator_peer.lnworker.open_channel_with_peer(peer=initiator_peer, funding_sat=funding_sat)
+
+        async def run_test():
+            chan1, _ = await open_channel(bob_alice_peer)
+            chan2, _ = await open_channel(bob_alice_peer)
+            # test per-peer rate limit
+            with self.assertLogs('electrum', level='INFO') as logs:
+                with mock.patch('electrum.lnworker.LN_P2P_NETWORK_TIMEOUT', 0.1):
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await open_channel(bob_alice_peer)  # bob exhausted his allowed budget
+            self.assertTrue(any("remote peer sent warning [DO NOT TRUST THIS MESSAGE]: 'per-peer rate limit" in msg for msg in logs.output))
+
+            chan3, _ = await open_channel(carol_alice_peer)
+            # test global rate limit
+            with self.assertLogs('electrum', level='INFO') as logs:
+                with mock.patch('electrum.lnworker.LN_P2P_NETWORK_TIMEOUT', 0.1):
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await open_channel(dave_alice_peer)  # global limit is full, dave cannot open channel
+            self.assertTrue(any("remote peer sent warning [DO NOT TRUST THIS MESSAGE]: 'global rate limit" in msg for msg in logs.output))
+
+            # alice can still open channels to bob, exceeding her own rate-limit(s)
+            await open_channel(alice_bob_peer)
+
+            # a known peer is allowed to exceed the global rate limit
+            # inject a confirmed channel into alice so she knows dave
+            graph_def = {"alice": {"channels": {"dave": [{"local_balance_msat": 10_000_000_000,"remote_balance_msat": 50_000_000}],}}, "dave": {}}
+            g = lnhelpers.prepare_chans_and_peers_in_graph(self, graph_def, workers={'alice': alice, 'dave': dave})
+            # bump the ctn of 'alice->dave' so the channel is considered active by alice
+            force_state_transition(g.channels[('alice', 'dave')][0], g.channels[('dave', 'alice')][0])
+            await open_channel(dave_alice_peer)  # dave should now be able to open a channel as he is known to alice
+
+            raise SuccessfulTest
+
+        with self.assertRaises(SuccessfulTest):
+            async with OldTaskGroup() as group:
+                await group.spawn(asyncio.wait_for(run_test(), timeout=5))
+                for peer in peer_loops:
+                    await group.spawn(peer.main_loop())


### PR DESCRIPTION
Implements rate-limiting incoming channel opening requests as protection for public nodes.

* 20 unfunded channels overall
* 2 unfunded channels per peer
* a peer with whom we had an active channel before is allowed to exceed the global limit

unfunded channel = channel with less than one confirmation