### PR TITLE
wallet:  move checks for {sign,verify,encrypt,decrypt}_message from UIs to wallet.py

### DIFF
--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -918,7 +918,7 @@ class Commands(Logger):
             raise UserFacingException(f"address must be a str instead of {type(address)}")
         if not isinstance(message, str):
             raise UserFacingException(f"message must be a str instead of {type(message)}")
-        sig = wallet.sign_message(address, message, password)
+        sig = wallet.sign_message(address=address, message=message, password=password)
         return base64.b64encode(sig).decode('ascii')
 
     @command('')

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -925,12 +925,7 @@ class Commands(Logger):
         arg:str:message:Clear text message. Use quotes if it contains spaces.
         arg:str:signature:The signature, base64-encoded.
         """
-        try:
-            sig = base64.b64decode(signature, validate=True)
-        except binascii.Error:
-            return False
-        message = util.to_bytes(message)
-        return bitcoin.verify_usermessage_with_address(address, sig, message)
+        return Abstract_Wallet.verify_message(address=address, signature=signature, message=message)
 
     def _get_fee_policy(self, fee: str, feerate: str):
         if fee is not None and feerate is not None:
@@ -1236,7 +1231,7 @@ class Commands(Logger):
         try:
             message = to_bytes(message)
         except TypeError:
-            raise UserFacingException(f"message must be a string-like object instead of {repr(message)}")
+            raise UserFacingException(f"message must be a str instead of {repr(message)}")
         public_key = ecc.ECPubkey(bfh(pubkey))
         encrypted = crypto.ecies_encrypt_message(public_key, message)
         return encrypted.decode('utf-8')
@@ -1250,8 +1245,8 @@ class Commands(Logger):
         """
         if not is_hex_str(pubkey):
             raise UserFacingException(f"pubkey must be a hex string instead of {repr(pubkey)}")
-        if not isinstance(encrypted, (str, bytes, bytearray)):
-            raise UserFacingException(f"encrypted must be a string-like object instead of {repr(encrypted)}")
+        if not isinstance(encrypted, str):
+            raise UserFacingException(f"encrypted must be a str instead of {repr(encrypted)}")
         decrypted = wallet.decrypt_message(pubkey, encrypted, password)
         return decrypted.decode('utf-8')
 

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1226,15 +1226,7 @@ class Commands(Logger):
         arg:str:pubkey:Public key
         arg:str:message:Clear text message. Use quotes if it contains spaces.
         """
-        if not is_hex_str(pubkey):
-            raise UserFacingException(f"pubkey must be a hex string instead of {repr(pubkey)}")
-        try:
-            message = to_bytes(message)
-        except TypeError:
-            raise UserFacingException(f"message must be a str instead of {repr(message)}")
-        public_key = ecc.ECPubkey(bfh(pubkey))
-        encrypted = crypto.ecies_encrypt_message(public_key, message)
-        return encrypted.decode('utf-8')
+        return Abstract_Wallet.encrypt_message(pubkey=pubkey, message=message)
 
     @command('wp')
     async def decrypt(self, pubkey, encrypted, password=None, wallet: Abstract_Wallet = None) -> str:

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -1235,11 +1235,7 @@ class Commands(Logger):
         arg:str:encrypted:Encrypted message
         arg:str:pubkey:Public key of one of your wallet addresses
         """
-        if not is_hex_str(pubkey):
-            raise UserFacingException(f"pubkey must be a hex string instead of {repr(pubkey)}")
-        if not isinstance(encrypted, str):
-            raise UserFacingException(f"encrypted must be a str instead of {repr(encrypted)}")
-        decrypted = wallet.decrypt_message(pubkey, encrypted, password)
+        decrypted = wallet.decrypt_message(pubkey=pubkey, message=encrypted, password=password)
         return decrypted.decode('utf-8')
 
     @command('w')

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -914,6 +914,10 @@ class Commands(Logger):
         arg:str:address:Bitcoin address
         arg:str:message:Clear text message. Use quotes if it contains spaces.
         """
+        if not isinstance(address, str):
+            raise UserFacingException(f"address must be a str instead of {type(address)}")
+        if not isinstance(message, str):
+            raise UserFacingException(f"message must be a str instead of {type(message)}")
         sig = wallet.sign_message(address, message, password)
         return base64.b64encode(sig).decode('ascii')
 
@@ -925,6 +929,12 @@ class Commands(Logger):
         arg:str:message:Clear text message. Use quotes if it contains spaces.
         arg:str:signature:The signature, base64-encoded.
         """
