### PR TITLE
util.make_aiohttp_session: wrap aiohttp-socks 0.11+ excs to ClientError

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1184,7 +1184,7 @@ class LNWallet(Logger):
                     watchtower.add_method('add_sweep_tx')
                     for chan in self.channels.values():
                         await self.sync_channel_with_watchtower(chan, watchtower)
-            except aiohttp.client_exceptions.ClientConnectorError:
+            except aiohttp.ClientError:
                 self.logger.info(f'could not contact remote watchtower {watchtower_url}')
 
     def get_watchtower_ctn(self, channel_point):

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -55,6 +55,7 @@ import functools
 from functools import partial
 from abc import abstractmethod, ABC
 import enum
+import contextlib
 from contextlib import nullcontext, suppress
 import traceback
 import inspect
@@ -62,6 +63,7 @@ import weakref
 
 import aiohttp
 from aiohttp_socks import ProxyConnector, ProxyType
+from aiohttp_socks import ProxyConnectionError, ProxyTimeoutError, ProxyError
 import aiorpcx
 import certifi
 import dns.asyncresolver
@@ -1354,7 +1356,7 @@ def make_aiohttp_proxy_connector(proxy: 'ProxySettings', ssl_context: Optional[s
     )
 
 
-def make_aiohttp_session(proxy: Optional['ProxySettings'], headers=None, timeout=None):
+def _make_aiohttp_session(proxy: Optional['ProxySettings'], headers=None, timeout=None):
     if headers is None:
         headers = {'User-Agent': 'Electrum'}
     if timeout is None:
@@ -1371,6 +1373,23 @@ def make_aiohttp_session(proxy: Optional['ProxySettings'], headers=None, timeout
         connector = aiohttp.TCPConnector(ssl=ssl_context)
 
     return aiohttp.ClientSession(headers=headers, timeout=timeout, connector=connector)
+
+
+@contextlib.asynccontextmanager
+async def make_aiohttp_session(proxy: Optional['ProxySettings'], headers=None, timeout=None):
+    """
+    Caller should typically handle at least:
+    - aiohttp.ClientError
+    - asyncio.TimeoutError
+    """
+    try:
+        async with _make_aiohttp_session(proxy, headers=headers, timeout=timeout) as session:
+            yield session
+    except (ProxyConnectionError, ProxyTimeoutError, ProxyError) as e:
+        # We unify all proxy-related exceptions to a single type.
+        # Maybe it would be better to unify to ProxyError, but ~all call sites already expect aiohttp.ClientError,
+        # and that is a generic http-related error that we usually display the str() of, so let's just reuse that.
+        raise aiohttp.ClientError(f"proxy error: {repr(e)}") from e
 
 
 class OldTaskGroup(aiorpcx.TaskGroup):


### PR DESCRIPTION
older versions of aiohttp-socks and python-socks used to raise
- ProxyConnectionError(OSError)
- ProxyTimeoutError(TimeoutError)
- ProxyError(Exception)

now they raise:
- ProxyConnectionError(Exception)
- ProxyTimeoutError(Exception)
- ProxyError(Exception)

In many call sites, we currently handle OSError and TimeoutError, usually by simply logging the error or showing it to the user. Another exceptions our call sites handle similarly is aiohttp.ClientError, which is the aiohttp base class for any client connection error.

A simple "fix" for us to restore the old behaviour is converting the new aiohttp_socks exception types to aiohttp.ClientError.

ref https://github.com/romis2012/aiohttp-socks/commit/db4235c2b9805f088e47074647c946873a231487
ref https://github.com/romis2012/python-socks/commit/50a3024a8ac10888085f963e44ab3a79d6574703

-----

related:
https://github.com/spesmilo/electrum/pull/10727#issuecomment-4863659725 (LLM output:)
> Worth passing upstream (correctness, not security): aiohttp-socks 0.11.0's ProxyConnectionError is no o Electrum call sites like electrum/exchange_rate.py:90 that catch (aiohttp.ClientError, TimeoutError,OSError) now fall through to their generic except Exception when a SOCKS/Tor proxy is unreachable — functional but noisier; catching the aiohttp_socks exceptions explicitly would restore clean handling.