### PR TITLE
Coincontrol to backend

### DIFF
--- a/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum/gui/qt/confirm_tx_dialog.py
@@ -193,6 +193,7 @@ class TxEditor(WindowModalDialog, SubmarineSwapMixin, Logger):
             self.needs_update = False
 
     def update(self):
+        self.error = ''
         self.update_tx()
         self.set_locktime()
         self._update_widgets()

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1569,16 +1569,35 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
                 self.show_error(str(pi.error))
 
     def set_frozen_state_of_addresses(self, addrs, freeze: bool):
+        numcc = len(self.wallet.get_coincontrol_outpoints())
         self.wallet.set_frozen_state_of_addresses(addrs, freeze)
+        if numcc != len(self.wallet.get_coincontrol_outpoints()):
+            self.update_coincontrol_bar()
         self.address_list.refresh_all()
         self.utxo_list.refresh_all()
         self.address_list.selectionModel().clearSelection()
 
     def set_frozen_state_of_coins(self, utxos: Sequence[PartialTxInput], freeze: bool):
         utxos_str = {utxo.prevout.to_str() for utxo in utxos}
+        numcc = len(self.wallet.get_coincontrol_outpoints())
         self.wallet.set_frozen_state_of_coins(utxos_str, freeze)
+        if numcc != len(self.wallet.get_coincontrol_outpoints()):
+            self.update_coincontrol_bar()
         self.utxo_list.refresh_all()
         self.utxo_list.selectionModel().clearSelection()
+
+    def update_coincontrol_bar(self):
+        # update coincontrol status bar
+        cc_utxo_strs = self.wallet.get_coincontrol_outpoints()
+        if bool(cc_utxo_strs):
+            utxos = self.wallet.get_utxos()
+            coins = list(filter(lambda x: x.prevout.to_str() in cc_utxo_strs, utxos))
+            amount = sum(x.value_sats() for x in coins)
+            amount_str = self.format_amount_and_units(amount)
+            num_outputs_str = _("{} outputs available ({} total)").format(len(coins), len(utxos))
+            self.set_coincontrol_msg(_("Coin control active") + f': {num_outputs_str}, {amount_str}')
+        else:
+            self.set_coincontrol_msg(None)
 
     def create_list_tab(self, l):
         w = QWidget()

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1409,18 +1409,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.notify(_('Payment failed') + '\n\n' + description + '\n\n' + reason)
 
     def get_coins(self, **kwargs) -> Sequence[PartialTxInput]:
-        coins = self.get_manually_selected_coins()
-        if coins is not None:
-            return coins
-        else:
-            return self.wallet.get_spendable_coins(None, **kwargs)
-
-    def get_manually_selected_coins(self) -> Optional[Sequence[PartialTxInput]]:
-        """Return a list of selected coins or None.
-        Note: None means selection is not being used,
-              while an empty sequence means the user specifically selected that.
-        """
-        return self.utxo_list.get_spend_list()
+        cc = kwargs.pop('coincontrol', True)
+        return self.wallet.get_spendable_coins(None, coincontrol=cc, **kwargs)
 
     def broadcast_or_show(self, tx: Transaction, *, invoice: 'Invoice' = None):
         if not tx.is_complete():

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1569,9 +1569,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
     def set_frozen_state_of_coins(self, utxos: Sequence[PartialTxInput], freeze: bool):
         utxos_str = {utxo.prevout.to_str() for utxo in utxos}
-        numcc = len(self.wallet.get_coincontrol_outpoints())
+        numcc = len(self.wallet.get_coincontrol_outpoints() or set())
         self.wallet.set_frozen_state_of_coins(utxos_str, freeze)
-        if numcc != len(self.wallet.get_coincontrol_outpoints()):
+        if numcc != len(self.wallet.get_coincontrol_outpoints() or set()):
             self.update_coincontrol_bar()
         self.utxo_list.refresh_all()
         self.utxo_list.selectionModel().clearSelection()
@@ -1579,7 +1579,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     def update_coincontrol_bar(self):
         # update coincontrol status bar
         cc_utxo_strs = self.wallet.get_coincontrol_outpoints()
-        if bool(cc_utxo_strs):
+        if cc_utxo_strs is not None:
             utxos = self.wallet.get_utxos()
             coins = list(filter(lambda x: x.prevout.to_str() in cc_utxo_strs, utxos))
             amount = sum(x.value_sats() for x in coins)

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
 
 
 class UTXOList(MyTreeView):
-    _spend_set: Set[str]  # coins selected by the user to spend from
     _utxo_dict: Dict[str, PartialTxInput]  # coin name -> coin
 
     class Columns(MyTreeView.BaseColumnsEnum):
