### PR TITLE
interface: add method for "server.peers.subscribe"

### DIFF
--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -1676,6 +1676,26 @@ class Interface(Logger):
             res = int(res * bitcoin.COIN)
         return res
 
+    async def get_server_peers(self) -> list[tuple[str, str, Sequence[str]]]:
+        # do request
+        peers = await self.session.send_request('server.peers.subscribe')
+        # check response
+        assert_list_or_tuple(peers)
+        for peer in peers:
+            assert_list_or_tuple(peer)
+            if len(peer) != 3:
+                raise RequestCorrupted(f"found peer in list with unexpected length. {peer=!r}")
+            ip_addr, hostname, features = peer
+            if not isinstance(ip_addr, str):
+                raise RequestCorrupted(f"peer ip_addr should be str, got {ip_addr!r}")
+            if not isinstance(hostname, str):
+                raise RequestCorrupted(f"peer hostname should be str, got {hostname!r}")
+            assert_list_or_tuple(features)
+            for feat in features:
+                if not isinstance(feat, str):
+                    raise RequestCorrupted(f"peer feature should be str, got {feat!r}")
+        return [tuple(peer) for peer in peers]
+
 
 def _assert_header_does_not_check_against_any_chain(header: dict) -> None:
     chain_bad = blockchain.check_header(header)

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -86,12 +86,12 @@ class ConnectionState(IntEnum):
     CONNECTED     = 2
 
 
-def parse_servers(result: Sequence[Tuple[str, str, List[str]]]) -> Dict[str, dict]:
+def parse_servers(proto_resp: Sequence[Tuple[str, str, Sequence[str]]]) -> Dict[str, dict]:
     """Convert servers list (from protocol method "server.peers.subscribe") into dict format.
     Also validate values, such as IP addresses and ports.
     """
     servers = {}
-    for item in result:
+    for item in proto_resp:
         host = item[1]
         out = {}
         version = None
@@ -520,7 +520,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
             self.donation_address = await interface.get_donation_address()
 
         async def get_server_peers():
-            server_peers = await session.send_request('server.peers.subscribe')
+            server_peers = await interface.get_server_peers()
             random.shuffle(server_peers)
             max_accepted_peers = len(constants.net.DEFAULT_SERVERS) + NUM_RECENT_SERVERS
             server_peers = server_peers[:max_accepted_peers]
@@ -1358,8 +1358,8 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
     async def get_peers(self):
         while not self.is_connected():
             await asyncio.sleep(1)
-        session = self.interface.session
-        return parse_servers(await session.send_request('server.peers.subscribe'))
+        server_peers = await self.interface.get_server_peers()
+        return parse_servers(server_peers)
 
     async def send_multiple_requests(
             self,


### PR DESCRIPTION
Instead of having callers manually construct and call the electrum protocol RPC, add convenience method in Interface class. Minimal validation of response shape is also done here, with some further deeper checks left in network.parse_servers().

ref https://github.com/spesmilo/electrum-protocol/blob/b3db795b3efd2a0e45a5b3f67fb360b65d4cd4d9/docs/protocol-methods.rst?plain=1#L1503