### PR TITLE
android service onchain monitoring watched addresses/outpoints

### DIFF
--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -101,7 +101,7 @@ fullscreen = False
 #
 
 # (list) Permissions
-android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE, POST_NOTIFICATIONS, USE_BIOMETRIC
+android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE, POST_NOTIFICATIONS, USE_BIOMETRIC, FOREGROUND_SERVICE, REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
 
 # (int) Android API to use  (compileSdkVersion)
 # note: when changing, Dockerfile also needs to be changed to install corresponding build tools
@@ -162,13 +162,19 @@ android.add_aars =
     contrib/android/.cache/aars/zxing-cpp.aar
 
 
+# (list) p4a services (NAME:entrypoint.py[:foreground][:sticky]).
+# Started hourly by org.electrum.worker.ElectrumWorker via WorkManager.
+services = Chainwatch:electrum/gui/qml/service/chainwatch_service.py:foreground
+
 # (list) List of Java files to add to the android project (can be java or a
 # directory containing the files)
 android.add_src = electrum/gui/qml/java_classes/
 
 # kotlin-stdlib is required for zxing-cpp (BarcodeScannerView)
+# work-runtime provides WorkManager (periodic scheduling for Chainwatch)
 android.gradle_dependencies =
     androidx.core:core:1.16.0,
+    androidx.work:work-runtime:2.9.1,
     org.jetbrains.kotlin:kotlin-stdlib:1.8.22
 
 android.add_activities = org.electrum.qr.SimpleScannerActivity, org.electrum.biometry.BiometricActivity
@@ -183,7 +189,7 @@ android.add_activities = org.electrum.qr.SimpleScannerActivity, org.electrum.bio
 # 3) A directory, here 'legal_resources' must contain one or more directories,
 # each of a resource kind:  drawable, xml, etc...
 # android.add_resources = legal_resources
-android.add_resources = electrum/gui/qml/android_res/layout:layout
+android.add_resources = electrum/gui/qml/android_res/layout:layout, electrum/gui/icons/electrum_light_icon.png:drawable
 
 # (str) python-for-android branch to use, if not master, useful to try
 # not yet merged features.

--- a/electrum/gui/qml/__init__.py
+++ b/electrum/gui/qml/__init__.py
@@ -98,6 +98,16 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.timer.start()
         signal.signal(signal.SIGINT, lambda *args: self._handle_sigint())
 
+        # Starting ChainwatchService from the background needs the app to be on
+        # the battery-optimization allowlist (Android 12+ FGS-start rule).
+        # Ask at most once; the method no-ops if already allowlisted.
+        try:
+            if not self.config.WALLET_ANDROID_BATTERY_OPTIMIZATION_PROMPTED:
+                self.app.appController.requestIgnoreBatteryOptimizations()
+                self.config.WALLET_ANDROID_BATTERY_OPTIMIZATION_PROMPTED = True
+        except Exception as e:
+            self.logger.warning(f'could not prompt battery optimization exemption: {e!r}')
+
         # schedule the hourly background "Chainwatch" service (Android only; no-op elsewhere)
         from .service.chainwatch import schedule_chainwatch
         try:

--- a/electrum/gui/qml/__init__.py
+++ b/electrum/gui/qml/__init__.py
@@ -98,6 +98,21 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.timer.start()
         signal.signal(signal.SIGINT, lambda *args: self._handle_sigint())
 
+        # schedule the hourly background "Chainwatch" service (Android only; no-op elsewhere)
+        from .service.chainwatch import schedule_chainwatch
+        try:
+            schedule_chainwatch()
+        except Exception as e:
+            self.logger.warning(f'could not schedule chainwatch: {e!r}')
+
+        # # DEBUG: fire one immediate run so the worker/service is observable
+        # # without waiting for the hourly period. uncomment to debug on startup.
+        # from .service.chainwatch import run_chainwatch_now
+        # try:
+        #     run_chainwatch_now()
+        # except Exception as e:
+        #     self.logger.warning(f'could not run chainwatch now: {e!r}')
+
         self.logger.info('Entering main loop')
         self.app.exec()
 