@@ -77,7 +76,7 @@ class UTXOList(MyTreeView):
             main_window=main_window,
             stretch_column=self.stretch_column,
         )
-        self._spend_set = set()
+
         self._utxo_dict = {}
         self.wallet = self.main_window.wallet
         self.std_model = QStandardItemModel(self)
@@ -130,20 +129,8 @@ class UTXOList(MyTreeView):
         self.filter()
         self.proxy.setDynamicSortFilter(True)
         self.sortByColumn(self.Columns.OUTPOINT, Qt.SortOrder.DescendingOrder)
-        self.update_coincontrol_bar()
+        self.main_window.update_coincontrol_bar()
         self.num_coins_label.setText(_('{} unspent transaction outputs').format(len(utxos)))
-
-    def update_coincontrol_bar(self):
-        # update coincontrol status bar
-        if bool(self._spend_set):
-            coins = [self._utxo_dict[x] for x in self._spend_set]
-            coins = self._filter_frozen_coins(coins)
-            amount = sum(x.value_sats() for x in coins)
-            amount_str = self.main_window.format_amount_and_units(amount)
-            num_outputs_str = _("{} outputs available ({} total)").format(len(coins), len(self._utxo_dict))
-            self.main_window.set_coincontrol_msg(_("Coin control active") + f': {num_outputs_str}, {amount_str}')
-        else:
-            self.main_window.set_coincontrol_msg(None)
 
     def refresh_row(self, key, row):
         assert row is not None
@@ -151,7 +138,7 @@ class UTXOList(MyTreeView):
         utxo_item = [self.std_model.item(row, col) for col in self.Columns]
         txid = utxo.prevout.txid.hex()
         num_parents = self.wallet.get_num_parents(txid)
-        utxo_item[self.Columns.PARENTS].setText('%6s'%num_parents if num_parents else '-')
+        utxo_item[self.Columns.PARENTS].setText('%6s' % num_parents if num_parents else '-')
         label = self.wallet.get_label_for_txid(txid) or ''
         utxo_item[self.Columns.LABEL].setText(label)
         sort_key = (
@@ -159,9 +146,9 @@ class UTXOList(MyTreeView):
             str(utxo.short_id),                                           # order inside block (if mined), or just txid
         )
         utxo_item[self.Columns.OUTPOINT].setData(sort_key, self.ROLE_SORT_ORDER)
-        SELECTED_TO_SPEND_TOOLTIP = _('Coin selected to be spent')
-        if key in self._spend_set:
-            tooltip = key + "\n" + SELECTED_TO_SPEND_TOOLTIP
+        spend_set = self.wallet.get_coincontrol_outpoints()
+        if key in spend_set:
+            tooltip = key + "\n" + _('Coin selected to be spent')
             color = ColorScheme.GREEN.as_color(True)
         else:
             tooltip = key
@@ -182,33 +169,25 @@ class UTXOList(MyTreeView):
         items = self.selected_in_column(self.Columns.OUTPOINT)
         return [x.data(self.ROLE_PREVOUT_STR) for x in items]
 
-    def _filter_frozen_coins(self, coins: List[PartialTxInput]) -> List[PartialTxInput]:
-        coins = [utxo for utxo in coins
-                 if (not self.wallet.is_frozen_address(utxo.address) and
-                     not self.wallet.is_frozen_coin(utxo))]
-        return coins
+    def are_in_coincontrol(self, coins: Set[PartialTxInput]) -> bool:
+        return self.wallet.are_in_coincontrol(coins)
 
-    def are_in_coincontrol(self, coins: List[PartialTxInput]) -> bool:
-        return all([utxo.prevout.to_str() in self._spend_set for utxo in coins])
-
-    def add_to_coincontrol(self, coins: List[PartialTxInput]):
+    def add_to_coincontrol(self, coins: Set[PartialTxInput]):
         assert all(utxo.prevout.to_str() in self._utxo_dict for utxo in coins) # see issue 10206
-        coins = self._filter_frozen_coins(coins)
-        for utxo in coins:
-            self._spend_set.add(utxo.prevout.to_str())
+        self.wallet.add_to_coincontrol(coins)
         self._refresh_coincontrol()
 
-    def remove_from_coincontrol(self, coins: List[PartialTxInput]):
-        for utxo in coins:
-            self._spend_set.remove(utxo.prevout.to_str())
+    def remove_from_coincontrol(self, coins: Set[PartialTxInput]):
+        self.wallet.remove_from_coincontrol(coins)
         self._refresh_coincontrol()
 
     def clear_coincontrol(self):