+        if not isinstance(address, str):
+            raise UserFacingException(f"address must be a str instead of {type(address)}")
+        if not isinstance(signature, str):
+            raise UserFacingException(f"signature must be a str instead of {type(signature)}")
+        if not isinstance(message, str):
+            raise UserFacingException(f"message must be a str instead of {type(message)}")
         return Abstract_Wallet.verify_message(address=address, signature=signature, message=message)
 
     def _get_fee_policy(self, fee: str, feerate: str):
@@ -1226,6 +1236,10 @@ class Commands(Logger):
         arg:str:pubkey:Public key
         arg:str:message:Clear text message. Use quotes if it contains spaces.
         """
+        if not isinstance(pubkey, str):
+            raise UserFacingException(f"pubkey must be a str instead of {type(pubkey)}")
+        if not isinstance(message, str):
+            raise UserFacingException(f"message must be a str instead of {type(message)}")
         return Abstract_Wallet.encrypt_message(pubkey=pubkey, message=message)
 
     @command('wp')
@@ -1235,6 +1249,10 @@ class Commands(Logger):
         arg:str:encrypted:Encrypted message
         arg:str:pubkey:Public key of one of your wallet addresses
         """
+        if not isinstance(pubkey, str):
+            raise UserFacingException(f"pubkey must be a str instead of {type(pubkey)}")
+        if not isinstance(encrypted, str):
+            raise UserFacingException(f"encrypted must be a str instead of {type(encrypted)}")
         decrypted = wallet.decrypt_message(pubkey=pubkey, message=encrypted, password=password)
         return decrypted.decode('utf-8')
 