--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -560,9 +560,14 @@ ApplicationWindow
                 })
                 dialog.open()
             } else {
+                console.log('Starting network and load wallet if available')
                 Daemon.startNetwork()
                 if (Daemon.availableWallets.rowCount() > 0) {
-                    Daemon.loadWallet()
+                    if (AppController.getIntentRequestedWallet()) {
+                        Daemon.loadWallet(AppController.getIntentRequestedWallet())
+                    } else {
+                        Daemon.loadWallet()
+                    }
                 } else {
                     var newww = app.newWalletWizard.createObject(app)
                     newww.walletCreated.connect(function() {
@@ -772,6 +777,10 @@ ApplicationWindow
         function onUriReceived(uri) {
             console.log('uri received (main): ' + uri)
             app.pendingIntent = uri
+        }
+        function onLoadWalletRequested(wname) {
+            console.log('onLoadWalletRequested: ', wname)
+            Daemon.loadWallet(wname)
         }
     }
 

--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -560,9 +560,14 @@ ApplicationWindow
                 })
                 dialog.open()
             } else {
+                console.log('Starting network and load wallet if available')
                 Daemon.startNetwork()
                 if (Daemon.availableWallets.rowCount() > 0) {
-                    Daemon.loadWallet()
+                    if (AppController.getIntentRequestedWallet()) {
+                        Daemon.loadWallet(AppController.getIntentRequestedWallet())
+                    } else {
+                        Daemon.loadWallet()
+                    }
                 } else {
                     var newww = app.newWalletWizard.createObject(app)
                     newww.walletCreated.connect(function() {
@@ -774,6 +779,10 @@ ApplicationWindow
         function onUriReceived(uri) {
             console.log('uri received (main): ' + uri)
             app.pendingIntent = uri
+        }
+        function onLoadWalletRequested(wname) {
+            console.log('onLoadWalletRequested: ', wname)
+            Daemon.loadWallet(wname)
         }
     }
 

--- a/electrum/gui/qml/java_classes/org/electrum/worker/ElectrumWorker.java
+++ b/electrum/gui/qml/java_classes/org/electrum/worker/ElectrumWorker.java
@@ -1,0 +1,74 @@
+package org.electrum.worker;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import p4a.services.ServiceChainwatch;
+
+/**
+ * Periodic worker that wakes up on WorkManager's schedule (see the enqueue in
+ * chainwatch.py) and hands off to the p4a Python service ServiceChainwatch.
+ */
+public class ElectrumWorker extends Worker {
+    private static final String TAG = "ElectrumWorker";
+
+    public ElectrumWorker(@NonNull Context ctx, @NonNull WorkerParameters params) {
+        super(ctx, params);
+        Log.i(TAG, "constructed: id=" + params.getId()
+                + " runAttempt=" + params.getRunAttemptCount()
+                + " tags=" + params.getTags());
+    }
+
+    @Override
+    public @NonNull Result doWork() {
+        Log.i(TAG, "doWork() ENTER"
+                + " id=" + getId()
+                + " runAttempt=" + getRunAttemptCount()
+                + " isStopped=" + isStopped()
+                + " thread=" + Thread.currentThread().getName()
+                + " process.pid=" + android.os.Process.myPid());
+
+        Context ctx = getApplicationContext();
+        Intent intent;
+        try {
+            // Reuse p4a's fully-populated intent: it sets serviceEntrypoint,
+            // pythonHome/pythonPath, serviceStartAsForeground and the
+            // pythonServiceArgument extra.
+            intent = ServiceChainwatch.getDefaultIntent(
+                    ctx, "", "Electrum", "Chainwatch", "hourly-peek");
+        } catch (Throwable t) {
+            Log.e(TAG, "failed to build ServiceChainwatch intent", t);
+            return Result.failure();
+        }
+
+        try {
+            // The generated ServiceChainwatch.start() uses plain startService(),
+            // which throws IllegalStateException from the background; call
+            // startForegroundService() ourselves. Requires the service to
+            // be declared `:foreground` so it calls startForeground()
+            // within ~5s (else ForegroundServiceDidNotStartInTimeException).
+            Log.i(TAG, "startForegroundService(ServiceChainwatch)...");
+            ctx.startForegroundService(intent);
+            Log.i(TAG, "service start dispatched OK");
+        } catch (Throwable t) {
+            Log.e(TAG, "failed to start ServiceChainwatch; will retry", t);
+            return Result.retry();
+        }
+
+        Log.i(TAG, "doWork() EXIT -> success");
+        return Result.success();
+    }
+
+    @Override
+    public void onStopped() {
+        super.onStopped();
+        Log.w(TAG, "onStopped(): worker was cancelled/preempted"
+                + " id=" + getId() + " runAttempt=" + getRunAttemptCount());
+    }
+}

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -81,6 +81,7 @@ class QEAppController(BaseCrashReporter, QObject):
     wantCloseChanged = pyqtSignal()
     pluginLoaded = pyqtSignal(str)
     startupFinished = pyqtSignal()
+    loadWalletRequested = pyqtSignal(str, arguments=['wallet_name'])
 
     def __init__(self, qeapp: 'ElectrumQmlApplication', plugins: 'Plugins'):
         BaseCrashReporter.__init__(self, None, None, None)
@@ -94,6 +95,8 @@ class QEAppController(BaseCrashReporter, QObject):
         self._app_started = False
         self._intent = ''
         self._secureWindow = False
+
+        self._intent_requested_wallet = ''
 
         # map of permissions and grant status _after_ asking user
         self._permissions = {}  # type: dict[str, bool]
@@ -258,8 +261,19 @@ class QEAppController(BaseCrashReporter, QObject):
         jpythonActivity.startActivity(intent)
 
     def on_new_intent(self, intent):
+        intent_requested_wallets = self._chainwatch_wallets_from_intent(intent)
         if not self._app_started:
-            self._intent = intent
+            # store requested wallet name on cold start
+            if intent_requested_wallets:
+                self._intent_requested_wallet = intent_requested_wallets[0]
+            else:
+                self._intent = intent
+                self.logger.info(f'new intent stashed for later')
+            return
+
+        if intent_requested_wallets:
+            self._intent_requested_wallet = intent_requested_wallets[0]
+            self.loadWalletRequested.emit(self._intent_requested_wallet)
             return
 
         data = str(intent.getDataString())
@@ -270,7 +284,22 @@ class QEAppController(BaseCrashReporter, QObject):
                 or scheme in SUPPORTED_LNURL_SCHEMES:
             self.uriReceived.emit(data)
 
+    def _chainwatch_wallets_from_intent(self, intent) -> List[str]:
+        """Read the `chainwatch_wallets` string-array extra as a python list.
+        """
+        try:
+            jlist = intent.getStringArrayListExtra(jString("chainwatch_wallets"))
+            return [str(jlist.get(i)) for i in range(jlist.size())] if jlist else []
+        except Exception as e:
+            self.logger.error(f'could not read chainwatch_wallets extra: {repr(e)}')
+            return []
+
+    @pyqtSlot(result=str)
+    def getIntentRequestedWallet(self) -> str:
+        return self._intent_requested_wallet
+
     def startup_finished(self):
+        self.logger.info('GUI startup finished')
         self._app_started = True
         self.startupFinished.emit()
         for plugin_name in self._plugins.plugins.keys():

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -289,7 +289,11 @@ class QEAppController(BaseCrashReporter, QObject):
         """
         try:
             jlist = intent.getStringArrayListExtra(jString("chainwatch_wallets"))
-            return [str(jlist.get(i)) for i in range(jlist.size())] if jlist else []
+            wallets = [str(jlist.get(i)) for i in range(jlist.size())] if jlist else []
+            if any([wallet != os.path.basename(wallet) for wallet in wallets]):
+                # avoid confused-deputy, ignore if any wallet is passed as (abs/rel) path instead of wallet name
+                wallets = []
+            return wallets
         except Exception as e:
             self.logger.error(f'could not read chainwatch_wallets extra: {repr(e)}')
             return []

--- a/electrum/gui/qml/qeapp.py
+++ b/electrum/gui/qml/qeapp.py
@@ -228,6 +228,35 @@ class QEAppController(BaseCrashReporter, QObject):
         if permission_result_cb:
             permission_result_cb(grant_result)
 
+    @pyqtSlot(result=bool)
+    def hasBatteryOptimizationExemption(self) -> bool:
+        # Whether the app is on the battery-optimization allowlist, which is
+        # required to start ChainwatchService from the background (Android 12+
+        # FGS-start rule). NOTE: this is not a runtime permission -
+        # checkSelfPermission(REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) is always
+        # granted; only PowerManager reflects the real allowlist state.
+        if not self.isAndroid():
+            return True
+        Context = autoclass('android.content.Context')
+        pm = cast('android.os.PowerManager',
+                  jpythonActivity.getSystemService(Context.POWER_SERVICE))
+        return pm.isIgnoringBatteryOptimizations(jpythonActivity.getPackageName())
+
+    @pyqtSlot()
+    def requestIgnoreBatteryOptimizations(self):
+        # Prompt the user (one-tap system dialog) to allowlist the app. No-op if
+        # already allowlisted. Requires the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+        # permission. This is a Settings action, not a requestPermissions() flow.
+        if not self.isAndroid():
+            return
+        if self.hasBatteryOptimizationExemption():
+            return
+        Settings = autoclass('android.provider.Settings')
+        Uri = autoclass('android.net.Uri')
+        intent = jIntent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+        intent.setData(Uri.parse("package:" + jpythonActivity.getPackageName()))
+        jpythonActivity.startActivity(intent)
+
     def on_new_intent(self, intent):
         if not self._app_started:
             self._intent = intent

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -192,6 +192,9 @@ class QEDaemon(AuthMixin, QObject, QtEventListener):
             if self._path is None:
                 self._path = self.daemon.config.CURRENT_WALLET
         else:
+            # wallet name -> wallet path
+            if path == os.path.basename(path):
+                path = os.path.join(self.daemon.config.get_datadir_wallet_path(), path)
             self._path = path
         if self._path is None:
             self._loading = False

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -184,6 +184,9 @@ class QEDaemon(AuthMixin, QObject, QtEventListener):
             if self._path is None:
                 self._path = self.daemon.config.CURRENT_WALLET
         else:
+            # wallet name -> wallet path
+            if path == os.path.basename(path):
+                path = os.path.join(self.daemon.config.get_datadir_wallet_path(), path)
             self._path = path
         if self._path is None:
             self._loading = False

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -8,7 +8,8 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 
 from electrum.i18n import _
 from electrum.logging import get_logger
-from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, write_json_file, read_json_file
+from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, \
+    write_json_file, read_json_file, FileImportFailed
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.bitcoin import is_address
@@ -556,7 +557,10 @@ class QEDaemon(AuthMixin, QObject, QtEventListener):
         path = self.watched_items_path()
         data = {}
         if os.path.exists(path):
-            data = read_json_file(path)
+            try:
+                data = read_json_file(path)
+            except FileImportFailed:
+                pass  # corrupt, start from scratch, will be eventually correct.
         data.update(self.get_watched_items_by_wallet())
         # prune wallets with no watched items (e.g. dormant/closed channels)
         data = {name: items for name, items in data.items() if items}

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -9,7 +9,7 @@ from electrum.i18n import _
 from electrum.logging import get_logger
 from electrum.util import (
     WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, UserFacingException,
-    write_json_file, read_json_file
+    write_json_file, read_json_file, FileImportFailed
 )
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
@@ -561,7 +561,10 @@ class QEDaemon(AuthMixin, QObject, QtEventListener):
         path = self.watched_items_path()
         data = {}
         if os.path.exists(path):
-            data = read_json_file(path)
+            try:
+                data = read_json_file(path)
+            except FileImportFailed:
+                pass  # corrupt, start from scratch, will be eventually correct.
         data.update(self.get_watched_items_by_wallet())
         # prune wallets with no watched items (e.g. dormant/closed channels)
         data = {name: items for name, items in data.items() if items}

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -8,12 +8,13 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 
 from electrum.i18n import _
 from electrum.logging import get_logger
-from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter
+from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, write_json_file, read_json_file
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.bitcoin import is_address
 from electrum.bitcoin import verify_usermessage_with_address
 from electrum.storage import StorageReadWriteError, WalletStorage
+from electrum.gui.common_qt.util import QtEventListener, qt_event_listener
 
 from .auth import AuthMixin, auth_protect
 from .qefx import QEFX
@@ -120,7 +121,7 @@ class QEWalletListModel(QAbstractListModel):
             i += 1
 
 
-class QEDaemon(AuthMixin, QObject):
+class QEDaemon(AuthMixin, QObject, QtEventListener):
     instance = None  # type: Optional[QEDaemon]
 
     _logger = get_logger(__name__)
@@ -162,6 +163,7 @@ class QEDaemon(AuthMixin, QObject):
         self.qefx = QEFX(daemon.fx, daemon.config)
 
         self._backendWalletLoaded.connect(self._on_backend_wallet_loaded)
+        self.register_callbacks()
 
     @pyqtSlot()
     def passwordValidityCheck(self):
@@ -274,6 +276,7 @@ class QEDaemon(AuthMixin, QObject):
         self._loading = False
         self.loadingChanged.emit()
         self.walletLoaded.emit(self._name, self._path)
+        self.export_watched_items()
 
     @pyqtSlot(QEWallet)
     @pyqtSlot(QEWallet, bool)
@@ -513,3 +516,48 @@ class QEDaemon(AuthMixin, QObject):
         if len(password) == 0:
             return 0
         return check_password_strength(password)[0]
+
+    def get_watched_items_by_wallet(self) -> dict:
+        """Collect the watched addresses/outpoints of every loaded wallet,
+        keyed by wallet name."""
+        result = {}
+        for wallet in self.daemon.get_wallets().values():
+            result[wallet.basename()] = [
+                {
+                    'type': item.type,
+                    'outpoint': item.outpoint,
+                    'address': item.address,
+                    'depth': item.depth,  # min confirmations to trigger (0 = mempool/seen)
+                }
+                for item in wallet.get_watched_addresses_and_outpoints()
+            ]
+        return result
+
+    @qt_event_listener
+    def on_event_request_status(self, wallet, key, status):
+        # a payment request was added or paid; keep the export in sync.
+        # note: passive expiry does not fire an event, but expired requests are
+        # filtered out on the next export anyway (added/paid/wallet-load).
+        self.export_watched_items()
+
+    def watched_items_path(self) -> str:
+        return os.path.join(self.daemon.config.path, 'watched_items.json')
+
+    def export_watched_items(self):
+        """Serialize the watched items of all loaded wallets into a single
+        JSON file, keyed by wallet name.
+
+        Existing entries are read first and merged, so wallets that are not
+        currently loaded keep their previously exported watched items instead of
+        being dropped. (On android basenames are unique, so keys cannot collide.)
+        """
+        if 'ANDROID_DATA' not in os.environ:
+            return
+        path = self.watched_items_path()
+        data = {}
+        if os.path.exists(path):
+            data = read_json_file(path)
+        data.update(self.get_watched_items_by_wallet())
+        # prune wallets with no watched items (e.g. dormant/closed channels)
+        data = {name: items for name, items in data.items() if items}
+        write_json_file(path, data)

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -9,11 +9,13 @@ from electrum.i18n import _
 from electrum.logging import get_logger
 from electrum.util import (
     WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, UserFacingException,
+    write_json_file, read_json_file
 )
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.storage import StorageReadWriteError, WalletStorage
 from electrum.wallet import Abstract_Wallet
+from electrum.gui.common_qt.util import QtEventListener, qt_event_listener
 
 from .auth import AuthMixin, auth_protect
 from .qefx import QEFX
@@ -127,7 +129,7 @@ class QEWalletListModel(QAbstractListModel):
             i += 1
 
 
-class QEDaemon(AuthMixin, QObject):
+class QEDaemon(AuthMixin, QObject, QtEventListener):
     instance = None  # type: Optional[QEDaemon]
 
     _logger = get_logger(__name__)
@@ -170,6 +172,7 @@ class QEDaemon(AuthMixin, QObject):
         self.qefx = QEFX(daemon.fx, daemon.config)
 
         self._backendWalletLoaded.connect(self._on_backend_wallet_loaded)
+        self.register_callbacks()
 
     @pyqtSlot()
     def passwordValidityCheck(self):
@@ -282,6 +285,7 @@ class QEDaemon(AuthMixin, QObject):
         self._loading = False
         self.loadingChanged.emit()
         self.walletLoaded.emit(self._name, self._path)
+        self.export_watched_items()
 
     @pyqtSlot(QEWallet)
     @pyqtSlot(QEWallet, bool)
@@ -517,3 +521,48 @@ class QEDaemon(AuthMixin, QObject):
         if len(password) == 0:
             return 0
         return check_password_strength(password)[0]
+
+    def get_watched_items_by_wallet(self) -> dict:
+        """Collect the watched addresses/outpoints of every loaded wallet,
+        keyed by wallet name."""
+        result = {}
+        for wallet in self.daemon.get_wallets().values():
+            result[wallet.basename()] = [
+                {
+                    'type': item.type,
+                    'outpoint': item.outpoint,
+                    'address': item.address,
+                    'depth': item.depth,  # min confirmations to trigger (0 = mempool/seen)
+                }
+                for item in wallet.get_watched_addresses_and_outpoints()
+            ]
+        return result
+
+    @qt_event_listener
+    def on_event_request_status(self, wallet, key, status):
+        # a payment request was added or paid; keep the export in sync.
+        # note: passive expiry does not fire an event, but expired requests are
+        # filtered out on the next export anyway (added/paid/wallet-load).
+        self.export_watched_items()
+
+    def watched_items_path(self) -> str:
+        return os.path.join(self.daemon.config.path, 'watched_items.json')
+
+    def export_watched_items(self):
+        """Serialize the watched items of all loaded wallets into a single
+        JSON file, keyed by wallet name.
+
+        Existing entries are read first and merged, so wallets that are not
+        currently loaded keep their previously exported watched items instead of
+        being dropped. (On android basenames are unique, so keys cannot collide.)
+        """
+        if 'ANDROID_DATA' not in os.environ:
+            return
+        path = self.watched_items_path()
+        data = {}
+        if os.path.exists(path):
+            data = read_json_file(path)
+        data.update(self.get_watched_items_by_wallet())
+        # prune wallets with no watched items (e.g. dormant/closed channels)
+        data = {name: items for name, items in data.items() if items}
+        write_json_file(path, data)

--- a/electrum/gui/qml/service/chainwatch.py
+++ b/electrum/gui/qml/service/chainwatch.py
@@ -1,0 +1,98 @@
+# Scheduling helper for the "Chainwatch" background service.
+#
+# Registers a WorkManager PeriodicWorkRequest that fires ~hourly and survives
+# reboot (WorkManager reschedules; no BOOT_COMPLETED receiver
+# needed). The work is deferrable and inexact (batched, Doze-aware) and the minimum
+# periodic interval is 15 minutes. Requires the app to have been launched at
+# least once since install before it will run.
+#
+# Call schedule_chainwatch() once on Android during app startup for WorkManager
+# registration (idempotent via ExistingPeriodicWorkPolicy.KEEP).
+
+import os
+
+from electrum.logging import get_logger
+
+_logger = get_logger(__name__)
+
+UNIQUE_WORK_NAME = "electrum-chainwatch"
+
+
+def is_android():
+    return 'ANDROID_DATA' in os.environ
+
+
+def schedule_chainwatch():
+    if not is_android():
+        return
+    from jnius import autoclass, cast
+    PythonActivity = autoclass('org.kivy.android.PythonActivity')
+    context = PythonActivity.mActivity.getApplicationContext()
+
+    WorkManager = autoclass('androidx.work.WorkManager')
+    Builder = autoclass('androidx.work.PeriodicWorkRequest$Builder')
+    TimeUnit = autoclass('java.util.concurrent.TimeUnit')
+    Policy = autoclass('androidx.work.ExistingPeriodicWorkPolicy')
+    JClass = autoclass('java.lang.Class')
+
+    worker_cls = JClass.forName('org.electrum.worker.ElectrumWorker')
+    request = cast('androidx.work.PeriodicWorkRequest',
+                   Builder(worker_cls, 1, TimeUnit.HOURS).build())
+
+    WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+        UNIQUE_WORK_NAME, Policy.KEEP, request)
+    _logger.info(f'schedule_chainwatch: enqueued periodic work {UNIQUE_WORK_NAME!r}')
+
+
+def cancel_chainwatch():
+    if not is_android():
+        return
+    from jnius import autoclass
+    PythonActivity = autoclass('org.kivy.android.PythonActivity')
+    context = PythonActivity.mActivity.getApplicationContext()
+    WorkManager = autoclass('androidx.work.WorkManager')
+    WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
+
+
+def run_chainwatch_now():
+    """Debug: enqueue a OneTimeWorkRequest that runs ElectrumWorker immediately.
+
+    Unlike the periodic job, this has no timing gate, so it dispatches within
+    seconds of enqueue and is observable in logcat. Useful because
+    `cmd jobscheduler run` cannot force a WorkManager *periodic* job to run
+    early (WorkManager just reschedules on its own next-run time).
+    """
+    if not is_android():
+        _logger.info('run_chainwatch_now: not android, skipping')
+        return
+
+    DEBUG_WORK_TAG = "chainwatch-debug"
+
+    from jnius import autoclass
+    PythonActivity = autoclass('org.kivy.android.PythonActivity')
+    context = PythonActivity.mActivity.getApplicationContext()
+
+    WorkManager = autoclass('androidx.work.WorkManager')
+    Builder = autoclass('androidx.work.OneTimeWorkRequest$Builder')
+    JClass = autoclass('java.lang.Class')
+
+    worker_cls = JClass.forName('org.electrum.worker.ElectrumWorker')
+    # Tag it so we can read back the WorkInfo state and confirm WorkManager
+    # actually accepted (and is scheduling) the request.
+    request = Builder(worker_cls).addTag(DEBUG_WORK_TAG).build()
+
+    # getInstance() raises IllegalStateException if WorkManager was never
+    # initialized (e.g. its startup InitializationProvider got stripped from the
+    # merged manifest) - surface that clearly rather than as a generic failure.
+    wm = WorkManager.getInstance(context)
+    _logger.info('run_chainwatch_now: enqueueing OneTimeWorkRequest for ElectrumWorker')
+    wm.enqueue(request)
+
+    # Read back the state synchronously (ListenableFuture.get()) to prove the
+    # request landed: expect ENQUEUED here, transitioning to RUNNING/SUCCEEDED.
+    try:
+        infos = wm.getWorkInfosByTag(DEBUG_WORK_TAG).get()
+        states = [str(infos.get(i).getState()) for i in range(infos.size())]
+        _logger.info(f'run_chainwatch_now: enqueued OK, WorkInfo states={states}')
+    except Exception as e:
+        _logger.warning(f'run_chainwatch_now: enqueued, but reading WorkInfo failed: {e!r}')

--- a/electrum/gui/qml/service/chainwatch_service.py
+++ b/electrum/gui/qml/service/chainwatch_service.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# p4a service entry point for "Chainwatch". Launched by org.electrum.worker.ElectrumWorker
+# once per period.
+#
+# Declared in contrib/android/buildozer_qml.spec as:
+#   services = Chainwatch:electrum/gui/qml/service/chainwatch_service.py:foreground
+#
+# Runs in a separate process with its own interpreter.
+# must exit / stopSelf() when done so the foreground notification clears.
+
+import os
+import sys
+
+
+def _bootstrap_syspath():
+    """Put the app bundle root and its packages/ dir on sys.path.
+
+    This entrypoint does NOT go through run_electrum, which is what normally
+    adds the top-level packages/ dir to sys.path.
+
+    TODO: collects using two strategies, probably one is sufficient
+    1. ask the Android service context for filesDir; typically /data/user/0/<pkg>/files/app.
+    2. resolve electrum's on-disk location via find_spec; typically /data/data/<pkg>/files/app.
+    """
+    roots = []
+    try:
+        from jnius import autoclass
+        svc = autoclass('org.kivy.android.PythonService').mService
+        roots.append(os.path.join(svc.getFilesDir().getPath(), 'app'))
+    except Exception:
+        pass
+    try:
+        import importlib.util
+        spec = importlib.util.find_spec('electrum')
+        if spec and spec.origin:  # .../app/electrum/__init__.py
+            roots.append(os.path.dirname(os.path.dirname(spec.origin)))
+    except Exception:
+        pass
+
+    for root in roots:
+        for p in (root, os.path.join(root, 'packages')):
+            if os.path.isdir(p) and p not in sys.path:
+                sys.path.insert(0, p)
+
+
+def _repair_ctypes_pythonapi():
+    """Repoint ctypes.pythonapi at libpython opened by name.
+
+    In a p4a *service* process ctypes.pythonapi (PyDLL(None) -> dlopen(NULL) ->
+    RTLD_DEFAULT) cannot resolve libpython's C-API symbols, because Android's
+    default/global symbol scope does not include the System.loadLibrary'd
+    libpython. Code that calls the Python C-API via ctypes.pythonapi then dies,
+    e.g. pycryptodome's buffer handling (Cryptodome/Util/_raw_api.py:
+    `ctypes.pythonapi.PyObject_GetBuffer`) raises
+    'AttributeError: undefined symbol: PyObject_GetBuffer', which surfaces as
+    crypto.py's "at least one of ('pycryptodomex', 'cryptography')".
+
+    libpython opened by name resolves those symbols fine (dlsym on its own
+    handle), so we swap pythonapi's handle for that one. Must run before the
+    first user of ctypes.pythonapi (i.e. before importing electrum).
+    """
+    import ctypes
+    try:
+        ver = f"{sys.version_info.major}.{sys.version_info.minor}"
+        libpy = ctypes.CDLL(f"libpython{ver}.so")
+        ctypes.cast(libpy.PyObject_GetBuffer, ctypes.c_void_p)  # sanity check
+        ctypes.pythonapi._handle = libpy._handle
+    except Exception:
+        pass
+
+
+_bootstrap_syspath()
+_repair_ctypes_pythonapi()
+
+CHANNEL_ID = "electrum_chainwatch"
+CHANNEL_NAME = "Chainwatch"
+NOTIFICATION_ID = 4711
+
+
+def _stop_self():
+    """Stop the Android foreground service so its notification is dismissed."""
+    try:
+        from jnius import autoclass
+        PythonService = autoclass('org.kivy.android.PythonService')
+        PythonService.mService.stopSelf()
+    except Exception:
+        pass
+
+
+def _notify(title, text):
+    """Post a notification whose tap target opens the app.
+
+    The activity is launched by the OS when the user taps (via the
+    PendingIntent), so it sidesteps the Background-Activity-Launch restriction.
+    Extras are readable from the QML side after PythonActivity is (re)started.
+    """
+    from jnius import autoclass, cast
+    PythonService = autoclass('org.kivy.android.PythonService')
+    PythonActivity = autoclass('org.kivy.android.PythonActivity')
+    Context = autoclass('android.content.Context')
+    Intent = autoclass('android.content.Intent')
+    PendingIntent = autoclass('android.app.PendingIntent')
+    NotificationBuilder = autoclass('android.app.Notification$Builder')
+    NotificationManager = autoclass('android.app.NotificationManager')
+    NotificationChannel = autoclass('android.app.NotificationChannel')
+    String = autoclass('java.lang.String')
+
+    service = PythonService.mService
+    nm = cast('android.app.NotificationManager',
+              service.getSystemService(Context.NOTIFICATION_SERVICE))
+
+    channel = NotificationChannel(
+        CHANNEL_ID, cast('java.lang.CharSequence', String(CHANNEL_NAME)),
+        NotificationManager.IMPORTANCE_DEFAULT)
+    nm.createNotificationChannel(channel)
+
+    # Tap target: (re)open the app.
+    intent = Intent(service, PythonActivity)
+    intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK)
+    intent.putExtra("chainwatch", String(text))
+    pi = PendingIntent.getActivity(
+        service, 0, intent,
+        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE)
+
+    builder = NotificationBuilder(service, CHANNEL_ID)
+    builder.setContentTitle(cast('java.lang.CharSequence', String(title)))
+    builder.setContentText(cast('java.lang.CharSequence', String(text)))
+    builder.setContentIntent(pi)
+    builder.setAutoCancel(True)
+
+    # electrum_light_icon.png is packaged into res/drawable via
+    # `android.add_resources` in buildozer_qml.spec; resolve its id by name so
+    # we don't need a generated R reference. Note: the system renders the small
+    # icon as a tinted alpha silhouette, not the full-color image.
+    icon_id = service.getResources().getIdentifier(
+        "electrum_light_icon", "drawable", service.getPackageName())
+    if icon_id == 0:  # not packaged/renamed as expected: fall back to app icon
+        icon_id = service.getApplicationInfo().icon
+    builder.setSmallIcon(icon_id)
+
+    nm.notify(NOTIFICATION_ID, builder.build())
+
+
+def _build_config():
+    """Build the SimpleConfig for this service process and select the chain.
+    """
+    from jnius import autoclass
+    from electrum import constants
+    from electrum.simple_config import SimpleConfig
+
+    service = autoclass('org.kivy.android.PythonService').mService
+    pkgname = str(service.getPackageName())
+    data_dir = service.getFilesDir().getPath() + '/data'
+
+    # electrum_path pins the same data dir the GUI uses (avoids android_data_dir).
+    options = {'electrum_path': data_dir}
+    # mirror SimpleConfig.set_chain_config_opt_based_on_android_packagename(),
+    # which we can't call directly (it reads mActivity).
+    for chain in constants.NETS_LIST:
+        if pkgname == f"org.electrum.{chain.cli_flag()}.electrum":
+            options[chain.cli_flag()] = True
+
+    # reads the same user config the GUI uses, incl. server + proxy settings.
+    config = SimpleConfig(options)
+    # set the global constants.net (ports, genesis, default servers).
+    config.get_selected_chain().set_as_network()
+    return config
+
+
+def _fetch_chain_tip(config, timeout=45):
+    """Connect to the configured server and return the current chain-tip height.
+
+    Starts a private asyncio loop + Network and returns the height, or None on
+    failure/timeout. Bounded by `timeout` seconds.
+    """
+    import time
+    import asyncio
+    from electrum.network import Network
+    from electrum.util import create_and_start_event_loop
+
+    loop, stopping_fut, loop_thread = create_and_start_event_loop()
+    network = Network(config)
+    network.start()
+    try:
+        waited = 0.0
+        while not network.is_connected() and waited < timeout:
+            time.sleep(1.0)
+            waited += 1.0
+        if not network.is_connected():
+            return None
+        # server's claimed tip; fall back to the POW-verified local height
+        return network.get_server_height() or network.get_local_height()
+    finally:
+        # set_result must run on the loop thread; stop the network first so its
+        # tasks unwind cleanly before the loop is torn down.
+        try:
+            asyncio.run_coroutine_threadsafe(
+                network.stop(full_shutdown=True), loop).result(10)
+        except Exception:
+            pass
+        loop.call_soon_threadsafe(stopping_fut.set_result, 1)
+        while loop_thread.is_alive():
+            loop_thread.join(1)
+
+
+def main():
+    try:
+        config = _build_config()
+        height = _fetch_chain_tip(config)
+        if height:
+            _notify("Electrum", f"Current block height: {height:,}")
+        else:
+            _notify("Electrum", "Could not reach the Electrum server")
+    except Exception as e:
+        # p4a redirects stdout/stderr to logcat, so this makes failures of this
+        # otherwise-invisible background service debuggable.
+        import traceback
+        traceback.print_exc()
+        _notify("Electrum", f"Chainwatch failed: {e}")
+    finally:
+        # shortService: must stop well within ~3 min or the OS kills us
+        _stop_self()
+
+
+if __name__ == '__main__':
+    main()

--- a/electrum/gui/qml/service/chainwatch_service.py
+++ b/electrum/gui/qml/service/chainwatch_service.py
@@ -10,6 +10,10 @@
 
 import os
 import sys
+import time
+import asyncio
+from contextlib import contextmanager
+from typing import List
 
 
 def _bootstrap_syspath():
@@ -72,6 +76,16 @@ def _repair_ctypes_pythonapi():
 _bootstrap_syspath()
 _repair_ctypes_pythonapi()
 
+# electrum imports only AFTER the two calls above: _bootstrap_syspath() puts the
+# bundled packages/ dir (aiohttp etc.) on sys.path, and _repair_ctypes_pythonapi()
+# must run before electrum's crypto code first touches ctypes.pythonapi.
+from electrum.util import create_and_start_event_loop, read_json_file, write_json_file
+from electrum.bitcoin import address_to_scripthash, script_to_scripthash
+from electrum.transaction import Transaction
+from electrum.network import Network
+from electrum import constants
+from electrum.simple_config import SimpleConfig
+
 CHANNEL_ID = "electrum_chainwatch"
 CHANNEL_NAME = "Chainwatch"
 NOTIFICATION_ID = 4711
@@ -87,7 +101,7 @@ def _stop_self():
         pass
 
 
-def _notify(title, text):
+def _notify(title, text: str, wallets: List[str] = None):
     """Post a notification whose tap target opens the app.
 
     The activity is launched by the OS when the user taps (via the
@@ -104,6 +118,7 @@ def _notify(title, text):
     NotificationManager = autoclass('android.app.NotificationManager')
     NotificationChannel = autoclass('android.app.NotificationChannel')
     String = autoclass('java.lang.String')
+    ArrayList = autoclass('java.util.ArrayList')
 
     service = PythonService.mService
     nm = cast('android.app.NotificationManager',
@@ -117,7 +132,11 @@ def _notify(title, text):
     # Tap target: (re)open the app.
     intent = Intent(service, PythonActivity)
     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK)
-    intent.putExtra("chainwatch", String(text))
+    jWallets = ArrayList()
+    wallets = [] if wallets is None else wallets
+    for wallet in wallets:
+        jWallets.add(String(wallet))
+    intent.putStringArrayListExtra("chainwatch_wallets", jWallets)
     pi = PendingIntent.getActivity(
         service, 0, intent,
         PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE)
@@ -145,8 +164,6 @@ def _build_config():
     """Build the SimpleConfig for this service process and select the chain.
     """
     from jnius import autoclass
-    from electrum import constants
-    from electrum.simple_config import SimpleConfig
 
     service = autoclass('org.kivy.android.PythonService').mService
     pkgname = str(service.getPackageName())
@@ -167,17 +184,16 @@ def _build_config():
     return config
 
 
-def _fetch_chain_tip(config, timeout=45):
-    """Connect to the configured server and return the current chain-tip height.
+@contextmanager
+def _network_session(config, timeout=45):
+    """Start a private asyncio loop + Network and yield the connected Network.
 
-    Starts a private asyncio loop + Network and returns the height, or None on
-    failure/timeout. Bounded by `timeout` seconds.
+    Honors the config's server and proxy settings. Waits up to `timeout` seconds
+    for the initial connection; the yielded Network may still be disconnected if
+    the timeout elapsed, so callers should check `network.is_connected()`.
+    Guarantees the network is stopped and the loop torn down on exit, keeping the
+    service well under the shortService ~3-minute cap.
     """
-    import time
-    import asyncio
-    from electrum.network import Network
-    from electrum.util import create_and_start_event_loop
-
     loop, stopping_fut, loop_thread = create_and_start_event_loop()
     network = Network(config)
     network.start()
@@ -186,10 +202,7 @@ def _fetch_chain_tip(config, timeout=45):
         while not network.is_connected() and waited < timeout:
             time.sleep(1.0)
             waited += 1.0
-        if not network.is_connected():
-            return None
-        # server's claimed tip; fall back to the POW-verified local height
-        return network.get_server_height() or network.get_local_height()
+        yield network
     finally:
         # set_result must run on the loop thread; stop the network first so its
         # tasks unwind cleanly before the loop is torn down.
@@ -203,14 +216,199 @@ def _fetch_chain_tip(config, timeout=45):
             loop_thread.join(1)
 
 
+def _fetch_chain_tip(network):
+    """Return the current chain-tip height for a connected Network.
+    """
+    # server's claimed tip
+    return network.get_server_height()
+
+
+def _confirmations_for_height(height: int, tip: int) -> int:
+    """Actual confirmation depth of a tx given its server history height.
+
+    0 means unconfirmed/in mempool (also when our tip is unknown or behind, so
+    we never over-report). Server heights: >0 confirmed at that block; 0 or -1
+    unconfirmed (in mempool, possibly with an unconfirmed parent).
+    """
+    if height <= 0 or not tip:
+        return 0
+    return max(0, tip - height + 1)
+
+
+def _query_watched_items(network, config, tip, timeout=30):
+    """Read watched_items.json and query the server for the relevant event.
+
+    The GUI process exports the addresses/outpoints it wants watched to
+    <data_dir>/watched_items.json (see QEDaemon.export_watched_items), keyed by
+    wallet name. Detection differs by how the item is watched:
+
+    - address: *arrival* -- any tx paying the address' scripthash.
+    - outpoint: *spend* -- a tx whose input spends the specific outpoint
+
+    `txids` holds the tx(s) that constitute the event (the incoming payment(s),
+    or the single spending tx); it is empty when the event has not happened yet.
+    `confirmations` is the actual confirmation depth of that event (deepest
+    incoming tx for an address; the spending tx for an outpoint), 0 when
+    unconfirmed or nothing qualifies. The caller triggers once it is >= the
+    item's required depth.
+
+    Returns {wallet_name: [{'item': item, 'txids': [...], 'confirmations': n}, ...]}.
+    """
+
+    path = os.path.join(config.path, 'watched_items.json')
+    if not os.path.exists(path):
+        return {}
+    data = read_json_file(path)
+
+    def _get_tx(txid):
+        raw = network.run_from_another_thread(
+            network.get_transaction(txid), timeout=timeout)
+        return Transaction(raw)
+
+    def _history(sh):
+        return network.run_from_another_thread(
+            network.get_history_for_scripthash(sh), timeout=timeout)
+
+    def _query_address(address):
+        """Arrival detection: any history on the address' scripthash counts.
+        confirmations is the deepest incoming tx (max)."""
+        history = _history(address_to_scripthash(address))
+        txids = [h['tx_hash'] for h in history]
+        confirmations = max(
+            (_confirmations_for_height(h['height'], tip) for h in history),
+            default=0)
+        return txids, confirmations
+
+    def _query_outpoint(outpoint):
+        """Spend detection: find the tx that spends this specific outpoint.
+
+        The funding tx gives us the watched output's scriptpubkey -> scripthash;
+        its history contains the funder plus anything spending from that script.
+        A history tx spends our outpoint iff one of its inputs' prevout equals
+        txid:idx. An outpoint is spent at most once, so we stop at the first hit
+        and report that tx and its confirmations."""
+        fund_txid, idx = outpoint.split(':')
+        spk = _get_tx(fund_txid).outputs()[int(idx)].scriptpubkey
+        for h in _history(script_to_scripthash(spk)):
+            if h['tx_hash'] == fund_txid:
+                continue  # the funder itself cannot spend its own output
+            spender = _get_tx(h['tx_hash'])
+            if any(txin.prevout.to_str() == outpoint for txin in spender.inputs()):
+                return [h['tx_hash']], _confirmations_for_height(h['height'], tip)
+        return [], 0
+
+    result = {}
+    for wallet_name, items in data.items():
+        found = []
+        for item in items:
+            try:
+                if address := item.get('address'):
+                    txids, confirmations = _query_address(address)
+                elif outpoint := item.get('outpoint'):
+                    txids, confirmations = _query_outpoint(outpoint)
+                else:
+                    continue
+                found.append({
+                    'item': item,
+                    'txids': txids,
+                    'confirmations': confirmations,
+                })
+            except Exception:
+                import traceback
+                traceback.print_exc()
+        if found:
+            result[wallet_name] = found
+    return result
+
+
+def _describe_events(entries):
+    """Human-readable notification text summarizing the fired events by type.
+
+    Phrasing reflects what each WatchedItemType actually observed: a REQUEST
+    address received a payment, while a SWAP/LIGHTNING lockup outpoint was spent
+    (swap claim/refund, or channel close)."""
+    counts = {}
+    for e in entries:
+        t = e['item'].get('type') or 'unknown'
+        counts[t] = counts.get(t, 0) + 1
+    phrasing = {
+        'request': lambda n: f"{n} payment(s) received",
+        'swap': lambda n: f"{n} swap lockup(s) spent",
+        'lightning': lambda n: f"{n} channel(s) closed on-chain",
+    }
+    parts = [
+        phrasing.get(t, lambda n: f"{n} {t} event(s)")(n)
+        for t, n in counts.items()
+    ]
+    return "; ".join(parts)
+
+
+def _mark_notified(config, entries):
+    """Persist a `notified` flag onto the given watched items in watched_items.json.
+
+    We reuse the existing export file as our notify-once state store (no extra
+    file): the flag survives across the repeated background runs that happen
+    while the GUI is closed. When the GUI later re-exports a loaded wallet it
+    recomputes the list from scratch, dropping the flag -- which is harmless, as
+    a paid request drops out entirely and an app that's open won't spam anyway.
+
+    Best-effort: never raises.
+    """
+    try:
+        path = os.path.join(config.path, 'watched_items.json')
+        if not os.path.exists(path):
+            return
+        data = read_json_file(path)
+        keys = {(e['item'].get('address'), e['item'].get('outpoint')) for e in entries}
+        changed = False
+        for items in data.values():
+            for item in items:
+                if (item.get('address'), item.get('outpoint')) in keys and not item.get('notified'):
+                    item['notified'] = True
+                    changed = True
+        if changed:
+            write_json_file(path, data)
+    except Exception:
+        import traceback
+        traceback.print_exc()
+
+
 def main():
     try:
         config = _build_config()
-        height = _fetch_chain_tip(config)
-        if height:
-            _notify("Electrum", f"Current block height: {height:,}")
-        else:
-            _notify("Electrum", "Could not reach the Electrum server")
+        with _network_session(config) as network:
+            if not network.is_connected():
+                return
+            height = _fetch_chain_tip(network)
+            watched = _query_watched_items(network, config, height)
+            n_items = sum(len(items) for items in watched.values())
+            n_txids = sum(len(entry['txids']) for items in watched.values() for entry in items)
+            print(f"chainwatch: queried {n_items} watched item(s) across "
+                  f"{len(watched)} wallet(s); {n_txids} relevant tx(s) at {height=}")
+            # Every watched item is notified exactly once, and only once its tx
+            # has reached the item's required depth, i.e. its actual confirmation
+            # count is >= the item's `depth` (0 = trigger as soon as seen, even in
+            # mempool). An empty txids means the event (arrival / spend) has not
+            # happened yet.
+            def _required_depth(item):
+                try:
+                    return int(item.get('depth', 0))
+                except (TypeError, ValueError):
+                    return 0
+            fresh = [
+                entry
+                for items in watched.values() for entry in items
+                if entry['txids']
+                and entry['confirmations'] >= _required_depth(entry['item'])
+                and not entry['item'].get('notified')
+            ]
+            if fresh:
+                wallets = sorted({
+                    name for name, items in watched.items()
+                    if any(e in fresh for e in items)
+                })
+                _notify("Electrum", _describe_events(fresh), wallets)
+                _mark_notified(config, fresh)
     except Exception as e:
         # p4a redirects stdout/stderr to logcat, so this makes failures of this
         # otherwise-invisible background service debuggable.

--- a/electrum/gui/qml/service/chainwatch_service.py
+++ b/electrum/gui/qml/service/chainwatch_service.py
@@ -85,6 +85,7 @@ from electrum.transaction import Transaction
 from electrum.network import Network
 from electrum import constants
 from electrum.simple_config import SimpleConfig
+from electrum.i18n import _, set_language
 
 CHANNEL_ID = "electrum_chainwatch"
 CHANNEL_NAME = "Chainwatch"
@@ -179,6 +180,8 @@ def _build_config():
 
     # reads the same user config the GUI uses, incl. server + proxy settings.
     config = SimpleConfig(options)
+    # use proper translations (with the same language the GUI uses).
+    set_language(config.LOCALIZATION_LANGUAGE)
     # set the global constants.net (ports, genesis, default servers).
     config.get_selected_chain().set_as_network()
     return config
@@ -322,23 +325,25 @@ def _query_watched_items(network, config, tip, timeout=30):
 
 
 def _describe_events(entries):
-    """Human-readable notification text summarizing the fired events by type.
-
-    Phrasing reflects what each WatchedItemType actually observed: a REQUEST
-    address received a payment, while a SWAP/LIGHTNING lockup outpoint was spent
-    (swap claim/refund, or channel close)."""
+    """Human-readable notification text summarizing the fired events.
+    """
     counts = {}
     for e in entries:
-        t = e['item'].get('type') or 'unknown'
-        counts[t] = counts.get(t, 0) + 1
+        item = e['item']
+        t = item.get('type') or 'unknown'
+        how = 'address' if item.get('address') else 'outpoint'
+        key = (t, how)
+        counts[key] = counts.get(key, 0) + 1
     phrasing = {
-        'request': lambda n: f"{n} payment(s) received",
-        'swap': lambda n: f"{n} swap lockup(s) spent",
-        'lightning': lambda n: f"{n} channel(s) closed on-chain",
+        ('request', 'address'): lambda n: _("{} payment(s) received").format(n),
+        ('swap', 'address'): lambda n: _("{} swap(s) claimable").format(n),
+        ('swap', 'outpoint'): lambda n: _("{} swap lockup(s) spent").format(n),
+        ('lightning', 'address'): lambda n: _("{} force-close(s) matured").format(n),
+        ('lightning', 'outpoint'): lambda n: _("{} channel(s) closed on-chain").format(n),
     }
     parts = [
-        phrasing.get(t, lambda n: f"{n} {t} event(s)")(n)
-        for t, n in counts.items()
+        phrasing.get(key, lambda n, key=key: _("{count} {type} event(s)").format(count=n, type=key[0]))(n)
+        for key, n in counts.items()
     ]
     return "; ".join(parts)
 

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -684,6 +684,9 @@ class SimpleConfig(Logger):
     WALLET_ANDROID_BIOMETRIC_AUTH_ENCRYPTED_WRAP_KEY = ConfigVar('android_biometrics_encrypted_wrap_key', default='', type_=str)
     # this is the "unified wallet password", encrypted with the wrap key
     WALLET_ANDROID_BIOMETRIC_AUTH_WRAPPED_WALLET_PASSWORD = ConfigVar('android_biometrics_wrapped_wallet_password', default='', type_=str)
+    # whether we already prompted the user to allowlist the app from battery
+    # optimizations (needed for the background Chainwatch service); ask at most once
+    WALLET_ANDROID_BATTERY_OPTIMIZATION_PROMPTED = ConfigVar('android_battery_optimization_prompted', default=False, type_=bool)
     # note: 'use_change' and 'multiple_change' are per-wallet settings
     WALLET_SEND_CHANGE_TO_LIGHTNING = ConfigVar(
         'send_change_to_lightning', default=False, type_=bool,

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -699,6 +699,9 @@ class SimpleConfig(Logger):
     WALLET_ANDROID_BIOMETRIC_AUTH_ENCRYPTED_WRAP_KEY = ConfigVar('android_biometrics_encrypted_wrap_key', default='', type_=str)
     # this is the "unified wallet password", encrypted with the wrap key
     WALLET_ANDROID_BIOMETRIC_AUTH_WRAPPED_WALLET_PASSWORD = ConfigVar('android_biometrics_wrapped_wallet_password', default='', type_=str)
+    # whether we already prompted the user to allowlist the app from battery
+    # optimizations (needed for the background Chainwatch service); ask at most once
+    WALLET_ANDROID_BATTERY_OPTIMIZATION_PROMPTED = ConfigVar('android_battery_optimization_prompted', default=False, type_=bool)
     # note: 'use_change' and 'multiple_change' are per-wallet settings
     WALLET_SEND_CHANGE_TO_LIGHTNING = ConfigVar(
         'send_change_to_lightning', default=False, type_=bool,

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3132,6 +3132,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             self._requests_addr_to_key[addr].add(request_id)
         if write_to_disk:
             self.save_db()
+        util.trigger_callback('request_status', self, request_id, self.get_invoice_status(req))
         return request_id
 
     def delete_request(self, request_id, *, write_to_disk: bool = True):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1180,7 +1180,35 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             result.extend(self._get_lightning_forceclose_watched_items())
             result.extend(self._get_lightning_breach_watched_items())
             result.extend(self._get_reverse_swap_watched_items())
+            result.extend(self._get_forward_swap_watched_items())
 
+        return result
+
+    def _get_forward_swap_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems that alert when a forward swap's funding is claimed.
+        """
+        sm = self.lnworker.swap_manager
+        with sm.swaps_lock:
+            swaps = list(sm._swaps.values())
+        result = []  # type: List[WatchedItem]
+        for swap in swaps:
+            # forward swaps we have funded but not yet resolved (claimed/refunded)
+            if swap.is_reverse or swap.is_redeemed or swap.preimage or swap.spending_txid:
+                continue
+            if not swap.funding_txid:
+                continue
+            funding_tx = self.adb.get_transaction(swap.funding_txid)
+            if not funding_tx:
+                continue
+            idxs = funding_tx.get_output_idxs_from_address(swap.lockup_address)
+            if not idxs:
+                continue
+            outpoint = f"{swap.funding_txid}:{min(idxs)}"
+            result.append(WatchedItem(
+                depth=0,  # react the instant the server's claim (preimage reveal) is seen
+                type=WatchedItemType.SWAP,
+                outpoint=outpoint,
+            ))
         return result
 
     def _get_reverse_swap_watched_items(self) -> List['WatchedItem']:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1175,6 +1175,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             ))
 
         if self.has_lightning():
+            result.extend(self._get_lightning_forceclose_watched_items())
             result.extend(self._get_lightning_breach_watched_items())
 
         return result
@@ -1196,6 +1197,48 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 ))
             except Exception:
                 self.logger.exception(f"failed to build breach watched item for {chan.get_id_for_log()}")