-        self._spend_set.clear()
+        self.wallet.clear_coincontrol()
         self._refresh_coincontrol()
 
     def add_selection_to_coincontrol(self):
-        if bool(self._spend_set):
+        spend_set = self.wallet.get_coincontrol_outpoints()
+        if bool(spend_set):
             self.clear_coincontrol()
             return
         selected = self.get_selected_outpoints()
@@ -220,27 +199,29 @@ class UTXOList(MyTreeView):
 
     def _refresh_coincontrol(self):
         self.refresh_all()
-        self.update_coincontrol_bar()
+        self.main_window.update_coincontrol_bar()
         self.selectionModel().clearSelection()
 
     def get_spend_list(self) -> Optional[Sequence[PartialTxInput]]:
-        if not bool(self._spend_set):
+        spend_set = self.wallet.get_coincontrol_outpoints()
+        if not bool(spend_set):
             return None
-        utxos = [self._utxo_dict[x] for x in self._spend_set]
+        utxos = [self._utxo_dict[x] for x in spend_set]
         return copy.deepcopy(utxos)  # copy so that side-effects don't affect utxo_dict
 
     def _maybe_reset_coincontrol(self, current_wallet_utxos: Sequence[PartialTxInput]) -> None:
-        if not self._spend_set and not self._currently_open_menu:
+        spend_set = self.wallet.get_coincontrol_outpoints()
+        if not bool(spend_set) and not self._currently_open_menu:
             return
         utxo_set = {utxo.prevout.to_str() for utxo in current_wallet_utxos}
         if self._currently_open_menu:
             # if we spent one of the qt-highlighted UTXOs, close context-menu
             if not all(prevout_str in utxo_set for prevout_str in self.get_selected_outpoints()):
                 self.close_menu()
-        if self._spend_set:
+        if spend_set:
             # if we spent one of the green-marked UTXOs, just reset selection
-            if not all([prevout_str in utxo_set for prevout_str in self._spend_set]):
-                self._spend_set.clear()
+            if not all([prevout_str in utxo_set for prevout_str in spend_set]):
+                self.clear_coincontrol()
 
     def can_swap_coins(self, coins):
         # fixme: min and max_amounts are known only after first request
@@ -258,9 +239,10 @@ class UTXOList(MyTreeView):
             return False
         return True
 
-    def swap_coins(self, coins: list[PartialTxInput]) -> None:
+    def swap_coins(self, coins: Set[PartialTxInput]) -> None:
         assert coins, "no coins selected?"
-        self.main_window.run_swap_dialog(is_reverse=False, recv_amount_sat_or_max='!', get_coins=lambda *args, **kwargs: coins)
+        self.main_window.run_swap_dialog(
+            is_reverse=False, recv_amount_sat_or_max='!', get_coins=lambda *args, **kwargs: list(coins))
 
     def can_open_channel(self, coins):
         if self.wallet.lnworker is None:
@@ -268,10 +250,10 @@ class UTXOList(MyTreeView):
         value = sum(x.value_sats() for x in coins)
         return value >= MIN_FUNDING_SAT and value <= self.config.LIGHTNING_MAX_FUNDING_SAT
 
-    def open_channel_with_coins(self, coins: list[PartialTxInput]) -> None:
+    def open_channel_with_coins(self, coins: Set[PartialTxInput]) -> None:
         assert coins, "no coins selected?"
         # todo : use a single dialog in new flow
-        d = NewChannelDialog(self.main_window, get_coins=lambda *args, **kwargs: coins)
+        d = NewChannelDialog(self.main_window, get_coins=lambda *args, **kwargs: list(coins))
         d.max_button.setChecked(True)
         d.max_button.setEnabled(False)
         d.min_button.setEnabled(False)
@@ -284,7 +266,7 @@ class UTXOList(MyTreeView):
         text = self.main_window.app.clipboard().text()
         return is_address(text)
 
-    def pay_to_clipboard_address(self, coins: list[PartialTxInput]) -> None:
+    def pay_to_clipboard_address(self, coins: Set[PartialTxInput]) -> None:
         assert coins, "no coins selected?"
         if not self.clipboard_contains_address():
             self.main_window.show_error(_('Clipboard doesn\'t contain a valid address'))
@@ -292,7 +274,7 @@ class UTXOList(MyTreeView):
         addr = self.main_window.app.clipboard().text()
         outputs = [PartialTxOutput.from_address_and_value(addr, '!')]
 
-        self.main_window.send_tab.pay_onchain_dialog(outputs, get_coins=lambda *args, **kwargs: coins)
+        self.main_window.send_tab.pay_onchain_dialog(outputs, get_coins=lambda *args, **kwargs: list(coins))
 
     def on_double_click(self, idx):
         outpoint = idx.sibling(idx.row(), self.Columns.OUTPOINT).data(self.ROLE_PREVOUT_STR)
