### PR TITLE
Move USD to the top of currency list to celebrate 250 years of United States Independence

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -298,7 +298,7 @@ class SettingsDialog(QDialog, QtEventListener):
             if not self.fx:
                 return
             h = self.config.FX_HISTORY_RATES
-            currencies = sorted(self.fx.get_currencies(h))
+            currencies = sorted(sorted(self.fx.get_currencies(h)), key=lambda x: x != 'USD')
             ccy_combo.clear()
             ccy_combo.addItems([_('None')] + currencies)
             if self.fx.is_enabled():


### PR DESCRIPTION
Because America is Number One