### PR TITLE
lnutil: make minimum channel funding amount configurable

### DIFF
--- a/electrum/gui/qml/qechannelopener.py
+++ b/electrum/gui/qml/qechannelopener.py
@@ -9,7 +9,6 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject, QVariant
 from electrum.i18n import _
 from electrum.gui import messages
 from electrum.util import bfh
-from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.lntransport import extract_nodeid, ConnStringFormatError
 from electrum.bitcoin import DummyAddress
 from electrum.lnworker import hardcoded_trampoline_nodes
@@ -159,9 +158,10 @@ class QEChannelOpener(QObject, AuthMixin):
             return
 
         # for MAX, estimate is assumed to be calculated and set in self._amount.satsInt
-        if self._amount.satsInt < MIN_FUNDING_SAT:
+        min_funding_sat = self._wallet.wallet.config.LIGHTNING_MIN_FUNDING_SAT
+        if self._amount.satsInt < min_funding_sat:
             message = _('Minimum required amount: {}').format(
-                self._wallet.wallet.config.format_amount_and_units(MIN_FUNDING_SAT)
+                self._wallet.wallet.config.format_amount_and_units(min_funding_sat)
             )
             if self._amount.isMax and self._determine_max_message:
                 message += '\n' + self._determine_max_message

--- a/electrum/gui/qml/qerequestdetails.py
+++ b/electrum/gui/qml/qerequestdetails.py
@@ -8,7 +8,7 @@ from electrum.logging import get_logger
 from electrum.invoices import (
     PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID, PR_INFLIGHT, PR_FAILED, PR_ROUTING, PR_UNCONFIRMED, LN_EXPIRY_NEVER
 )
-from electrum.lnutil import MIN_FUNDING_SAT, RECEIVED
+from electrum.lnutil import RECEIVED
 from electrum.lnurl import LNURL3Data, request_lnurl_withdraw_callback, LNURLError
 from electrum.payment_identifier import PaymentIdentifier, PaymentIdentifierType
 from electrum.i18n import _
@@ -151,7 +151,7 @@ class QERequestDetails(QObject, QtEventListener):
         can_receive = wallet.lnworker.num_sats_can_receive()
         will_req_zeroconf = wallet.lnworker.receive_requires_jit_channel(amount_msat=amount_sat*1000)
         if self._req and ((can_receive > 0 and amount_sat <= can_receive)
-                          or (will_req_zeroconf and amount_sat >= MIN_FUNDING_SAT)):
+                          or (will_req_zeroconf and amount_sat >= wallet.config.LIGHTNING_MIN_FUNDING_SAT)):
             bolt11 = wallet.get_bolt11_invoice(self._req)
         else:
             return ''

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -16,7 +16,6 @@ from electrum.transaction import PartialTransaction, Transaction
 from electrum.util import (
     InvalidPassword, event_listener, AddTransactionException, get_asyncio_loop, NotEnoughFunds, NoDynamicFeeEstimates
 )
-from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.plugin import run_hook
 from electrum.wallet import Multisig_Wallet
 from electrum.crypto import pw_decode_with_version_and_mac
@@ -105,7 +104,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         self._frozenbalance = QEAmount()
         self._totalbalance = QEAmount()
         self._lightningcanreceive = QEAmount()
-        self._minchannelfunding = QEAmount(amount_sat=int(MIN_FUNDING_SAT))
+        self._minchannelfunding = QEAmount(amount_sat=int(self.wallet.config.LIGHTNING_MIN_FUNDING_SAT))
         self._lightningcansend = QEAmount()
         self._lightningbalancefrozen = QEAmount()
 

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1976,11 +1976,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             tab.searchable_list.filter(t)
 
     def new_channel_dialog(self, *, amount_sat=None, min_amount_sat=None):
-        from electrum.lnutil import MIN_FUNDING_SAT
         from .new_channel_dialog import NewChannelDialog
         assert self.wallet.can_have_lightning()
         confirmed = self.wallet.get_spendable_balance_sat(confirmed_only=True)
-        min_amount_sat = min_amount_sat or MIN_FUNDING_SAT
+        min_amount_sat = min_amount_sat or self.config.LIGHTNING_MIN_FUNDING_SAT
         if confirmed < min_amount_sat:
             msg = _('Not enough funds') + '\n\n' + _('You need at least {} to open a channel.').format(self.format_amount_and_units(min_amount_sat))
             self.show_error(msg)

