### PR TITLE
trezor: drop session after closing it

### DIFF
--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -282,11 +282,14 @@ class TrezorClientBase(HardwareClientBase, Logger):
     @runs_in_hwd_thread
     def close(self):
         '''Called when Our wallet was closed or the device removed.'''
-        self.logger.info("locking: %s", self.client)
-        self.client.lock()
-        self.logger.info("closing: %s", self._session)
-        if self._session is not None:
-            self._session.close()
+        try:
+            self.logger.info("locking: %s", self.client)
+            self.client.lock()
+            self.logger.info("closing: %s", self._session)
+            if self._session is not None:
+                self._session.close()
+        finally:
+            self._session = None
 
     @runs_in_hwd_thread
     def is_uptodate(self):


### PR DESCRIPTION
Set `TrezorClientBase._session = None` after closing a session (e.g. after session timeout) so the next session access will prompt for the pin on the device instead of throwing an `InvalidSessionError` when trying to access the device.

E.g. when trying to sign a tx after the session timed out:
```
 80.64 | I | plugins.trezor.clientbase.TrezorClientBase | timed out
 80.64 | I | plugins.trezor.clientbase.TrezorClientBase | clear session: <electrum.plugins.trezor.clientbase.TrezorClientBase object at 0x7f24cd34f080>
 80.64 | I | plugins.trezor.clientbase.TrezorClientBase | locking: <trezorlib.protocol_v1.TrezorClientV1 object at 0x7f24cd34e160>
 80.90 | I | plugins.trezor.clientbase.TrezorClientBase | closing: SessionV1(id=d5e6015e501acf4b10b3a3e50f1f9307768e434330568e7d5e7b1babed066438)
112.83 | I | plugin.DeviceMgr | getting client for keystore
112.83 | I | plugin.DeviceMgr | end client for keystore
113.10 | I | plugin.DeviceMgr | getting client for keystore
113.10 | I | plugin.DeviceMgr | end client for keystore
113.11 | E | gui.qt.main_window.[trezor] | on_error
Traceback (most recent call last):
  File "/var/home/user/code/code_vm/electrum/electrum/gui/common_qt/util.py", line 165, in run
    result = task.task()
  File "/var/home/user/code/code_vm/electrum/electrum/wallet.py", line 2822, in sign_transaction
    k.sign_transaction(tmp_tx, password)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/var/home/user/code/code_vm/electrum/electrum/plugins/trezor/trezor.py", line 100, in sign_transaction
    self.plugin.sign_transaction(self, tx, prev_tx)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/var/home/user/code/code_vm/electrum/electrum/plugin.py", line 1000, in wrapper
    return run_in_hwd_thread(partial(func, *args, **kwargs))
  File "/var/home/user/code/code_vm/electrum/electrum/plugin.py", line 993, in run_in_hwd_thread
    return fut.result()
           ~~~~~~~~~~^^
  File "/usr/lib64/python3.14/concurrent/futures/_base.py", line 454, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/concurrent/futures/_base.py", line 396, in __get_result
    raise self._exception
  File "/usr/lib64/python3.14/concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File "/usr/lib64/python3.14/concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File "/var/home/user/code/code_vm/electrum/electrum/plugins/trezor/trezor.py", line 344, in sign_transaction
    signatures, _ = client.sign_tx(self.get_coin_name(),
                    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
                                   inputs, outputs,
                                   ^^^^^^^^^^^^^^^^
    ...<3 lines>...
                                   serialize=False,
                                   ^^^^^^^^^^^^^^^^
                                   prev_txes=prev_tx)
                                   ^^^^^^^^^^^^^^^^^^
  File "/var/home/user/code/code_vm/electrum/electrum/plugin.py", line 1000, in wrapper
    return run_in_hwd_thread(partial(func, *args, **kwargs))
  File "/var/home/user/code/code_vm/electrum/electrum/plugin.py", line 990, in run_in_hwd_thread
    return func()
  File "/var/home/user/code/code_vm/electrum/electrum/plugins/trezor/clientbase.py", line 356, in sign_tx
    return trezorlib.btc.sign_tx(self.session, *args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/user/code/code_vm/electrum/env/lib64/python3.14/site-packages/trezorlib/tools.py", line 379, in wrapper
    result = self.func(session, *args, **kwargs)
  File "/var/home/user/code/code_vm/electrum/env/lib64/python3.14/site-packages/trezorlib/btc.py", line 329, in sign_tx
    res = session.call(signtx, expect=messages.TxRequest)
  File "/var/home/user/code/code_vm/electrum/env/lib64/python3.14/site-packages/trezorlib/client.py", line 113, in call
    raise exceptions.InvalidSessionError(self.id)
trezorlib.exceptions.InvalidSessionError: b'\xd5\xe6\x01^P\x1a\xcfK\x10\xb3\xa3\xe5\x0f\x1f\x93\x07v\x8eCC0V\x8e}^{\x1b\xab\xed\x06d8'
```