--- a/electrum/gui/qml/components/SignVerifyMessageDialog.qml
+++ b/electrum/gui/qml/components/SignVerifyMessageDialog.qml
@@ -215,6 +215,26 @@ ElDialog {
         function onMessageSigned(sig) {
             signature.text = sig
         }
+        function onSignMessageError(error) {
+            var dialog = app.messageDialog.createObject(app, {
+                title: qsTr('Error'),
+                iconSource: Qt.resolvedUrl('../../icons/warning.png'),
+                text: error
+            })
+            dialog.open()
+        }
+    }
+
+    Connections {
+        target: Daemon
+        function onVerifyMessageError(error) {
+            var dialog = app.messageDialog.createObject(app, {
+                title: qsTr('Error'),
+                iconSource: Qt.resolvedUrl('../../icons/warning.png'),
+                text: error
+            })
+            dialog.open()
+        }
     }
 
     Component.onCompleted: {

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -1,4 +1,3 @@
-import base64
 import os
 import threading
 from typing import TYPE_CHECKING
@@ -11,9 +10,8 @@ from electrum.logging import get_logger
 from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
-from electrum.bitcoin import is_address
-from electrum.bitcoin import verify_usermessage_with_address
 from electrum.storage import StorageReadWriteError, WalletStorage
+from electrum.wallet import Abstract_Wallet
 
 from .auth import AuthMixin, auth_protect
 from .qefx import QEFX
@@ -506,16 +504,9 @@ class QEDaemon(AuthMixin, QObject):
     @pyqtSlot(str, str, str, result=bool)
     def verifyMessage(self, address, message, signature):
         address = address.strip()
-        message = message.strip().encode('utf-8')
-        if not is_address(address):
-            return False
-        try:
-            # This can throw on invalid base64
-            sig = base64.b64decode(str(signature.strip()), validate=True)
-            verified = verify_usermessage_with_address(address, sig, message)
-        except Exception as e:
-            verified = False
-        return verified
+        message = message.strip()
+        signature = signature.strip()
+        return Abstract_Wallet.verify_message(address=address, signature=signature, message=message)
 
     @pyqtSlot(str, result=int)
     def passwordStrength(self, password):

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -7,7 +7,9 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 
 from electrum.i18n import _
 from electrum.logging import get_logger
-from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter
+from electrum.util import (
+    WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, UserFacingException,
+)
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.storage import StorageReadWriteError, WalletStorage
@@ -156,6 +158,7 @@ class QEDaemon(AuthMixin, QObject):
     walletOpenError = pyqtSignal([str], arguments=["error"])
     walletDeleteError = pyqtSignal([str, str], arguments=['code', 'message'])
     walletRenameError = pyqtSignal([str], arguments=['message'])
+    verifyMessageError = pyqtSignal([str], arguments=['error'])
 
     def __init__(self, daemon: 'Daemon', plugins: 'Plugins', parent=None):
         super().__init__(parent)
@@ -506,7 +509,11 @@ class QEDaemon(AuthMixin, QObject):
         address = address.strip()
         message = message.strip()
         signature = signature.strip()
-        return Abstract_Wallet.verify_message(address=address, signature=signature, message=message)
+        try:
+            return Abstract_Wallet.verify_message(address=address, signature=signature, message=message)
+        except UserFacingException as e:
+            self.verifyMessageError.emit(str(e))
+            return False
 
     @pyqtSlot(str, result=int)
     def passwordStrength(self, password):

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -14,7 +14,8 @@ from electrum.logging import get_logger
 from electrum.network import TxBroadcastError, BestEffortRequestFailed
 from electrum.transaction import PartialTransaction, Transaction
 from electrum.util import (
-    InvalidPassword, event_listener, AddTransactionException, get_asyncio_loop, NotEnoughFunds, NoDynamicFeeEstimates
+    InvalidPassword, event_listener, AddTransactionException, get_asyncio_loop, NotEnoughFunds, NoDynamicFeeEstimates,
+    UserFacingException,
 )
 from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.plugin import run_hook
@@ -81,6 +82,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
     peersUpdated = pyqtSignal()
     seedRetrieved = pyqtSignal()
     messageSigned = pyqtSignal([str], arguments=['signature'])
+    signMessageError = pyqtSignal([str], arguments=['error'])
 
     _network_signal = pyqtSignal(str, object)
 
@@ -849,7 +851,11 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         # strip, as in qt gui and in qml verifyMessage (see #4327)
         address = address.strip()
         message = message.strip()
-        sig = self.wallet.sign_message(address, message, self.password)
+        try:
+            sig = self.wallet.sign_message(address, message, self.password)
+        except UserFacingException as e:
+            self.signMessageError.emit(str(e))
+            return
         result = base64.b64encode(sig).decode('ascii')
         self.messageSigned.emit(result)
 

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -852,7 +852,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         address = address.strip()
         message = message.strip()
         try:
-            sig = self.wallet.sign_message(address, message, self.password)
+            sig = self.wallet.sign_message(address=address, message=message, password=self.password)
         except UserFacingException as e:
             self.signMessageError.emit(str(e))
             return

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2123,12 +2123,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         d.setLayout(vbox)
         d.exec()
 
-    msg_sign = _("Signing with an address actually means signing with the corresponding "
-                "private key, and verifying with the corresponding public key. The "
-                "address you have entered does not have a unique public key, so these "
-                "operations cannot be performed.") + '\n\n' + \
-               _('The operation is undefined. Not just in Electrum, but in general.')
-
     @protected
     def do_sign(
         self,
@@ -2140,20 +2134,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     ) -> None:
         address = address_e.text().strip()
         message = message_e.toPlainText().strip()
-        if not bitcoin.is_address(address):
-            self.show_message(_('Invalid Bitcoin address.'))
-            return
-        if self.wallet.is_watching_only():
-            self.show_message(_('This is a watching-only wallet.'))
-            return
-        if not self.wallet.is_mine(address):
-            self.show_message(_('Address not in wallet.'))
-            return
-        txin_type = self.wallet.get_txin_type(address)
-        if txin_type not in ['p2pkh', 'p2wpkh', 'p2wpkh-p2sh']:
-            self.show_message(_('Cannot sign messages with this type of address:') + \
-                              ' ' + txin_type + '\n\n' + self.msg_sign)
-            return
         task = partial(self.wallet.sign_message, address, message, password)
 
         def show_signed_message(sig):
@@ -2174,9 +2154,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     ) -> None:
         address = address_e.text().strip()
         message = message_e.toPlainText().strip()
-        if not bitcoin.is_address(address):
-            self.show_message(_('Invalid Bitcoin address.'))
-            return
         verified = self.wallet.verify_message(
             address=address, signature=str(signature_e.toPlainText()), message=message)
         if verified:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2173,16 +2173,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         signature_e: ButtonsTextEdit,
     ) -> None:
         address = address_e.text().strip()