--- a/electrum/gui/qt/new_channel_dialog.py
+++ b/electrum/gui/qt/new_channel_dialog.py
@@ -4,7 +4,6 @@ from PyQt6.QtWidgets import QLabel, QVBoxLayout, QGridLayout, QPushButton, QComb
 import electrum_ecc as ecc
 
 from electrum.i18n import _
-from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.lnworker import hardcoded_trampoline_nodes
 from electrum.util import NotEnoughFunds, NoDynamicFeeEstimates
 from electrum.fee_policy import FeePolicy
@@ -37,7 +36,7 @@ class NewChannelDialog(WindowModalDialog):
         self.lnworker = self.window.wallet.lnworker
         self.trampolines = hardcoded_trampoline_nodes()
         self.trampoline_names = list(self.trampolines.keys())
-        self.min_amount_sat = min_amount_sat or MIN_FUNDING_SAT
+        self.min_amount_sat = min_amount_sat or self.config.LIGHTNING_MIN_FUNDING_SAT
         self.get_coins = get_coins
         vbox = QVBoxLayout(self)
         toolbar, menu = create_toolbar_with_menu(self.config, '')

--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -138,6 +138,29 @@ class SettingsDialog(QDialog, QtEventListener):
             util.trigger_callback('channels_updated', self.wallet)
         trampoline_cb.stateChanged.connect(on_trampoline_checked)
 
+        # minimum channel funding amount (the risk warning is shown right below the field)
+        min_funding_label = HelpLabel.from_configvar(self.config.cv.LIGHTNING_MIN_FUNDING_SAT)
+        min_funding_sb = QSpinBox()
+        min_funding_sb.setMinimum(0)
+        min_funding_sb.setMaximum(self.config.LIGHTNING_MAX_FUNDING_SAT)
+        min_funding_sb.setSingleStep(1000)
+        min_funding_sb.setGroupSeparatorShown(True)
+        min_funding_sb.setSuffix(' ' + _('sat'))
+        min_funding_sb.setValue(self.config.LIGHTNING_MIN_FUNDING_SAT)
+        if not self.config.cv.LIGHTNING_MIN_FUNDING_SAT.is_modifiable():
+            for w in [min_funding_sb, min_funding_label]:
+                w.setEnabled(False)
+
+        def on_min_funding():
+            value = min_funding_sb.value()
+            if self.config.LIGHTNING_MIN_FUNDING_SAT != value:
+                self.config.LIGHTNING_MIN_FUNDING_SAT = value
+        min_funding_sb.valueChanged.connect(on_min_funding)
+
+        min_funding_warning = QLabel(self.config.cv.LIGHTNING_MIN_FUNDING_SAT.get_long_desc())
+        min_funding_warning.setWordWrap(True)
+        min_funding_warning.setStyleSheet(ColorScheme.ORANGE.as_stylesheet())
+
 
         alias_label = HelpLabel.from_configvar(self.config.cv.OPENALIAS_ID)
         alias = self.config.OPENALIAS_ID
@@ -361,6 +384,8 @@ class SettingsDialog(QDialog, QtEventListener):
         units_widgets.append((thousandsep_cb, None))
         lightning_widgets = []
         lightning_widgets.append((trampoline_cb, None))
+        lightning_widgets.append((min_funding_label, min_funding_sb))
+        lightning_widgets.append((min_funding_warning, None))
         fiat_widgets = []
         fiat_widgets.append((QLabel(_('Fiat currency')), ccy_combo))
         fiat_widgets.append((QLabel(_('Source')), ex_combo))

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -34,7 +34,6 @@ from PyQt6.QtWidgets import QAbstractItemView, QMenu
 from electrum.i18n import _
 from electrum.bitcoin import is_address
 from electrum.transaction import PartialTxInput, PartialTxOutput
-from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.util import profiler
 from electrum.plugin import run_hook
 
@@ -266,7 +265,7 @@ class UTXOList(MyTreeView):
         if self.wallet.lnworker is None:
             return False
         value = sum(x.value_sats() for x in coins)
