### PR TITLE
lnrouter/lnworker: move liquidity hint update to htlc removal callbacks

### DIFF
--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -371,6 +371,8 @@ class LiquidityHintMgr:
     def reset_liquidity_hints(self):
         for k, v in self._liquidity_hints.items():
             v.hint_timestamp = 0
+            v._inflight_htlcs_forward = 0
+            v._inflight_htlcs_backward = 0
 
     def __repr__(self):
         string = "liquidity hints:\n"

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2093,14 +2093,6 @@ class LNWallet(Logger):
         or OnionRoutingFailure (if forwarding trampoline).
         """
         if htlc_log.success:
-            if self.network.path_finder:
-                # TODO: report every route to liquidity hints for mpp
-                # in the case of success, we report channels of the
-                # route as being able to send the same amount in the future,
-                # as we assume to not know the capacity
-                self.network.path_finder.update_liquidity_hints(htlc_log.route, htlc_log.amount_msat)
-                # remove inflight htlcs from liquidity hints
-                self.network.path_finder.update_inflight_htlcs(htlc_log.route, add_htlcs=False)
             raise PaymentSuccess()
         # htlc failed
         # if we get a tmp channel failure, it might work to split the amount and try more routes
@@ -2168,7 +2160,7 @@ class LNWallet(Logger):
             self.logger.info(f'adding active forwarding {fw_payment_key}')
             self.active_forwardings[fw_payment_key].append(htlc_key)
         if self.network.path_finder:
-            # add inflight htlcs to liquidity hints
+            # add inflight htlcs to liquidity hints; removed again in htlc_fulfilled/htlc_failed
             self.network.path_finder.update_inflight_htlcs(shi.route, add_htlcs=True)
         util.trigger_callback('htlc_added', chan, htlc, SENT)
 
@@ -2182,9 +2174,6 @@ class LNWallet(Logger):
 
         assert self.channel_db  # cannot be in trampoline mode
         assert self.network.path_finder
-
-        # remove inflight htlcs from liquidity hints
-        self.network.path_finder.update_inflight_htlcs(route, add_htlcs=False)
 
         code, data = failure_msg.code, failure_msg.data
         # TODO can we use lnmsg.OnionWireSerializer here?
@@ -3168,6 +3157,9 @@ class LNWallet(Logger):
         shi = self.sent_htlcs_info.get((payment_hash, chan.short_channel_id, htlc_id))
         if shi and htlc_id in chan.onion_keys:
             chan.pop_onion_key(htlc_id)
+            if self.network.path_finder:
+                self.network.path_finder.update_liquidity_hints(shi.route, shi.amount_receiver_msat)
+                self.network.path_finder.update_inflight_htlcs(shi.route, add_htlcs=False)
             payment_key = payment_hash + shi.payment_secret_orig
             paysession = self._paysessions[payment_key]
             q = paysession.sent_htlcs_q
@@ -3214,6 +3206,8 @@ class LNWallet(Logger):
         shi = self.sent_htlcs_info.get((payment_hash, chan.short_channel_id, htlc_id))
         if shi and htlc_id in chan.onion_keys:
             onion_key = chan.pop_onion_key(htlc_id)
+            if self.network.path_finder:
+                self.network.path_finder.update_inflight_htlcs(shi.route, add_htlcs=False)
             payment_okey = payment_hash + shi.payment_secret_orig
             paysession = self._paysessions[payment_okey]
             q = paysession.sent_htlcs_q

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -2250,6 +2250,23 @@ class TestPeerForwarding(TestPeer):
         with self.assertRaises(PaymentDone):
             await f()
 
+    async def _assert_no_inflight_htlcs_in_liquidity_hints(self, w: MockLNWallet):
+        # pay_invoice returns when the first htlc resolution is processed; the remaining
+        # parts resolve later. only when all parts have resolved is the paysession removed.
+        async def wait_for_paysessions_to_be_cleaned_up():
+            while w._paysessions:
+                await asyncio.sleep(0.01)
+        await util.wait_for2(wait_for_paysessions_to_be_cleaned_up(), timeout=10)
+        for hint in w.network.path_finder.liquidity_hints._liquidity_hints.values():
+            self.assertEqual(0, hint.num_inflight_htlcs(True))
+            self.assertEqual(0, hint.num_inflight_htlcs(False))
+
+    def _assert_all_parts_reported_can_send(self, w: MockLNWallet):
+        # every part of the mpp resolved successfully, so every edge an htlc was
+        # sent over should have received a can_send report for its direction of use
+        for hint in w.network.path_finder.liquidity_hints._liquidity_hints.values():
+            self.assertTrue(hint.can_send(True) is not None or hint.can_send(False) is not None)
+
     async def _run_mpp(self, graph, kwargs):
         """Tests a multipart payment scenario for failing and successful cases."""
         self.assertEqual(500_000_000_000, graph.channels[('alice', 'bob')][0].balance(LOCAL))
@@ -2299,8 +2316,11 @@ class TestPeerForwarding(TestPeer):
                         await g.spawn(peer.wait_one_htlc_switch_iteration())
                 for peer in peers:
                     self.assertEqual(len(peer.lnworker.received_mpp_htlcs), 0)
+                await self._assert_no_inflight_htlcs_in_liquidity_hints(alice_w)
+                self._assert_all_parts_reported_can_send(alice_w)
                 raise PaymentDone()
             elif len(log) == 1 and log[0].failure_msg.code == OnionFailureCode.MPP_TIMEOUT:
+                await self._assert_no_inflight_htlcs_in_liquidity_hints(alice_w)
                 raise PaymentTimeout()
             else:
                 raise NoPathFound()

--- a/tests/test_lnrouter.py
+++ b/tests/test_lnrouter.py
@@ -373,6 +373,19 @@ class Test_LNRouter(ElectrumTestCase):
         # we have got 600 (attempt) + 600 (inflight) penalty
         self.assertEqual(1200, liquidity_hints.penalty(node_from, node_to, channel_id, 1_000_000))
 
+    def test_reset_liquidity_hints_clears_inflight_htlcs(self):
+        liquidity_hints = LiquidityHintMgr()
+        node_from, node_to = bytes(0), bytes(1)
+        channel_id = ShortChannelID.from_components(0, 0, 0)
+        liquidity_hints.add_htlc(node_from, node_to, channel_id)
+        liquidity_hints.add_htlc(node_to, node_from, channel_id)
+        hint = liquidity_hints.get_hint(channel_id)
+        self.assertEqual(1, hint.num_inflight_htlcs(node_from < node_to))
+        self.assertEqual(1, hint.num_inflight_htlcs(node_to < node_from))
+        liquidity_hints.reset_liquidity_hints()
+        self.assertEqual(0, hint.num_inflight_htlcs(node_from < node_to))
+        self.assertEqual(0, hint.num_inflight_htlcs(node_to < node_from))
+
     @needs_test_with_all_chacha20_implementations
     def test_new_onion_packet(self):
         # test vector from bolt-04


### PR DESCRIPTION
Move the liquidity hint updates from the htlc log processing to the htlc removal callbacks so they
get called for all htlcs we sent out.
On master we would decrement the inflight htlc counter on the liquidity hint only for the first
successful htlc's route, after which `PaymentSuccess` would end the payment flow.
The remaining (successful) routes used for the other htlcs of a payment wouldn't get their counter decremented and 
be penalized for this in subsequent payment attempts until the in-memory liquidity hints get reset through a restart.