### PR TITLE
coldcard: fix get_soft_device_id() discarding its return value

### DIFF
--- a/electrum/plugins/coldcard/coldcard.py
+++ b/electrum/plugins/coldcard/coldcard.py
@@ -93,7 +93,7 @@ class CKCCClient(HardwareClientBase):
 
     def get_soft_device_id(self) -> Optional[str]:
         try:
-            super().get_soft_device_id()
+            return super().get_soft_device_id()
         except CCProtoError:
             return None
 


### PR DESCRIPTION
`CKCCClient.get_soft_device_id()` calls `super().get_soft_device_id()` but does not return its result, so it always returns `None`.

The override was added in 94a6f6cd0e257e5acfa499a8042b0374bf02dccf ("coldcard: don't raise when get_soft_device_id can't get xpub") to swallow the exception; the `return` was missing from the start. 6222b5ad400f34301c53b2d9a619114055af0381 only narrowed the caught exception type. It has been in releases since 4.5.0.

### Why it matters

`HardwareClientBase.get_soft_device_id()` returns the device root fingerprint, which is stored in the wallet file and used to re-identify the device across reconnects. Because the Coldcard override drops it:

- `Hardware_KeyStore.opportunistically_fill_in_missing_info_from_device()` never persists a `soft_device_id` for Coldcard keystores — the guard is `self.soft_device_id != client.get_soft_device_id()`, which is `None != None`, i.e. false.
- `Hardware_KeyStore.pairing_code()` therefore always returns `None`, so `DeviceMgr.client_by_pairing_code()` can never take its fast path and every lookup falls through to a full device scan.
- `DeviceMgr.select_device()` "method 1" (auto-select by `soft_device_id`) is unreachable for Coldcard, leaving auto-pairing to rely solely on an exact string match of the stored label (method 2).

When the stored label does not match what the device reports, auto-pairing fails. Since `Hardware_KeyStore.has_usable_connection_with_device()` calls `get_client(allow_user_interaction=False)`, that failure is silent: `select_device()` raises `CannotAutoSelectDevice`, `client_for_keystore()` swallows it, and the wallet reports the device as not connected without prompting the user. Pairing manually recovers the current session, but because `soft_device_id` still cannot be persisted, the next session starts from the same state.

### Reproduction

With an initialized Coldcard connected (Mk2, firmware 4.1.9) on 4.6.2, the other client methods work while this one returns `None` (fingerprint redacted):

```
client.label()              -> 'Coldcard 1234abcd'
client.is_initialized()     -> True
client.device_model_name()  -> 'Coldcard'
client.get_soft_device_id() -> None          # expected: the root fingerprint
```

### Fix

Return the value, as the original commit intended.
