### PR TITLE
json_db: set_modified after removing incomplete data

### DIFF
--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -126,6 +126,7 @@ class JsonDB(Logger):
                 data, patches = r, []
             elif r := self.maybe_load_incomplete_data(s):
                 data, patches = r, []
+                self.set_modified(True)
             else:
                 raise WalletFileException("Cannot read wallet file. (parsing failed)")
         if not isinstance(data, dict):
@@ -170,7 +171,7 @@ class JsonDB(Logger):
             if n == 0:
                 s = s[0:i]
                 assert s[-2:] == ',\n'
-                self.logger.info('found incomplete data {s[i:]}')
+                self.logger.info('found incomplete data')
                 return self.load_data(s[0:-2])
 
     def set_modified(self, b):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -91,6 +91,26 @@ class TestWalletStorage(WalletTestCase):
         for key, value in some_dict.items():
             self.assertEqual(d[key], value)
 
+    async def test_appends_after_incomplete_data_recovery_survive_reload(self):
+        storage = WalletStorage(self.wallet_path, allow_partial_writes=True)
+        db = JsonDB('', storage=storage)
+        db.put("a", "b")
+        db.write()
+        # simulate a crash that truncated an appended patch
+        with open(self.wallet_path, "a") as f:
+            f.write(',\n{"op": "add", "path": "/x", "value": {"inco')
+        # reopen: recovery drops the incomplete patch
+        storage = WalletStorage(self.wallet_path, allow_partial_writes=True)
+        db = JsonDB(storage.read(), storage=storage)
+        self.assertEqual(db.get("a"), "b")
+        # append a new patch to the recovered wallet
+        db.put("c", "d")
+        db.write()
+        # reopen: the appended patch must not be lost
+        storage = WalletStorage(self.wallet_path, allow_partial_writes=True)
+        db = JsonDB(storage.read(), storage=storage)
+        self.assertEqual(db.get("c"), "d")
+
     async def test_storage_imported_add_privkeys_persistence_test(self):
         text = ' '.join([
             'p2wpkh:L4jkdiXszG26SUYvwwJhzGwg37H2nLhrbip7u6crmgNeJysv5FHL',


### PR DESCRIPTION
Set the JsonDB modified after `maybe_load_incomplete_data` removed a corrupted patch. Otherwise we might not override the file on disk, append more patches and lose them all again on the next reload.