### PR TITLE
contrib: drop protobuf requirement

### DIFF
--- a/contrib/build-linux/sdist/README.md
+++ b/contrib/build-linux/sdist/README.md
@@ -11,7 +11,6 @@ and a strictly source-only one (for Linux distro packagers).
 The normal tarball, in addition to including everything from
 the source-only one, also includes:
 - compiled (`.mo`) locale files (in addition to source `.po` locale files)
-- compiled (`_pb2.py`) protobuf files (in addition to source `.proto` files)
 - the `packages/` folder containing source-only pure-python runtime dependencies
 
 

--- a/contrib/deterministic-build/requirements.txt
+++ b/contrib/deterministic-build/requirements.txt
@@ -36,8 +36,6 @@ pip==25.1.1 \
     --hash=sha256:3de45d411d308d5054c2168185d8da7f9a2cd753dbac8acbfa88a8909ecd9077
 propcache==0.3.1 \
     --hash=sha256:40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf
-protobuf==3.20.3 \
-    --hash=sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2
 python-socks==2.8.1 \
     --hash=sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687
 QDarkStyle==3.2.3 \

--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -1,5 +1,4 @@
 qrcode
-protobuf>=3.20
 qdarkstyle>=3.2
 aiorpcx>=0.25.0,<0.26
 aiohttp>=3.11.0,<4.0.0

--- a/run_electrum
+++ b/run_electrum
@@ -76,7 +76,6 @@ def check_imports():
         import dns
         import certifi
         import qrcode
-        import google.protobuf
         import aiorpcx
         import aiohttp
         import aiohttp_socks
@@ -87,11 +86,6 @@ def check_imports():
         sys.exit(f"Error: {str(e)}. Some dependencies are missing. Have you read the README? Or just try '$ python3 -m pip install -r contrib/requirements/requirements.txt'")
     if not ((0, 25, 0) <= aiorpcx._version < (0, 26)):
         raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.25.0<=ver<0.26')
-    # the following imports are for pyinstaller
-    from google.protobuf import descriptor
-    from google.protobuf import message
-    from google.protobuf import reflection
-    from google.protobuf import descriptor_pb2
     # make sure that certificates are here
     assert os.path.exists(certifi.where())
 


### PR DESCRIPTION
The protobuf dependency was introduced with bip 70 payment requests in commits 4120678df / c44427d33e but not removed with the bip 70 removal in https://github.com/spesmilo/electrum/pull/10535

Currently it fails the installation of the deterministic requirements as newer setuptools doesn't seem to have the `pkg_resources` module anymore:
```
Collecting protobuf==3.20.3 (from -r /tmp/requirements.txt (line 39))
  Downloading protobuf-3.20.3.tar.gz (216 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      Traceback (most recent call last):
        File "/usr/local/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/usr/local/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-b04pv17_/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-b04pv17_/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/tmp/pip-build-env-b04pv17_/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-b04pv17_/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 11, in <module>
      ModuleNotFoundError: No module named 'pkg_resources'
      [end of output]
```