+        return result
+
+    def _get_lightning_forceclose_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems for force-closed channels' time-locked outputs."""
+        from .lnsweep import SweepInfo
+        result = []  # type: List[WatchedItem]
+        for chan in self.lnworker.get_channel_objects().values():
+            try:
+                if chan.is_redeemed():
+                    continue  # fully swept long ago; nothing left to claim
+                funding_outpoint = chan.funding_outpoint.to_str()
+                closing_txid = self.adb.get_spender(funding_outpoint)
+                if not closing_txid:
+                    continue  # not closed (or closing tx still local/unconfirmed)
+                closing_tx = self.adb.get_transaction(closing_txid)
+                if not closing_tx:
+                    continue
+                _is_local_ctx, sweep_info_dict = chan.get_ctx_sweep_info(closing_tx)
+                for prevout, sweep_info in sweep_info_dict.items():
+                    # only CSV-delayed outputs we sweep ourselves (the to_local
+                    # output); skip anchors, and htlc/cltv outputs whose maturity
+                    # is an absolute height rather than a confirmation depth.
+                    if not isinstance(sweep_info, SweepInfo) or sweep_info.is_anchor():
+                        continue
+                    csv_delay = sweep_info.csv_delay
+                    if not csv_delay:
+                        continue
+                    if self.adb.get_spender(prevout):
+                        continue  # output already swept; no longer claimable
+                    prev_txid, prev_idx = prevout.split(':')
+                    if prev_txid != closing_txid:
+                        continue  # can only resolve an address for ctx outputs
+                    address = closing_tx.outputs()[int(prev_idx)].address
+                    if not address:
+                        continue
+                    result.append(WatchedItem(
+                        depth=csv_delay,  # claimable once the ctx is this deep
+                        type=WatchedItemType.LIGHTNING,
+                        address=address,
+                    ))
+            except Exception:
+                self.logger.exception(f"failed to build forceclose watched item for {chan.get_id_for_log()}")
         return result
 
     def get_spendable_coins(

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3146,6 +3146,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             self._requests_addr_to_key[addr].add(request_id)
         if write_to_disk:
             self.save_db()
+        util.trigger_callback('request_status', self, request_id, self.get_invoice_status(req))
         return request_id
 
     def delete_request(self, request_id, *, write_to_disk: bool = True):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1174,6 +1174,28 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 address=address,
             ))
 