-        return value >= MIN_FUNDING_SAT and value <= self.config.LIGHTNING_MAX_FUNDING_SAT
+        return value >= self.config.LIGHTNING_MIN_FUNDING_SAT and value <= self.config.LIGHTNING_MAX_FUNDING_SAT
 
     def open_channel_with_coins(self, coins: list[PartialTxInput]) -> None:
         assert coins, "no coins selected?"

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -125,8 +125,8 @@ class ChannelConfig(StoredObject):
         ):
             if not (len(key.pubkey) == 33 and ecc.ECPubkey.is_pubkey_bytes(key.pubkey)):
                 raise Exception(f"{conf_name}. invalid pubkey in channel config")
-        if funding_sat < MIN_FUNDING_SAT:
-            raise Exception(f"funding_sat too low: {funding_sat} sat < {MIN_FUNDING_SAT}")
+        if funding_sat < config.LIGHTNING_MIN_FUNDING_SAT:
+            raise Exception(f"funding_sat too low: {funding_sat} sat < {config.LIGHTNING_MIN_FUNDING_SAT} (config setting)")
         if not peer_features.supports(LnFeatures.OPTION_SUPPORT_LARGE_CHANNEL_OPT):
             # MUST set funding_satoshis to less than 2^24 satoshi
             if funding_sat > LN_MAX_FUNDING_SAT_LEGACY:
@@ -499,8 +499,10 @@ CHANNEL_OPENING_TIMEOUT_SEC = 14*24*60*60  # 2 weeks
 # force-closing the channel costs much of the funds in the channel.
 # Closing a channel uses ~200 vbytes onchain, feerates could spike to 100 sat/vbyte or even higher;
 # that in itself is already 20_000 sats. This mining fee is reserved and cannot be used for payments.
-# The value below is chosen arbitrarily to be one order of magnitude higher than that.
-MIN_FUNDING_SAT = 200_000
+# The value below is the default minimum; it can be overridden by the user via the
+# LIGHTNING_MIN_FUNDING_SAT config setting (see simple_config.py). Users lowering it should be
+# aware of the risks small channels carry in a high onchain-fee environment.
+MIN_FUNDING_SAT = 50_000
 
 
 ##### CLTV-expiry-delta-related values

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -71,7 +71,7 @@ from .lnutil import (
     LnKeyFamily, LOCAL, REMOTE, MIN_FINAL_CLTV_DELTA_ACCEPTED, SENT, RECEIVED, HTLCOwner, UpdateAddHtlc, LnFeatures,
     ShortChannelID, HtlcLog, NoPathFound, InvalidGossipMsg, FeeBudgetExceeded, ImportedChannelBackupStorage,
     OnchainChannelBackupStorage, ln_compare_features, IncompatibleLightningFeatures, PaymentFeeBudget,
-    NBLOCK_CLTV_DELTA_TOO_FAR_INTO_FUTURE, GossipForwardingMessage, MIN_FUNDING_SAT,
+    NBLOCK_CLTV_DELTA_TOO_FAR_INTO_FUTURE, GossipForwardingMessage,
     MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE, RecvMPPResolution, ReceivedMPPStatus, ReceivedMPPHtlc,
     PaymentSuccess, ChannelType, LocalConfig, Keypair, ZEROCONF_TIMEOUT,
 )