@@ -306,7 +288,6 @@ class UTXOList(MyTreeView):
         if not coins:
             return
 
-        unfrozen_coins = self._filter_frozen_coins(coins)
         menu = QMenu()
         menu.setSeparatorsCollapsible(True)  # consecutive separators are merged together
 
@@ -323,21 +304,29 @@ class UTXOList(MyTreeView):
                 menu.addAction(_("Privacy analysis"), lambda: self.main_window.show_utxo(utxo))
             cc = self.add_copy_menu(menu, idx)
             cc.addAction(_("Long Output point"), lambda: self.place_text_on_clipboard(utxo.prevout.to_str(), title="Long Output point"))
-        # fully spend
-        m = menu_spend = menu.addMenu(_("Fully spend") + '…')
-        m.setEnabled(bool(unfrozen_coins))
-        m = menu_spend.addAction(_("send to address in clipboard"), lambda: self.pay_to_clipboard_address(unfrozen_coins))
+
+        selection_ex_frozen_coins = self.wallet._filter_frozen_coins(set(coins))
+        coincontrol_coins = self.wallet.get_coincontrol_coins()
+        # use CC set if not empty, else use selection
+        fully_spend_coins = coincontrol_coins if coincontrol_coins else selection_ex_frozen_coins
+
+        fully_spend_text = _("Fully spend") if not bool(coincontrol_coins) else _("Fully spend coin control")
+        menu_spend = menu.addMenu(fully_spend_text + '…')
+        menu_spend.setEnabled(bool(fully_spend_coins))
+        m = menu_spend.addAction(_("send to address in clipboard"), lambda: self.pay_to_clipboard_address(fully_spend_coins))
         m.setEnabled(self.clipboard_contains_address())
-        m = menu_spend.addAction(_("in new channel"), lambda: self.open_channel_with_coins(unfrozen_coins))
-        m.setEnabled(self.can_open_channel(unfrozen_coins))
-        m = menu_spend.addAction(_("in submarine swap"), lambda: self.swap_coins(unfrozen_coins))
-        m.setEnabled(self.can_swap_coins(unfrozen_coins))
+        m = menu_spend.addAction(_("in new channel"), lambda: self.open_channel_with_coins(fully_spend_coins))
+        m.setEnabled(self.can_open_channel(fully_spend_coins))
+        m = menu_spend.addAction(_("in submarine swap"), lambda: self.swap_coins(fully_spend_coins))
+        m.setEnabled(self.can_swap_coins(fully_spend_coins))
+
         # coin control
-        if self.are_in_coincontrol(coins):
-            menu.addAction(_("Remove from coin control"), lambda: self.remove_from_coincontrol(coins))
+        if selection_ex_frozen_coins and self.are_in_coincontrol(selection_ex_frozen_coins):
+            menu.addAction(_("Remove from coin control"), lambda: self.remove_from_coincontrol(selection_ex_frozen_coins))
         else:
-            m = menu.addAction(_("Add to coin control"), lambda: self.add_to_coincontrol(coins))
-            m.setEnabled(bool(unfrozen_coins))
+            m = menu.addAction(_("Add to coin control"), lambda: self.add_to_coincontrol(selection_ex_frozen_coins))
+            m.setEnabled(bool(selection_ex_frozen_coins))
+
         # Freeze menu
         if len(coins) == 1:
             utxo = coins[0]

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -202,13 +202,6 @@ class UTXOList(MyTreeView):
         self.main_window.update_coincontrol_bar()
         self.selectionModel().clearSelection()
 
-    def get_spend_list(self) -> Optional[Sequence[PartialTxInput]]:
-        spend_set = self.wallet.get_coincontrol_outpoints()
-        if not bool(spend_set):
-            return None
-        utxos = [self._utxo_dict[x] for x in spend_set]
-        return copy.deepcopy(utxos)  # copy so that side-effects don't affect utxo_dict
-
     def _maybe_reset_coincontrol(self, current_wallet_utxos: Sequence[PartialTxInput]) -> None:
         spend_set = self.wallet.get_coincontrol_outpoints()
         if not bool(spend_set) and not self._currently_open_menu:

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -78,6 +78,7 @@ class UTXOList(MyTreeView):
         )
 
         self._utxo_dict = {}
+        self._spend_set = set()
         self.wallet = self.main_window.wallet
         self.std_model = QStandardItemModel(self)
         self.proxy = MySortModel(self, sort_role=self.ROLE_SORT_ORDER)
