### PR TITLE
channel_db: skip non-ASCII DNS hostnames in node announcements

### DIFF
--- a/electrum/channel_db.py
+++ b/electrum/channel_db.py
@@ -281,8 +281,12 @@ class NodeInfo(NamedTuple):
                 addresses.append((host, port))
             elif atype == 5:  # dns hostname
                 len_hostname = int.from_bytes(read(1), 'big')
-                host = read(len_hostname).decode('ascii')
+                host_bytes = read(len_hostname)
                 port = int.from_bytes(read(2), 'big')
+                try:
+                    host = host_bytes.decode('ascii')
+                except UnicodeDecodeError:
+                    continue
                 if not NodeInfo.invalid_announcement_hostname(host) and port > 0:
                     addresses.append((host, port))
             else:

--- a/tests/test_lnmsg.py
+++ b/tests/test_lnmsg.py
@@ -380,6 +380,7 @@ class TestLNMsg(ElectrumTestCase):
         invalid_inputs_parsing = (
             b'', # empty input
             b'\x06\x00', # address type 6 (\x06) is not specified
+            b'\x05\x02\xff\xff\x26\x07', # non-ASCII dns hostname
         )
         invalid_inputs_serialization = (
             ("::1", 9735),  # local ipv6


### PR DESCRIPTION
BOLT-07 mentions [here](https://github.com/lightning/bolts/blob/35e79db504560b9d3494a0ed07bf1e8379c3663a/07-routing-gossip.md?plain=1#L324-L327) that senders of `node_announcement` need to encode DNS hostname bytes with ASCII:

```
   * `5`: DNS hostname; data = `[1:hostname_len][hostname_len:hostname][2:port]` (length up to 258)
       * `hostname` bytes MUST be ASCII characters.
       * Non-ASCII characters MUST be encoded using Punycode:
         https://en.wikipedia.org/wiki/Punycode
```

(Punycode maps non-ASCII characters to ASCII characters.)

However, receivers need to check that the bytes are indeed decodable as ASCII. Currently, the code to parse address descriptors would throw `UnicodeDecodeError` on the first DNS hostname with non-ASCII characters and drop the remaining descriptors.[^1] With this PR, such invalid address descriptors are skipped. 

[^1]: I haven't tested this against running code, only using the existing tests, so I don't know if Electrum would crash during runtime or not.

FYI, LND [additionally checks](https://github.com/lightningnetwork/lnd/blob/d932f48678228e337a7cc75ee4e864245e6e2b99/lnwire/dns_addr.go#L56-L92) that the characters are within `[a-zA-Z0-9_.]` but this is not part of the specification.