### PR TITLE
lnwallet: use split config channel for single channel mpp

### DIFF
--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -597,6 +597,9 @@ class LNPathFinder(Logger):
                         continue
                     if not ignore_amount_constraints \
                             and not my_sending_channels[edge_channel_id].can_pay(amount_msat, check_frozen=True):
+                        # note: in case of MPP, we might be constructing multiple routes for different HTLCs around the same time,
+                        #       and only a tiny bit later will the HTLCs get added to the channels. If another HTLC has not been
+                        #       added yet but we already selected to use the same channel for it, this "can_pay()" can return a false positive.
                         continue
                 edge_cost, fee_for_edge_msat = self._edge_cost(
                     short_channel_id=edge_channel_id,

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -2421,7 +2421,6 @@ class LNWallet(Logger):
             receiver_pubkey=paysession.invoice_pubkey,
         )
         for sc in split_configurations:
-            is_multichan_mpp = len(sc.config.items()) > 1
             is_mpp = sc.config.number_parts() > 1
             if is_mpp and not paysession.invoice_features.supports(LnFeatures.BASIC_MPP_OPT):
                 continue
@@ -2520,7 +2519,7 @@ class LNWallet(Logger):
                                     invoice_pubkey=paysession.invoice_pubkey,
                                     r_tags=paysession.r_tags,
                                     invoice_features=paysession.invoice_features,