@@ -103,6 +104,7 @@ class UTXOList(MyTreeView):
         self.proxy.setDynamicSortFilter(False)  # temp. disable re-sorting after every change
         utxos = self.wallet.get_utxos()
         self._maybe_reset_coincontrol(utxos)
+        self._spend_set = self.wallet.get_coincontrol_outpoints()
         self._utxo_dict = dict([(utxo.prevout.to_str(), utxo) for utxo in utxos])
         self.std_model.clear()
         self.update_headers(self.__class__.headers)
@@ -146,8 +148,7 @@ class UTXOList(MyTreeView):
             str(utxo.short_id),                                           # order inside block (if mined), or just txid
         )
         utxo_item[self.Columns.OUTPOINT].setData(sort_key, self.ROLE_SORT_ORDER)
-        spend_set = self.wallet.get_coincontrol_outpoints()
-        if key in spend_set:
+        if key in self._spend_set:
             tooltip = key + "\n" + _('Coin selected to be spent')
             color = ColorScheme.GREEN.as_color(True)
         else:
@@ -198,6 +199,7 @@ class UTXOList(MyTreeView):
         self.add_to_coincontrol(coins)
 
     def _refresh_coincontrol(self):
+        self._spend_set = self.wallet.get_coincontrol_outpoints()
         self.refresh_all()
         self.main_window.update_coincontrol_bar()
         self.selectionModel().clearSelection()

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -148,7 +148,7 @@ class UTXOList(MyTreeView):
             str(utxo.short_id),                                           # order inside block (if mined), or just txid
         )
         utxo_item[self.Columns.OUTPOINT].setData(sort_key, self.ROLE_SORT_ORDER)
-        if key in self._spend_set:
+        if self._spend_set and key in self._spend_set:
             tooltip = key + "\n" + _('Coin selected to be spent')
             color = ColorScheme.GREEN.as_color(True)
         else:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -441,6 +441,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self._reserved_addresses   = set(db.get('reserved_addresses', []))
         self._num_parents          = db.get_dict('num_parents')
 
+        # not saved
+        self._coincontrol_utxos = dict()
+
         self._freeze_lock = threading.RLock()  # for mutating/iterating frozen_{addresses,coins}
 
         self.load_keystore()
@@ -2227,6 +2230,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if all(self.is_mine(addr) for addr in addrs):
             with self._freeze_lock:
                 if freeze:
+                    coins = self.get_spendable_coins(addrs)
+                    self.remove_from_coincontrol(set(coins))
                     self._frozen_addresses |= set(addrs)
                 else:
                     self._frozen_addresses -= set(addrs)
@@ -2252,15 +2257,56 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         # basic sanity check that input is not garbage: (see if raises)
         [TxOutpoint.from_str(utxo) for utxo in utxos]
         assert freeze in (None, False, True), f"{freeze=!r}"
+        wallet_utxos = self.get_utxos() if bool(freeze) else []
         with self._freeze_lock:
             for utxo in utxos:
                 if freeze is None:
                     self._frozen_coins.pop(utxo, None)
                 else:
                     self._frozen_coins[utxo] = bool(freeze)
+                if bool(freeze):
+                    # frozen coins trump coincontrol coins
+                    if utxo in self._coincontrol_utxos:
+                        txinputs = set(filter(lambda x: x.prevout.to_str() == utxo, wallet_utxos))
+                        self.remove_from_coincontrol(txinputs)
+
         util.trigger_callback('status')
         if write_to_disk:
             self.save_db()
+
+    def _filter_frozen_coins(self, coins: Set[PartialTxInput]) -> Set[PartialTxInput]:
+        coins = {utxo for utxo in coins
+                 if (not self.is_frozen_address(utxo.address) and
+                     not self.is_frozen_coin(utxo))}
+        return coins
+
+    def are_in_coincontrol(self, coins: Set[PartialTxInput]) -> bool:
+        with self._freeze_lock:
+            return all([utxo.prevout.to_str() in self._coincontrol_utxos.keys() for utxo in coins])
+
+    def add_to_coincontrol(self, coins: Set[PartialTxInput]):
+        coins = self._filter_frozen_coins(coins)
+        if not coins:
+            return
+        with self._freeze_lock:
+            for utxo in coins:
+                self._coincontrol_utxos[utxo.prevout.to_str()] = utxo
+
+    def get_coincontrol_outpoints(self) -> Set[str]:
+        return {x.prevout.to_str() for x in self.get_coincontrol_coins()}
+
+    def get_coincontrol_coins(self) -> Set[PartialTxInput]:
+        with self._freeze_lock:
+            return self._filter_frozen_coins(set(self._coincontrol_utxos.values()))
+
+    def remove_from_coincontrol(self, coins: Set[PartialTxInput]):
+        with self._freeze_lock:
+            for utxo in coins:
+                self._coincontrol_utxos.pop(utxo.prevout.to_str(), None)
+
+    def clear_coincontrol(self):
+        with self._freeze_lock:
+            self._coincontrol_utxos.clear()
 
     def is_address_reserved(self, addr: str) -> bool:
         # note: atm 'reserved' status is only taken into consideration for 'change addresses'

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1138,6 +1138,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             *,
             nonlocal_only: bool = False,
             confirmed_only: bool = None,
