### PR TITLE
contrib: change release procedure, to avoid reusing tags

### DIFF
--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -60,8 +60,8 @@ source.exclude_patterns = Makefile,setup*,
     packages/frozenlist-*.dist-info/*
 
 # (str) Application versioning (method 1)
-version.regex = ELECTRUM_VERSION = '(.*)'
-version.filename = %(source.dir)s/electrum/version.py
+#version.regex = ELECTRUM_VERSION = '(.*)'
+#version.filename = %(source.dir)s/electrum/version.py
 
 # (str) Application versioning (method 2)
 #version = 1.9.8

--- a/contrib/android/make_apk.sh
+++ b/contrib/android/make_apk.sh
@@ -11,6 +11,9 @@ PACKAGES="$PROJECT_ROOT"/packages/
 
 git -C "$PROJECT_ROOT" rev-parse 2>/dev/null || fail "Building outside a git clone is not supported."
 
+VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)
+info "VERSIONC: $VERSIONC"
+export APP_VERSION="$VERSIONC"
 
 # arguments have been checked in build.sh
 export ELEC_APK_GUI=$1

--- a/contrib/build-linux/appimage/make_appimage.sh
+++ b/contrib/build-linux/appimage/make_appimage.sh
@@ -24,8 +24,10 @@ PYTHON_VERSION=3.12.13
 PY_VER_MAJOR="3.12"  # as it appears in fs paths
 PKG2APPIMAGE_COMMIT="a9c85b7e61a3a883f4a35c41c5decb5af88b6b5d"
 
-VERSION=$(git describe --tags --dirty --always)
-APPIMAGE="$DISTDIR/electrum-$VERSION-x86_64.AppImage"
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)
+VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)
+
+APPIMAGE="$DISTDIR/electrum-$VERSIONC-x86_64.AppImage"
 
 rm -rf "$BUILDDIR"
 mkdir -p "$APPDIR" "$CACHEDIR" "$PIP_CACHE_DIR" "$DISTDIR" "$DLL_TARGET_DIR"
@@ -271,7 +273,7 @@ args=\$(echo "\$@" | sed -e 's/-mkfs-time 0//')
 "$BUILDDIR/squashfs-root/usr/bin/mksquashfs_orig" \$args
 EOF
     chmod +x "$BUILDDIR/squashfs-root/usr/bin/mksquashfs"
-    env VERSION="$VERSION" ARCH=x86_64 ./squashfs-root/AppRun --runtime-file "$TYPE2_RUNTIME_REPO_DIR/runtime-x86_64" --no-appstream --verbose "$APPDIR" "$APPIMAGE"
+    env VERSION="$VERSIONB" ARCH=x86_64 ./squashfs-root/AppRun --runtime-file "$TYPE2_RUNTIME_REPO_DIR/runtime-x86_64" --no-appstream --verbose "$APPDIR" "$APPIMAGE"
 )
 
 

--- a/contrib/build-linux/sdist/make_sdist.sh
+++ b/contrib/build-linux/sdist/make_sdist.sh
@@ -49,14 +49,19 @@ info "preparing electrum-locale."
     # build initial tar.gz
     python3 setup.py --quiet sdist --format=gztar --dist-dir="$PY_DISTDIR"
 
-    VERSION=$("$CONTRIB"/print_electrum_version.py)
+    VERSIONB=$("$CONTRIB"/print_electrum_version.py)
+    VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)
+
+    # put commit-id in tarball name
+    mv "$PY_DISTDIR/Electrum-$VERSIONB.tar.gz" "$PY_DISTDIR/Electrum-$VERSIONC.tar.gz"
+
     if ([ "$OMIT_UNCLEAN_FILES" = 1 ]); then
-        FINAL_DISTNAME="Electrum-sourceonly-$VERSION.tar.gz"
+        FINAL_DISTNAME="Electrum-sourceonly-$VERSIONC.tar.gz"
     else
-        FINAL_DISTNAME="Electrum-$VERSION.tar.gz"
+        FINAL_DISTNAME="Electrum-$VERSIONC.tar.gz"
     fi
     if ([ "$OMIT_UNCLEAN_FILES" = 1 ]); then
-        mv "$PY_DISTDIR/Electrum-$VERSION.tar.gz" "$PY_DISTDIR/../$FINAL_DISTNAME"
+        mv "$PY_DISTDIR/Electrum-$VERSIONC.tar.gz" "$PY_DISTDIR/../$FINAL_DISTNAME"
         rmdir "$PY_DISTDIR"
     fi
 
@@ -66,7 +71,7 @@ info "preparing electrum-locale."
     cd "$BUILDDIR/dist2"
     tar -xzf "$BUILDDIR/dist1/$FINAL_DISTNAME"
     find -exec touch -h -d '2000-11-11T11:11:11+00:00' {} +
-    GZIP=-n tar --sort=name -czf "$FINAL_DISTNAME" "Electrum-$VERSION/"
+    GZIP=-n tar --sort=name -czf "$FINAL_DISTNAME" "Electrum-$VERSIONB/"
     mv "$FINAL_DISTNAME" "$DISTDIR/$FINAL_DISTNAME"
 )
 

--- a/contrib/build-wine/build-electrum-git.sh
+++ b/contrib/build-wine/build-electrum-git.sh
@@ -13,8 +13,10 @@ set -e
 
 pushd "$PROJECT_ROOT"
 
-VERSION=$(git describe --tags --dirty --always)
-info "Last commit: $VERSION"
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)
+VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)
+info "VERSIONB: $VERSIONB"
+info "VERSIONC: $VERSIONC"
 
 info "preparing electrum-locale."
 (
@@ -62,7 +64,7 @@ rm -rf dist/
 
 # build standalone and portable versions
 info "Running pyinstaller..."
-ELECTRUM_CMDLINE_NAME="$NAME_ROOT-$VERSION" wine "$WINE_PYHOME/scripts/pyinstaller.exe" --noconfirm --clean pyinstaller.spec
+ELECTRUM_CMDLINE_NAME="$NAME_ROOT-$VERSIONC" wine "$WINE_PYHOME/scripts/pyinstaller.exe" --noconfirm --clean pyinstaller.spec
 
 # set timestamps in dist, in order to make the installer reproducible
 pushd dist
@@ -71,10 +73,10 @@ popd
 
 info "building NSIS installer"
 # $VERSION could be passed to the electrum.nsi script, but this would require some rewriting in the script itself.
-makensis -DPRODUCT_VERSION=$VERSION electrum.nsi
+makensis "-DPRODUCT_VERSION=$VERSIONB" electrum.nsi
 
 cd dist
-mv electrum-setup.exe $NAME_ROOT-$VERSION-setup.exe
+mv electrum-setup.exe "$NAME_ROOT-$VERSIONC-setup.exe"
 cd ..
 
 info "Padding binaries to 8-byte boundaries, and fixing COFF image checksum in PE header"

--- a/contrib/build-wine/unsign.sh
+++ b/contrib/build-wine/unsign.sh
@@ -18,7 +18,7 @@ rm -rf signed/stripped
 mkdir -p signed >/dev/null 2>&1
 mkdir -p signed/stripped >/dev/null 2>&1
 
-version=$("$CONTRIB"/print_electrum_version.py)
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)
 
 echo "Found $(ls dist/*.exe | wc -w) files to verify."
 
@@ -28,8 +28,8 @@ for mine in dist/*.exe; do
     if test -f "signed/$f"; then
         echo "Found file at signed/$f"
     else
-        echo "Downloading https://download.electrum.org/$version/$f"
-        wget -q "https://download.electrum.org/$version/$f" -O "signed/$f"
+        echo "Downloading https://download.electrum.org/$VERSIONB/$f"
+        wget -q "https://download.electrum.org/$VERSIONB/$f" -O "signed/$f"
     fi
     out="signed/stripped/$f"
     # Remove PE signature from signed binary

--- a/contrib/make_download
+++ b/contrib/make_download
@@ -31,12 +31,8 @@ download_template = download_page + ".template"
 with open(download_template) as f:
     download_page_str = f.read()
 
-version = version_win = version_mac = version_android = ELECTRUM_VERSION
+version = ELECTRUM_VERSION
 download_page_str = download_page_str.replace("##VERSION##", version)
-download_page_str = download_page_str.replace("##VERSION_WIN##", version_win)
-download_page_str = download_page_str.replace("##VERSION_MAC##", version_mac)
-download_page_str = download_page_str.replace("##VERSION_ANDROID##", version_android)
-download_page_str = download_page_str.replace("##VERSION_APK##", version_android)
 
 # note: all dist files need to be listed here that we expect sigs for,
 #       even if they are not linked to from the website
@@ -44,13 +40,13 @@ files = {
     "tgz": f"Electrum-{version}.tar.gz",
     "tgz_srconly": f"Electrum-sourceonly-{version}.tar.gz",
     "appimage": f"electrum-{version}-x86_64.AppImage",
-    "mac": f"electrum-{version_mac}.dmg",
-    "win": f"electrum-{version_win}.exe",
-    "win_setup": f"electrum-{version_win}-setup.exe",
-    "win_portable": f"electrum-{version_win}-portable.exe",
-    "apk_arm64": f"Electrum-{version_android}-arm64-v8a-release.apk",
-    "apk_armeabi": f"Electrum-{version_android}-armeabi-v7a-release.apk",
-    "apk_x86_64": f"Electrum-{version_android}-x86_64-release.apk",
+    "mac": f"electrum-{version}.dmg",
+    "win": f"electrum-{version}.exe",
+    "win_setup": f"electrum-{version}-setup.exe",
+    "win_portable": f"electrum-{version}-portable.exe",
+    "apk_arm64": f"Electrum-{version}-arm64-v8a-release.apk",
+    "apk_armeabi": f"Electrum-{version}-armeabi-v7a-release.apk",
+    "apk_x86_64": f"Electrum-{version}-x86_64-release.apk",
 }
 
 # default signers

--- a/contrib/make_download
+++ b/contrib/make_download
@@ -3,6 +3,7 @@ import re
 import os
 import sys
 import importlib
+import importlib.util
 from collections import defaultdict
 
 
@@ -13,13 +14,15 @@ if len(sys.argv) < 2:
 # cd to project root
 os.chdir(os.path.dirname(os.path.dirname(__file__)))
 
-# load version.py; needlessly complicated alternative to "imp.load_source":
-version_spec = importlib.util.spec_from_file_location('version', 'electrum/version.py')
-version_module = importlib.util.module_from_spec(version_spec)
-version_spec.loader.exec_module(version_module)
+# load print_electrum_version.py; needlessly complicated alternative to "imp.load_source":
+pev_spec = importlib.util.spec_from_file_location('print_electrum_version', 'contrib/print_electrum_version.py')
+pev_module = importlib.util.module_from_spec(pev_spec)
+pev_spec.loader.exec_module(pev_module)
 
-ELECTRUM_VERSION = version_module.ELECTRUM_VERSION
-print(f"version: {ELECTRUM_VERSION}", file=sys.stderr)
+versionb = pev_module.get_bare_version()
+versionc = pev_module.get_versionc()
+print(f"{versionb=!r}", file=sys.stderr)
+print(f"{versionc=!r}", file=sys.stderr)
 
 dirname = sys.argv[1]
 
@@ -31,22 +34,21 @@ download_template = download_page + ".template"
 with open(download_template) as f:
     download_page_str = f.read()
 
-version = ELECTRUM_VERSION
-download_page_str = download_page_str.replace("##VERSION##", version)
+download_page_str = download_page_str.replace("##VERSION##", versionb)
 
 # note: all dist files need to be listed here that we expect sigs for,
 #       even if they are not linked to from the website
 files = {
-    "tgz": f"Electrum-{version}.tar.gz",
-    "tgz_srconly": f"Electrum-sourceonly-{version}.tar.gz",
-    "appimage": f"electrum-{version}-x86_64.AppImage",
-    "mac": f"electrum-{version}.dmg",
-    "win": f"electrum-{version}.exe",
-    "win_setup": f"electrum-{version}-setup.exe",
-    "win_portable": f"electrum-{version}-portable.exe",
-    "apk_arm64": f"Electrum-{version}-arm64-v8a-release.apk",
-    "apk_armeabi": f"Electrum-{version}-armeabi-v7a-release.apk",
-    "apk_x86_64": f"Electrum-{version}-x86_64-release.apk",
+    "tgz": f"Electrum-{versionc}.tar.gz",
+    "tgz_srconly": f"Electrum-sourceonly-{versionc}.tar.gz",
+    "appimage": f"electrum-{versionc}-x86_64.AppImage",
+    "mac": f"electrum-{versionc}.dmg",
+    "win": f"electrum-{versionc}.exe",
+    "win_setup": f"electrum-{versionc}-setup.exe",
+    "win_portable": f"electrum-{versionc}-portable.exe",
+    "apk_arm64": f"Electrum-{versionc}-arm64-v8a-release.apk",
+    "apk_armeabi": f"Electrum-{versionc}-armeabi-v7a-release.apk",
+    "apk_x86_64": f"Electrum-{versionc}-x86_64-release.apk",
 }
 
 # default signers
@@ -74,8 +76,8 @@ download_page_str = download_page_str.replace("##signers_list##", signers_list)
 
 for k, filename in files.items():
     path = "dist/%s"%filename
-    assert filename in list_dir
-    link = "https://download.electrum.org/%s/%s"%(version, filename)
+    assert filename in list_dir, f"{filename!r} missing from dist/"
+    link = "https://download.electrum.org/%s/%s"%(versionb, filename)
     download_page_str = download_page_str.replace("##link_%s##" % k, link)
     download_page_str = download_page_str.replace("##sigs_%s##" % k, link + '.asc')
     download_page_str = download_page_str.replace("##distname_%s##" % k, filename)

--- a/contrib/make_download
+++ b/contrib/make_download
@@ -78,6 +78,7 @@ for k, filename in files.items():
     link = "https://download.electrum.org/%s/%s"%(version, filename)
     download_page_str = download_page_str.replace("##link_%s##" % k, link)
     download_page_str = download_page_str.replace("##sigs_%s##" % k, link + '.asc')
+    download_page_str = download_page_str.replace("##distname_%s##" % k, filename)
 
 
 # download page has been constructed from template; now insert it into index.html

--- a/contrib/osx/make_osx.sh
+++ b/contrib/osx/make_osx.sh
@@ -211,17 +211,17 @@ find "$VENV_DIR/lib/python$PY_VER_MAJOR/site-packages/" -type f -name '*.so' -pr
 info "Faking timestamps..."
 find . -exec touch -t '200101220000' {} + || true
 
-# note: no --dirty, as we have dirtied electrum/locale/ ourselves.
-VERSION=$(git describe --tags --always)
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)
+VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)
 
 info "Building binary"
-ELECTRUM_VERSION=$VERSION pyinstaller --noconfirm --clean contrib/osx/pyinstaller.spec || fail "Could not build binary"
+ELECTRUM_VERSION="$VERSIONB" pyinstaller --noconfirm --clean contrib/osx/pyinstaller.spec || fail "Could not build binary"
 
 info "Finished building unsigned dist/${PACKAGE}.app. This hash should be reproducible:"
 find "dist/${PACKAGE}.app" -type f -print0 | sort -z | xargs -0 shasum -a 256 | shasum -a 256
 
 info "Creating unsigned .DMG"
-hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION-unsigned.dmg || fail "Could not create .DMG"
+hdiutil create -fs HFS+ -volname "$PACKAGE" -srcfolder "dist/$PACKAGE.app" "dist/electrum-$VERSIONC-unsigned.dmg" || fail "Could not create .DMG"
 
 info "App was built successfully but was not code signed. Users may get security warnings from macOS."
 info "Now you also need to run sign_osx.sh to codesign/notarize the binary."

--- a/contrib/osx/sign_osx.sh
+++ b/contrib/osx/sign_osx.sh
@@ -59,8 +59,7 @@ function DoCodeSignMaybe { # ARGS: infoName fileOrDirName
     codesign -f -v $deep -s "$CODESIGN_CERT" $hardened_arg "$file" || fail "Could not code sign ${infoName}"
 }
 
-# note: no --dirty, as we have dirtied electrum/locale/ ourselves.
-VERSION=$(git describe --tags --always)
+VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)
 
 DoCodeSignMaybe "app bundle" "dist/${PACKAGE}.app"
 
@@ -74,6 +73,6 @@ if [ ! -z "$CODESIGN_CERT" ]; then
 fi
 
 info "Creating .DMG"
-hdiutil create -fs HFS+ -volname $PACKAGE -srcfolder dist/$PACKAGE.app dist/electrum-$VERSION.dmg || fail "Could not create .DMG"
+hdiutil create -fs HFS+ -volname "$PACKAGE" -srcfolder "dist/$PACKAGE.app" "dist/electrum-$VERSIONC.dmg" || fail "Could not create .DMG"
 
-DoCodeSignMaybe ".DMG" "dist/electrum-${VERSION}.dmg"
+DoCodeSignMaybe ".DMG" "dist/electrum-${VERSIONC}.dmg"

--- a/contrib/print_electrum_version.py
+++ b/contrib/print_electrum_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # For usage in shell, to get the version of electrum, without needing electrum installed.
-# usage: ./print_electrum_version.py [<attr_name>]
+# usage: ./print_electrum_version.py [--with-commit]
 #
 # For example:
 # $ VERSION=$("$CONTRIB"/print_electrum_version.py)
@@ -9,16 +9,15 @@
 
 import importlib.util
 import os
+import subprocess
 import sys
 
 
-if __name__ == '__main__':
-    if len(sys.argv) >= 2:
-        attr_name = sys.argv[1]
-    else:
-        attr_name = "ELECTRUM_VERSION"
+project_root = os.path.abspath(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-    project_root = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+def get_bare_version() -> str:
+    """example: '4.8.0' """
     version_file_path = os.path.join(project_root, "electrum", "version.py")
 
     # load version.py; needlessly complicated alternative to "imp.load_source":
@@ -26,6 +25,25 @@ if __name__ == '__main__':
     version_module = version = importlib.util.module_from_spec(version_spec)
     version_spec.loader.exec_module(version_module)
 
-    attr_val = getattr(version, attr_name)
-    print(attr_val, file=sys.stdout)
+    elec_ver = getattr(version, "ELECTRUM_VERSION")
+    return str(elec_ver)
+
+
+def get_versionc() -> str:
+    """example: '4.8.0-8c0adcd' """
+    commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=project_root)
+    commit = str(commit, "utf8").strip()
+    commit = commit[:7]
+    elec_ver = get_bare_version()
+    return f"{elec_ver}-{commit}"
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print(get_bare_version(), file=sys.stdout)
+    elif len(sys.argv) == 2 and sys.argv[1] == "--with-commit":
+        print(get_versionc(), file=sys.stdout)
+    else:
+        print("usage: ./print_electrum_version.py [--with-commit]", file=sys.stderr)
+        sys.exit(1)
 

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -24,8 +24,11 @@
 #     2. cd to the submodule dir, and git pull
 #     3. cd .. && git push
 # - update RELEASE-NOTES and version.py
-# - $ git tag -s "$VERSION" -m "$VERSION"
-# - $ git push "$REMOTE_ORIGIN" tag "$VERSION"
+#   - ELECTRUM_VERSION = '9.8.7'
+# - create git tag
+#       (initially suffix tag name with -rcX)
+#   - $ git tag -s "9.8.7-rc1" -m "9.8.7-rc1"
+#   - $ git push "$REMOTE_ORIGIN" tag "9.8.7-rc1"
 #
 # -----
 # Then, typical release flow:
@@ -40,7 +43,7 @@
 # - after some time, RM can run release_www.sh to create and commit website-update
 #   - then run WWW_DIR/publish.sh to update website
 # - at least two people need to run WWW_DIR/publish.sh
-#
+# - create a new git tag for the rc that became the release: "9.8.7"
 
 set -e
 
@@ -84,12 +87,12 @@ if [ ! -z "$RELEASEMANAGER" ] ; then
 fi
 
 
-VERSION=$("$CONTRIB"/print_electrum_version.py)
-info "VERSION: $VERSION"
-REV=$(git describe --tags)
-info "REV: $REV"
-COMMIT=$(git rev-parse HEAD)
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)  # Bare version
+VERSIONC=$("$CONTRIB"/print_electrum_version.py --with-commit)  # version+Commit
+info "VERSIONB: $VERSIONB"
+info "VERSIONC: $VERSIONC"
 
+COMMIT=$(git rev-parse HEAD)
 export ELECBUILD_COMMIT="${COMMIT}^{commit}"
 
 
@@ -102,7 +105,7 @@ fi
 set -x
 
 # create tarball
-tarball="Electrum-$VERSION.tar.gz"
+tarball="Electrum-$VERSIONC.tar.gz"
 if test -f "dist/$tarball"; then
     info "file exists: $tarball"
 else
@@ -110,7 +113,7 @@ else
 fi
 
 # create source-only tarball
-srctarball="Electrum-sourceonly-$VERSION.tar.gz"
+srctarball="Electrum-sourceonly-$VERSIONC.tar.gz"
 if test -f "dist/$srctarball"; then
     info "file exists: $srctarball"
 else
@@ -118,7 +121,7 @@ else
 fi
 
 # appimage
-appimage="electrum-$REV-x86_64.AppImage"
+appimage="electrum-$VERSIONC-x86_64.AppImage"
 if test -f "dist/$appimage"; then
     info "file exists: $appimage"
 else
@@ -127,9 +130,9 @@ fi
 
 
 # windows
-win1="electrum-$REV.exe"
-win2="electrum-$REV-portable.exe"
-win3="electrum-$REV-setup.exe"
+win1="electrum-$VERSIONC.exe"
+win2="electrum-$VERSIONC-portable.exe"
+win3="electrum-$VERSIONC-setup.exe"
 if test -f "dist/$win1"; then
     info "file exists: $win1"
 else
@@ -150,13 +153,13 @@ else
 fi
 
 # android
-apk1="Electrum-$VERSION-armeabi-v7a-release.apk"
-apk2="Electrum-$VERSION-arm64-v8a-release.apk"
-apk3="Electrum-$VERSION-x86_64-release.apk"
+apk1="Electrum-$VERSIONC-armeabi-v7a-release.apk"
+apk2="Electrum-$VERSIONC-arm64-v8a-release.apk"
+apk3="Electrum-$VERSIONC-x86_64-release.apk"
 for arch in armeabi-v7a arm64-v8a x86_64
 do
-    apk="Electrum-$VERSION-$arch-release.apk"
-    apk_unsigned="Electrum-$VERSION-$arch-release-unsigned.apk"
+    apk="Electrum-$VERSIONC-$arch-release.apk"
+    apk_unsigned="Electrum-$VERSIONC-$arch-release-unsigned.apk"
     if test -f "dist/$apk"; then
         info "file exists: $apk"
     else
@@ -177,7 +180,7 @@ done
 
 # the macos binary is built on a separate machine.
 # the file that needs to be copied over is the codesigned release binary (regardless of builder role)
-dmg="electrum-$VERSION.dmg"
+dmg="electrum-$VERSIONC.dmg"
 if ! test -f "dist/$dmg"; then
     if [ ! -z "$RELEASEMANAGER" ] ; then  # RM
         fail "dmg is missing, aborting. Please build and codesign the dmg on a mac and copy it over."
@@ -219,7 +222,7 @@ if [ -z "$RELEASEMANAGER" ] ; then
 
     if [ -z "$SSHUSER" ]; then
         info "No SFTP access, downloading binaries from website"
-        BASE_URL="https://download.electrum.org/$VERSION"
+        BASE_URL="https://download.electrum.org/$VERSIONB"
         FILES_TO_DOWNLOAD=(
             "$tarball"
             "$srctarball"
@@ -245,7 +248,7 @@ if [ -z "$RELEASEMANAGER" ] ; then
         # TODO check somehow that RM had finished uploading
         sftp -oBatchMode=no -b - "$SSHUSER@uploadserver" <<-EOF
            cd electrum-downloads-airlock
-           cd "$VERSION"
+           cd "$VERSIONB"
            mget *
            bye
 EOF
@@ -315,10 +318,6 @@ else
     test -f "$PROJECT_ROOT/dist/$apk2"       || fail "apk2 not found among built files"
     test -f "$PROJECT_ROOT/dist/$apk3"       || fail "apk3 not found among built files"
     test -f "$PROJECT_ROOT/dist/$dmg"        || fail "dmg not found among built files"
-
-    if [ "$REV" != "$VERSION" ]; then
-        fail "versions differ, not uploading"
-    fi
 
     # upload the files
     ./contrib/upload.sh

--- a/contrib/release_www.sh
+++ b/contrib/release_www.sh
@@ -34,8 +34,8 @@ if [ -z "$ELECTRUM_SIGNING_WALLET" ] || [ -z "$ELECTRUM_SIGNING_ADDRESS" ]; then
     exit 1
 fi
 
-VERSION=$("$CONTRIB"/print_electrum_version.py)
-info "VERSION: $VERSION"
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)
+info "VERSIONB: $VERSIONB"
 
 ANDROID_VERSIONCODE_NULLARCH=$("$CONTRIB"/android/get_apk_versioncode.py "null")
 # ^ note: should parse as an integer in the final json
@@ -46,13 +46,13 @@ set -x
 info "updating www repo"
 ./contrib/make_download "$WWW_DIR"
 info "signing the version announcement file"
-sig=$(./run_electrum -o signmessage "$ELECTRUM_SIGNING_ADDRESS" "$VERSION" -w "$ELECTRUM_SIGNING_WALLET")
+sig=$(./run_electrum -o signmessage "$ELECTRUM_SIGNING_ADDRESS" "$VERSIONB" -w "$ELECTRUM_SIGNING_WALLET")
 # note: the contents of "extradata" are currently not signed. We could add another field, extradata_sigs,
 #       containing signature(s) for "extradata". extradata, being json, would have to be canonically
 #       serialized before signing.
 cat <<EOF > "$WWW_DIR"/version
 {
-    "version": "$VERSION",
+    "version": "$VERSIONB",
     "signatures": {"$ELECTRUM_SIGNING_ADDRESS": "$sig"},
     "extradata": {
         "android_versioncode_nullarch": $ANDROID_VERSIONCODE_NULLARCH
@@ -63,7 +63,7 @@ EOF
 # push changes to website repo
 pushd "$WWW_DIR"
 git diff
-git commit -a -m "version $VERSION"
+git commit -a -m "version $VERSIONB"
 git push
 popd
 

--- a/contrib/trigger_deploy.sh
+++ b/contrib/trigger_deploy.sh
@@ -6,7 +6,7 @@ SSHUSER=$1
 TRIGGERVERSION=$2
 if [ -z "$SSHUSER" ] || [ -z "$TRIGGERVERSION" ]; then
     echo "usage: $0 SSHUSER TRIGGERVERSION"
-    echo "e.g. $0 thomasv 3.0.0"
+    echo "e.g. $0 thomasv 3.0.0"  # bare version, without commit
     echo "e.g. $0 thomasv website"
     exit 1
 fi

--- a/contrib/upload.sh
+++ b/contrib/upload.sh
@@ -16,8 +16,8 @@ fi
 
 cd "$PROJECT_ROOT"
 
-VERSION=$("$CONTRIB"/print_electrum_version.py)
-echo "$VERSION"
+VERSIONB=$("$CONTRIB"/print_electrum_version.py)
+echo "$VERSIONB"
 
 if [ -z "$ELECBUILD_UPLOADFROM" ]; then
     cd "$PROJECT_ROOT/dist"
@@ -31,12 +31,12 @@ fi
 
 sftp -oBatchMode=no -b - "$SSHUSER@uploadserver" << !
    cd electrum-downloads-airlock
-   -mkdir "$VERSION"
-   -chmod 777 "$VERSION"
-   cd "$VERSION"
+   -mkdir "$VERSIONB"
+   -chmod 777 "$VERSIONB"
+   cd "$VERSIONB"
    -mput *
    -chmod 444 *  # this prevents future re-uploads of same file
    bye
 !
 
-"$CONTRIB/trigger_deploy.sh" "$SSHUSER" "$VERSION"
+"$CONTRIB/trigger_deploy.sh" "$SSHUSER" "$VERSIONB"


### PR DESCRIPTION
Towards making git tags immutable...
Let's avoid reusing tags and ambiguous binary names.

-----

- primary goal: immutable git tags
    - don't delete tag (e.g. "4.8.0") and then create another with the same name
- secondary goal: immutable distributable names
    - don't make a signed "Electrum-4.8.0-arm64-v8a-release.apk" file publicly downloadable, and then later delete it, and release another identically named file

-----

Problem: it happened several times during releases that we had to "cancel" a release
at the last minute, after there already was a git tag, after we already built binaries,
and sometimes even after those binaries were publicly available on download.electrum.org,
but always before running `release_www.sh` (so before the main webserver linked to them
or before qt gui update notifications were triggered).
At almost any point during making a release we might notice that we cannot reproduce
some distributables, meaning we have to cancel the release. In our current workflow,
very early in the process we create a git tag, e.g. "4.8.0". If we have to cancel
the release and apply some fixes, we will need a new git tag, and in that case historically
we have deleted and reused git tags (so the second attempt would also be from a git tag named "4.8.0" but now pointing to a new commit). This is bad practice. We should aim
to have immutable git tags.

The idea here is:
- construct binary name from:
    version.py::ELECTRUM_VERSION + git commit hash
    (independent of the tag)
- when we build, only create an "-rc1" git tag, e.g. "4.8.0-rc1"
- after we are satisfied to finalise the release, near the very end,
  create another git tag, e.g. "4.8.0", pointing to the same commit

- so in the typical happy path, we will have two git tags:
    - "4.8.0-rc1" == commit1
    - "4.8.0" == commit1
- if something goes wrong and we have to retry, we will have:
    - "4.8.0-rc1" == commit1
    - "4.8.0-rc2" == commit2
    - "4.8.0" == commit2
