### PR TITLE
qml: wizard: hide passphrase input if disabled

### DIFF
--- a/electrum/gui/qml/components/wizard/WCEnterExt.qml
+++ b/electrum/gui/qml/components/wizard/WCEnterExt.qml
@@ -88,7 +88,7 @@ WizardComponent {
 
             TextField {
                 id: customwordstext
-                enabled: extendcb.checked
+                visible: extendcb.checked  // users confuse this with the seed re-entry if shown
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
                 placeholderText: qsTr('Enter your custom word(s)')


### PR DESCRIPTION
Hide the passphrase input text box in the QML wizard while the checkbox is disabled. Otherwise users see it, don't read the text above, and assume it is to re-enter the seedphrase generated in the step before.
I noticed repeatedly while helping users to set up wallets.

<img width="502" height="856" alt="Screenshot_20260812_150059" src="https://github.com/user-attachments/assets/5d492546-1ed4-4568-9942-66602380710e" />
<img width="494" height="848" alt="Screenshot_20260812_150031" src="https://github.com/user-attachments/assets/0e64d498-8c06-49f5-a391-a8c608057e5e" />