+            coincontrol: bool = False,
     ) -> Sequence[PartialTxInput]:
         with self._freeze_lock:
             frozen_addresses = self._frozen_addresses.copy()
@@ -1150,7 +1151,11 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             confirmed_funding_only=confirmed_only,
             nonlocal_only=nonlocal_only,
         )
+        if coincontrol:
+            if cc := self.get_coincontrol_outpoints():
+                utxos = [utxo for utxo in utxos if utxo.prevout.to_str() in cc]
         utxos = [utxo for utxo in utxos if not self.is_frozen_coin(utxo)]
+
         return utxos
 
     @abstractmethod

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -442,7 +442,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self._num_parents          = db.get_dict('num_parents')
 
         # not saved
-        self._coincontrol_utxos = dict()
+        self._coincontrol_utxos = None
 
         self._freeze_lock = threading.RLock()  # for mutating/iterating frozen_{addresses,coins}
 
@@ -2272,7 +2272,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                     self._frozen_coins[utxo] = bool(freeze)
                 if bool(freeze):
                     # frozen coins trump coincontrol coins
-                    if utxo in self._coincontrol_utxos:
+                    cc = self._coincontrol_utxos or dict()
+                    if utxo in cc:
                         txinputs = set(filter(lambda x: x.prevout.to_str() == utxo, wallet_utxos))
                         self.remove_from_coincontrol(txinputs)
 
@@ -2322,6 +2323,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 return
             for utxo in coins:
                 self._coincontrol_utxos.pop(utxo.prevout.to_str(), None)
+            if not self._coincontrol_utxos:
+                self._coincontrol_utxos = None
 
     def clear_coincontrol(self):
         with self._freeze_lock:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2295,14 +2295,16 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             return
         with self._freeze_lock:
             for utxo in coins:
-                self._coincontrol_utxos[utxo.prevout.to_str()] = utxo
+                stored_utxo = copy.deepcopy(utxo)
+                self._coincontrol_utxos[utxo.prevout.to_str()] = stored_utxo
 
     def get_coincontrol_outpoints(self) -> Set[str]:
         return {x.prevout.to_str() for x in self.get_coincontrol_coins()}
 
     def get_coincontrol_coins(self) -> Set[PartialTxInput]:
         with self._freeze_lock:
-            return self._filter_frozen_coins(set(self._coincontrol_utxos.values()))
+            coins = self._filter_frozen_coins(set(self._coincontrol_utxos.values()))
+            return copy.deepcopy(coins)
 
     def remove_from_coincontrol(self, coins: Set[PartialTxInput]):
         with self._freeze_lock:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1152,7 +1152,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             nonlocal_only=nonlocal_only,
         )
         if coincontrol:
-            if cc := self.get_coincontrol_outpoints():
+            cc = self.get_coincontrol_outpoints()
+            if cc is not None:
                 utxos = [utxo for utxo in utxos if utxo.prevout.to_str() in cc]
         utxos = [utxo for utxo in utxos if not self.is_frozen_coin(utxo)]
 
@@ -2286,35 +2287,45 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         return coins
 
     def are_in_coincontrol(self, coins: Set[PartialTxInput]) -> bool:
+        outpoints = self._coincontrol_utxos if self._coincontrol_utxos else {}
         with self._freeze_lock:
-            return all([utxo.prevout.to_str() in self._coincontrol_utxos.keys() for utxo in coins])
+            return all([utxo.prevout.to_str() in outpoints.keys() for utxo in coins])
 
     def add_to_coincontrol(self, coins: Set[PartialTxInput]):
         coins = self._filter_frozen_coins(coins)
         if not coins:
             return
         with self._freeze_lock:
+            if self._coincontrol_utxos is None:
+                self._coincontrol_utxos = dict()
             for utxo in coins:
                 stored_utxo = copy.deepcopy(utxo)
                 self._coincontrol_utxos[utxo.prevout.to_str()] = stored_utxo
 
-    def get_coincontrol_outpoints(self) -> Set[str]:
-        return {x.prevout.to_str() for x in self.get_coincontrol_coins()}
+    def get_coincontrol_outpoints(self) -> None | Set[str]:
+        coins = self.get_coincontrol_coins()
+        if coins is None:
+            return None
+        return {x.prevout.to_str() for x in coins}
 
