### PR TITLE
android: show password validation feedback

### DIFF
--- a/electrum/gui/qml/components/PasswordDialog.qml
+++ b/electrum/gui/qml/components/PasswordDialog.qml
@@ -16,6 +16,7 @@ ElDialog {
     property bool confirmPassword: false
     property string infotext
     property string errorMessage
+    readonly property int minimumPasswordLength: 6
 
     signal passwordEntered(string password)
 
@@ -78,6 +79,21 @@ ElDialog {
                 }
             }
 
+            InfoTextArea {
+                Layout.fillWidth: true
+                visible: confirmPassword && text !== ''
+                text: {
+                    if (pw_1.text.length > 0 && pw_1.text.length < minimumPasswordLength)
+                        return qsTr('Password must be at least %1 characters.').arg(minimumPasswordLength)
+                    if (pw_2.text.length > 0 && pw_1.text !== pw_2.text)
+                        return qsTr("Passwords don't match")
+                    return ''
+                }
+                iconStyle: InfoTextArea.IconStyle.Warn
+                backgroundColor: constants.darkerDialogBackground
+                compact: true
+            }
+
             Label {
                 Layout.maximumWidth: parent.width
                 Layout.alignment: Qt.AlignHCenter
@@ -96,7 +112,9 @@ ElDialog {
                 Layout.fillWidth: true
                 text: qsTr("Ok")
                 icon.source: '../../icons/confirmed.png'
-                enabled: confirmPassword ? pw_1.text.length >= 6 && pw_1.text == pw_2.text : true
+                enabled: confirmPassword
+                    ? pw_1.text.length >= minimumPasswordLength && pw_1.text == pw_2.text
+                    : true
                 onClicked: {
                     passwordEntered(pw_1.text)
                 }

--- a/electrum/gui/qml/components/PasswordDialog.qml
+++ b/electrum/gui/qml/components/PasswordDialog.qml
@@ -16,6 +16,7 @@ ElDialog {
     property bool confirmPassword: false
     property string infotext
     property string errorMessage
+    readonly property int minimumPasswordLength: 6
 
     signal passwordEntered(string password)
 
@@ -81,9 +82,19 @@ ElDialog {
             Label {
                 Layout.maximumWidth: parent.width
                 Layout.alignment: Qt.AlignHCenter
-                text: errorMessage
+                text: {
+                    if (errorMessage)
+                        return errorMessage
+                    if (!confirmPassword)
+                        return ''
+                    if (pw_1.text.length > 0 && pw_1.text.length < minimumPasswordLength)
+                        return qsTr('Password must be at least %1 characters.').arg(minimumPasswordLength)
+                    if (pw_2.text.length > 0 && pw_1.text !== pw_2.text)
+                        return qsTr("Passwords don't match")
+                    return ''
+                }
                 wrapMode: Text.Wrap
-                visible: errorMessage
+                visible: text !== ''
                 color: constants.colorError
                 font.pixelSize: constants.fontSizeLarge
             }
@@ -96,7 +107,9 @@ ElDialog {
                 Layout.fillWidth: true
                 text: qsTr("Ok")
                 icon.source: '../../icons/confirmed.png'
-                enabled: confirmPassword ? pw_1.text.length >= 6 && pw_1.text == pw_2.text : true
+                enabled: confirmPassword
+                    ? pw_1.text.length >= minimumPasswordLength && pw_1.text == pw_2.text
+                    : true
                 onClicked: {
                     passwordEntered(pw_1.text)
                 }


### PR DESCRIPTION
## What changed

- show an inline warning when a new password is shorter than six characters
- show an inline warning when the confirmation does not match
- reuse one minimum-length value for both feedback and button validation

## Why

The Android password dialog already prevented submission of passwords shorter than six characters, but the requirement was only encoded in the disabled OK button. Users were not told why the password could not be accepted.

This makes the existing validation visible without changing the password policy.

Fixes #8497.

## Validation

- existing QML test suite: 8 passed
- headless state checks against the real `PasswordDialog` component, including short, mismatched, valid, and non-confirmation modes
- repeated the component checks against an isolated, non-editable install built from the source distribution
- `git diff --check`
