### PR TITLE
add crandom.py, for our RNG, where we mix stuff with os.urandom

### DIFF
--- a/electrum/__init__.py
+++ b/electrum/__init__.py
@@ -29,6 +29,7 @@ from .transaction import Transaction
 from .plugin import BasePlugin
 from .commands import Commands, known_commands
 from .logging import get_logger
+from . import crandom  # this initializes our RNG state and checks os.urandom is not trivially broken
 
 
 __version__ = ELECTRUM_VERSION
@@ -45,11 +46,3 @@ except AssertionError:
     pass
 else:
     raise ImportError("Running with asserts disabled. Refusing to continue. Exiting...")
-
-
-# Check that os.urandom works
-import zlib
-length = len(zlib.compress(os.urandom(1000)))
-if length <= 900:
-    raise ImportError("Broken PRNG. Refusing to continue. Exiting...")
-

--- a/electrum/crandom.py
+++ b/electrum/crandom.py
@@ -3,19 +3,151 @@
 # file LICENCE or http://www.opensource.org/licenses/mit-license.php
 #
 # Cryptographically secure RNG.
+#
+# This mostly uses os.urandom, and extreme care should be taken here not to make things worse
+# compared to just directly using that.
+# We check os.urandom is not trivially broken (passes the zlib test), in which case we panic and runtime exit.
+# However, os.urandom could still be subtly "broken" (undetected by us) and produce bad quality output.
+# That's the motivation of all this code. We expect os.urandom to work well, BUT if it undetectably does not,
+# hopefully mixing in other sources of entropy mitigates the situation somewhat.
+#
+# inspired by https://github.com/bitcoin/bitcoin/blob/67efced1fc83a0b7215cc1513e7c4754fee0f12f/src/random.h#L25
+#
+# The logic is split across two modules: crandom.py and crandom_env.py.
+# - The core sensitive logic (RNG mixing, extracting random bytes) is in this module (crandom.py),
+#   which is absolutely security critical and is kept concise to ease review.
+# - crandom_env.py contains secondary sources of entropy and potentially platform-specific code.
+#   Even if all the entropy sources listed in crandom_env.py are broken, assuming os.urandom()
+#   produces high quality random, this module should never produce low-quality random output.
 
+import hashlib
 import os
-import secrets
+import threading
+from typing import Callable
+import zlib
+
+from . import crandom_env
 
 
-def get_rand_bytes(nbytes: int) -> bytes:
-    """Returns uniformly distributed bytes, of length nbytes."""
-    assert nbytes >= 0, nbytes
-    return os.urandom(nbytes)
+# Check that os.urandom works
+length = len(zlib.compress(os.urandom(1000)))
+if length <= 900:
+    raise ImportError("Broken PRNG. Refusing to continue. Exiting...")
 
 
-def get_rand_below(upper_bound: int) -> int:
-    """Return a uniformly distributed int in the range [0, upper_bound)."""
-    assert upper_bound > 0, upper_bound
-    return secrets.randbelow(upper_bound)
+def sha512(x: bytes) -> bytes:
+    assert isinstance(x, bytes)
+    return hashlib.sha512(x).digest()
 
+
+CRANDOM_FEEDER_API = Callable[[bytes | str | int], None]
+
+
+class RNGState:
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self._state = os.urandom(32)  # secret!  access needs lock.
+        # gather ghetto-entropy:
+        self.rand_add_refresh()  # clock
+        crandom_env.rand_add_static_env(self.feed_entropy)
+        self.rand_add_refresh()  # clock again
+
+    def rand_add_refresh(self) -> None:
+        """Gather dynamic environment data that changes over time and mix it in.
+        This includes a high-precision clock.
+
+        Never raises.
+        """
+        crandom_env.rand_add_dynamic_env(self.feed_entropy)
+
+    def feed_entropy(self, data: bytes | str | int) -> None:
+        """Mix in some data into our internal RNG state, in hopes of increasing entropy.
+
+        We MUST be robust for given 'data' not to contain any randomness, it could even be static.
+        Assuming our internal hash function is cryptographically secure, our internal state
+        MUST not be left with less entropy than before the call.
+
+        Never raises (assuming input type-checks).
+        Matches CRANDOM_FEEDER_API.
+        """
+        if not data:
+            return
+        if isinstance(data, int):
+            data = hex(data)
+        if isinstance(data, str):
+            # we must not raise UnicodeError, hence "backslashreplace"
+            data = data.encode("utf-8", errors='backslashreplace')
+        with self.lock:
+            self._state = sha512(data + self._state)[0:32]
+            assert len(self._state) == 32
+
+    def _mix_extract(self) -> bytes:
+        """Return 32 bytes of secure randomness.
+
+        Mix in some new entropy from os.urandom first, and then extract 32 bytes.
+        When mixing in new entropy, H = SHA512(new_entropy || old_rng_state) is computed, and
+        the first 32 bytes of H are produced as output, while the last 32 bytes
+        become the new RNG state.
+
+        Never raises.
+        """
+        with self.lock:
+            fresh_entropy = os.urandom(32)
+            h = sha512(fresh_entropy + self._state)
+            out, self._state = h[0:32], h[32:64]
+            assert len(out) == 32
+            assert len(self._state) == 32
+            return out
+
+    def get_rand_bytes(self, nbytes: int) -> bytes:
+        """Returns uniformly distributed bytes, of length nbytes.
+
+        Never raises.
+        """
+        assert nbytes >= 0, nbytes
+        out = b""
+        while len(out) < nbytes:
+            out += self._mix_extract()
+        return out[:nbytes]
+
+    def _get_rand_bits(self, nbits: int) -> int:
+        """Return a uniformly distributed int in the range [0, 2**nbits).
+
+        Never raises.
+        """
+        assert nbits >= 0, nbits
+        nbytes = nbits // 8 + (1 if nbits % 8 else 0)
+        rb = self.get_rand_bytes(nbytes)
+        ri = int.from_bytes(rb, byteorder="big", signed=False)
+        # strip excess bits (we got up to 7 more than we asked for)
+        extra_bits = 8 * nbytes - nbits
+        assert 0 <= extra_bits < 8
+        ri = ri >> extra_bits
+        return ri
+
+    def get_rand_below(self, upper_bound: int) -> int:
+        """Return a uniformly distributed int in the range [0, upper_bound).
+
+        Never raises.
+        """
+        assert upper_bound > 0, upper_bound
+        nbits = upper_bound.bit_length()
+        ri = upper_bound + 1
+        # Keep generating random ints until we get one inside the requested range.
+        # On average, we expect around 2 iterations.
+        while ri >= upper_bound:
+            ri = self._get_rand_bits(nbits)
+        return ri
+
+
+_rng = RNGState()
+
+
+########################################
+# External API (thread-safe):
+
+get_rand_bytes = _rng.get_rand_bytes
+get_rand_below = _rng.get_rand_below
+feed_entropy = _rng.feed_entropy
+rand_add_refresh = _rng.rand_add_refresh

