### PR TITLE
jsondb: handle structural json characters in data during recovery

### DIFF
--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -159,20 +159,25 @@ class JsonDB(Logger):
         # json roundtrip: recursively converts int keys to str
         return json.loads(json.dumps(data))
 
-    def maybe_load_incomplete_data(self, s):
-        n = s.count('{') - s.count('}')
-        i = len(s)
-        while n > 0 and i > 0:
-            i = i - 1
-            if s[i] == '{':
-                n = n - 1
-            if s[i] == '}':
-                n = n + 1
-            if n == 0:
-                s = s[0:i]
-                assert s[-2:] == ',\n'
-                self.logger.info('found incomplete data')
-                return self.load_data(s[0:-2])
+    def maybe_load_incomplete_data(self, s: str) -> Optional[Dict[str, Any]]:
+        """Try to recover a file that was truncated mid-write (e.g. crash during append).
+        The file consists of a JSON object followed by JSON patches, separated by ',\n'
+        (see _append_pending_changes). We parse complete segments with a real JSON parser,
+        and drop the incomplete tail (note there might be '{' and '}' in user-controled input).
+        """
+        decoder = json.JSONDecoder()
+        end: Optional[int] = None  # end of last complete segment
+        try:
+            _, end = decoder.raw_decode(s)  # main json object
+            while end < len(s):
+                if not (s.startswith(',\n', end) or s[end:] == ','):
+                    return None  # unexpected structure, not a truncated append. cannot recover.
+                _, end = decoder.raw_decode(s, end + 2)  # patch
+        except json.JSONDecodeError:
+            if end is None:
+                return None  # main json object itself is truncated. cannot recover.
+            self.logger.warning(f'found incomplete data, dropping {len(s) - end} trailing characters from json database')
+            return self.load_data(s[0:end])
 
     def set_modified(self, b):
         with self.lock:

--- a/tests/test_jsondb.py
+++ b/tests/test_jsondb.py
@@ -11,6 +11,7 @@ from jsonpointer import JsonPointerException
 from . import ElectrumTestCase
 
 from electrum.json_db import JsonDB
+from electrum.util import WalletFileException
 
 class TestJsonpatch(ElectrumTestCase):
 
@@ -159,6 +160,31 @@ class TestJsonDB(ElectrumTestCase):
         raw_json_db = raw_json_db[:-4]  # truncate some characters, to trigger maybe_load_incomplete_data()
         db = JsonDB(raw_json_db)
         self.assertEqual({"a": {"b": "c1"}, "d": "e"}, dict(db.data))
+
+    async def test_json_db_load_arbitrarily_truncated_data(self):
+        # a file cut at any offset after the main object must recover to a valid prefix state;
+        # a cut inside the main object must raise WalletFileException
+        base = {'labels': {'tx1': 'nasty } { label'}, 'nested': {'a': [1, {'b': '}}}'}]}}
+        patches = [
+            {'op': 'add', 'path': '/labels/tx2', 'value': 'user_supp}}}lied {{{ text'},
+            {'op': 'replace', 'path': '/labels/tx1', 'value': 'fake ,\\n{ separator'},
+        ]
+        # the valid prefix states: base with 0, 1, ..., len(patches) patches applied
+        states = [base]
+        for p in patches:
+            states.append(jsonpatch.JsonPatch([p]).apply(states[-1]))
+        s = json.dumps(base)
+        for p in patches:
+            s += ',\n' + json.dumps(p)
+        self.assertEqual(states[-1], json.loads(json.dumps(JsonDB(s).data)))
+        main_len = len(json.dumps(base))
+        for i in range(1, len(s)):
+            if i < main_len:  # main object truncated: unrecoverable
+                with self.assertRaises(WalletFileException):
+                    JsonDB(s[:i])
+            else:  # main object intact: must recover
+                db = JsonDB(s[:i])
+                self.assertIn(json.loads(json.dumps(db.data)), states)
 
     async def test_jsondb_pointer_escaping(self):
         # keys containing '/' or '~' must be escaped per RFC 6901 in emitted patches

--- a/tests/test_jsondb.py
+++ b/tests/test_jsondb.py
@@ -153,6 +153,13 @@ class TestJsonDB(ElectrumTestCase):
                 data = jpatch.apply(data)
                 self.assertEqual(data, {'d': 3})
 
+    async def test_json_db_maybe_load_incomplete_data_with_control_characters(self):
+        # user-supplied text such as tx labels can contain arbitrary characters, such as "}"
+        raw_json_db = '{"a": {"b": "c1"}, "d": "e"},\n{"op": "replace", "path": "/a/b", "value": "user_supp}}}lied_text"}'
+        raw_json_db = raw_json_db[:-4]  # truncate some characters, to trigger maybe_load_incomplete_data()
+        db = JsonDB(raw_json_db)
+        self.assertEqual({"a": {"b": "c1"}, "d": "e"}, dict(db.data))
+
     async def test_jsondb_pointer_escaping(self):
         # keys containing '/' or '~' must be escaped per RFC 6901 in emitted patches
         data = {'labels': {'some/label~key': 'hello'}, 'x1/': {'type': 'bip32'}}


### PR DESCRIPTION
Handle structural json characters like '{' or '}' in the database content
while attempting to recover from truncated json patches.
Fixes https://github.com/spesmilo/electrum/issues/10766