### PR TITLE
qml: improve UI responsiveness during sync

### DIFF
--- a/electrum/gui/qml/qetransactionlistmodel.py
+++ b/electrum/gui/qml/qetransactionlistmodel.py
@@ -35,7 +35,8 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
         self.onchain_domain = onchain_domain
         self.include_lightning = include_lightning
 
-        self.tx_history = []
+        self.tx_history: list[dict] = []
+        self._tx_positions: dict[str, int] = {}  # txid -> row index in tx_history
 
         self.register_callbacks()
         self.destroyed.connect(lambda: self.on_destroy())
@@ -58,10 +59,9 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
         if adb != self.wallet.adb:
             return
         self._logger.debug(f'adb_set_future_tx event for txid {txid}')
-        for i, item in enumerate(self.tx_history):
-            if 'txid' in item and item['txid'] == txid:
-                self._update_future_txitem(i)
-                return
+        i = self._tx_positions.get(txid)
+        if i is not None:
+            self._update_future_txitem(i)
 
     @qt_event_listener
     def on_event_fee_histogram(self, histogram):
@@ -122,6 +122,7 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
     def clear(self):
         self.beginResetModel()
         self.tx_history = []
+        self._tx_positions = {}
         self.endResetModel()
 
     def tx_to_model(self, tx_item):
@@ -224,6 +225,7 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
         self.beginInsertRows(QModelIndex(), 0, len(txs) - 1)
         self.tx_history = txs
         self.tx_history.reverse()
+        self._tx_positions = {tx['txid']: i for i, tx in enumerate(self.tx_history) if 'txid' in tx}
         self.endInsertRows()
 
         self.countChanged.emit()
@@ -231,17 +233,18 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
         self._dirty = False
 
     def on_tx_verified(self, txid: str, info: TxMinedInfo):
-        for i, tx in enumerate(self.tx_history):
-            if 'txid' in tx and tx['txid'] == txid:
-                tx['height'] = info.height()
-                tx['confirmations'] = info.conf
-                tx['timestamp'] = info.timestamp
-                tx['section'] = self.get_section_by_timestamp(info.timestamp)
-                tx['date'] = self.format_date_by_section(tx['section'], datetime.fromtimestamp(info.timestamp))
-                index = self.index(i, 0)
-                roles = [self._ROLE_RMAP[x] for x in ['section', 'height', 'confirmations', 'timestamp', 'date']]
-                self.dataChanged.emit(index, index, roles)
-                return
+        i = self._tx_positions.get(txid)
+        if i is None:
+            return
+        tx = self.tx_history[i]
+        tx['height'] = info.height()
+        tx['confirmations'] = info.conf
+        tx['timestamp'] = info.timestamp
+        tx['section'] = self.get_section_by_timestamp(info.timestamp)
+        tx['date'] = self.format_date_by_section(tx['section'], datetime.fromtimestamp(info.timestamp))
+        index = self.index(i, 0)
+        roles = [self._ROLE_RMAP[x] for x in ['section', 'height', 'confirmations', 'timestamp', 'date']]
+        self.dataChanged.emit(index, index, roles)
 
     def _update_future_txitem(self, tx_item_idx: int):
         tx_item = self.tx_history[tx_item_idx]

--- a/electrum/gui/qml/qetransactionlistmodel.py
+++ b/electrum/gui/qml/qetransactionlistmodel.py
@@ -275,13 +275,17 @@ class QETransactionListModel(QAbstractListModel, QtEventListener):
 
     @pyqtSlot(int)
     def updateBlockchainHeight(self, height):
-        self._logger.debug('updating height to %d' % height)
+        self._logger.debug(f'updating height to {height}')
+        if not self.tx_history:
+            return
         for i, tx_item in enumerate(self.tx_history):
             if 'height' in tx_item:
                 if tx_item['height'] > 0:
                     tx_item['confirmations'] = height - tx_item['height'] + 1
