### PR TITLE
docs: correct Coldcard firmware range in seed-entropy notice

### DIFF
--- a/electrum/plugins/coldcard/README.md
+++ b/electrum/plugins/coldcard/README.md
@@ -2,7 +2,7 @@
 
 ## Security notice
 
-Coinkite disclosed (July 2026) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1-5.0.3) and pre-fix **Mk4/Q**. Seeds generated on-device without extra dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
+Coinkite disclosed (July 2026) a firmware build error that reduced generated-seed entropy on **Coldcard Mk2/Mk3** (firmware 4.0.1-4.1.9) and **Mk4/Mk5/Q** before their fixed firmware. Seeds generated on-device with fewer than 50 independent dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
 
 ## Just the glue please
 


### PR DESCRIPTION
## Summary

Follow-up to the merged Coldcard seed-entropy notice. The firmware/model range in the merged text was taken from a secondary source and is inaccurate. This corrects it to match [Coinkite's advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/):

- Affected: **Coldcard Mk2/Mk3 (firmware 4.0.1-4.1.9, fixed in 4.2.0+)** and **Mk4/Mk5/Q** before their fixed firmware.
- The old range omitted **Mk2** (telling affected Mk2 owners they are safe) and over-extended the upper bound to 5.0.3 (covering Mk3 4.2.0-5.0.3, which is already fixed — telling safe users to reseed).
- Also clarifies the dice-roll qualifier (fewer than 50 independent rolls).

Docs-only change.