### PR TITLE
docs: add Coldcard Mk3 seed-entropy security notice to plugin README

### DIFF
--- a/electrum/plugins/coldcard/README.md
+++ b/electrum/plugins/coldcard/README.md
@@ -1,5 +1,9 @@
 # Coldcard Hardware Wallet Plugin
 
+## ⚠ Security notice
+
+Coinkite disclosed (July 2026) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. Seeds generated on-device without extra dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
+
 ## Just the glue please
 
 This code connects the public USB API and Electrum. Leverages all

--- a/electrum/plugins/coldcard/README.md
+++ b/electrum/plugins/coldcard/README.md
@@ -1,8 +1,8 @@
 # Coldcard Hardware Wallet Plugin
 
-## ⚠ Security notice
+## Security notice
 
-Coinkite disclosed (July 2026) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. Seeds generated on-device without extra dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
+Coinkite disclosed (July 2026) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1-5.0.3) and pre-fix **Mk4/Q**. Seeds generated on-device without extra dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
 
 ## Just the glue please
 


### PR DESCRIPTION
## Summary

Adds a short **Security notice** to the Coldcard plugin README (`electrum/plugins/coldcard/README.md`).

In July 2026 Coinkite [disclosed](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. Electrum doesn't generate the Coldcard seed, so this isn't an Electrum flaw — but users who set up a Coldcard via Electrum may hold funds on an affected seed. Docs-only change.

Refs #10804.
