### PR TITLE
swaps: destroy swap transport on failed initialization

### DIFF
--- a/electrum/gui/common_qt/swaps.py
+++ b/electrum/gui/common_qt/swaps.py
@@ -81,7 +81,9 @@ class SubmarineSwapMixin(QtEventListener):
 
         def transport_initialize_done(future: Future):
             if future.cancelled() or future.exception() is not None:
-                self.swap_transport = None
+                if self.swap_transport is not None:
+                    self.swap_transport.destroy()
+                    self.swap_transport = None
             self.swapAvailabilityChanged.emit()
 
         self.swap_transport.initialize(transport_initialize_done)

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -1658,7 +1658,7 @@ class SwapServerTransport(Logger):
         self.config = config
         self.is_connected = asyncio.Event()
         self.connect_timeout = 10 if self.uses_proxy else 5
-        self.ongoing_connection_attempt: Future = None
+        self.ongoing_connection_attempt: Optional[Future] = None
 
     def __enter__(self):
         pass


### PR DESCRIPTION
Call `swap_transport.destroy()` when the swap transport initialization task fails, otherwise the swap transport tasks will stay alive after a connection failure, leaking resources.