### PR TITLE
wallet_db: register onion_keys converter

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -3228,6 +3228,7 @@ class LNWallet(Logger):
                         [x.node_id for x in route],
                         onion_key)
                 except Exception as e:
+                    self.logger.warning(f"failed to decode onion error for htlc {htlc_id}", exc_info=True)
                     sender_idx = None
                     failure_message = OnionRoutingFailure(OnionFailureCode.INVALID_ONION_PAYLOAD, str(e).encode())
             else:

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -106,6 +106,7 @@ class WalletFileExceptionVersion51(WalletFileException): pass
 # register dicts that require value conversions not handled by constructor
 register_name('/transactions/*', None, lambda x: tx_from_any(x, deserialize=False, sanitize=False))
 register_name('/channels/*/data_loss_protect_remote_pcp/*', None, lambda x: bytes.fromhex(x))
+register_name('/channels/*/onion_keys/*', None, lambda x: bytes.fromhex(x))
 # register tuples, otherwise they will default to StoredList
 register_name('/contacts/*', None, tuple)
 register_name('/lightning_preimages/*', None, tuple)


### PR DESCRIPTION
`Channel.onion_keys` had no registered converter for hex -> bytes, causing `pop_onion_key()` to return a hex str instead of bytes after the keys got loaded from db following a restart.