### PR TITLE
qml: wallet, tx and callbacks were incorrectly scoped to class level for trustedcoin plugin.

### DIFF
--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -114,6 +114,8 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         self._seed = ''
         self._seed_passphrase = ''
 
+        self._otp_on_submit = None  # type: Callable[[str], None]
+
         self.tx_notification_queue = queue.Queue()
         self.tx_notification_last_time = 0
 
@@ -599,7 +601,7 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
         if cb:
             cb()
 
-    def request_otp(self, on_submit):
+    def request_otp(self, on_submit: Callable[[str], None]):
         self._otp_on_submit = on_submit
         self.otpRequested.emit()
 

--- a/electrum/plugins/trustedcoin/common_qt.py
+++ b/electrum/plugins/trustedcoin/common_qt.py
@@ -63,10 +63,6 @@ class TrustedcoinPluginQObject(PluginQObject):
     def shortId(self):
         return self._shortId
 
-    @pyqtSlot(str)
-    def otpSubmit(self, otp):
-        self._plugin.on_otp(otp)
-
     @pyqtProperty(str, notify=remoteKeyStateChanged)
     def remoteKeyState(self):
         return self._remoteKeyState

--- a/electrum/plugins/trustedcoin/qml.py
+++ b/electrum/plugins/trustedcoin/qml.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import TYPE_CHECKING, Callable
 
 from electrum.i18n import _
@@ -8,7 +9,7 @@ from electrum.gui.qml.qewallet import QEWallet
 from electrum.gui.qml.qedaemon import QEDaemon
 
 from .common_qt import TrustedcoinPluginQObject
-from .trustedcoin import TrustedCoinPlugin, TrustedCoinException
+from .trustedcoin import TrustedCoinPlugin, TrustedCoinException, Wallet_2fa
 
 if TYPE_CHECKING:
     from electrum.gui.qml import ElectrumQmlApplication
@@ -16,14 +17,11 @@ if TYPE_CHECKING:
     from electrum.wizard import NewWalletWizard
     from electrum.transaction import PartialTransaction
 
-    from .trustedcoin import Wallet_2fa
-
 
 class Plugin(TrustedCoinPlugin):
     def __init__(self, *args):
         super().__init__(*args)
         self._app = None  # type: ElectrumQmlApplication
-        self.wallet = None  # type: Wallet_2fa
         self.so = None  # type: TrustedcoinPluginQObject
         self.on_success = None  # type: Callable
         self.on_failure = None  # type: Callable
@@ -107,39 +105,46 @@ class Plugin(TrustedCoinPlugin):
 
     def prompt_user_for_otp(
         self,
-        wallet: 'Wallet_2fa',
+        wallet: Wallet_2fa,
         tx: 'PartialTransaction',
-        on_success: Callable,
-        on_failure: Callable
+        on_success: Callable[['PartialTransaction'], None],
+        on_failure: Callable[[str], None],
     ):
         self.logger.debug('prompt_user_for_otp')
-        self.on_success = on_success
-        self.on_failure = on_failure if on_failure else lambda x: self.logger.error(x)
-        self.wallet = wallet
-        self.tx = tx
         qewallet = QEWallet.getInstanceFor(wallet)
-        qewallet.request_otp(self.on_otp)
+        qewallet.request_otp(partial(self.on_otp, wallet, tx, on_success=on_success, on_failure=on_failure))
 
-    def on_otp(self, otp):
+    def on_otp(
+            self,
+            wallet: Wallet_2fa,
+            tx: 'PartialTransaction',
+            otp,
+            *,
+            on_success: Callable[['PartialTransaction'], None],
+            on_failure: Callable[[str], None] = None
+    ):
         self.logger.debug('on_otp')
+        assert wallet and isinstance(wallet, Wallet_2fa)
+
+        on_failure = on_failure if on_failure else lambda x: self.logger.error(x)
 
         if not otp:
-            self.on_failure(_('No auth code'))
+            on_failure(_('No auth code'))
             return
 
         try:
-            self.wallet.on_otp(self.tx, otp)
+            wallet.on_otp(tx, otp)
         except UserFacingException as e:
-            self.on_failure(_('Invalid one-time password.'))
+            on_failure(_('Invalid one-time password.'))
         except TrustedCoinException as e:
             if e.status_code == 400:  # invalid OTP
-                self.on_failure(_('Invalid one-time password.'))
+                on_failure(_('Invalid one-time password.'))
             else:
-                self.on_failure(_('Service Error') + ':\n' + str(e))
+                on_failure(_('Service Error') + ':\n' + str(e))
         except Exception as e:
-            self.on_failure(_('Error') + ':\n' + str(e))
+            on_failure(_('Error') + ':\n' + str(e))
         else:
-            self.on_success(self.tx)
+            on_success(tx)
 
     def billing_info_retrieved(self, wallet):
         self.logger.info('billing_info_retrieved')

--- a/electrum/plugins/trustedcoin/qml.py
+++ b/electrum/plugins/trustedcoin/qml.py
@@ -23,9 +23,6 @@ class Plugin(TrustedCoinPlugin):
         super().__init__(*args)
         self._app = None  # type: ElectrumQmlApplication
         self.so = None  # type: TrustedcoinPluginQObject
-        self.on_success = None  # type: Callable
-        self.on_failure = None  # type: Callable
-        self.tx = None  # type: PartialTransaction
 
     @hook
     def load_wallet(self, wallet: 'Abstract_Wallet'):


### PR DESCRIPTION
Pass these instances in the callback instead of retrieving it from the plugin.

