### PR TITLE
contrib/release.sh: do not re-download full dist/ after gpg errors

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -213,7 +213,15 @@ fi
 if [ -z "$RELEASEMANAGER" ] ; then
     # people OTHER THAN release manager.
     # download binaries built by RM
-    rm -rf "$PROJECT_ROOT/dist/releasemanager"
+    if test -d "$PROJECT_ROOT/dist/releasemanager" ; then  # resume after partial downloads from previous release.sh run
+        info "dist/releasemanager/ folder with (some?) downloads already exists!"
+        echo -n "Reuse dist/releasemanager/ folder and proceed (y/n)? "
+        read answer
+        if [ "$answer" != "y" ]; then
+            info "deleting dist/releasemanager/ folder"
+            rm -rf "$PROJECT_ROOT/dist/releasemanager"
+        fi
+    fi
     mkdir --parent "$PROJECT_ROOT/dist/releasemanager"
     cd "$PROJECT_ROOT/dist/releasemanager"
 
@@ -246,7 +254,7 @@ if [ -z "$RELEASEMANAGER" ] ; then
         sftp -oBatchMode=no -b - "$SSHUSER@uploadserver" <<-EOF
            cd electrum-downloads-airlock
            cd "$VERSION"
-           mget *
+           mget -a *
            bye
 EOF
     fi


### PR DESCRIPTION
When running release.sh as non-RM, with sftp access, `mget *` downloads ~500 MB of data. This takes several minutes for me. On line 299, `gpg --sign` can error, e.g. due to human-error with the hardware-security-module, in which case I have to re-run release.sh and redownload 500 MB again.

This change allows me to avoid redownloading and to reuse the existing files.