### PR TITLE
qml: update ConfirmTxDialog onValidChanged

### DIFF
--- a/electrum/gui/qml/components/ConfirmTxDialog.qml
+++ b/electrum/gui/qml/components/ConfirmTxDialog.qml
@@ -112,6 +112,9 @@ ElDialog {
                             function onEffectiveAmountChanged() {
                                 updateAmountText()
                             }
+                            function onValidChanged() {
+                                updateAmountText()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Commit 2de11eac923d51befe44dcc748505714196a7f2c gated the ConfirmTxDialog amount behind `finalizer.valid`.
When sweeping private keys from the sweep view the resulting `ConfirmTxDialog` is not valid in the beginning, and after it turns valid nothing causes it to update. This results in the amount being displayed as `0` even after it finished fetching the keys balances.