### PR TITLE
lnrouter: liquidity hints: add extra penalty if amt near cannot_send

### DIFF
--- a/electrum/lnrouter.py
+++ b/electrum/lnrouter.py
@@ -391,14 +391,24 @@ class LiquidityHintMgr:
             can_send = hint.can_send(node_from < node_to)
             cannot_send = hint.cannot_send(node_from < node_to)
             num_inflight_htlcs = hint.num_inflight_htlcs(node_from < node_to)
+        assert isinstance(num_inflight_htlcs, int), f"{num_inflight_htlcs=!r} should be an int"
+        assert num_inflight_htlcs >= 0, f"{num_inflight_htlcs=!r} should be non-negative"
 
+        # above known liquidity interval: inf
         if cannot_send is not None and amount_msat >= cannot_send:
             return inf
+        # below known liquidity interval: free
         if can_send is not None and amount_msat <= can_send:
             return 0
+        # inside known liquidity interval, or liquidity unknown
+        likely_cannotsend_factor = 0
+        if cannot_send is not None:
+            fcan_send = can_send or 0
+            # apply extra penalty if we are close to known interval upper bound
+            if amount_msat >= fcan_send + 0.8 * (cannot_send - fcan_send):
+                likely_cannotsend_factor = 2
         success_fee = fee_for_edge_msat(amount_msat, DEFAULT_PENALTY_BASE_MSAT, DEFAULT_PENALTY_PROPORTIONAL_MILLIONTH)
-        inflight_htlc_fee = num_inflight_htlcs * success_fee
-        return success_fee + inflight_htlc_fee
+        return success_fee * (1 + num_inflight_htlcs + likely_cannotsend_factor)
 
     @with_lock
     def reset_liquidity_hints(self):


### PR DESCRIPTION
We guide LNPathFinder away from channels where there is a known cannot_send amount just barely above the HTLC value.

Somewhat follows 6a97e74ce82b9e2055b1ccf31f43288c9becfa02, as before that commit, we were often (unintentionally) blacklisting chans with liquidity failures but now we allow retrying them. Without current change, the liqudity-based penalty would disallow sending an HTLC over the the known "cannot_send" but it would basically not distinguish between 0.999*cannot_send and 0.

Instead, just as a completely naive bandaid, I propose penalising HTLC values greater than 80% of the known cannot_send.