### PR TITLE
lntransport: wrap connection errors in send_bytes_and_drain

### DIFF
--- a/electrum/lntransport.py
+++ b/electrum/lntransport.py
@@ -235,7 +235,10 @@ class LNTransportBase:
         """Should be used when possible (in async scope), to avoid memory exhaustion."""
         async with self.drain_write_lock:
             self.send_bytes(msg)
-            await self.writer.drain()
+            try:
+                await self.writer.drain()
+            except ConnectionError as e:
+                raise LightningPeerConnectionClosed() from e
 
     async def read_messages(self):
         buffer = bytearray()


### PR DESCRIPTION
LightningPeerConnectionClosed is handled in Peer.handle_disconnect.

```
162.39 | E | lnpeer.Peer.[LNGossip, 02ab5336d0-d8be58cb] | Exception in main_loop: ConnectionResetError('Connection lost')
Traceback (most recent call last):
  File "/home/user/wspace/electrum/electrum/util.py", line 1218, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/wspace/electrum/electrum/lnpeer.py", line 544, in wrapper_func
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/wspace/electrum/electrum/lnpeer.py", line 558, in main_loop
    async with self.taskgroup as group:
               ^^^^^^^^^^^^^^
  File "/home/user/wspace/aiorpcX/aiorpcx/curio.py", line 304, in __aexit__
    await self.join()
  File "/home/user/wspace/electrum/electrum/util.py", line 1423, in join
    task.result()
    ~~~~~~~~~~~^^
  File "/home/user/wspace/electrum/electrum/lnpeer.py", line 897, in _message_loop
    await self._process_message(msg)
  File "/home/user/wspace/electrum/electrum/lnpeer.py", line 277, in _process_message
    await f(*args)
  File "/home/user/wspace/electrum/electrum/lnpeer.py", line 389, in on_ping
    await self.transport.send_bytes_and_drain(raw_msg)
  File "/home/user/wspace/electrum/electrum/lntransport.py", line 238, in send_bytes_and_drain
    await self.writer.drain()
  File "/usr/lib/python3.13/asyncio/streams.py", line 386, in drain
    await self._protocol._drain_helper()
  File "/usr/lib/python3.13/asyncio/streams.py", line 166, in _drain_helper
    raise ConnectionResetError('Connection lost')
ConnectionResetError: Connection lost
```