--- a/electrum/crandom.py
+++ b/electrum/crandom.py
@@ -23,10 +23,12 @@
 import hashlib
 import os
 import threading
+import time
 from typing import Callable
 import zlib
 
 from . import crandom_env
+from .logging import Logger
 
 
 # Check that os.urandom works
@@ -43,11 +45,13 @@ def sha512(x: bytes) -> bytes:
 CRANDOM_FEEDER_API = Callable[[bytes | str | int], None]
 
 
-class RNGState:
+class RNGState(Logger):
 
     def __init__(self):
-        self.lock = threading.Lock()
+        Logger.__init__(self)
+        self.lock = threading.RLock()
         self._state = os.urandom(32)  # secret!  access needs lock.
+        self._last_strengthened = 0
         # gather ghetto-entropy:
         self.rand_add_refresh()  # clock
         crandom_env.rand_add_static_env(self.feed_entropy)
@@ -93,6 +97,13 @@ class RNGState:
         Never raises.
         """
         with self.lock:
+            now = time.monotonic()
+            if self._last_strengthened == 0:  # on first invocation, do some work
+                self._last_strengthened = now
+                self._strengthen(0.1)  # 100 ms
+            elif now - self._last_strengthened > 60:  # been more than 1 minute
+                self._last_strengthened = now
+                self._strengthen(0)    # single hash-loop
             fresh_entropy = os.urandom(32)
             h = sha512(fresh_entropy + self._state)
             out, self._state = h[0:32], h[32:64]
@@ -139,6 +150,28 @@ class RNGState:
         while ri >= upper_bound:
             ri = self._get_rand_bits(nbits)
         return ri
+
+    def _strengthen(self, duration_sec: float | int) -> None:
+        """Extract some random bytes, repeatedly hash it using SHA512, and then feed it back.
+
+        This sort of mimics the iteration count of a KDF: an attacker trying to bruteforce/enumerate
+        the possible internal states, e.g. due to broken (low-entropy) randomness,
+        has to re-do this hashing for each attempt.
+
+        Never raises.
+        """
+        self.logger.info(f"starting strengthen for {duration_sec} sec")
+        self.rand_add_refresh()  # clock
+        xhash = self._mix_extract()
+        t0 = time.monotonic()
+        cnt = 0
+        while cnt == 0 or time.monotonic() - t0 < duration_sec:
+            for _i in range(1000):
+                cnt += 1
+                xhash = sha512(xhash)
+        self.rand_add_refresh()  # clock again
+        self.feed_entropy(xhash)
+        self.logger.info(f"finished strengthen. iter count: {cnt:_}")
 
 
 _rng = RNGState()

--- a/electrum/crandom.py
+++ b/electrum/crandom.py
@@ -52,6 +52,7 @@ class RNGState(Logger):
         self.lock = threading.RLock()
         self._state = os.urandom(32)  # secret!  access needs lock.
         self._last_strengthened = 0
+        self._last_dyn_refresh_slow = 0
         # gather ghetto-entropy:
         self.rand_add_refresh()  # clock
         crandom_env.rand_add_static_env(self.feed_entropy)
@@ -63,7 +64,13 @@ class RNGState(Logger):
 
         Never raises.
         """