+        if self.has_lightning():
+            result.extend(self._get_lightning_breach_watched_items())
+
+        return result
+
+    def _get_lightning_breach_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems that alert the instant a live channel is force-closed."""
+        result = []  # type: List[WatchedItem]
+        for chan in self.lnworker.channels.values():
+            try:
+                if not chan.is_funded() or chan.is_closed_or_closing():
+                    continue
+                funding_outpoint = chan.funding_outpoint.to_str()
+                if self.adb.get_spender(funding_outpoint):
+                    continue  # already spent on-chain; nothing left to race
+                result.append(WatchedItem(
+                    depth=0,  # alert the instant the force-close is seen (even in mempool)
+                    type=WatchedItemType.LIGHTNING,
+                    outpoint=funding_outpoint,
+                ))
+            except Exception:
+                self.logger.exception(f"failed to build breach watched item for {chan.get_id_for_log()}")
         return result
 
     def get_spendable_coins(

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1178,7 +1178,35 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             result.extend(self._get_lightning_forceclose_watched_items())
             result.extend(self._get_lightning_breach_watched_items())
             result.extend(self._get_reverse_swap_watched_items())
+            result.extend(self._get_forward_swap_watched_items())
 
+        return result
+
+    def _get_forward_swap_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems that alert when a forward swap's funding is claimed.
+        """
+        sm = self.lnworker.swap_manager
+        with sm.swaps_lock:
+            swaps = list(sm._swaps.values())
+        result = []  # type: List[WatchedItem]
+        for swap in swaps:
+            # forward swaps we have funded but not yet resolved (claimed/refunded)
+            if swap.is_reverse or swap.is_redeemed or swap.preimage or swap.spending_txid:
+                continue
+            if not swap.funding_txid:
+                continue
+            funding_tx = self.adb.get_transaction(swap.funding_txid)
+            if not funding_tx:
+                continue
+            idxs = funding_tx.get_output_idxs_from_address(swap.lockup_address)
+            if not idxs:
+                continue
+            outpoint = f"{swap.funding_txid}:{min(idxs)}"
+            result.append(WatchedItem(
+                depth=0,  # react the instant the server's claim (preimage reveal) is seen
+                type=WatchedItemType.SWAP,
+                outpoint=outpoint,
+            ))
         return result
 
     def _get_reverse_swap_watched_items(self) -> List['WatchedItem']:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1176,6 +1176,28 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 address=address,
             ))
 
