### PR TITLE
android: refactor deprecated android:allowBackup

### DIFF
--- a/contrib/android/Dockerfile
+++ b/contrib/android/Dockerfile
@@ -235,7 +235,7 @@ RUN cd /opt \
     && /opt/venv/bin/python3 -m pip install --no-build-isolation --no-dependencies -e .
 
 # install python-for-android
-ENV P4A_CHECKOUT_COMMIT="315bb8adf8022972f0ee87a45896d05c38134e1c"
+ENV P4A_CHECKOUT_COMMIT="b1b528cd8b681c0b5185ab82a319527037cc2421"
 # ^ from branch electrum_202602 (note: careful with force-pushing! see #8162)
 RUN cd /opt \
     && git clone https://github.com/spesmilo/python-for-android \


### PR DESCRIPTION
android: update p4a to ref b1b528cd8b681c0b5185ab82a319527037cc2421:
    
- qt6: refactor deprecated `android:allowBackup` and `android:fullBackupContent` to Android12+ `android:dataExtractionRules` + xml definition.
- qt6: retain `android:allowBackup` for android 8-11
    
Disallow device-transfer (nearby share, USB)
    
(old `allowBackup="false"` behaviour was only considering cloud backup)