-        crandom_env.rand_add_dynamic_env(self.feed_entropy)
+        with self.lock:
+            now = time.monotonic()
+            incl_slow = False
+            if now - self._last_dyn_refresh_slow > 60:  # been more than 1 minute
+                self._last_dyn_refresh_slow = now
+                incl_slow = True
+        crandom_env.rand_add_dynamic_env(self.feed_entropy, include_slow_sources=incl_slow)
 
     def feed_entropy(self, data: bytes | str | int) -> None:
         """Mix in some data into our internal RNG state, in hopes of increasing entropy.

--- a/electrum/crandom_env.py
+++ b/electrum/crandom_env.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2026 The Electrum developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENCE or http://www.opensource.org/licenses/mit-license.php
+#
+# This module is a companion to crandom.py and is only intended to be accessed from there.
+
+import gc
+import locale
+import os
+import platform
+import socket
+import ssl
+import sys
+import threading
+import time
+from typing import TYPE_CHECKING, Callable
+from uuid import getnode as get_mac_address
+
+try:
+    import pwd
+except ImportError:  # only available on UNIX
+    pwd = None
+
+from .logging import get_logger
+
+if TYPE_CHECKING:
+    from .crandom import CRANDOM_FEEDER_API
+
+
+_logger = get_logger(__name__)
+
+
+def _safe_feed(do_feed: Callable[[], None]) -> None:
+    try:
+        do_feed()
+    except Exception as e:
+        _logger.debug(f"skipping an entropy source due to error: {e!r}", only_once=True)
+
+
+def rand_add_static_env(feed: 'CRANDOM_FEEDER_API') -> None:
+    """Gather non-cryptographic environment data that does not change over time
+    and feed it into feed().
+
+    Never raises.
+    """
+    # os
+    _safe_feed(lambda: feed(str(os.environ)))
+    _safe_feed(lambda: feed(os.ctermid()))
+    _safe_feed(lambda: feed(os.getcwd()))
+    _safe_feed(lambda: feed(str(os.get_exec_path())))
+    _safe_feed(lambda: feed(str(os.getgroups())))
+    _safe_feed(lambda: feed(str(os.getlogin())))
+    _safe_feed(lambda: feed(os.getpgrp()))
+    _safe_feed(lambda: feed(os.getpid()))
+    _safe_feed(lambda: feed(os.getppid()))
+    _safe_feed(lambda: feed(str(os.getresuid())))
+    _safe_feed(lambda: feed(str(os.getresgid())))
+    _safe_feed(lambda: feed(str(os.uname())))
+    # timezone
+    _safe_feed(lambda: feed(time.timezone))
+    _safe_feed(lambda: feed(str(time.tzname)))
+    # system locale
+    _safe_feed(lambda: feed(str(locale.getlocale())))
+    # mac address
+    _safe_feed(lambda: feed(get_mac_address()))
+    # hostname
+    _safe_feed(lambda: feed(socket.gethostname()))
+    # sys
+    _safe_feed(lambda: feed(str(sys.argv)))
+    _safe_feed(lambda: feed(str(sys.builtin_module_names)))
+    _safe_feed(lambda: feed(sys.executable))
+    _safe_feed(lambda: feed(str(sys.float_info)))
+    _safe_feed(lambda: feed(str(sys.hash_info)))
+    _safe_feed(lambda: feed(str(sys.implementation)))
+    _safe_feed(lambda: feed(str(sys.int_info)))
+    _safe_feed(lambda: feed(str(sys.meta_path)))
+    _safe_feed(lambda: feed(str(sys.orig_argv)))
+    _safe_feed(lambda: feed(str(sys.path)))
+    _safe_feed(lambda: feed(str(sys.thread_info)))
+    _safe_feed(lambda: feed(sys.version))
+    # platform
+    _safe_feed(lambda: feed(str(platform.architecture())))
+    _safe_feed(lambda: feed(platform.machine()))
+    _safe_feed(lambda: feed(platform.node()))
+    _safe_feed(lambda: feed(platform.platform()))
+    _safe_feed(lambda: feed(platform.processor()))
+    _safe_feed(lambda: feed(str(platform.uname())))
+    _safe_feed(lambda: feed(str(platform.win32_ver())))
+    _safe_feed(lambda: feed(str(platform.mac_ver())))
+    _safe_feed(lambda: feed(str(platform.ios_ver())))
+    _safe_feed(lambda: feed(str(platform.libc_ver())))
+    _safe_feed(lambda: feed(str(platform.freedesktop_os_release())))
+    _safe_feed(lambda: feed(str(platform.android_ver())))
+    from .logging import describe_os_version
+    _safe_feed(lambda: feed(describe_os_version()))
+    # version of electrum
+    from . import ELECTRUM_VERSION
+    feed(ELECTRUM_VERSION)
+    from .logging import get_git_version
+    #feed(get_git_version() or "")  # skipping for now as resolving "git" from $PATH might open up its own issues
+    # path to this file
+    feed(__file__)
+    # memory locations
+    feed(id(__file__))
+    feed(id(id))
+    feed(id(os))
+    feed(id(feed))
+    feed(id(ELECTRUM_VERSION))
+    feed(id(_logger))
+    feed(id("longish_string_literal"))
+    feed(id(0))
+    # misc
+    if pwd is not None:
+        _safe_feed(lambda: feed(str(pwd.getpwall())))
+
+
+def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API') -> None:
+    """Gather non-cryptographic environment data that changes over time and feed it into feed().
+
+    Never raises.
+    """
+    # time
+    feed(time.time_ns())
+    feed(time.process_time_ns())
+    feed(time.perf_counter_ns())
+    # openssl
+    try:
+        feed(ssl.RAND_bytes(32))
+    except ssl.SSLError as e:
+        _logger.warning(f"failed to get randomness from openssl: {e!r}", only_once=True)
+    # memory locations
+    feed(id("longish_string_literal"))
+    # threading
+    active_threads = threading.enumerate()
+    feed(str(active_threads))
+    _safe_feed(lambda: feed(str([t.native_id for t in active_threads])))
+    # sys
+    feed(sys.getallocatedblocks())
+    _safe_feed(lambda: feed(sys.getunicodeinternedsize()))
+    _safe_feed(lambda: feed(str(sys._current_frames())))
+    _safe_feed(lambda: feed(str(sys._current_exceptions())))
+    _safe_feed(lambda: feed(str(sys.modules)))
+    _safe_feed(lambda: feed(str(sys.path_importer_cache)))
+    # gc
+    feed(str(gc.get_stats()))
+    feed(str(gc.get_count()))
+    feed(str(gc.get_threshold()))

--- a/electrum/crandom_env.py
+++ b/electrum/crandom_env.py
@@ -114,7 +114,7 @@ def rand_add_static_env(feed: 'CRANDOM_FEEDER_API') -> None:
         _safe_feed(lambda: feed(str(pwd.getpwall())))
 
 
-def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API') -> None:
+def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API', *, include_slow_sources: bool) -> None:
     """Gather non-cryptographic environment data that changes over time and feed it into feed().
 
     Never raises.