+        if self.has_lightning():
+            result.extend(self._get_lightning_breach_watched_items())
+
+        return result
+
+    def _get_lightning_breach_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems that alert the instant a live channel is force-closed."""
+        result = []  # type: List[WatchedItem]
+        for chan in self.lnworker.channels.values():
+            try:
+                if not chan.is_funded() or chan.is_closed_or_closing():
+                    continue
+                funding_outpoint = chan.funding_outpoint.to_str()
+                if self.adb.get_spender(funding_outpoint):
+                    continue  # already spent on-chain; nothing left to race
+                result.append(WatchedItem(
+                    depth=0,  # alert the instant the force-close is seen (even in mempool)
+                    type=WatchedItemType.LIGHTNING,
+                    outpoint=funding_outpoint,
+                ))
+            except Exception:
+                self.logger.exception(f"failed to build breach watched item for {chan.get_id_for_log()}")
         return result
 
     def get_spendable_coins(

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1177,7 +1177,26 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if self.has_lightning():
             result.extend(self._get_lightning_forceclose_watched_items())
             result.extend(self._get_lightning_breach_watched_items())
+            result.extend(self._get_reverse_swap_watched_items())
 
+        return result
+
+    def _get_reverse_swap_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems for reverse swaps awaiting the confirmation we claim on.
+        """
+        sm = self.lnworker.swap_manager
+        with sm.swaps_lock:
+            swaps = list(sm._swaps.values())
+        result = []  # type: List[WatchedItem]
+        for swap in swaps:
+            # reverse swaps we have not yet claimed (spending_txid) or wound down
+            if not swap.is_reverse or swap.is_redeemed or swap.spending_txid:
+                continue
+            result.append(WatchedItem(
+                depth=1,  # claimable once the funding tx has 1 confirmation
+                type=WatchedItemType.SWAP,
+                address=swap.lockup_address,
+            ))
         return result
 
     def _get_lightning_breach_watched_items(self) -> List['WatchedItem']:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -359,6 +359,27 @@ class TxWalletDelta(NamedTuple):
     fee: Optional[int]
 
 
