### PR TITLE
qml: strip whitespace from message before signing, as in qt gui

### DIFF
--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -846,6 +846,9 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     @pyqtSlot(str, str)
     @auth_protect(message=_("Sign message?"))
     def signMessage(self, address, message):
+        # strip, as in qt gui and in qml verifyMessage (see #4327)
+        address = address.strip()
+        message = message.strip()
         sig = self.wallet.sign_message(address, message, self.password)
         result = base64.b64encode(sig).decode('ascii')
         self.messageSigned.emit(result)


### PR DESCRIPTION
The qt gui strips leading/trailing whitespace from the message (and address) both when signing (`do_sign`) and when verifying (`do_verify`) in `main_window.py`. This behaviour was discussed in #4327 and kept as intended.

The qml gui already strips in `verifyMessage` (`qedaemon.py`), but not in `signMessage` (`qewallet.py`): a message with leading/trailing whitespace (e.g. a trailing newline) signed in the qml gui produces a signature that fails verification even in the same Sign/Verify dialog, and is inconsistent with the qt gui.

This PR strips address and message in `signMessage` too, replicating the qt gui behaviour.

**Note:** this PR takes the current gui behaviour (#4327) as given and just fixes the qml inconsistency. The complementary alternative #10788 removes the message trimming everywhere in the gui instead, aligning with Bitcoin Core (which does not trim, not even in its gui) and with the electrum CLI/RPC — in my opinion the better resolution of the two. The two PRs are mutually exclusive: whichever is preferred, the qml sign/verify asymmetry should not stay as it is.

Related: #4327
Related: https://github.com/btclib-org/btclib/issues/200

🤖 Generated with [Claude Code](https://claude.com/claude-code)