@@ -139,9 +139,12 @@ def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API') -> None:
     _safe_feed(lambda: feed(sys.getunicodeinternedsize()))
     _safe_feed(lambda: feed(str(sys._current_frames())))
     _safe_feed(lambda: feed(str(sys._current_exceptions())))
-    _safe_feed(lambda: feed(str(sys.modules)))
     _safe_feed(lambda: feed(str(sys.path_importer_cache)))
     # gc
     feed(str(gc.get_stats()))
     feed(str(gc.get_count()))
     feed(str(gc.get_threshold()))
+    # --- end of fast sources ---
+    if not include_slow_sources:
+        return
+    _safe_feed(lambda: feed(str(sys.modules)))  # takes 1.5 msec

--- a/electrum/crandom_env.py
+++ b/electrum/crandom_env.py
@@ -20,6 +20,10 @@ try:
     import pwd
 except ImportError:  # only available on UNIX
     pwd = None
+try:
+    import resource
+except ImportError:  # only available on UNIX
+    resource = None
 
 from .logging import get_logger
 
@@ -35,6 +39,27 @@ def _safe_feed(do_feed: Callable[[], None]) -> None:
         do_feed()
     except Exception as e:
         _logger.debug(f"skipping an entropy source due to error: {e!r}", only_once=True)
+
+
+def add_path(feed: 'CRANDOM_FEEDER_API', path: str) -> None:
+    """stat a path"""
+    feed(path)
+    try:
+        stat = os.stat(path)
+    except OSError:
+        stat = ""
+    feed(str(stat))
+
+
+def add_file(feed: 'CRANDOM_FEEDER_API', path: str) -> None:
+    """read file at path"""
+    add_path(feed, path)
+    try:
+        with open(path, "rb") as f:
+            data = f.read(1024*1024)  # up to 1 MB
+    except OSError:
+        data = b""
+    feed(data)
 
 
 def rand_add_static_env(feed: 'CRANDOM_FEEDER_API') -> None:
@@ -112,6 +137,23 @@ def rand_add_static_env(feed: 'CRANDOM_FEEDER_API') -> None:
     # misc
     if pwd is not None:
         _safe_feed(lambda: feed(str(pwd.getpwall())))
+    if resource is not None:
+        _safe_feed(lambda: feed(resource.getpagesize()))
+    # filesystem-provided data
+    add_path(feed, "/")
+    add_path(feed, ".")
+    add_path(feed, "/tmp")
+    add_path(feed, "/home")
+    add_path(feed, "/proc")
+    add_file(feed, "/proc/cmdline")
+    add_file(feed, "/proc/cpuinfo")
+    add_file(feed, "/proc/version")
+    add_file(feed, "/etc/passwd")
+    add_file(feed, "/etc/group")
+    add_file(feed, "/etc/hosts")
+    add_file(feed, "/etc/resolv.conf")
+    add_file(feed, "/etc/timezone")
+    add_file(feed, "/etc/localtime")
 
 
 def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API', *, include_slow_sources: bool) -> None:
@@ -144,7 +186,22 @@ def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API', *, include_slow_sources: bo
     feed(str(gc.get_stats()))
     feed(str(gc.get_count()))
     feed(str(gc.get_threshold()))
+    # resource
+    if resource is not None:
+        _safe_feed(lambda: feed(str(resource.getrusage(resource.RUSAGE_SELF))))
+        _safe_feed(lambda: feed(str(resource.getrusage(resource.RUSAGE_CHILDREN))))
+        _safe_feed(lambda: feed(str(resource.getrusage(resource.RUSAGE_THREAD))))
+    # filesystem-provided data (whole section takes around 0.9 msec, but content changes fast)
+    add_file(feed, "/proc/diskstats")
+    add_file(feed, "/proc/vmstat")
+    add_file(feed, "/proc/schedstat")
+    add_file(feed, "/proc/zoneinfo")
+    add_file(feed, "/proc/meminfo")
+    add_file(feed, "/proc/softirqs")
+    add_file(feed, "/proc/stat")
+    add_file(feed, "/proc/self/schedstat")
+    add_file(feed, "/proc/self/status")
     # --- end of fast sources ---
     if not include_slow_sources:
         return
