### PR TITLE
build: move default FRESH_CLONE location from /tmp to /var/tmp

### DIFF
--- a/contrib/android/build.sh
+++ b/contrib/android/build.sh
@@ -51,7 +51,7 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE=${FRESH_CLONE:-"/tmp/electrum_build/android/fresh_clone/electrum"}
+    FRESH_CLONE=${FRESH_CLONE:-"/var/tmp/electrum_build/android/fresh_clone/electrum"}
     rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
     umask 0022
     git clone "$PROJECT_ROOT" "$FRESH_CLONE"

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -35,7 +35,7 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE="/tmp/electrum_build/appimage/fresh_clone/electrum"
+    FRESH_CLONE="/var/tmp/electrum_build/appimage/fresh_clone/electrum"
     rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
     umask 0022
     git clone "$PROJECT_ROOT" "$FRESH_CLONE"

--- a/contrib/build-linux/sdist/build.sh
+++ b/contrib/build-linux/sdist/build.sh
@@ -35,7 +35,7 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE="/tmp/electrum_build/sdist/fresh_clone/electrum"
+    FRESH_CLONE="/var/tmp/electrum_build/sdist/fresh_clone/electrum"
     rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
     umask 0022
     git clone "$PROJECT_ROOT" "$FRESH_CLONE"

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -37,7 +37,7 @@ docker build \
 # maybe do fresh clone
 if [ ! -z "$ELECBUILD_COMMIT" ] ; then
     info "ELECBUILD_COMMIT=$ELECBUILD_COMMIT. doing fresh clone and git checkout."
-    FRESH_CLONE="/tmp/electrum_build/windows/fresh_clone/electrum"
+    FRESH_CLONE="/var/tmp/electrum_build/windows/fresh_clone/electrum"
     rm -rf "$FRESH_CLONE" 2>/dev/null || ( info "we need sudo to rm prev FRESH_CLONE." && sudo rm -rf "$FRESH_CLONE" )
     umask 0022
     git clone "$PROJECT_ROOT" "$FRESH_CLONE"


### PR DESCRIPTION
Apparently many distros these days mount /tmp as RAM-disk. Even debian (starting with 13) does this now.
The Android build needs to store dozens of gigs, so RAM is often not sufficiently large.