### PR TITLE
android: limit biometric auth to biometric only

### DIFF
--- a/electrum/gui/qml/java_classes/org/electrum/biometry/BiometricActivity.java
+++ b/electrum/gui/qml/java_classes/org/electrum/biometry/BiometricActivity.java
@@ -55,7 +55,7 @@ public class BiometricActivity extends Activity {
         Executor executor = getMainExecutor();
         BiometricPrompt biometricPrompt = new BiometricPrompt.Builder(this)
                 .setTitle("Electrum Wallet")
-                .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
                 .setSubtitle(authMessage)
                 .build();
 
@@ -159,7 +159,7 @@ public class BiometricActivity extends Activity {
                 .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
                 .setUserAuthenticationRequired(true)
-                .setUserAuthenticationParameters(0, KeyProperties.AUTH_BIOMETRIC_STRONG | KeyProperties.AUTH_DEVICE_CREDENTIAL);
+                .setUserAuthenticationParameters(0, KeyProperties.AUTH_BIOMETRIC_STRONG);
 
         keyGenerator.init(builder.build());
         keyGenerator.generateKey();

--- a/electrum/gui/qml/java_classes/org/electrum/biometry/BiometricHelper.java
+++ b/electrum/gui/qml/java_classes/org/electrum/biometry/BiometricHelper.java
@@ -10,7 +10,7 @@ public class BiometricHelper {
     public static boolean isAvailable(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) { // API 30+
             BiometricManager biometricManager = context.getSystemService(BiometricManager.class);
-            return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL) == BiometricManager.BIOMETRIC_SUCCESS;
+            return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) == BiometricManager.BIOMETRIC_SUCCESS;
         }
         return false;
     }


### PR DESCRIPTION
android: limit biometric auth to biometric only, disallow standard device unlock (pin, pattern, device pw)