-    _safe_feed(lambda: feed(str(sys.modules)))  # takes 1.5 msec
+    _safe_feed(lambda: feed(str(sys.modules)))  # takes 1.5 msec, and content changes slowly

--- a/electrum/crandom_env.py
+++ b/electrum/crandom_env.py
@@ -4,6 +4,9 @@
 #
 # This module is a companion to crandom.py and is only intended to be accessed from there.
 
+import ctypes
+import ctypes.util
+from ctypes import byref, create_string_buffer, c_size_t
 import gc
 import locale
 import os
@@ -13,7 +16,7 @@ import ssl
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 from uuid import getnode as get_mac_address
 
 try:
@@ -60,6 +63,54 @@ def add_file(feed: 'CRANDOM_FEEDER_API', path: str) -> None:
     except OSError:
         data = b""
     feed(data)
+
+
+_libc = None  # type: ctypes.CDLL | None | False  # False means failed to load libc
+def _load_libc():
+    global _libc
+    if _libc is not None:
+        return
+    try:
+        _libc_path = ctypes.util.find_library("c")  # can raise OSError
+        _libc = ctypes.CDLL(_libc_path, use_errno=True)
+    except Exception as e:
+        _logger.debug(f"failed to load libc: {e!r}", only_once=True)
+        _libc = False
+
+
+def sysctl_byname(name: bytes) -> Optional[bytes]:
+    """
+    ref https://man.freebsd.org/cgi/man.cgi?query=sysctlbyname
+    ref https://github.com/freebsd/freebsd-src/blob/edb230c4af499203d7a6894b3711fe6574b26040/sys/sys/sysctl.h#L961
+    from https://gist.github.com/pudquick/581a71425439f2cf8f09
+    """
+    _load_libc()
+    if not _libc:
+        return None
+    size = c_size_t(0)
+    # Find out how big our buffer will be
+    ret = _libc.sysctlbyname(name, None, byref(size), None, 0)
+    if ret != 0:
+        return None
+    # Make the buffer
+    buf = create_string_buffer(size.value)
+    # Re-run, but provide the buffer
+    ret = _libc.sysctlbyname(name, buf, byref(size), None, 0)
+    if ret != 0:
+        return None
+    return buf.raw
+
+
+def add_sysctl(feed: 'CRANDOM_FEEDER_API', name: bytes) -> None:
+    feed(name)
+    _safe_feed(lambda: feed(sysctl_byname(name) or b""))
+
+
+def supports_sysctl() -> bool:
+    _load_libc()
+    if not _libc:
+        return False
+    return hasattr(_libc, "sysctlbyname")
 
 
 def rand_add_static_env(feed: 'CRANDOM_FEEDER_API') -> None:
@@ -154,6 +205,39 @@ def rand_add_static_env(feed: 'CRANDOM_FEEDER_API') -> None:
     add_file(feed, "/etc/resolv.conf")
     add_file(feed, "/etc/timezone")
     add_file(feed, "/etc/localtime")
+    # sysctls (macOS and BSDs)
+    if supports_sysctl():
+        add_sysctl(feed, b"hw.machine")
+        add_sysctl(feed, b"hw.model")
+        add_sysctl(feed, b"hw.ncpu")
+        add_sysctl(feed, b"hw.physmem")
+        add_sysctl(feed, b"hw.usermem")
+        add_sysctl(feed, b"hw.memsize")
+        add_sysctl(feed, b"hw.machine.arch")
+        add_sysctl(feed, b"hw.realmem")
+        add_sysctl(feed, b"hw.cpu.freq")
+        add_sysctl(feed, b"hw.cpufrequency")
+        add_sysctl(feed, b"hw.bus.freq")
+        add_sysctl(feed, b"hw.busfrequency")
+        add_sysctl(feed, b"hw.cacheline")
+        add_sysctl(feed, b"hw.cachelinesize")
+        add_sysctl(feed, b"hw.cachesize")
+        add_sysctl(feed, b"kern.bootfile")
+        add_sysctl(feed, b"kern.boottime")
+        add_sysctl(feed, b"kern.clockrate")
+        add_sysctl(feed, b"kern.hostid")
+        add_sysctl(feed, b"kern.hostuuid")
+        add_sysctl(feed, b"kern.hostname")
+        add_sysctl(feed, b"kern.osreldate")
+        add_sysctl(feed, b"kern.osrelease")
+        add_sysctl(feed, b"kern.osrev")
+        add_sysctl(feed, b"kern.ostype")
+        add_sysctl(feed, b"kern.version")
+        add_sysctl(feed, b"kern.uuid")
+        add_sysctl(feed, b"kern.bootuuid")
+        add_sysctl(feed, b"kern.bootsessionuuid")
+        add_sysctl(feed, b"kern.kernelcacheuuid")
+        add_sysctl(feed, b"kern.filesetuuid")
 
 
 def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API', *, include_slow_sources: bool) -> None:
