### PR TITLE
json_db: escape '\' and '~' in json patch pointer

### DIFF
--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -62,7 +62,7 @@ def key_path(path: Sequence[_FLEX_KEY], key: _FLEX_KEY) -> str:
             return str(int(x))
         else:
             assert isinstance(x, str), f"unexpected key type for: {x!r}"
-            return x
+            return jsonpointer.escape(x)  # RFC 6901: escape '~' and '/'
     items = [to_str(x) for x in path]
     if key is not None:
         items.append(to_str(key))

--- a/tests/test_jsondb.py
+++ b/tests/test_jsondb.py
@@ -152,3 +152,15 @@ class TestJsonDB(ElectrumTestCase):
                 jpatch = jsonpatch.JsonPatch(patches)
                 data = jpatch.apply(data)
                 self.assertEqual(data, {'d': 3})
+
+    async def test_jsondb_pointer_escaping(self):
+        # keys containing '/' or '~' must be escaped per RFC 6901 in emitted patches
+        data = {'labels': {'some/label~key': 'hello'}, 'x1/': {'type': 'bip32'}}
+        db = JsonDB(json.dumps(data))
+        labels = db.get_dict('labels')
+        labels['some/label~key'] = 'world'
+        db.data.pop('x1/')
+        patches = json.loads('[' + ','.join(db.pending_changes) + ']')
+        self.assertEqual({'/labels/some~1label~0key', '/x1~1'}, {p['path'] for p in patches})
+        data = jsonpatch.JsonPatch(patches).apply(data)
+        self.assertEqual({'labels': {'some/label~key': 'world'}}, data)


### PR DESCRIPTION
> Because the characters `~` (%x7E) and `/` (%x2F) have special
   meanings in JSON Pointer, `~` needs to be encoded as `~0` and `/`
   needs to be encoded as `~1` when these characters appear in a
   reference token.

https://www.rfc-editor.org/info/rfc6901/