-        message = message_e.toPlainText().strip().encode('utf-8')
+        message = message_e.toPlainText().strip()
         if not bitcoin.is_address(address):
             self.show_message(_('Invalid Bitcoin address.'))
             return
-        try:
-            # This can throw on invalid base64
-            sig = base64.b64decode(str(signature_e.toPlainText()), validate=True)
-            verified = bitcoin.verify_usermessage_with_address(address, sig, message)
-        except Exception as e:
-            verified = False
+        verified = self.wallet.verify_message(
+            address=address, signature=str(signature_e.toPlainText()), message=message)
         if verified:
             self.show_message(_("Signature verified"))
         else:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2231,11 +2231,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         encrypted_e: QTextEdit,
         password,
     ) -> None:
-        if self.wallet.is_watching_only():
-            self.show_message(_('This is a watching-only wallet.'))
-            return
         ciphertext = encrypted_e.toPlainText()
-        task = partial(self.wallet.decrypt_message, pubkey_e.text(), ciphertext, password)
+        task = partial(
+            self.wallet.decrypt_message,
+            pubkey=pubkey_e.text(),
+            message=ciphertext,
+            password=password,
+        )
 
         def setText(text):
             try:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2253,17 +2253,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         pubkey_e: QLineEdit,
         encrypted_e: QTextEdit,
     ) -> None:
-        from electrum import crypto
         message = message_e.toPlainText()
-        message = message.encode('utf-8')
         try:
-            public_key = ecc.ECPubkey(bfh(pubkey_e.text()))
-        except BaseException as e:
-            self.logger.exception('Invalid Public key')
-            self.show_warning(_('Invalid Public key'))
+            encrypted = self.wallet.encrypt_message(
+                pubkey=pubkey_e.text(),
+                message=message,
+            )
+        except UserFacingException as e:
+            self.show_warning(str(e))
             return
-        encrypted = crypto.ecies_encrypt_message(public_key, message)
-        encrypted_e.setText(encrypted.decode('ascii'))
+        encrypted_e.setText(encrypted)
 
     def encrypt_message(self, address: str = "") -> None:
         d = WindowModalDialog(self, _('Encrypt/decrypt Message'))

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -92,7 +92,8 @@ from .util import (read_QIcon, ColorScheme, text_dialog, icon_path, WaitingDialo
                    CloseButton, MessageBoxMixin, EnterButton, import_meta_gui, export_meta_gui,
                    filename_field, address_field, char_width_in_lineedit, webopen,
                    TRANSACTION_FILE_EXTENSION_FILTER_ANY, MONOSPACE_FONT,
-                   getOpenFileName, getSaveFileName, ShowQRLineEdit, scan_qr_from_screenshot)
+                   getOpenFileName, getSaveFileName, ShowQRLineEdit, scan_qr_from_screenshot,
+                   ButtonsTextEdit)
 from .wizard.wallet import WIF_HELP_TEXT
 from .history_list import HistoryList, HistoryModel
 from .update_checker import UpdateCheck, UpdateCheckThread
@@ -2129,9 +2130,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
                _('The operation is undefined. Not just in Electrum, but in general.')
 
     @protected
-    def do_sign(self, address, message, signature, password):
-        address  = address.text().strip()
-        message = message.toPlainText().strip()
+    def do_sign(
+        self,
+        *,
+        address_e: QLineEdit,
+        message_e: QTextEdit,
+        signature_e: ButtonsTextEdit,
+        password,
+    ) -> None:
+        address = address_e.text().strip()
+        message = message_e.toPlainText().strip()
         if not bitcoin.is_address(address):
             self.show_message(_('Invalid Bitcoin address.'))
             return
@@ -2150,22 +2158,28 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
         def show_signed_message(sig):
             try:
-                signature.setText(base64.b64encode(sig).decode('ascii'))
+                signature_e.setText(base64.b64encode(sig).decode('ascii'))
             except RuntimeError:
-                # (signature) wrapped C/C++ object has been deleted
+                # (signature_e) wrapped C/C++ object has been deleted
                 pass
 
         self.thread.add(task, on_success=show_signed_message)
 
