### PR TITLE
 test: test_we_disconnect_on_incoming_notification_spam fails on Macos

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -187,8 +187,8 @@ class TestInterface(ElectrumTestCase):
                     break
                 await srv_sess.send_notification('blockchain.headers.subscribe', headersub_res)
             # both parties should close their end of the session (triggered by the client DC-ing)
-            await asyncio.sleep(0)
-            assert srv_sess.got_disconnected.is_set()
+            async with util.async_timeout(1):
+                await srv_sess.got_disconnected.wait()
             async with util.async_timeout(1):
                 await interface.got_disconnected.wait()
         # the client should not have received most of the spam:


### PR DESCRIPTION
This test for me fails on macOS 26 (arm64, python 31.4). `await asyncio.sleep(0)` yields a single event loop iteration which isnt enough here for the client to disconnect and the server to observe it. With `sleep(0.5)`, the test passes in full including `recv_count/cost` assertions and the log check so i figured the resource limiting itself works but the check could be too tight? I didnt dig into why one iteration suffices on the CI runners but not here.

<img width="1049" height="225" alt="Screenshot 2026-08-12 at 09 40 58" src="https://github.com/user-attachments/assets/dd960134-2048-4170-b67e-613f08117752" />

I did change it to wait on the event with a timeout to match what the next two lines already do the for the Client side and it still passes. All CI runners are ubuntu so i dont think this would've showed up there

<img width="1159" height="123" alt="Screenshot 2026-08-12 at 09 49 42" src="https://github.com/user-attachments/assets/ffeb5717-5ac9-4c3f-8075-b535d98dd58e" />