@@ -201,6 +285,18 @@ def rand_add_dynamic_env(feed: 'CRANDOM_FEEDER_API', *, include_slow_sources: bo
     add_file(feed, "/proc/stat")
     add_file(feed, "/proc/self/schedstat")
     add_file(feed, "/proc/self/status")
+    # sysctls (macOS and BSDs)
+    if supports_sysctl():
+        add_sysctl(feed, b"kern.proc.all")  # takes around 0.9 msec, content changes fast
+        add_sysctl(feed, b"kern.memorystatus_level")
+        add_sysctl(feed, b"hw.diskstats")
+        add_sysctl(feed, b"vm.swapusage")
+        add_sysctl(feed, b"vm.loadavg")
+        add_sysctl(feed, b"vm.total")
+        add_sysctl(feed, b"vm.meter")
+        add_sysctl(feed, b"vm.page_free_count")
+        add_sysctl(feed, b"net.inet.tcp.pcbcount")
+        add_sysctl(feed, b"net.inet.udp.pcbcount")
     # --- end of fast sources ---
     if not include_slow_sources:
         return

--- a/electrum/gui/__init__.py
+++ b/electrum/gui/__init__.py
@@ -6,6 +6,9 @@
 
 from typing import TYPE_CHECKING, Mapping, Optional
 
+from electrum import crandom
+from electrum.crandom import CRANDOM_FEEDER_API
+
 if TYPE_CHECKING:
     from . import qt
     from electrum.simple_config import SimpleConfig
@@ -20,7 +23,13 @@ class BaseElectrumGui:
         self.plugins = plugins
 
     def main(self) -> None:
-        raise NotImplementedError()
+        """Main entry point to GUI. Normally this launches a GUI event loop and 'blocks' this thread.
+        The application will start to gracefully exit after this returns.
+        """
+        # Feed clock into crandom (again). This measures how long it took to create the GUI object.
+        crandom.rand_add_refresh()
+        # collect some GUI state as well:
+        self.rand_add_gui_static_env(crandom.feed_entropy)
 
     def stop(self) -> None:
         """Stops the GUI.
@@ -31,3 +40,9 @@ class BaseElectrumGui:
     @classmethod
     def version_info(cls) -> Mapping[str, Optional[str]]:
         return {}
+
+    def rand_add_gui_static_env(self, feed: CRANDOM_FEEDER_API) -> None:
+        """Gather non-cryptographic environment data, specific to the GUI, and feed that into crandom.
+        Never raises.
+        """
+        pass

--- a/electrum/gui/qml/__init__.py
+++ b/electrum/gui/qml/__init__.py
@@ -92,6 +92,7 @@ class ElectrumGui(BaseElectrumGui, Logger):
         self.app.quit()
 
     def main(self):
+        BaseElectrumGui.main(self)
         if not self.app._valid:
             return
 

--- a/electrum/gui/qt/__init__.py
+++ b/electrum/gui/qt/__init__.py
@@ -79,6 +79,7 @@ from electrum.wizard import WizardViewState
 from electrum.keystore import load_keystore
 from electrum.bip32 import is_xprv
 from electrum import constants
+from electrum import crandom
 
 from electrum.gui.common_qt.i18n import ElectrumTranslator
 from electrum.gui.messages import TERMS_OF_USE_LATEST_VERSION
@@ -568,6 +569,7 @@ class ElectrumGui(BaseElectrumGui, Logger):
             self.daemon.start_network()
 
     def main(self):
+        BaseElectrumGui.main(self)
         # setup Ctrl-C handling and tear-down code first, so that user can easily exit whenever
         self.app.setQuitOnLastWindowClosed(False)  # so _we_ can decide whether to quit
         self.app.lastWindowClosed.connect(self._maybe_quit_if_no_windows_open)
@@ -619,6 +621,16 @@ class ElectrumGui(BaseElectrumGui, Logger):
         # tooltip cannot be displayed immediately when called from a menu; wait 200ms
         QTimer.singleShot(200, lambda: QToolTip.showText(QCursor.pos(), message, None))
 
+    def rand_add_gui_static_env(self, feed) -> None:
+        for screen in self.app.screens():
+            feed(str(screen.serialNumber()))
+            feed(str(screen.manufacturer()))
+            feed(str(screen.model()))
+            feed(str(screen.name()))
+            feed(str(screen.size()))
+            feed(str(screen.availableSize()))
+            feed(str(screen.refreshRate()))
+            feed(str(screen.logicalDotsPerInch()))
 
 def standalone_exception_dialog(exception: Union[str, BaseException]) -> None:
     app = QApplication.instance()

--- a/electrum/gui/stdio.py
+++ b/electrum/gui/stdio.py
@@ -179,6 +179,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
 
 
     def main(self):
+        BaseElectrumGui.main(self)
         self.daemon.start_network()
         while self.done == 0:
             self.main_command()

--- a/electrum/gui/text.py
+++ b/electrum/gui/text.py
@@ -533,6 +533,7 @@ class ElectrumGui(BaseElectrumGui, EventListener):
         pass
 
     def main(self):
+        BaseElectrumGui.main(self)
         self.daemon.start_network()
         tty.setraw(sys.stdin)
         try:

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -24,6 +24,7 @@ from .lrucache import LRUCache
 from .crypto import sha256, sha256d, privkey_to_pubkey
 from . import bitcoin, util
 from . import constants
+from . import crandom
 from .util import (log_exceptions, ignore_exceptions, chunks, OldTaskGroup,
                    UnrelatedTransactionException, error_text_bytes_to_safe_str, AsyncHangDetector,
                    NoDynamicFeeEstimates, event_listener, EventListener)
@@ -188,6 +189,7 @@ class Peer(Logger, EventListener):
         if isinstance(self.transport, LNTransport):
             await self.transport.handshake()
         self.logger.info(f"handshake done for {self.transport.peer_addr or self.pubkey.hex()}")
+        crandom.rand_add_refresh()  # feed network timing entropy into our RNG
         features = self.features.for_init_message()
         flen = lnutil.int_min_byte_len(features)
         self.send_message(

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -58,6 +58,7 @@ from .version import PROTOCOL_VERSION_MIN
 from .i18n import _
 from .logging import get_logger, Logger
 from .fee_policy import FeeHistogram, FeeTimeEstimates, FEE_ETA_TARGETS
+from . import crandom
 
 
 if TYPE_CHECKING:
@@ -997,6 +998,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
                 self.interfaces[server] = interface
         finally:
             self._connecting_ifaces.discard(server)
+            crandom.rand_add_refresh()  # feed network timing entropy into our RNG
 
         if server == self.default_server:
             await self.switch_to_interface(server)

--- a/electrum/storage.py
+++ b/electrum/storage.py
@@ -33,6 +33,7 @@ from typing import Optional
 import electrum_ecc as ecc
 
 from . import crypto
+from . import crandom
 from .util import (profiler, InvalidPassword, WalletFileException, bfh, standardize_path,
                    test_read_write_permissions, os_chmod)
 
@@ -86,6 +87,11 @@ class WalletStorage(Logger):
             self._encryption_version = StorageEncryptionVersion.PLAINTEXT
             self.pos = 0
             self.init_pos = 0
+        # feed timing/wallet_name entropy into our RNG.
+        # note: both qt/qml GUIs create temp WalletStorage objects (to check R/W permissions)
+        #       on *every keypress* when editing wallet_name. what a gold mine!
+        crandom.rand_add_refresh()
+        crandom.feed_entropy(str(path))
 
     def get_path(self):
         return self.path

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -17,6 +17,7 @@ from electrum.util import UserFacingException
 from electrum.wallet_db import WalletDB
 from electrum.bip32 import normalize_bip32_derivation, xpub_type
 from electrum import descriptor, keystore, mnemonic, bitcoin
+from electrum import crandom
 from electrum.mnemonic import is_any_2fa_seed_type, can_seed_have_passphrase
 from electrum.util import multisig_type
 
@@ -120,6 +121,7 @@ class AbstractWizard:
 
         self.log_stack()
 
+        crandom.rand_add_refresh()  # feed "next"/"back" button timing entropy into our RNG
         return new_view
 
     def resolve_prev(self):
@@ -128,6 +130,7 @@ class AbstractWizard:
         self._logger.debug(f'resolve_prev view is "{self._current.view}"')
         self.log_stack()
 
+        crandom.rand_add_refresh()  # feed "next"/"back" button timing entropy into our RNG
         return self._current
 
     # check if this view is the final view

--- a/tests/test_crandom.py
+++ b/tests/test_crandom.py
@@ -1,4 +1,5 @@
 import hashlib
+import time
 from unittest import mock
 
 from electrum import crandom
@@ -7,6 +8,10 @@ from . import ElectrumTestCase
 from .test_wallet_vertical import UNICODE_HORROR
 
 class TestCRandom(ElectrumTestCase):
+
+    def setUp(self):
+        super().setUp()
+        crandom._rng._last_strengthened = time.monotonic()  # disable periodic strengthen() calls
 
     def test_feed_entropy_naive(self):
         def run():

--- a/tests/test_crandom.py
+++ b/tests/test_crandom.py
@@ -1,0 +1,103 @@
+import hashlib
+from unittest import mock
+
+from electrum import crandom
+
+from . import ElectrumTestCase
+from .test_wallet_vertical import UNICODE_HORROR
+
+class TestCRandom(ElectrumTestCase):
+
+    def test_feed_entropy_naive(self):
+        def run():
+            datas = ["mystr1", 53, -866, b"\x01\x02\x03"]
+            for data in datas:
+                state = crandom._rng._state
+                crandom.feed_entropy(data)
+                self.assertNotEqual(state, crandom._rng._state)
+        # internal state changes after feed_entropy():
+        state1 = crandom._rng._state
+        run()
+        state2 = crandom._rng._state
+        assert state1 != state2
+        # feed_entropy() is deterministic, so given access to the secret internal state, I can predict it:
+        crandom._rng._state = bytes(32)
+        run()
+        state3 = crandom._rng._state
+        assert state2 != state3
+        self.assertEqual(bytes.fromhex("a24e7c4c91c095226d254ad3fba5f3ef60a1dcf32fb769113bbc3d95d6160a6c"), state3)
+
+    def test_feed_entropy_unicode(self):
+        """This tests feed_entropy() does not raise on weird str inputs."""
+        # feed in some vanilla unicode:
+        state = crandom._rng._state
+        crandom.feed_entropy(UNICODE_HORROR)
+        self.assertNotEqual(state, crandom._rng._state)
+        # feed in str that cannot be encoded as unicode in "strict" (default) mode:
+        state = crandom._rng._state
+        weird_string = ''.join(map(chr, range(0x110_000)))
+        crandom.feed_entropy(weird_string)
+        self.assertNotEqual(state, crandom._rng._state)
+
+    def test_get_rand_bytes_api(self):
+        # test output length:
+        for nbytes in range(1000):
+            self.assertEqual(nbytes, len(crandom.get_rand_bytes(nbytes)))
+        # test internal state changes:
+        state = crandom._rng._state
+        r1 = crandom.get_rand_bytes(16)
+        self.assertNotEqual(state, crandom._rng._state)
+        # test output changes:
+        self.assertNotEqual(r1, crandom.get_rand_bytes(16))
+
+    def test_get_rand_bytes_os_urandom(self):
+        # even if I have access to the secret internal state, I cannot predict the output,
+        # as it depends on os.urandom:
+        crandom._rng._state = bytes(32)
+        r1 = crandom.get_rand_bytes(16)
+        crandom._rng._state = bytes(32)
+        r2 = crandom.get_rand_bytes(16)
+        assert r1 != r2
+        # but if os.urandom is broken, then the output can be predicted:
+        with mock.patch('os.urandom', return_value=bytes(32)):
+            crandom._rng._state = bytes(32)
+            r3 = crandom.get_rand_bytes(16)
+            self.assertEqual(bytes.fromhex("7be9fda48f4179e611c698a73cff09fa"), r3)
+
+    def test_mix_extract(self):
+        """Check mix_extract calls os.urandom(32) and it mixes in all those bytes."""
+        #   h = sha512(os.urandom(32) + self._state)
+        #   out, self._state = h[0:32], h[32:64]
+        orig_state = b"state___" * 4
+        osurandom_res = b"osurandom" * 4
+        sha512res = hashlib.sha512(osurandom_res + orig_state).digest()
+        assert sha512res == bytes.fromhex("e7a9e48bdcae23834fbc1bc35e61101eb9afd68c32473c250db9155cfa82018aec76a5ec216f7d4aad1bfb8aee012a1cab5869956327a39a2b1994366e899d0d")
+        crandom._rng._state = orig_state
+        with mock.patch('os.urandom', autospec=True) as mock_urandom:
+            mock_urandom.return_value = osurandom_res
+            extracted_bytes = crandom._rng._mix_extract()
+        self.assertEqual(sha512res[:32], extracted_bytes)
+        self.assertEqual(sha512res[32:], crandom._rng._state)
+        mock_urandom.assert_called_once_with(32)  # os.urandom was asked for exactly 32 bytes
+
+    def test_get_rand_below(self):
+        self.assertEqual({0}, {crandom.get_rand_below(1) for i in range(128)})
+        self.assertEqual({0, 1}, {crandom.get_rand_below(2) for i in range(128)})
+        self.assertEqual({0, 1, 2}, {crandom.get_rand_below(3) for i in range(128)})
+        self.assertEqual({0, 1, 2, 3}, {crandom.get_rand_below(4) for i in range(128)})
+
+        upper_bound = 10000
+        seen = set()
+        for i in range(128):
+            x = crandom.get_rand_below(upper_bound)
+            assert 0 <= x < upper_bound
+            seen.add(x)
+        assert len(seen) >= 10, seen
+        assert min(seen) < upper_bound // 2, seen
+        assert max(seen) > upper_bound // 2, seen
+        assert max(seen) - min(seen) > upper_bound // 2, seen
+
+    def test_rand_add_refresh(self):
+        state = crandom._rng._state
+        crandom.rand_add_refresh()
+        self.assertNotEqual(state, crandom._rng._state)


### PR DESCRIPTION
(still WIP)

Currently we rely on `os.urandom()` ~everywhere for cryptographically secure randomness. Existing code already checks at runtime that the output of `os.urandom()` looks at least somewhat sane (see if it compresses with zlib) and hard-fails if it does not.

However, `os.urandom` could still be subtly "broken" (undetected by us) and produce bad quality output. That's the motivation of the new code here. We expect `os.urandom` to work well, BUT if it undetectably does not, mixing in other sources of entropy mitigates the situation somewhat.

This PR introduces a new module `crandom.py` that manages the RNG, and that our other code should call. Extreme care should be taken here not to make things worse than the status quo by "rolling our own" thing.

The logic is split across two modules: `crandom.py` and `crandom_env.py`.
- The core sensitive logic (RNG mixing, extracting random bytes) is in `crandom.py`, which is absolutely security critical and is kept concise to ease review.
- `crandom_env.py` contains secondary sources of entropy and potentially platform-specific code. It is just a companion to `crandom.py` and is only intended to be accessed from there. Even if all the entropy sources listed in `crandom_env.py` are broken, assuming `os.urandom()` produces high quality random, `crandom.py` should never produce low-quality random output. Hence `crandom_env.py` is much less critical to review in depth.

This is inspired by https://github.com/bitcoin/bitcoin/blob/67efced1fc83a0b7215cc1513e7c4754fee0f12f/src/random.h#L25, which is significantly more advanced. But I wanted to (1) lessen our dependence on `os.urandom()`, (2) while keeping it simple.