### PR TITLE
qt: rename color themes (the user-visible names of the themes)

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -205,8 +205,8 @@ class SettingsDialog(QDialog, QtEventListener):
         qr_combo.currentIndexChanged.connect(on_video_device)
 
         colortheme_combo = QComboBox()
-        colortheme_combo.addItem(_('Light'), 'default')
-        colortheme_combo.addItem(_('Dark'), 'dark')
+        colortheme_combo.addItem(_("System"), "default")
+        colortheme_combo.addItem("qdarkstyle", "dark")
         index = colortheme_combo.findData(self.config.GUI_QT_COLOR_THEME)
         colortheme_combo.setCurrentIndex(index)
         colortheme_label = QLabel(self.config.cv.GUI_QT_COLOR_THEME.get_short_desc() + ':')


### PR DESCRIPTION
"Light" is actually the Platform-dependent system theme, where we let Qt define the palette and it leave it alone. Qt in turn mostly defers to the OS. On modern windows/macos/gnome/kde/etc, if the OS is set to "dark mode", Electrum will end up using a system-specific dark mode. Hence the name "Light" is confusing.

"Dark" is the qdarkstyle theme, which is largely platform-independent.

I think it's fine if these names are not completely "user-friendly".

closes https://github.com/spesmilo/electrum/issues/10767