-                    index = self.index(i, 0)
-                    roles = [self._ROLE_RMAP['confirmations']]
-                    self.dataChanged.emit(index, index, roles)
                 elif tx_item['height'] in (TX_HEIGHT_FUTURE, TX_HEIGHT_LOCAL):
                     self._update_future_txitem(i)
+        self.dataChanged.emit(
+            self.index(0, 0),
+            self.index(len(self.tx_history) - 1, 0),
+            [self._ROLE_RMAP['confirmations']],
+        )

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -204,7 +204,10 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
             self.add_tx_notification(tx)
             self.addressCoinModel.setDirty()
             self.historyModel.setDirty()  # assuming wallet.is_up_to_date triggers after
-            self.balanceChanged.emit()
+            if self.wallet.is_up_to_date():
+                # don't update during sync as this recomputes the balance on each new tx, blocking the UI thread.
+                # on_event_wallet_updated emits balanceChanged once we are up-to-date.
+                self.balanceChanged.emit()
 
     @qt_event_listener
     def on_event_adb_tx_height_changed(self, adb, txid, old_height, new_height):

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -200,7 +200,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     @qt_event_listener
     def on_event_new_transaction(self, wallet: 'Abstract_Wallet', tx: Transaction):
         if wallet == self.wallet:
-            self._logger.info(f'new transaction {tx.txid()}')
+            self._logger.debug(f'new transaction {tx.txid()}')
             self.add_tx_notification(tx)
             if self._addressCoinModel is not None:  # only setDirty if it was already initialized
                 self._addressCoinModel.setDirty()
@@ -213,7 +213,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     @qt_event_listener
     def on_event_adb_tx_height_changed(self, adb, txid, old_height, new_height):
         if adb == self.wallet.adb:
-            self._logger.info(f'tx_height_changed {txid}. {old_height} -> {new_height}')
+            self._logger.debug(f'tx_height_changed {txid}. {old_height} -> {new_height}')
             self.historyModel.setDirty()  # assuming wallet.is_up_to_date triggers after
 
     @qt_event_listener

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -202,7 +202,8 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         if wallet == self.wallet:
             self._logger.info(f'new transaction {tx.txid()}')
             self.add_tx_notification(tx)
-            self.addressCoinModel.setDirty()
+            if self._addressCoinModel is not None:  # only setDirty if it was already initialized
+                self._addressCoinModel.setDirty()
             self.historyModel.setDirty()  # assuming wallet.is_up_to_date triggers after
             if self.wallet.is_up_to_date():
                 # don't update during sync as this recomputes the balance on each new tx, blocking the UI thread.
@@ -221,7 +222,8 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         # is deleted along with multiple associated txs
         if wallet == self.wallet:
             self._logger.info(f'removed transaction {tx.txid()}')
-            self.addressCoinModel.setDirty()
+            if self._addressCoinModel is not None:
+                self._addressCoinModel.setDirty()
             self.historyModel.setDirty()
             self.balanceChanged.emit()
 

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3715,8 +3715,11 @@ class Abstract_Wallet(ABC, Logger, EventListener):
 
     def get_user_notifications_for_new_txns(self, txns: Sequence[Transaction]) -> Sequence[str]:
         notifications = []
-        # Combine the transactions if there are at least three
-        if len(txns) >= 3:
+        if len(txns) > 20:
+            # skip the delta calculation if there are many txs, otherwise it may block the UI for seconds
+            notifications.append(_('{} new transactions').format(len(txns)))
+        elif len(txns) >= 3:
+            # Combine the transactions if there are at least three
             total_amount = 0
             total_debit = 0
             total_credit = 0


### PR DESCRIPTION
I wanted to sync a watch only wallet with this large history address "1K6KoYC69NnafWJ7YgtrpwJxBLiijWqwa6" on Android which was so slow the app became unresponsive after some minutes during the sync.
These commits resolve several inefficiencies and the UI stays fully responsive and manages to finish the sync.