-                                    my_sending_channels=[channel] if is_multichan_mpp else my_active_channels,
+                                    my_sending_channels=[channel] if is_mpp else my_active_channels,
                                     full_path=full_path,
                                 ))
                             if not is_route_within_budget(

--- a/tests/lnhelpers.py
+++ b/tests/lnhelpers.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import os
+from decimal import Decimal
 from pprint import pformat
 from typing import NamedTuple, Tuple, Dict, Mapping, TYPE_CHECKING, Sequence
 
@@ -11,16 +12,18 @@ from electrum import (
 )
 from electrum.coinchooser import PRNG
 from electrum.network import ProxySettings
-from electrum.bolt11 import BOLT11Addr
+from electrum.bitcoin import COIN, sha256
+from electrum.bolt11 import encode_bolt11_invoice, BOLT11Addr, decode_bolt11_invoice
+from electrum.invoices import PR_UNPAID, Invoice, LN_EXPIRY_NEVER
 from electrum.lnpeer import Peer
 from electrum.lnutil import (
     LnFeatures, PaymentFeeBudget, LOCAL, REMOTE, ChannelType, LocalConfig, RemoteConfig,
-    OnlyPubkeyKeypair, secret_to_pubkey,
+    OnlyPubkeyKeypair, secret_to_pubkey, RECEIVED,
 )
 from electrum.lnchannel import ChannelState, Channel
 from electrum.lnrouter import LNPathFinder
 from electrum.channel_db import ChannelDB
-from electrum.lnworker import LNWallet, PaySession
+from electrum.lnworker import LNWallet, PaySession, PaymentInfo
 from electrum.simple_config import SimpleConfig
 from electrum.fee_policy import FeeTimeEstimates, FEE_ETA_TARGETS
 from electrum.wallet import  Standard_Wallet
@@ -29,6 +32,121 @@ from . import restore_wallet_from_text__for_unittest
 
 if TYPE_CHECKING:
     from . import ElectrumTestCase
+
+
+high_fee_channel = {
+   'local_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
+   'remote_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
+   'local_base_fee_msat': 500_000,
+   'local_fee_rate_millionths': 500,
+   'remote_base_fee_msat': 500_000,
+   'remote_fee_rate_millionths': 500,
+}
+
+low_fee_channel = {
+    'local_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
+    'remote_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
+    'local_base_fee_msat': 1_000,
+    'local_fee_rate_millionths': 1,
+    'remote_base_fee_msat': 1_000,
+    'remote_fee_rate_millionths': 1,
+}
+
+depleted_channel = {
+    'local_balance_msat': 330 * 1000, # local pays anchors
+    'remote_balance_msat': 10 * bitcoin.COIN * 1000,
+    'local_base_fee_msat': 1_000,
+    'local_fee_rate_millionths': 1,
+    'remote_base_fee_msat': 1_000,
+    'remote_fee_rate_millionths': 1,
+}
+
+_GRAPH_DEFINITIONS = {
+    # A -- B
+    'single_chan' : {
+        'alice': {
+            'channels': {
+                'bob': [
+                    {
+                       'local_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
+                       'remote_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
+                    },
+                ],
+            },
+        },
+        'bob': {
+        },
+    },
+    #                A
+    #     high fee /   \ low fee
+    #             B     C
+    #     high fee \   / low fee
+    #                D
+    'square_graph': {
+        'alice': {
+            'channels': {
+                # we should use copies of channel definitions if
+                # we want to independently alter them in a test
+                'bob': [high_fee_channel.copy()],
+                'carol': [low_fee_channel.copy()],
+            },
+        },
+        'bob': {
+            'channels': {
+                'dave': [high_fee_channel.copy()],
+            },
+            'config': {
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_TRAMPOLINE_PAYMENTS: True,
+            },
+        },
+        'carol': {
+            'channels': {
+                'dave': [low_fee_channel.copy()],
+            },
+            'config': {
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_TRAMPOLINE_PAYMENTS: True,
+            },
+        },
+        'dave': {
+        },
+    },
+    # A -- B -- C -- D -- E
+    'line_graph': {
+        'alice': {
+            'channels': {
+                'bob': [low_fee_channel.copy()],
+            },
+        },
+        'bob': {  # Trampoline Forwarder
+            'channels': {
+                'carol': [low_fee_channel.copy()],
+            },
+            'config': {
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
+            },
+        },
+        'carol': {
+            'channels': {
+                'dave': [low_fee_channel.copy()],
+            },
+            'config': {
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
+            },
+        },
+        'dave': {  # Trampoline Forwarder
+            'channels': {
+                'edward': [low_fee_channel.copy()],
+            },
+            'config': {
+                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
+            },
+        },
+        'edward': {
+        },
+    },
+}
 
 
 class MockNetwork:
@@ -225,6 +343,63 @@ def transport_pair(k1, k2, name1, name2):
     return t1, t2
 
 
+def prepare_invoice(
+        w2: MockLNWallet,  # receiver
+        *,
+        amount_msat=100_000_000,
+        include_routing_hints=False,
+        payment_preimage: bytes = None,
+        payment_hash: bytes = None,
+        invoice_features: LnFeatures = None,
+        min_final_cltv_delta: int = None,
+        expiry: int = None,
+) -> Tuple[BOLT11Addr, Invoice]:
+    amount_btc = amount_msat/Decimal(COIN*1000)
+    if payment_preimage is None and not payment_hash:
+        payment_preimage = os.urandom(32)
+    if payment_hash is None:
+        payment_hash = sha256(payment_preimage)
+    if payment_preimage:
+        w2.save_preimage(payment_hash, payment_preimage)
+    if include_routing_hints:
+        routing_hints = w2.calc_routing_hints_for_invoice(amount_msat)
+    else:
+        routing_hints = []
+        trampoline_hints = []
+    if invoice_features is None:
+        invoice_features = w2.features.for_bolt11_invoice()
+    if invoice_features.supports(LnFeatures.PAYMENT_SECRET_OPT):
+        payment_secret = w2.get_payment_secret(payment_hash)
+    else:
+        payment_secret = None
+    if min_final_cltv_delta is None:
+        min_final_cltv_delta = lnutil.MIN_FINAL_CLTV_DELTA_ACCEPTED
+    info = PaymentInfo(
+        payment_hash=payment_hash,
+        amount_msat=amount_msat,
+        direction=RECEIVED,
+        status=PR_UNPAID,
+        min_final_cltv_delta=min_final_cltv_delta,
+        expiry_delay=expiry or LN_EXPIRY_NEVER,
+        invoice_features=invoice_features,
+    )
+    w2.save_payment_info(info)
+    lnaddr1 = BOLT11Addr(
+        paymenthash=payment_hash,
+        amount=amount_btc,
+        tags=[
+            ('c', min_final_cltv_delta),
+            ('d', 'coffee'),
+            ('9', invoice_features),
+            ('x', expiry or 3600),
+        ] + routing_hints,
+        payment_secret=payment_secret,
+    )
+    invoice = encode_bolt11_invoice(lnaddr1, w2.node_keypair.privkey)
+    lnaddr2 = decode_bolt11_invoice(invoice)  # unlike lnaddr1, this now has a pubkey set
+    return lnaddr2, Invoice.from_bech32(invoice)
+
+
 def prepare_lnwallets(elec_test_case: 'ElectrumTestCase', graph_definition) -> Mapping[str, MockLNWallet]:
     workers = {}  # type: Dict[str, MockLNWallet]
     for a, definition in graph_definition.items():
@@ -239,10 +414,8 @@ def prepare_chans_and_peers_in_graph(
     workers: Dict[str, MockLNWallet] = None,
     channels: dict[Tuple[str, str], list[Channel]] = None,
 ) -> Graph:
-    from . import test_lnpeer
-
     if graph_definition is None:
-        graph_definition = test_lnpeer._GRAPH_DEFINITIONS['single_chan']
+        graph_definition = _GRAPH_DEFINITIONS['single_chan']
     graph_definition = copy.deepcopy(graph_definition)  # paranoia
 
     # create workers

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -3,7 +3,6 @@ import dataclasses
 import shutil
 import copy
 import tempfile
-from decimal import Decimal
 import os
 from contextlib import contextmanager
 from collections import defaultdict
@@ -29,8 +28,8 @@ from electrum import constants
 from electrum import bip32
 from electrum.network import Network, ProxySettings
 from electrum import simple_config, lnutil
-from electrum.bolt11 import encode_bolt11_invoice, BOLT11Addr, decode_bolt11_invoice
-from electrum.bitcoin import COIN, sha256
+from electrum.bolt11 import encode_bolt11_invoice, BOLT11Addr
+from electrum.bitcoin import sha256
 from electrum.transaction import Transaction
 from electrum.util import NetworkRetryManager, bfh, OldTaskGroup, EventListener, InvoiceError
 from electrum.lnpeer import Peer
@@ -44,134 +43,17 @@ from electrum.lnworker import LNWallet, NoPathFound, SentHtlcInfo, PaySession, L
 from electrum.lnmsg import encode_msg, decode_msg
 from electrum import lnmsg
 from electrum.logging import console_stderr_handler, Logger
-from electrum.lnworker import PaymentInfo
 from electrum.lnonion import OnionFailureCode, OnionRoutingFailure, OnionHopsDataSingle, OnionPacket
 from electrum.lnutil import LOCAL, REMOTE, UpdateAddHtlc, RecvMPPResolution, RevocationStore
-from electrum.invoices import PR_PAID, PR_UNPAID, Invoice, LN_EXPIRY_NEVER
+from electrum.invoices import PR_PAID, PR_UNPAID, Invoice
 from electrum.interface import GracefulDisconnect
-from electrum.simple_config import SimpleConfig
 from electrum.fee_policy import FeeTimeEstimates, FEE_ETA_TARGETS
 from electrum.mpp_split import split_amount_normal
 from electrum.wallet import Abstract_Wallet, Standard_Wallet
 
 from .test_bitcoin import needs_test_with_all_chacha20_implementations
 from . import ElectrumTestCase, restore_wallet_from_text__for_unittest, lnhelpers
-from .lnhelpers import Graph, MockLNWallet, create_test_channels
-
-
-high_fee_channel = {
-   'local_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
-   'remote_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
-   'local_base_fee_msat': 500_000,
-   'local_fee_rate_millionths': 500,
-   'remote_base_fee_msat': 500_000,
-   'remote_fee_rate_millionths': 500,
-}
-
-low_fee_channel = {
-    'local_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
-    'remote_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
-    'local_base_fee_msat': 1_000,
-    'local_fee_rate_millionths': 1,
-    'remote_base_fee_msat': 1_000,
-    'remote_fee_rate_millionths': 1,
-}
-
-depleted_channel = {
-    'local_balance_msat': 330 * 1000, # local pays anchors
-    'remote_balance_msat': 10 * bitcoin.COIN * 1000,
-    'local_base_fee_msat': 1_000,
-    'local_fee_rate_millionths': 1,
-    'remote_base_fee_msat': 1_000,
-    'remote_fee_rate_millionths': 1,
-}
-
-_GRAPH_DEFINITIONS = {
-    # A -- B
-    'single_chan' : {
-        'alice': {
-            'channels': {
-                'bob': [
-                    {
-                       'local_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
-                       'remote_balance_msat': 10 * bitcoin.COIN * 1000 // 2,
-                    },
-                ],
-            },
-        },
-        'bob': {
-        },
-    },
-    #                A
-    #     high fee /   \ low fee
-    #             B     C
-    #     high fee \   / low fee
-    #                D
-    'square_graph': {
-        'alice': {
-            'channels': {
-                # we should use copies of channel definitions if
-                # we want to independently alter them in a test
-                'bob': [high_fee_channel.copy()],
-                'carol': [low_fee_channel.copy()],
-            },
-        },
-        'bob': {
-            'channels': {
-                'dave': [high_fee_channel.copy()],
-            },
-            'config': {
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_TRAMPOLINE_PAYMENTS: True,
-            },
-        },
-        'carol': {
-            'channels': {
-                'dave': [low_fee_channel.copy()],
-            },
-            'config': {
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_TRAMPOLINE_PAYMENTS: True,
-            },
-        },
-        'dave': {
-        },
-    },
-    # A -- B -- C -- D -- E
-    'line_graph': {
-        'alice': {
-            'channels': {
-                'bob': [low_fee_channel.copy()],
-            },
-        },
-        'bob': {  # Trampoline Forwarder
-            'channels': {
-                'carol': [low_fee_channel.copy()],
-            },
-            'config': {
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
-            },
-        },
-        'carol': {
-            'channels': {
-                'dave': [low_fee_channel.copy()],
-            },
-            'config': {
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
-            },
-        },
-        'dave': {  # Trampoline Forwarder
-            'channels': {
-                'edward': [low_fee_channel.copy()],
-            },
-            'config': {
-                SimpleConfig.EXPERIMENTAL_LN_FORWARD_PAYMENTS: True,
-            },
-        },
-        'edward': {
-        },
-    },
-}
+from .lnhelpers import Graph, MockLNWallet, create_test_channels, low_fee_channel, depleted_channel
 
 
 class PaymentDone(Exception): pass
@@ -210,68 +92,13 @@ class TestPeer(ElectrumTestCase):
 
     def setUp(self):
         super().setUp()
-        self.GRAPH_DEFINITIONS = copy.deepcopy(_GRAPH_DEFINITIONS)
+        self.GRAPH_DEFINITIONS = copy.deepcopy(lnhelpers._GRAPH_DEFINITIONS)
 
     async def asyncTearDown(self):
         electrum.trampoline._TRAMPOLINE_NODES_UNITTESTS = {}
         await super().asyncTearDown()
 
-    @staticmethod
-    def prepare_invoice(
-            w2: MockLNWallet,  # receiver
-            *,
-            amount_msat=100_000_000,
-            include_routing_hints=False,
-            payment_preimage: bytes = None,
-            payment_hash: bytes = None,
-            invoice_features: LnFeatures = None,
-            min_final_cltv_delta: int = None,
-            expiry: int = None,
-    ) -> Tuple[BOLT11Addr, Invoice]:
-        amount_btc = amount_msat/Decimal(COIN*1000)
-        if payment_preimage is None and not payment_hash:
-            payment_preimage = os.urandom(32)
-        if payment_hash is None:
-            payment_hash = sha256(payment_preimage)
-        if payment_preimage:
-            w2.save_preimage(payment_hash, payment_preimage)
-        if include_routing_hints:
-            routing_hints = w2.calc_routing_hints_for_invoice(amount_msat)
-        else:
-            routing_hints = []
-            trampoline_hints = []
-        if invoice_features is None:
-            invoice_features = w2.features.for_bolt11_invoice()
-        if invoice_features.supports(LnFeatures.PAYMENT_SECRET_OPT):
-            payment_secret = w2.get_payment_secret(payment_hash)
-        else:
-            payment_secret = None
-        if min_final_cltv_delta is None:
-            min_final_cltv_delta = lnutil.MIN_FINAL_CLTV_DELTA_ACCEPTED
-        info = PaymentInfo(
-            payment_hash=payment_hash,
-            amount_msat=amount_msat,
-            direction=RECEIVED,
-            status=PR_UNPAID,
-            min_final_cltv_delta=min_final_cltv_delta,
-            expiry_delay=expiry or LN_EXPIRY_NEVER,
-            invoice_features=invoice_features,
-        )
-        w2.save_payment_info(info)
-        lnaddr1 = BOLT11Addr(
-            paymenthash=payment_hash,
-            amount=amount_btc,
-            tags=[
-                ('c', min_final_cltv_delta),
-                ('d', 'coffee'),
-                ('9', invoice_features),
-                ('x', expiry or 3600),
-            ] + routing_hints,
-            payment_secret=payment_secret,
-        )
-        invoice = encode_bolt11_invoice(lnaddr1, w2.node_keypair.privkey)
-        lnaddr2 = decode_bolt11_invoice(invoice)  # unlike lnaddr1, this now has a pubkey set
-        return lnaddr2, Invoice.from_bech32(invoice)
+    prepare_invoice = staticmethod(lnhelpers.prepare_invoice)
 
     async def _activate_trampoline(self, w: MockLNWallet):
         if w.network.channel_db:

--- a/tests/test_lnwallet.py
+++ b/tests/test_lnwallet.py
@@ -15,6 +15,7 @@ from electrum.invoices import LN_EXPIRY_NEVER, PR_UNPAID
 from electrum.lnpeer import Peer
 from electrum.lnchannel import Channel, ChannelState
 from electrum.lnonion import OnionPacket, OnionRoutingFailure
+from electrum.mpp_split import SplitConfig, SplitConfigRating
 from electrum.crypto import sha256
 from electrum.simple_config import SimpleConfig
 
@@ -474,3 +475,24 @@ class TestLNWallet(ElectrumTestCase):
         chan1.set_frozen_for_sending(True)  # shouldn't matter, this channel will receive
         success, log = await alice.rebalance_channels(chan0, chan1, amount_msat=150_000_000)
         self.assertTrue(success, msg=log)
+
+    async def test_payment_multipart_single_channel_split(self):
+        """A split configuration can put multiple parts on a single channel. The parts
+        must then be sent over that channel, instead of the pathfinder freely choosing
+        a first hop, which would ignore the balance allocation of the config."""
+        graph = lnhelpers.prepare_chans_and_peers_in_graph(self, lnhelpers._GRAPH_DEFINITIONS['square_graph'])
+        alice_w, dave_w = graph.workers['alice'], graph.workers['dave']
+        dave_w.features |= LnFeatures.BASIC_MPP_OPT
+        self.assertFalse(alice_w.uses_trampoline())
+        amount_to_pay = 200_000_000
+        lnaddr, _pay_req = lnhelpers.prepare_invoice(dave_w, include_routing_hints=True, amount_msat=amount_to_pay)
+        # force a split config with two parts on the high-fee alice-bob channel,
+        # although the pathfinder considers the route via carol cheaper
+        bob_chan = graph.channels[('alice', 'bob')][0]
+        split_config = SplitConfig({(bob_chan.channel_id, bob_chan.node_id): [amount_to_pay // 2, amount_to_pay // 2]})
+        alice_w.suggest_payment_splits = lambda **kwargs: [SplitConfigRating(config=split_config, rating=0)]
+        routes = await alice_w.create_routes_from_invoice(amount_to_pay, decoded_invoice=lnaddr)
+        self.assertEqual(2, len(routes))
+        for shi, _, _ in routes:
+            # all constructed routes use the outgoing channel of the split config
+            self.assertEqual(bob_chan.short_channel_id, shi.route[0].short_channel_id)


### PR DESCRIPTION
Use the channel returned by the split config when sending a
single channel mpp, instead of allowing the pathfinding to use any channel.
Otherwise it can happen that we have a good split config fitting a
specific channel, but the pathfinding then tries to put both parts
on another channel that cannot handle the sum of the parts, raising
at `_assert_can_add_htlc` later on and failing the payment.