### PR TITLE
ci: bump security review ci model to opus 5

### DIFF
--- a/contrib/ci/claude_security_review.py
+++ b/contrib/ci/claude_security_review.py
@@ -37,7 +37,7 @@ PROMPT_FILE = os.path.join(SCRIPT_DIR, "security_review_prompt.md")
 
 MAX_DIFF_CHARS = 800_000
 CLAUDE_TIMEOUT_SECONDS = 60 * 60
-CLAUDE_MODEL = "claude-opus-4-8"
+CLAUDE_MODEL = "claude-opus-5"
 CLAUDE_EFFORT = "max"
 
 VERDICT_PASS = "PASS"


### PR DESCRIPTION
Bump the LLM used by the security review CI script from Claude Opus 4.8 to Claude Opus 5