-    def get_coincontrol_coins(self) -> Set[PartialTxInput]:
+    def get_coincontrol_coins(self) -> None | Set[PartialTxInput]:
         with self._freeze_lock:
+            if self._coincontrol_utxos is None:
+                return None
             coins = set(self._coincontrol_utxos.values())
         coins = self._filter_frozen_coins(coins)
         return copy.deepcopy(coins)
 
     def remove_from_coincontrol(self, coins: Set[PartialTxInput]):
         with self._freeze_lock:
+            if self._coincontrol_utxos is None:
+                return
             for utxo in coins:
                 self._coincontrol_utxos.pop(utxo.prevout.to_str(), None)
 
     def clear_coincontrol(self):
         with self._freeze_lock:
-            self._coincontrol_utxos.clear()
+            self._coincontrol_utxos = None
 
     def is_address_reserved(self, addr: str) -> bool:
         # note: atm 'reserved' status is only taken into consideration for 'change addresses'

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2233,9 +2233,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     ) -> bool:
         """Set frozen state of the addresses to FREEZE, True or False"""
         if all(self.is_mine(addr) for addr in addrs):
+            coins = self.get_spendable_coins(addrs) if freeze else []
             with self._freeze_lock:
                 if freeze:
-                    coins = self.get_spendable_coins(addrs)
                     self.remove_from_coincontrol(set(coins))
                     self._frozen_addresses |= set(addrs)
                 else:
@@ -2303,8 +2303,9 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def get_coincontrol_coins(self) -> Set[PartialTxInput]:
         with self._freeze_lock:
-            coins = self._filter_frozen_coins(set(self._coincontrol_utxos.values()))
-            return copy.deepcopy(coins)
+            coins = set(self._coincontrol_utxos.values())
+        coins = self._filter_frozen_coins(coins)
+        return copy.deepcopy(coins)
 
     def remove_from_coincontrol(self, coins: Set[PartialTxInput]):
         with self._freeze_lock:

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -3312,6 +3312,58 @@ class TestWalletSending(ElectrumTestCase):
             wallet.set_frozen_state_of_coins([utxo1], freeze=None)
             self.assertTrue(utxo1 not in wallet._frozen_coins)
 
