### PR TITLE
QML wallet search followup

### DIFF
--- a/electrum/daemon.py
+++ b/electrum/daemon.py
@@ -44,7 +44,7 @@ from . import util
 from .network import Network
 from .util import (
     json_decode, to_bytes, to_string, profiler, standardize_path, constant_time_compare, InvalidPassword,
-    log_exceptions, randrange, OldTaskGroup, UserFacingException, JsonRPCError, os_chmod
+    log_exceptions, randrange, OldTaskGroup, UserFacingException, JsonRPCError, os_chmod, is_hidden_wallet_path
 )
 from .wallet import Wallet, Abstract_Wallet
 from .storage import WalletStorage
@@ -515,7 +515,7 @@ class Daemon(Logger):
         if wallet := self._wallets.get(wallet_key):
             if force_check_password:
                 wallet.check_password(password)
-            if self.config.get('wallet_path') is None:
+            if self.config.get('wallet_path') is None and not is_hidden_wallet_path(path):
                 self.config.CURRENT_WALLET = path
             return wallet
         wallet = self._load_wallet(
@@ -527,7 +527,7 @@ class Daemon(Logger):
             coro = wallet.lnworker.lnwatcher.trigger_callbacks(requires_synchronizer=False)
             asyncio.run_coroutine_threadsafe(coro, self.asyncio_loop)
         self.add_wallet(wallet)
-        if self.config.get('wallet_path') is None:
+        if self.config.get('wallet_path') is None and not is_hidden_wallet_path(path):
             self.config.CURRENT_WALLET = path
         self.update_recently_opened_wallets(path)
         return wallet
@@ -593,7 +593,7 @@ class Daemon(Logger):
         os.rename(old_path, new_path)
         self.logger.debug(f'renamed wallet: {old_path} -> {new_path}')
         self.update_recently_opened_wallets(old_path, remove=True)
-        if self.config.CURRENT_WALLET == old_path:
+        if self.config.CURRENT_WALLET == old_path and not is_hidden_wallet_path(new_path):
             self.config.CURRENT_WALLET = new_path
 
     def stop_wallet(self, path: str) -> bool:
@@ -613,7 +613,7 @@ class Daemon(Logger):
         await wallet.stop()
         if self.config.get('wallet_path') is None:
             wallet_paths = [w.storage.get_path() for w in self._wallets.values()
-                            if w.storage and w.storage.get_path()]
+                            if w.storage and w.storage.get_path() and not is_hidden_wallet_path(w.storage.get_path())]
             if self.config.CURRENT_WALLET == path and wallet_paths:
                 self.config.CURRENT_WALLET = wallet_paths[0]
         return True

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -8,7 +8,7 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 
 from electrum.i18n import _
 from electrum.logging import get_logger
-from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter
+from electrum.util import WalletFileException, standardize_path, InvalidPassword, send_exception_to_crash_reporter, is_hidden_wallet_path
 from electrum.plugin import run_hook
 from electrum.lnchannel import ChannelState
 from electrum.bitcoin import is_address
@@ -42,6 +42,7 @@ class QEWalletListModel(QAbstractListModel):
         QAbstractListModel.__init__(self, parent)
         self.daemon = daemon
         self._wallets = []
+        self._hidden = []
         self.reload()
 
     def rowCount(self, index):
@@ -75,8 +76,10 @@ class QEWalletListModel(QAbstractListModel):
                 if i.is_file():
                     available.append(i.path)
         for path in sorted(available):
-            wallet = self.daemon.get_wallet(path)
-            self.add_wallet(wallet_path=path)
+            if is_hidden_wallet_path(path) and self.daemon.get_wallet(path) is None:
+                self._hidden.append((os.path.basename(path), standardize_path(path)))
+            else:
+                self.add_wallet(wallet_path=path)
 
     def add_wallet(self, wallet_path):
         self.beginInsertRows(QModelIndex(), len(self._wallets), len(self._wallets))
@@ -104,14 +107,14 @@ class QEWalletListModel(QAbstractListModel):
 
     @pyqtSlot(str, result=bool)
     def wallet_name_exists(self, name):
-        for wallet_name, wallet_path in self._wallets:
+        for wallet_name, wallet_path in self._wallets + self._hidden:
             if name == wallet_name:
                 return True
         return False
 
     @pyqtSlot(str, result=str)
     def pathForName(self, name):
-        for wallet_name, wallet_path in self._wallets:
+        for wallet_name, wallet_path in self._wallets + self._hidden:
             if name == wallet_name:
                 return wallet_path
         return ''

--- a/electrum/gui/qml/qedaemon.py
+++ b/electrum/gui/qml/qedaemon.py
@@ -82,12 +82,13 @@ class QEWalletListModel(QAbstractListModel):
                 self.add_wallet(wallet_path=path)
 
     def add_wallet(self, wallet_path):
-        self.beginInsertRows(QModelIndex(), len(self._wallets), len(self._wallets))
         wallet_name = os.path.basename(wallet_path)
         wallet_path = standardize_path(wallet_path)
         item = (wallet_name, wallet_path)
-        self._wallets.append(item)
-        self.endInsertRows()
+        if item not in self._wallets:
+            self.beginInsertRows(QModelIndex(), len(self._wallets), len(self._wallets))
+            self._wallets.append(item)
+            self.endInsertRows()
 
     def remove_wallet(self, path):
         i = 0
@@ -278,6 +279,7 @@ class QEDaemon(AuthMixin, QObject):
         wallet = self.daemon.get_wallet(self._path)
         assert wallet is not None
         self._current_wallet = QEWallet.getInstanceFor(wallet)
+        self.availableWallets.add_wallet(self._path)  # idempotent, needed for hidden wallets
         self.availableWallets.updateWallet(self._path)
         wallet.unlock(password or None)  # not conditional on wallet.requires_unlock in qml, as
         # the auth wrapper doesn't pass the entered password, but instead we rely on the password in memory

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -797,10 +797,7 @@ Warning: setting this to too low will result in lots of payment failures."""),
     DISABLE_MEMORY_HARDENING_LINUX = ConfigVar('nohardening', default=None, type_=bool) # default is False in add_global_options
 
     GUI_NAME = ConfigVar('gui', default='qt', type_=str)
-    CURRENT_WALLET = ConfigVar(
-        'current_wallet', default=None, type_=str,
-        convert_setter=lambda v: None if util.is_hidden_wallet_path(v) else v,  # don't save "hidden wallet" paths
-    )
+    CURRENT_WALLET = ConfigVar('current_wallet', default=None, type_=str)
 
     GUI_QT_COLOR_THEME = ConfigVar(
         'qt_gui_color_theme', default='default', type_=str,


### PR DESCRIPTION
Currently, hidden wallets are still detectable; 

1. closing the app with a hidden wallet active -> on app start, no wallet is loaded, wallet list is shown
2. last remaining wallet is hidden -> on app start, new wallet wizard not started, (empty) wallet list shown. So, under coercion, user could be forced to drain non-hidden wallets, then remove them -> hidden wallet detected as wizard is not shown

This PR makes app behaviour when hidden wallets are present identical to no hidden wallets present

one caveat; this opens up potential non-unified password situations again :/