-    def do_verify(self, address, message, signature):
-        address  = address.text().strip()
-        message = message.toPlainText().strip().encode('utf-8')
+    def do_verify(
+        self,
+        *,
+        address_e: QLineEdit,
+        message_e: QTextEdit,
+        signature_e: ButtonsTextEdit,
+    ) -> None:
+        address = address_e.text().strip()
+        message = message_e.toPlainText().strip().encode('utf-8')
         if not bitcoin.is_address(address):
             self.show_message(_('Invalid Bitcoin address.'))
             return
         try:
             # This can throw on invalid base64
-            sig = base64.b64decode(str(signature.toPlainText()), validate=True)
+            sig = base64.b64decode(str(signature_e.toPlainText()), validate=True)
             verified = bitcoin.verify_usermessage_with_address(address, sig, message)
         except Exception as e:
             verified = False
@@ -2174,7 +2188,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         else:
             self.show_error(_("Wrong signature"))
 
-    def sign_verify_message(self, address=''):
+    def sign_verify_message(self, address: str = "") -> None:
         d = WindowModalDialog(self, _('Sign/verify Message'))
         d.setMinimumSize(610, 290)
 
@@ -2199,11 +2213,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         hbox = QHBoxLayout()
 
         b = QPushButton(_("Sign"))
-        b.clicked.connect(lambda: self.do_sign(address_e, message_e, signature_e))
+        b.clicked.connect(lambda: self.do_sign(address_e=address_e, message_e=message_e, signature_e=signature_e))
         hbox.addWidget(b)
 
         b = QPushButton(_("Verify"))
-        b.clicked.connect(lambda: self.do_verify(address_e, message_e, signature_e))
+        b.clicked.connect(lambda: self.do_verify(address_e=address_e, message_e=message_e, signature_e=signature_e))
         hbox.addWidget(b)
 
         b = QPushButton(_("Close"))
@@ -2213,7 +2227,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         d.exec()
 
     @protected
-    def do_decrypt(self, message_e, pubkey_e, encrypted_e, password):
+    def do_decrypt(
+        self,
+        *,
+        message_e: QTextEdit,
+        pubkey_e: QLineEdit,
+        encrypted_e: QTextEdit,
+        password,
+    ) -> None:
         if self.wallet.is_watching_only():
             self.show_message(_('This is a watching-only wallet.'))
             return
@@ -2229,7 +2250,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
         self.thread.add(task, on_success=setText)
 
-    def do_encrypt(self, message_e, pubkey_e, encrypted_e):
+    def do_encrypt(
+        self,
+        *,
+        message_e: QTextEdit,
+        pubkey_e: QLineEdit,
+        encrypted_e: QTextEdit,
+    ) -> None:
         from electrum import crypto
         message = message_e.toPlainText()
         message = message.encode('utf-8')
@@ -2242,7 +2269,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         encrypted = crypto.ecies_encrypt_message(public_key, message)
         encrypted_e.setText(encrypted.decode('ascii'))
 
-    def encrypt_message(self, address=''):
+    def encrypt_message(self, address: str = "") -> None:
         d = WindowModalDialog(self, _('Encrypt/decrypt Message'))
         d.setMinimumSize(610, 490)
 
@@ -2269,11 +2296,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
 
         hbox = QHBoxLayout()
         b = QPushButton(_("Encrypt"))
-        b.clicked.connect(lambda: self.do_encrypt(message_e, pubkey_e, encrypted_e))
+        b.clicked.connect(lambda: self.do_encrypt(message_e=message_e, pubkey_e=pubkey_e, encrypted_e=encrypted_e))
         hbox.addWidget(b)
 
         b = QPushButton(_("Decrypt"))
-        b.clicked.connect(lambda: self.do_decrypt(message_e, pubkey_e, encrypted_e))
+        b.clicked.connect(lambda: self.do_decrypt(message_e=message_e, pubkey_e=pubkey_e, encrypted_e=encrypted_e))
         hbox.addWidget(b)
 
         b = QPushButton(_("Close"))

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2134,7 +2134,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     ) -> None:
         address = address_e.text().strip()
         message = message_e.toPlainText().strip()
-        task = partial(self.wallet.sign_message, address, message, password)
+        task = partial(
+            self.wallet.sign_message,
+            address=address,
+            message=message,
+            password=password,
+        )
 
         def show_signed_message(sig):
             try:

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2159,12 +2159,20 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     ) -> None:
         address = address_e.text().strip()
         message = message_e.toPlainText().strip()