+        with self.subTest(msg="coincontrol"):
+            coins = {txi.prevout.to_str(): txi for txi in wallet.get_utxos()}
+            coin1, coin2 = coins[utxo1], coins[utxo2]
+
+            wallet.add_to_coincontrol({coin1})
+            self.assertEqual({utxo1}, wallet.get_coincontrol_outpoints())
+            self.assertEqual(
+                {utxo1, utxo2},
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins()})
+            self.assertEqual(
+                {utxo1},
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins(coincontrol=True)})
+            wallet.add_to_coincontrol({coin2})
+            self.assertEqual(
+                {utxo1, utxo2},
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins(coincontrol=True)})
+            self.assertEqual(
+                {utxo2},
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins(
+                    ["tb1q6n99dl96mx8mfh90m3tn5awk5mllkzdh25dw7z"], coincontrol=True)})
+            wallet.remove_from_coincontrol({coin1, coin2})
+            self.assertEqual(set(), wallet.get_coincontrol_outpoints())
+            self.assertEqual(
+                {utxo1, utxo2},
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins(coincontrol=True)})
+            wallet.add_to_coincontrol({coin1})
+            self.assertEqual(
+                set(),
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins(
+                    ["tb1q6n99dl96mx8mfh90m3tn5awk5mllkzdh25dw7z"], coincontrol=True)})
+            wallet.clear_coincontrol()
+            self.assertEqual(set(), wallet.get_coincontrol_outpoints())
+
+        # freezing trumps coin control
+        with self.subTest(msg="coincontrol_and_freeze"):
+            coins = {txi.prevout.to_str(): txi for txi in wallet.get_utxos()}
+            coin1, coin2 = coins[utxo1], coins[utxo2]
+
+            wallet.add_to_coincontrol({coin1, coin2})
+            self.assertEqual({utxo1, utxo2}, wallet.get_coincontrol_outpoints())
+            wallet.set_frozen_state_of_coins([utxo1], freeze=True)
+            self.assertEqual({utxo2}, wallet.get_coincontrol_outpoints())
+            self.assertEqual(
+                {utxo2},
+                {txi.prevout.to_str() for txi in wallet.get_spendable_coins(coincontrol=True)})
+            wallet.add_to_coincontrol({coin1})
+            self.assertEqual({utxo2}, wallet.get_coincontrol_outpoints())
+            # cleanup
+            wallet.set_frozen_state_of_coins([utxo1], freeze=None)
+            wallet.clear_coincontrol()
+            self.assertEqual(set(), wallet.get_coincontrol_outpoints())
+
     async def test_export_psbt_with_xpubs__multisig(self):
         """When exporting a PSBT to be signed by a hw device, test that we populate
         the PSBT_GLOBAL_XPUB field with wallet xpubs.

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -3333,9 +3333,9 @@ class TestWalletSending(ElectrumTestCase):
                 {txi.prevout.to_str() for txi in wallet.get_spendable_coins(
                     ["tb1q6n99dl96mx8mfh90m3tn5awk5mllkzdh25dw7z"], coincontrol=True)})
             wallet.remove_from_coincontrol({coin1, coin2})
-            self.assertEqual(set(), wallet.get_coincontrol_outpoints())
+            self.assertIsNone(wallet.get_coincontrol_outpoints())
             self.assertEqual(
-                set(),
+                {utxo1, utxo2},
                 {txi.prevout.to_str() for txi in wallet.get_spendable_coins(coincontrol=True)})
             wallet.add_to_coincontrol({coin1})
             self.assertEqual(

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -3335,7 +3335,7 @@ class TestWalletSending(ElectrumTestCase):
             wallet.remove_from_coincontrol({coin1, coin2})
             self.assertEqual(set(), wallet.get_coincontrol_outpoints())
             self.assertEqual(
-                {utxo1, utxo2},
+                set(),
                 {txi.prevout.to_str() for txi in wallet.get_spendable_coins(coincontrol=True)})
             wallet.add_to_coincontrol({coin1})
             self.assertEqual(
@@ -3343,7 +3343,7 @@ class TestWalletSending(ElectrumTestCase):
                 {txi.prevout.to_str() for txi in wallet.get_spendable_coins(
                     ["tb1q6n99dl96mx8mfh90m3tn5awk5mllkzdh25dw7z"], coincontrol=True)})
             wallet.clear_coincontrol()
-            self.assertEqual(set(), wallet.get_coincontrol_outpoints())
+            self.assertIsNone(wallet.get_coincontrol_outpoints())
 
         # freezing trumps coin control
         with self.subTest(msg="coincontrol_and_freeze"):
@@ -3360,9 +3360,11 @@ class TestWalletSending(ElectrumTestCase):
             wallet.add_to_coincontrol({coin1})
             self.assertEqual({utxo2}, wallet.get_coincontrol_outpoints())
             # cleanup
-            wallet.set_frozen_state_of_coins([utxo1], freeze=None)
+            wallet.set_frozen_state_of_coins([utxo1], freeze=False)
+            # unfreeze does not re-add
+            self.assertEqual({utxo2}, wallet.get_coincontrol_outpoints())
             wallet.clear_coincontrol()
-            self.assertEqual(set(), wallet.get_coincontrol_outpoints())
+            self.assertIsNone(wallet.get_coincontrol_outpoints())
 
     async def test_export_psbt_with_xpubs__multisig(self):
         """When exporting a PSBT to be signed by a hw device, test that we populate


### PR DESCRIPTION
Refactor coin control from GUI to backend, in preparation of adding coin control features to QML

Edit: Opus 5 found a number of issues (1619a75bc3c16a81678012b730cbfd4f2be85d23) Opus 4.8 didn't find. I've tried to resolve these but this ripples out to a bit more code than I'd like. Now analyzing the coincontrol state of `master`, and it finds basically the same issues pre-existing. 

Short summary:
- `main_window.py:1419` docstring declares coincontrol a tri-state, and wallet layer honours it (`get_spendable_coins`), but GUI's `utxo_list.get_spend_list` collapses empty set to `None`, so it might inadvertendly select coins outside coincontrol if the last coin is removed from coincontrol.
- interplay with frozen state is flaky; `add_to_coincontrol` frozen-filters only at insertion time. `update_coincontrol_bar` frozen-filters, but `get_spend_list` doesn't, so the status bar can understate the number and amount. Frozen coins can be spent (add to CC, freeze, send)
- coincontrol bypasses every non-frozen filter; `get_coins(**kwargs)` discards all kwargs when a spend list exists, so no `mature_only`, `nonlocal_only`, `confirmed_only` etc. Think of funding a channel from a local, never broadcasted tx, or `get_candidates_for_batching` wanting a conservative coin selection but getting the unfiltered coin set.

I'm tempted to limit this PR to just the refactor to the backend, without regressing, but also without fixing all of the above issues, and incrementally fix the issues in other PRs