@@ -1808,7 +1808,7 @@ class LNWallet(Logger):
         lightning_needed = amount_to_pay - num_sats_can_send
         assert lightning_needed > 0
         min_funding_sat = lightning_needed + (lightning_needed // 20) + 1000  # safety margin
-        min_funding_sat = max(min_funding_sat, MIN_FUNDING_SAT)  # at least MIN_FUNDING_SAT
+        min_funding_sat = max(min_funding_sat, self.config.LIGHTNING_MIN_FUNDING_SAT)  # at least the configured minimum
         if min_funding_sat > self.config.LIGHTNING_MAX_FUNDING_SAT:
             return
         fee_policy = FeePolicy(f'feerate:{FEERATE_FALLBACK_STATIC_FEE}')

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -14,7 +14,7 @@ from .util import base_units, base_unit_name_to_decimal_point, decimal_point_to_
 from .util import format_satoshis, format_fee_satoshis, os_chmod
 from .util import user_dir, make_dir
 from .util import is_valid_websocket_url
-from .lnutil import LN_MAX_FUNDING_SAT_LEGACY
+from .lnutil import LN_MAX_FUNDING_SAT_LEGACY, MIN_FUNDING_SAT
 from .i18n import _
 from .logging import get_logger, Logger
 
@@ -751,6 +751,16 @@ Note that static backups only allow you to request a force-close with the remote
 If this is enabled, other nodes cannot open a channel to you. Channel recovery data is encrypted, so that only your wallet can decrypt it. However, blockchain analysis will be able to tell that the transaction was probably created by Electrum."""),
     )
     LIGHTNING_TO_SELF_DELAY_CSV = ConfigVar('lightning_to_self_delay', default=7 * 144, type_=int)
+    LIGHTNING_MIN_FUNDING_SAT = ConfigVar(
+        'lightning_min_funding_sat', default=MIN_FUNDING_SAT, type_=int,
+        short_desc=lambda: _("Minimum channel funding amount (sat)"),
+        long_desc=lambda: _(
+            "⚠️ Warning: Small channel sizes (<50 000 sats) come with some risks. "
+            "If your channel partner tries to cheat you by publishing an old channel state and "
+            "does so in a high onchain fee environment, on-chain fees could make challenging that "
+            "uneconomical (you could lose money). Don't open small channels with channel partners "
+            "you don't trust."),
+    )
     LIGHTNING_MAX_FUNDING_SAT = ConfigVar('lightning_max_funding_sat', default=LN_MAX_FUNDING_SAT_LEGACY, type_=int)
     LIGHTNING_MAX_HTLC_VALUE_IN_FLIGHT_MSAT = ConfigVar('lightning_max_htlc_value_in_flight_msat', default=None, type_=int)
     INITIAL_TRAMPOLINE_FEE_LEVEL = ConfigVar('initial_trampoline_fee_level', default=1, type_=int)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -78,7 +78,7 @@ from .invoices import BaseInvoice, Invoice, Request, PR_PAID, PR_UNPAID, PR_EXPI
 from .contacts import Contacts
 from .mnemonic import Mnemonic
 from .lnworker import LNWallet
-from .lnutil import MIN_FUNDING_SAT, RECEIVED, SENT
+from .lnutil import RECEIVED, SENT
 from .lntransport import extract_nodeid
 from .descriptor import Descriptor
 from .txbatcher import TxBatcher
@@ -3523,11 +3523,11 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                     ln_swap_suggestion = self.lnworker.suggest_swap_to_receive(max(amount_sat, MIN_SWAP_AMOUNT_SAT))
                     # prefer to use swaps over JIT channels if possible
                     if can_get_zeroconf_channel and not bool(ln_rebalance_suggestion) and not bool(ln_swap_suggestion):
-                        if amount_sat < MIN_FUNDING_SAT:
+                        if amount_sat < self.config.LIGHTNING_MIN_FUNDING_SAT:
                             ln_is_error = True
                             ln_help = (_('Cannot receive this payment. Request at least {} '
                                        'to purchase a Lightning channel from your service provider.')
-                                       .format(self.config.format_amount_and_units(amount_sat=MIN_FUNDING_SAT)))
+                                       .format(self.config.format_amount_and_units(amount_sat=self.config.LIGHTNING_MIN_FUNDING_SAT)))
                         else:
                             ln_zeroconf_suggestion = True
                             ln_help = _(f'Receiving this payment will purchase a payment channel from your '

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -1190,4 +1190,48 @@ class TestLNUtil(ElectrumTestCase):
         self.assertEqual(budget.fee_msat, config.LIGHTNING_PAYMENT_FEE_CUTOFF_MSAT)
         self.assertEqual(reversed_fee_msat, budget.fee_msat)
 
+    async def test_validate_params_min_funding_is_configurable(self):
+        # The minimum channel funding amount is read from config
+        # (LIGHTNING_MIN_FUNDING_SAT), not from a hardcoded constant.
+        from electrum.lnutil import LOCAL, MIN_FUNDING_SAT
+
+        lnwallet = self.create_mock_lnwallet(name="alice")
+        config = lnwallet.config
+        peer_features = lnwallet.features | LnFeatures.OPTION_SUPPORT_LARGE_CHANNEL_OPT
+        if config.TEST_LN_OPEN_SRK_CHANNELS:
+            channel_type = ChannelType.OPTION_STATIC_REMOTEKEY
+        else:
+            channel_type = ChannelType.OPTION_STATIC_REMOTEKEY | ChannelType.OPTION_ANCHORS
+
+        funding_sat = 100_000
+        lconfig = lnwallet.make_local_config_for_new_channel(
+            funding_sat=funding_sat,
+            push_msat=0,
+            initiator=LOCAL,
+            channel_type=channel_type,
+            multisig_funding_keypair=None,
+            peer_features=peer_features,
+        )
+
+        # sanity: the new default minimum is 50_000 (was hardcoded 200_000 before)
+        self.assertEqual(50_000, MIN_FUNDING_SAT)
+        self.assertEqual(MIN_FUNDING_SAT, config.LIGHTNING_MIN_FUNDING_SAT)
+
+        # with the default minimum (50k), a 100k channel is accepted
+        # (it would have been rejected under the old hardcoded 200k minimum).
+        lconfig.validate_params(
+            funding_sat=funding_sat, config=config, peer_features=peer_features)
+
+        # raising the configured minimum above the funding amount rejects it
+        config.LIGHTNING_MIN_FUNDING_SAT = 150_000
+        with self.assertRaises(Exception) as ctx:
+            lconfig.validate_params(
+                funding_sat=funding_sat, config=config, peer_features=peer_features)
+        self.assertIn("too low", str(ctx.exception))
+
+        # lowering the configured minimum below the funding amount accepts it again
+        config.LIGHTNING_MIN_FUNDING_SAT = 10_000
+        lconfig.validate_params(
+            funding_sat=funding_sat, config=config, peer_features=peer_features)
+
 

--- a/tests/test_simple_config.py
+++ b/tests/test_simple_config.py
@@ -135,6 +135,24 @@ class Test_SimpleConfig(ElectrumTestCase):
             # revert:
             config.NETWORK_SERVER = None
 
+    def test_lightning_min_funding_sat(self):
+        from electrum.lnutil import MIN_FUNDING_SAT
+        config = SimpleConfig(self.options)
+        # default equals the module-level default constant (now 50_000)
+        self.assertEqual(50_000, MIN_FUNDING_SAT)
+        self.assertEqual(MIN_FUNDING_SAT, config.LIGHTNING_MIN_FUNDING_SAT)
+        self.assertEqual(MIN_FUNDING_SAT, config.cv.LIGHTNING_MIN_FUNDING_SAT.get_default_value())
+        self.assertIsInstance(config.LIGHTNING_MIN_FUNDING_SAT, int)
+        # user can override it, and the value round-trips through the key
+        config.LIGHTNING_MIN_FUNDING_SAT = 25_000
+        self.assertEqual(25_000, config.LIGHTNING_MIN_FUNDING_SAT)
+        self.assertEqual(25_000, config.get("lightning_min_funding_sat"))
+        # the preferences UI relies on these descriptions being present
+        self.assertTrue(config.cv.LIGHTNING_MIN_FUNDING_SAT.get_short_desc())
+        long_desc = config.cv.LIGHTNING_MIN_FUNDING_SAT.get_long_desc()
+        self.assertIn("⚠️", long_desc)
+        self.assertIn("50 000 sats", long_desc)
+
     def test_configvars_setter_catches_typo(self):
         config = SimpleConfig(self.options)
         assert not hasattr(config, "NETORK_AUTO_CONNECTT")


### PR DESCRIPTION
Rationale:

Electrum comes with a hardcoded constant (MIN_FUNDING_SAT) which specifies the smallest allowable lightning channel, set to 200,000 sats, roughly equivalent to $200 USD. This is a burdensome amount for new Bitcoin users and puts lightning out of reach for them. This is especially relevant to lightning since it is really designed for small payments in the first place.

Some minimum, however, is needed for funds safety since if a channel partner published an old channel state (in an attempt to steal), it must be economical to challenge that state on-chain.

Other popular lightning wallets like Zeus set this at 20,000 sats (the LND default). Given that LND is the most popular lightning node client, this is a good reference amount.

This change enables users to set their own risk tolerance and advises them about how to do so, while sticking with a conservative 50,000 sat default.


Solution:
The minimum channel funding amount was a hardcoded constant (MIN_FUNDING_SAT = 200_000). Lower it to a 50_000 sat default and expose it as a new config setting, LIGHTNING_MIN_FUNDING_SAT, mirroring the existing LIGHTNING_MAX_FUNDING_SAT.

All call sites that previously read the hardcoded constant now read the value from config, so it is loaded at startup and honored at runtime like any other config value. The Qt Preferences dialog (Tools -> Preferences -> Lightning) gains an editor for the setting, together with a warning describing the risks of small channels in a high onchain-fee environment.

MIN_FUNDING_SAT is kept in lnutil as the default value for the new config var.