-        verified = self.wallet.verify_message(
-            address=address, signature=str(signature_e.toPlainText()), message=message)
-        if verified:
-            self.show_message(_("Signature verified"))
-        else:
-            self.show_error(_("Wrong signature"))
+        task = partial(
+            self.wallet.verify_message,
+            address=address,
+            signature=str(signature_e.toPlainText()),
+            message=message,
+        )
+
+        def on_result(verified):
+            if verified:
+                self.show_message(_("Signature verified"))
+            else:
+                self.show_error(_("Wrong signature"))
+
+        self.thread.add(task, on_success=on_result)
 
     def sign_verify_message(self, address: str = "") -> None:
         d = WindowModalDialog(self, _('Sign/verify Message'))
@@ -2238,15 +2246,20 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         encrypted_e: QTextEdit,
     ) -> None:
         message = message_e.toPlainText()
-        try:
-            encrypted = self.wallet.encrypt_message(
-                pubkey=pubkey_e.text(),
-                message=message,
-            )
-        except UserFacingException as e:
-            self.show_warning(str(e))
-            return
-        encrypted_e.setText(encrypted)
+        task = partial(
+            self.wallet.encrypt_message,
+            pubkey=pubkey_e.text(),
+            message=message,
+        )
+
+        def setText(text):
+            try:
+                encrypted_e.setText(text)
+            except RuntimeError:
+                # (encrypted_e) wrapped C/C++ object has been deleted
+                pass
+
+        self.thread.add(task, on_success=setText)
 
     def encrypt_message(self, address: str = "") -> None:
         d = WindowModalDialog(self, _('Encrypt/decrypt Message'))

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -48,6 +48,7 @@ from aiorpcx import ignore_after, run_in_thread
 
 from . import util, keystore, transaction, bitcoin, coinchooser, bip32, descriptor
 from . import constants
+from . import crypto
 from .i18n import _
 from .bip32 import BIP32Node, convert_bip32_intpath_to_strpath, convert_bip32_strpath_to_intpath
 from .logging import get_logger, Logger