+class WatchedItemType(str, enum.Enum):
+    """What a WatchedItem is being watched for. str-mixed so members serialize
+    to their string value (e.g. in JSON) and compare equal to that string."""
+    REQUEST = 'request'      # a payment-request receive address
+    SWAP = 'swap'            # a submarine-swap funding/claim script
+    LIGHTNING = 'lightning'  # a lightning channel outpoint
+
+    def __str__(self):
+        return self.value
+
+
+class WatchedItem(NamedTuple):
+    # 'outpoint' and 'address' are an either/or: exactly one is set, the other is
+    # None. An item watches either a specific outpoint (for a spend) or an address
+    # (scripthash subscription), not both.
+    depth: int                              # min confirmations to trigger (0 = mempool/seen)
+    type: Optional[WatchedItemType] = None  # what kind of item this is
+    outpoint: Optional[str] = None          # "txid:idx"
+    address: Optional[str] = None           # scriptpubkey address
+
+
 class TxWalletDetails(NamedTuple):
     txid: Optional[str]
     status: str
@@ -1128,6 +1149,32 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if domain is None:
             domain = self.get_addresses()
         return self.adb.get_utxos(domain=domain, **kwargs)
+
+    def get_watched_addresses_and_outpoints(self) -> List['WatchedItem']:
+        """Enumerate the outpoints/addresses this wallet is interested in watching on-chain.
+
+        Only used on android, this feeds the background chain-watch service.
+
+        Returns a list of WatchedItem, one per watched item. 'outpoint' and
+        'address' are an either/or: exactly one of them is set per item (the other
+        is None). An item watches either a specific outpoint (for a spend) or an
+        address (scripthash subscription), not both.
+        """
+        result = []  # type: List[WatchedItem]
+
+        for req in self.get_unpaid_requests():
+            if self.get_invoice_status(req) == PR_EXPIRED:
+                continue
+            address = req.get_address()
+            if not address:
+                continue
+            result.append(WatchedItem(
+                depth=0,  # notify as soon as a payment is seen (even in mempool)
+                type=WatchedItemType.REQUEST,
+                address=address,
+            ))
+
+        return result
 
     def get_spendable_coins(
             self,

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1179,7 +1179,26 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if self.has_lightning():
             result.extend(self._get_lightning_forceclose_watched_items())
             result.extend(self._get_lightning_breach_watched_items())
+            result.extend(self._get_reverse_swap_watched_items())
 
+        return result
+
+    def _get_reverse_swap_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems for reverse swaps awaiting the confirmation we claim on.
+        """
+        sm = self.lnworker.swap_manager
+        with sm.swaps_lock:
+            swaps = list(sm._swaps.values())
+        result = []  # type: List[WatchedItem]
+        for swap in swaps:
+            # reverse swaps we have not yet claimed (spending_txid) or wound down
+            if not swap.is_reverse or swap.is_redeemed or swap.spending_txid:
+                continue
+            result.append(WatchedItem(
+                depth=1,  # claimable once the funding tx has 1 confirmation
+                type=WatchedItemType.SWAP,
+                address=swap.lockup_address,
+            ))
         return result
 
     def _get_lightning_breach_watched_items(self) -> List['WatchedItem']:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1177,6 +1177,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             ))
 
         if self.has_lightning():
+            result.extend(self._get_lightning_forceclose_watched_items())
             result.extend(self._get_lightning_breach_watched_items())
 
         return result
@@ -1198,6 +1199,48 @@ class Abstract_Wallet(ABC, Logger, EventListener):
                 ))
             except Exception:
                 self.logger.exception(f"failed to build breach watched item for {chan.get_id_for_log()}")
+        return result
+
+    def _get_lightning_forceclose_watched_items(self) -> List['WatchedItem']:
+        """WatchedItems for force-closed channels' time-locked outputs."""
+        from .lnsweep import SweepInfo
+        result = []  # type: List[WatchedItem]
+        for chan in self.lnworker.get_channel_objects().values():
+            try:
+                if chan.is_redeemed():
+                    continue  # fully swept long ago; nothing left to claim
+                funding_outpoint = chan.funding_outpoint.to_str()
+                closing_txid = self.adb.get_spender(funding_outpoint)
+                if not closing_txid:
+                    continue  # not closed (or closing tx still local/unconfirmed)
+                closing_tx = self.adb.get_transaction(closing_txid)
+                if not closing_tx:
+                    continue
+                _is_local_ctx, sweep_info_dict = chan.get_ctx_sweep_info(closing_tx)
+                for prevout, sweep_info in sweep_info_dict.items():
+                    # only CSV-delayed outputs we sweep ourselves (the to_local
+                    # output); skip anchors, and htlc/cltv outputs whose maturity
+                    # is an absolute height rather than a confirmation depth.
+                    if not isinstance(sweep_info, SweepInfo) or sweep_info.is_anchor():
+                        continue
+                    csv_delay = sweep_info.csv_delay
+                    if not csv_delay:
+                        continue
+                    if self.adb.get_spender(prevout):
+                        continue  # output already swept; no longer claimable
+                    prev_txid, prev_idx = prevout.split(':')
+                    if prev_txid != closing_txid:
+                        continue  # can only resolve an address for ctx outputs
+                    address = closing_tx.outputs()[int(prev_idx)].address
+                    if not address:
+                        continue
+                    result.append(WatchedItem(
+                        depth=csv_delay,  # claimable once the ctx is this deep
+                        type=WatchedItemType.LIGHTNING,
+                        address=address,
+                    ))
+            except Exception:
+                self.logger.exception(f"failed to build forceclose watched item for {chan.get_id_for_log()}")
         return result
 
     def get_spendable_coins(

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -361,6 +361,27 @@ class TxWalletDelta(NamedTuple):
     fee: Optional[int]
 
 
+class WatchedItemType(str, enum.Enum):
+    """What a WatchedItem is being watched for. str-mixed so members serialize
+    to their string value (e.g. in JSON) and compare equal to that string."""
+    REQUEST = 'request'      # a payment-request receive address
+    SWAP = 'swap'            # a submarine-swap funding/claim script
+    LIGHTNING = 'lightning'  # a lightning channel outpoint
+
+    def __str__(self):
+        return self.value
+
+
+class WatchedItem(NamedTuple):
+    # 'outpoint' and 'address' are an either/or: exactly one is set, the other is
+    # None. An item watches either a specific outpoint (for a spend) or an address
+    # (scripthash subscription), not both.
+    depth: int                              # min confirmations to trigger (0 = mempool/seen)
+    type: Optional[WatchedItemType] = None  # what kind of item this is
+    outpoint: Optional[str] = None          # "txid:idx"
+    address: Optional[str] = None           # scriptpubkey address
+
+
 class TxWalletDetails(NamedTuple):
     txid: Optional[str]
     status: str
@@ -1130,6 +1151,32 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if domain is None:
             domain = self.get_addresses()
         return self.adb.get_utxos(domain=domain, **kwargs)
+
+    def get_watched_addresses_and_outpoints(self) -> List['WatchedItem']:
+        """Enumerate the outpoints/addresses this wallet is interested in watching on-chain.
+
+        Only used on android, this feeds the background chain-watch service.
+
+        Returns a list of WatchedItem, one per watched item. 'outpoint' and
+        'address' are an either/or: exactly one of them is set per item (the other
+        is None). An item watches either a specific outpoint (for a spend) or an
+        address (scripthash subscription), not both.
+        """
+        result = []  # type: List[WatchedItem]
+
+        for req in self.get_unpaid_requests():
+            if self.get_invoice_status(req) == PR_EXPIRED:
+                continue
+            address = req.get_address()
+            if not address:
+                continue
+            result.append(WatchedItem(
+                depth=0,  # notify as soon as a payment is seen (even in mempool)
+                type=WatchedItemType.REQUEST,
+                address=address,
+            ))
+
+        return result
 
     def get_spendable_coins(
             self,


### PR DESCRIPTION
Background service for checking onchain addresses/outpoints. Runs once per hour through android's `PeriodicWorkRequest` (periodic work services need the least amount of permissions, execution can be delayed so it doesn't run *exactly* every interval, but can be minutes delayed)

Wallets register their objects of interest in a `json` file, which is read by the service. A notification is shown when conditions are met for address/outpoint. Tapping the notification will open the corresponding wallet.

TODOs
- [ ] background service runs also when app is open, should not emit notifications for wallets that are already open in the app
- [ ] notifications can pass multiple wallets to open, app only opens first