### PR TITLE
lnutil: don't trim htlcs equal to dust level

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1870,7 +1870,7 @@ class Channel(AbstractChannel):
     def make_closing_tx(self, local_script: bytes, remote_script: bytes,
                         fee_sat: int, *, drop_remote = False) -> Tuple[bytes, PartialTransaction]:
         """ cooperative close """
-        _, outputs = make_commitment_outputs(
+        outputs = make_commitment_outputs(
             fees_per_participant={
                 LOCAL: fee_sat * 1000 if self.constraints.is_initiator else 0,
                 REMOTE: fee_sat * 1000 if not self.constraints.is_initiator else 0,

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -1146,18 +1146,18 @@ def make_commitment_outputs(
     has_anchors: bool,
     local_anchor_script: Optional[str],
     remote_anchor_script: Optional[str]
-) -> Tuple[List[PartialTxOutput], List[PartialTxOutput]]:
+) -> List[PartialTxOutput]:
 
-    # determine HTLC outputs and trim below dust to know if anchors need to be included
+    # convert htlcs to tx outputs
     htlc_outputs = []
     for script, htlc in htlcs:
         addr = bitcoin.redeem_script_to_address('p2wsh', script)
-        if htlc.amount_msat // 1000 > dust_limit_sat:
-            htlc_outputs.append(
-                PartialTxOutput(
-                    scriptpubkey=address_to_script(addr),
-                    value=htlc.amount_msat // 1000
-                ))
+        assert htlc.amount_msat // 1000 >= dust_limit_sat, f"{htlc} should have been trimmed before"
+        htlc_outputs.append(
+            PartialTxOutput(
+                scriptpubkey=address_to_script(addr),
+                value=htlc.amount_msat // 1000
+            ))
 
     # BOLT-03: "Base commitment transaction fees are extracted from the funder's amount;
     #           if that amount is insufficient, the entire amount of the funder's output is used."
@@ -1183,14 +1183,15 @@ def make_commitment_outputs(
             anchor_outputs.append(PartialTxOutput(scriptpubkey=remote_anchor_script, value=FIXED_ANCHOR_SAT))
 
     # if funder cannot afford feerate, their output might go negative, so take max(0, x) here
-    to_local_amt_msat = max(0, to_local_amt_msat)
-    to_remote_amt_msat = max(0, to_remote_amt_msat)
-    non_htlc_outputs.append(PartialTxOutput(scriptpubkey=local_script, value=to_local_amt_msat // 1000))
-    non_htlc_outputs.append(PartialTxOutput(scriptpubkey=remote_script, value=to_remote_amt_msat // 1000))
+    to_local_amt_sat = max(0, to_local_amt_msat) // 1000
+    to_remote_amt_sat = max(0, to_remote_amt_msat) // 1000
+    if to_local_amt_sat >= dust_limit_sat:
+        non_htlc_outputs.append(PartialTxOutput(scriptpubkey=local_script, value=to_local_amt_sat))
+    if to_remote_amt_sat >= dust_limit_sat:
+        non_htlc_outputs.append(PartialTxOutput(scriptpubkey=remote_script, value=to_remote_amt_sat))
 
-    c_outputs_filtered = list(filter(lambda x: x.value >= dust_limit_sat, non_htlc_outputs + htlc_outputs))
-    c_outputs = c_outputs_filtered + anchor_outputs
-    return htlc_outputs, c_outputs
+    c_outputs = non_htlc_outputs + htlc_outputs + anchor_outputs
+    return c_outputs
 
 
 def effective_htlc_tx_weight(success: bool, has_anchors: bool):
@@ -1299,7 +1300,7 @@ def make_commitment(
     htlcs = list(htlcs)
     htlcs.sort(key=lambda x: x.htlc.cltv_abs)
 
-    htlc_outputs, c_outputs_filtered = make_commitment_outputs(
+    c_outputs_filtered = make_commitment_outputs(
         fees_per_participant=fees_per_participant,
         local_amount_msat=local_amount,
         remote_amount_msat=remote_amount,

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -1008,6 +1008,43 @@ class TestDust(ElectrumTestCase):
         self.assertEqual(2, len(bob_channel.get_next_commitment(LOCAL).outputs()) - (2 if self.TEST_ANCHOR_CHANNELS else 0))
         self.assertEqual(htlc_amt, alice_channel.total_msat(SENT) // 1000)
 
+    async def test_DustLimit_at_trim_threshold(self):
+        """An HTLC worth *exactly* the trim threshold must NOT be trimmed.
+
+        BOLT-3 only trims when "the HTLC amount minus the HTLC-timeout/success fee
+        would be less than dust_limit_satoshis". For anchor channels that fee is
+        zero, so the threshold collapses onto the dust limit itself.
+        """
+        alice_channel, bob_channel = create_test_channels(
+            alice_lnwallet=self.alice_lnwallet, bob_lnwallet=self.bob_lnwallet)
+        dust_limit_bob = bob_channel.config[LOCAL].dust_limit_sat
+        feerate = bob_channel.get_next_feerate(LOCAL)
+        threshold_sat = lnutil.received_htlc_trim_threshold_sat(
+            dust_limit_sat=dust_limit_bob, feerate=feerate,
+            has_anchors=self.TEST_ANCHOR_CHANNELS)
+        htlc = UpdateAddHtlc(
+            payment_hash=bitcoin.sha256(b"\x01" * 32),
+            amount_msat=1000 * threshold_sat,
+            cltv_abs=5,  # consistent with channel policy
+            timestamp=0,
+        )
+        alice_channel.add_htlc(htlc)
+        bob_channel.receive_htlc(htlc)
+
+        ctn = bob_channel.get_next_ctn(LOCAL)
+        ctx = bob_channel.get_next_commitment(LOCAL)
+        _secret, pcp = bob_channel.get_secret_and_point(subject=LOCAL, ctn=ctn)
+        # the htlc counts as non-dust for fee purposes...
+        self.assertEqual(1, len(bob_channel.included_htlcs(LOCAL, RECEIVED, ctn=ctn)))
+        # ...so it must really have an output in the ctx
+        self.assertEqual(3, len(ctx.outputs()) - (2 if self.TEST_ANCHOR_CHANNELS else 0))
+        self.assertIn(threshold_sat, [x.value for x in ctx.outputs()])
+        self.assertEqual(1, len(lnutil.map_htlcs_to_ctx_output_idxs(
+            chan=bob_channel, ctx=ctx, pcp=pcp, subject=LOCAL, ctn=ctn)))
+        # ...and the peer must be sent exactly one htlc signature for it
+        _sig, htlc_sigs = alice_channel.sign_next_commitment()
+        self.assertEqual(1, len(htlc_sigs))
+
 
 class TestDustNoAnchors(TestDust):
     assert TestDust.TEST_ANCHOR_CHANNELS is True


### PR DESCRIPTION
We should include htlc outputs in the ctx if their values is equal to the dust limit

https://github.com/lightning/bolts/blob/35e79db504560b9d3494a0ed07bf1e8379c3663a/03-transactions.md?plain=1#L340-L342