### PR TITLE
android: bump target SDK to API36

### DIFF
--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -116,8 +116,8 @@ RUN apt -y update -qq \
 RUN yes | ${ANDROID_SDK_MANAGER} --licenses > /dev/null
 
 
-ENV ANDROID_SDK_BUILD_TOOLS_MAJOR_V="35"
-ENV ANDROID_SDK_BUILD_TOOLS_VERSION="35.0.0"
+ENV ANDROID_SDK_BUILD_TOOLS_MAJOR_V="36"
+ENV ANDROID_SDK_BUILD_TOOLS_VERSION="36.0.0"
 
 # download platforms, API, build tools
 RUN ${ANDROID_SDK_MANAGER} "platforms;android-${ANDROID_SDK_BUILD_TOOLS_MAJOR_V}" > /dev/null && \
@@ -235,7 +235,7 @@ RUN cd /opt \
     && /opt/venv/bin/python3 -m pip install --no-build-isolation --no-dependencies -e .
 
 # install python-for-android
-ENV P4A_CHECKOUT_COMMIT="8c0fcc9ef2e559918ca96ecde6e09fe521bb1427"
+ENV P4A_CHECKOUT_COMMIT="760f7f0f1d1946325be1cd4456179194635353eb"
 # ^ from branch electrum_202602 (note: careful with force-pushing! see #8162)
 RUN cd /opt \
     && git clone https://github.com/spesmilo/python-for-android \

--- a/contrib/android/buildozer_qml.spec
+++ b/contrib/android/buildozer_qml.spec
@@ -105,10 +105,10 @@ android.permissions = INTERNET, CAMERA, WRITE_EXTERNAL_STORAGE, POST_NOTIFICATIO
 
 # (int) Android API to use  (compileSdkVersion)
 # note: when changing, Dockerfile also needs to be changed to install corresponding build tools
-android.api = 35
+android.api = 36
 
 # (int) Android targetSdkVersion
-android.target_sdk_version = 35
+android.target_sdk_version = 36
 
 # (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
 android.minapi = 26


### PR DESCRIPTION
bump target SDK to API36

p4a ref updated to 760f7f0f1d1946325be1cd4456179194635353eb:
- manifest: add opt-out for enableOnBackInvokedCallback
- add NDK build missing APP_PLATFORM