### PR TITLE
android build: bump p4a to include "verbose logs" commit

### DIFF
--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -234,7 +234,7 @@ RUN cd /opt \
     && /opt/venv/bin/python3 -m pip install --no-build-isolation --no-dependencies -e .
 
 # install python-for-android
-ENV P4A_CHECKOUT_COMMIT="1098be6964cfc2156959e435e81c2c50f8398586"
+ENV P4A_CHECKOUT_COMMIT="c60f3f0341cea217a05d0d757c5d804e0bc5540d"
 # ^ from branch electrum_202602 (note: careful with force-pushing! see #8162)
 RUN cd /opt \
     && git clone https://github.com/spesmilo/python-for-android \


### PR DESCRIPTION
I am just trying to debug what causes the build repro issues for Android.

see https://github.com/spesmilo/python-for-android/commit/c60f3f0341cea217a05d0d757c5d804e0bc5540d