@@ -56,7 +57,7 @@ from .util import (
     WalletFileException, BitcoinException, InvalidPassword, format_time, timestamp_to_datetime,
     Satoshis, Fiat, TxMinedInfo, quantize_feerate, OrderedDictWithIndex, multisig_type, parse_max_spend,
     OnchainHistoryItem, read_json_file, write_json_file, UserFacingException, FileImportFailed, EventListener,
-    event_listener
+    event_listener, is_hex_str,
 )
 from .bitcoin import COIN, is_address, is_minikey, relayfee, dust_threshold, DummyAddress, DummyAddressUsedInTxException
 from .keystore import (
@@ -3256,6 +3257,22 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         addr = self.pubkeys_to_address([pubkey])
         index = self.get_address_index(addr)
         return self.keystore.decrypt_message(index, message, password)
+
+    @classmethod
+    def encrypt_message(cls, *, pubkey: Any | str, message: Any | str) -> str:
+        try:
+            message = util.to_bytes(message)
+        except TypeError:
+            raise UserFacingException(f"message must be a str instead of {type(message)}") from None
+        if not is_hex_str(pubkey):
+            raise UserFacingException(f"pubkey must be a hex string instead of {type(pubkey)}")
+        pubkey_bytes = bytes.fromhex(pubkey)
+        try:
+            eckey = ecc.ECPubkey(pubkey_bytes)
+        except ecc.InvalidECPointException as e:
+            raise UserFacingException(_("Invalid Public key")) from e
+        encrypted = crypto.ecies_encrypt_message(eckey, message)
+        return encrypted.decode("ascii")
 
     @abstractmethod
     def pubkeys_to_address(self, pubkeys: Sequence[str]) -> Optional[str]:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3234,7 +3234,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     def _update_password_for_keystore(self, old_pw: Optional[str], new_pw: Optional[str]) -> None:
         pass
 
-    def sign_message(self, address: str, message: str, password) -> bytes:
+    def sign_message(self, *, address: str, message: str, password) -> bytes:
         """Caller must handle UserFacingException."""
         assert isinstance(address, str), f"address must be str. got {type(address)}"
         assert isinstance(message, str), f"message must be str. got {type(message)}"

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -41,6 +41,7 @@ import threading
 import enum
 import asyncio
 from dataclasses import dataclass
+import base64
 
 import electrum_ecc as ecc
 from aiorpcx import ignore_after, run_in_thread
@@ -3238,7 +3239,20 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         assert script_type != "address"
         return self.keystore.sign_message(index, message, password, script_type=script_type)
 
-    def decrypt_message(self, pubkey: str, message, password) -> bytes:
+    @classmethod
+    def verify_message(cls, *, address: str, signature: str, message: str) -> bool:
+        if not is_address(address):
+            return False
+        try:
+            sig = base64.b64decode(signature, validate=True)
+        except ValueError:
+            # note: unicode chars in signature would result in ValueError,
+            #       so it is insufficient to catch binascii.Error(ValueError)
+            return False
+        message = util.to_bytes(message)
+        return bitcoin.verify_usermessage_with_address(address, sig, message)
+
+    def decrypt_message(self, pubkey: str, message: str, password) -> bytes:
         addr = self.pubkeys_to_address([pubkey])
         index = self.get_address_index(addr)
         return self.keystore.decrypt_message(index, message, password)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3253,13 +3253,27 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         message = util.to_bytes(message)
         return bitcoin.verify_usermessage_with_address(address, sig, message)
 
-    def decrypt_message(self, pubkey: str, message: str, password) -> bytes:
-        addr = self.pubkeys_to_address([pubkey])
-        index = self.get_address_index(addr)
-        return self.keystore.decrypt_message(index, message, password)
+    def decrypt_message(self, *, pubkey: Any | str, message: str, password) -> bytes:
+        """Caller must handle UserFacingException."""
+        if self.is_watching_only():
+            raise UserFacingException(_("This is a watching-only wallet."))
+        if isinstance(self, Multisig_Wallet):  # FIXME does not work with multisig wallets. (see #5856)
+            raise UserFacingException(_("Decrypting messages is currently not implemented for multisig wallets."))
+        if not isinstance(message, str):
+            raise UserFacingException(f"message must be a str instead of {type(message)}")
+        if not is_hex_str(pubkey):
+            raise UserFacingException(f"pubkey must be a hex string instead of {type(pubkey)}")
+        if isinstance(self, Imported_Wallet):
+            # this branch is significantly faster. Imported_Wallet.pubkeys_to_address is slow.
+            addr_index = pubkey
+        else:
+            addr = self.pubkeys_to_address([pubkey])  # note: broken for multisig
+            addr_index = self.get_address_index(addr)
+        return self.keystore.decrypt_message(addr_index, message, password)
 
     @classmethod
     def encrypt_message(cls, *, pubkey: Any | str, message: Any | str) -> str:
+        """Caller must handle UserFacingException."""
         try:
             message = util.to_bytes(message)
         except TypeError:
@@ -4027,10 +4041,6 @@ class Imported_Wallet(Simple_Wallet):
             if self.db.get_imported_address(addr)['pubkey'] == pubkey:
                 return addr
         return None
-
-    def decrypt_message(self, pubkey: str, message, password) -> bytes:
-        # this is significantly faster than the implementation in the superclass
-        return self.keystore.decrypt_message(pubkey, message, password)
 
 
 class Deterministic_Wallet(Abstract_Wallet):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3289,9 +3289,14 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if isinstance(self, Imported_Wallet):
             # this branch is significantly faster. Imported_Wallet.pubkeys_to_address is slow.
             addr_index = pubkey
+            assert isinstance(self.keystore, keystore.Imported_KeyStore)
+            if pubkey not in self.keystore.keypairs:
+                raise UserFacingException(_("Pubkey unrelated to wallet."))
         else:
             addr = self.pubkeys_to_address([pubkey])  # note: broken for multisig
             addr_index = self.get_address_index(addr)
+            if addr_index is None:
+                raise UserFacingException(_("Pubkey unrelated to wallet."))
         return self.keystore.decrypt_message(addr_index, message, password)
 
     @classmethod

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3235,15 +3235,38 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         pass
 
     def sign_message(self, address: str, message: str, password) -> bytes:
+        """Caller must handle UserFacingException."""
+        assert isinstance(address, str), f"address must be str. got {type(address)}"
+        assert isinstance(message, str), f"message must be str. got {type(message)}"
+        if not bitcoin.is_address(address):
+            raise UserFacingException(_("Invalid Bitcoin address."))
+        if self.is_watching_only():
+            raise UserFacingException(_("This is a watching-only wallet."))
+        if not self.is_mine(address):
+            raise UserFacingException(_("Address not in wallet."))
+        txin_type = self.get_txin_type(address)
+        assert txin_type != "address"  # logic error, as this implies watching-only
+        if txin_type not in ['p2pkh', 'p2wpkh', 'p2wpkh-p2sh']:
+            raise UserFacingException(
+                _("Cannot sign messages with this type of address:") +
+                " " + txin_type + "\n\n"
+                + _("Signing with an address actually means signing with the corresponding "
+                     "private key, and verifying with the corresponding public key. The "
+                     "address you have entered does not have a unique public key, so these "
+                     "operations cannot be performed.") + "\n\n"
+                + _("The operation is undefined. Not just in Electrum, but in general.")
+            )
         index = self.get_address_index(address)
-        script_type = self.get_txin_type(address)
-        assert script_type != "address"
-        return self.keystore.sign_message(index, message, password, script_type=script_type)
+        return self.keystore.sign_message(index, message, password, script_type=txin_type)
 
     @classmethod
     def verify_message(cls, *, address: str, signature: str, message: str) -> bool:
+        """Caller must handle UserFacingException."""
+        assert isinstance(address, str), f"address must be str. got {type(address)}"
+        assert isinstance(signature, str), f"signature must be str. got {type(signature)}"
+        assert isinstance(message, str), f"message must be str. got {type(message)}"
         if not is_address(address):
-            return False
+            raise UserFacingException(_("Invalid Bitcoin address."))
         try:
             sig = base64.b64decode(signature, validate=True)
         except ValueError:
@@ -3253,14 +3276,14 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         message = util.to_bytes(message)
         return bitcoin.verify_usermessage_with_address(address, sig, message)
 
-    def decrypt_message(self, *, pubkey: Any | str, message: str, password) -> bytes:
+    def decrypt_message(self, *, pubkey: str, message: str, password) -> bytes:
         """Caller must handle UserFacingException."""
+        assert isinstance(pubkey, str), f"pubkey must be str. got {type(pubkey)}"
+        assert isinstance(message, str), f"message must be str. got {type(message)}"
         if self.is_watching_only():
             raise UserFacingException(_("This is a watching-only wallet."))
         if isinstance(self, Multisig_Wallet):  # FIXME does not work with multisig wallets. (see #5856)
             raise UserFacingException(_("Decrypting messages is currently not implemented for multisig wallets."))
-        if not isinstance(message, str):
-            raise UserFacingException(f"message must be a str instead of {type(message)}")
         if not is_hex_str(pubkey):
             raise UserFacingException(f"pubkey must be a hex string instead of {type(pubkey)}")
         if isinstance(self, Imported_Wallet):
@@ -3272,12 +3295,11 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         return self.keystore.decrypt_message(addr_index, message, password)
 
     @classmethod
-    def encrypt_message(cls, *, pubkey: Any | str, message: Any | str) -> str:
+    def encrypt_message(cls, *, pubkey: str, message: str) -> str:
         """Caller must handle UserFacingException."""
-        try:
-            message = util.to_bytes(message)
-        except TypeError:
-            raise UserFacingException(f"message must be a str instead of {type(message)}") from None
+        assert isinstance(pubkey, str), f"pubkey must be str. got {type(pubkey)}"
+        assert isinstance(message, str), f"message must be str. got {type(message)}"
+        message = util.to_bytes(message)
         if not is_hex_str(pubkey):
             raise UserFacingException(f"pubkey must be a hex string instead of {type(pubkey)}")
         pubkey_bytes = bytes.fromhex(pubkey)


### PR DESCRIPTION
Previously we had `wallet.sign_message` and `wallet.decrypt_message`, and all preliminary checks had to be done by the caller. This meant Qt/qml/CLI all duplicated some subset of all desired checks.

Now we have `wallet.sign_message`, `wallet.verify_message`, `wallet.decrypt_message`, `wallet.encrypt_message` all in wallet.py, and all checks are self-contained inside. (The two new methods are classmethods, as they don't require a wallet, and that's why they did not exist before)

note: this is somewhat related to https://github.com/spesmilo/electrum/pull/10787 but I wanted to clean this code up before we decide to strip/not-strip whitespaces as it really should be un-duped.