### PR TITLE
qml/android: protect WIF keys from screenshots in more places

### DIFF
--- a/electrum/gui/qml/components/AddressDetails.qml
+++ b/electrum/gui/qml/components/AddressDetails.qml
@@ -351,6 +351,7 @@ Pane {
     Binding {
         target: AppController
         property: 'secureWindow'
+        when: root.visible  // enables stacking multiple secureWindow dialogs
         value: Boolean(addressdetails.privkey)
     }
 }

--- a/electrum/gui/qml/components/ImportAddressesKeysDialog.qml
+++ b/electrum/gui/qml/components/ImportAddressesKeysDialog.qml
@@ -123,4 +123,11 @@ ElDialog {
         id: bitcoin
     }
 
+    Binding {
+        target: AppController
+        property: 'secureWindow'
+        when: root.visible  // enables stacking multiple secureWindow dialogs
+        value: true
+    }
+
 }

--- a/electrum/gui/qml/components/SweepDialog.qml
+++ b/electrum/gui/qml/components/SweepDialog.qml
@@ -162,4 +162,11 @@ ElDialog {
     Bitcoin {
         id: bitcoin
     }
+
+    Binding {
+        target: AppController
+        property: 'secureWindow'
+        when: root.visible  // enables stacking multiple secureWindow dialogs
+        value: true
+    }
 }

--- a/electrum/gui/qml/components/WalletDetails.qml
+++ b/electrum/gui/qml/components/WalletDetails.qml
@@ -677,6 +677,7 @@ Pane {
     Binding {
         target: AppController
         property: 'secureWindow'
+        when: rootItem.visible  // enables stacking multiple secureWindow dialogs
         value: seedText.visible
     }
 

--- a/electrum/gui/qml/components/wizard/Wizard.qml
+++ b/electrum/gui/qml/components/wizard/Wizard.qml
@@ -155,6 +155,7 @@ ElDialog {
             Binding {
                 target: AppController
                 property: 'secureWindow'
+                when: pages.visible  // enables stacking multiple secureWindow dialogs
                 value: pages.contentChildren[pages.currentIndex].securePage
             }
         }


### PR DESCRIPTION
also fix bug in AddressDetails where we were never unsetting the secure flag