### PR TITLE
gui: don't strip whitespace from message when signing/verifying (match Bitcoin Core)

### DIFF
--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -506,7 +506,7 @@ class QEDaemon(AuthMixin, QObject):
     @pyqtSlot(str, str, str, result=bool)
     def verifyMessage(self, address, message, signature):
         address = address.strip()
-        message = message.strip().encode('utf-8')
+        message = message.encode('utf-8')
         if not is_address(address):
             return False
         try:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2131,7 +2131,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     @protected
     def do_sign(self, address, message, signature, password):
         address  = address.text().strip()
-        message = message.toPlainText().strip()
+        message = message.toPlainText()
         if not bitcoin.is_address(address):
             self.show_message(_('Invalid Bitcoin address.'))
             return
@@ -2159,7 +2159,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
     def do_verify(self, address, message, signature):
         address  = address.text().strip()
-        message = message.toPlainText().strip().encode('utf-8')
+        message = message.toPlainText().encode('utf-8')
         if not bitcoin.is_address(address):
             self.show_message(_('Invalid Bitcoin address.'))
             return


### PR DESCRIPTION
Complementary/alternative to #10787.

Currently the qt gui strips leading/trailing whitespace from the message both when signing (`do_sign`) and when verifying (`do_verify`), and the qml gui strips it when verifying (`verifyMessage`) — but, inconsistently, **not** when signing (`signMessage`): a message with a leading/trailing whitespace signed in the qml gui fails verification even in the same dialog. #10787 fixes that inconsistency by adding the strip to qml signing as well.

This PR proposes the opposite, and in my view better, resolution: **remove the message stripping everywhere in the gui**, so that the message is signed and verified exactly as provided. This matches:

- **Bitcoin Core**, which signs/verifies the message as-is — notably *also in its gui*: the Sign/Verify Message dialog ([`src/qt/signverifymessagedialog.cpp`](https://github.com/bitcoin/bitcoin/blob/master/src/qt/signverifymessagedialog.cpp)) passes the message from `toPlainText()` to `MessageSign`/`MessageVerify` without any trimming, so this is not a gui-vs-CLI convention but Core's behaviour everywhere;
- the **electrum CLI/RPC** commands `signmessage`/`verifymessage`, which do not strip either.

The stripping breaks interoperability for any message with leading/trailing whitespace (e.g. a trailing newline, easy to pick up on copy-paste): a signature produced by Bitcoin Core or by the electrum CLI over such a message fails verification in the electrum gui, and a gui signature does not verify elsewhere against the original message. It also means the signature does not commit to the exact text the user entered.

I am aware this was discussed in #4327 and rejected as wontfix at the time. However, the qml sign/verify asymmetry reported in #10787 shows how error-prone the trimming choice is in practice: the deviation from the as-is behaviour has to be re-implemented consistently in every sign *and* verify code path of every gui, and it was in fact missed in one of them. I'd argue that is evidence the trim is not an optimal choice, and that revisiting #4327 is warranted.

The address is still stripped: that is plain input sanitization which does not enter the signed payload.

If this approach is not shared, then at least the qml inconsistency should be fixed by merging #10787.

Related: #4327 (wontfix), #10787, https://github.com/btclib-org/btclib/issues/200

🤖 Generated with [Claude Code](https://claude.com/claude-code)