### PR TITLE
json_db/config: sanitize logging of unserializable values

### DIFF
--- a/electrum/json_db.py
+++ b/electrum/json_db.py
@@ -211,7 +211,8 @@ class JsonDB(Logger):
             json.dumps(key, cls=self.encoder)
             json.dumps(value, cls=self.encoder)
         except Exception:
-            self.logger.info(f"json error: cannot save {repr(key)} ({repr(value)})")
+            # note: "value" might be secret material, should probably not log it
+            self.logger.info(f"json error: cannot save {key=!r} ({type(value)})")
             return False
         if value is not None:
             if self.data.get(key) != value:

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -294,7 +294,8 @@ class SimpleConfig(Logger):
             json.dumps(key)
             json.dumps(value)
         except Exception:
-            self.logger.info(f"json error: cannot save {repr(key)} ({repr(value)})")
+            # note: "value" might be secret material, should probably not log it
+            self.logger.info(f"json error: cannot save {key=!r} ({type(value)})")
             return
         self._set_key_in_user_config(key, value, save=save)
 


### PR DESCRIPTION
We should aim not to log secrets.

The logging was added in https://github.com/spesmilo/electrum/commit/6958c0ccc3d97edfb7f8504f27270182cb3abcfa, to aid debugging, but now I think we should err on the side of cautiousness here. As middle-ground we could try to sanitize `value` a bit before logging it, similar to `bitcoin.neuter_bitcoin_address`, e.g. `str(value)[:2] + ".." + str(value)[-2:]`.