### PR TITLE
swap_server: fix some issues running swap server

### DIFF
--- a/electrum/plugins/swapserver/server.py
+++ b/electrum/plugins/swapserver/server.py
@@ -25,7 +25,7 @@
 import os
 import asyncio
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from aiohttp import web
 
@@ -54,6 +54,8 @@ class HttpSwapServer(Logger, EventListener):
         self.sm = self.wallet.lnworker.swap_manager
         self.port = self.config.SWAPSERVER_PORT
         self.register_callbacks() # eventlistener
+        self.runner = None  # type: Optional[web.AppRunner]
+        self._start_task = None  # type: Optional[asyncio.Task]
 
         self.pending = defaultdict(asyncio.Event)
         self.pending_msg = {}
@@ -66,17 +68,37 @@ class HttpSwapServer(Logger, EventListener):
             self.logger.info("This wallet is password-protected. Please unlock it to start the swapserver plugin")
             await asyncio.sleep(10)
 
+        # note: starting the site must not be interrupted, hence the shield. TCPSite.start()
+        # registers the site with the runner before it has a server to close, getting cancelled
+        # in between leaves a listening socket behind that nothing holds a reference to anymore.
+        self._start_task = asyncio.create_task(self._start_site())
+        await asyncio.shield(self._start_task)
+
+    async def _start_site(self):
         app = web.Application()
         app.add_routes([web.get('/getpairs', self.get_pairs)])
         app.add_routes([web.post('/createswap', self.create_swap)])
         app.add_routes([web.post('/createnormalswap', self.create_normal_swap)])
         app.add_routes([web.post('/addswapinvoice', self.add_swap_invoice)])
 
-        runner = web.AppRunner(app)
+        self.runner = runner = web.AppRunner(app)
         await runner.setup()
         site = web.TCPSite(runner, host='localhost', port=self.port)
         await site.start()
         self.logger.info(f"running and listening on port {self.port}")
+
+    async def stop(self):
+        """note: run() returns as soon as the site is up, so cancelling its task does not
+        stop the server. It has to be shut down explicitly."""
+        self.unregister_callbacks()
+        if self._start_task is not None:
+            # the site might still be coming up (see run), and we can only clean up what it created
+            await asyncio.gather(self._start_task, return_exceptions=True)
+            self._start_task = None
+        if self.runner is not None:
+            await self.runner.cleanup()
+            self.runner = None
+        self.logger.info(f"stopped listening on port {self.port}")
 
     async def get_pairs(self, r):
         sm = self.sm

--- a/electrum/plugins/swapserver/swapserver.py
+++ b/electrum/plugins/swapserver/swapserver.py
@@ -40,12 +40,26 @@ class SwapServerPlugin(BasePlugin):
         BasePlugin.__init__(self, parent, config, name)
         self.config = config
         self.server = None
+        self.sm = None
 
     @hook
     def daemon_wallet_loaded(self, daemon: 'Daemon', wallet: 'Abstract_Wallet'):
         # we use the first wallet loaded
+        # note: self.server must be set, otherwise we would start a second server (on the same
+        #       port, with the same nostr identity) for every further wallet that gets loaded.
         if self.server is not None:
             return
-        sm = wallet.lnworker.swap_manager
-        sm.is_server = True
-        sm.http_server = HttpSwapServer(self.config, wallet)
+        if wallet.lnworker is None:
+            self.logger.info(f"wallet {wallet.diagnostic_name()} has no lightning, cannot serve swaps with it")
+            return
+        self.server = HttpSwapServer(self.config, wallet)
+        self.sm = wallet.lnworker.swap_manager
+        self.sm.is_server = True
+        self.sm.http_server = self.server
+
+    def on_close(self):
+        # the plugin got disabled; stop serving swaps
+        if self.sm is not None:
+            self.sm.stop_server()  # also shuts down self.server
+            self.sm = None
+        self.server = None

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -291,6 +291,9 @@ class SwapManager(Logger):
                     self.lnworker.bundle_payments([payment_hash, swap.prepay_hash])
                 self.lnworker.register_hold_invoice(payment_hash, self.hold_invoice_callback)
         self.is_server = False # overridden by swapserver plugin if enabled
+        self.http_server = None  # set by the swapserver plugin if enabled
+        self._server_tasks = []  # type: List[asyncio.Task]
+        self._stopping_server = False
         self.is_initialized = asyncio.Event()
         self.pairs_updated = asyncio.Event()
 
@@ -309,6 +312,9 @@ class SwapManager(Logger):
             self.add_lnwatcher_callback(swap)
         asyncio.run_coroutine_threadsafe(self.main_loop(), self.network.asyncio_loop)
 
+    # note: must swallow its exceptions (like http_server.run does), otherwise it takes the whole
+    # taskgroup down with it.
+    @ignore_exceptions
     @log_exceptions
     async def run_nostr_server(self):
         await self.set_nostr_proof_of_work()
@@ -317,7 +323,7 @@ class SwapManager(Logger):
             self.logger.info("This wallet is password-protected. Please unlock it to start the swapserver plugin")
             await asyncio.sleep(10)
 
-        with NostrTransport(self.config, self, self.lnworker.nostr_keypair) as transport:
+        async with NostrTransport(self.config, self, self.lnworker.nostr_keypair) as transport:
             await transport.is_connected.wait()
             self.logger.info(f'nostr is connected')
             # will publish a new announcement if liquidity changed or every OFFER_UPDATE_INTERVAL_SEC
@@ -347,17 +353,65 @@ class SwapManager(Logger):
 
     @log_exceptions
     async def main_loop(self):
-        # nostr and http are not mutually exclusive
+        server_tasks = []
+        if self.is_server:
+            # nostr and http are not mutually exclusive
+            if self.config.SWAPSERVER_PORT:
+                server_tasks.append(self.http_server.run())
+            if self.config.NOSTR_RELAYS:
+                server_tasks.append(self.run_nostr_server())
+
         async with self.taskgroup as group:
-            if self.is_server:
-                if self.config.SWAPSERVER_PORT:
-                    await group.spawn(self.http_server.run())
-                if self.config.NOSTR_RELAYS:
-                    await group.spawn(self.run_nostr_server())
             await group.spawn(asyncio.Event().wait())  # run until cancel
+            for coro in server_tasks:
+                # keep a reference, so that stop_server() can cancel them
+                self._server_tasks.append(await group.spawn(coro))
 
     async def stop(self):
         await self.taskgroup.cancel_remaining()
+
+    def stop_server(self) -> None:
+        """Stops serving swaps. Called by the swapserver plugin when it gets disabled.
+        Note: this returns before we actually stopped; is_server stays set until we did.
+        Note: this does not affect swaps we are running as a client.
+        """
+        if not self.is_server or self._stopping_server:
+            return
+        if self.network is None:
+            # main_loop never ran, so there is nothing to unwind
+            self.is_server = False
+            self.http_server = None
+            return
+        self._stopping_server = True
+        asyncio.run_coroutine_threadsafe(self._stop_server_tasks(), self.network.asyncio_loop)
+
+    @log_exceptions
+    async def _stop_server_tasks(self) -> None:
+        assert get_running_loop() == get_asyncio_loop(), f"this must be run on the asyncio thread!"
+        try:
+            # loop, as main_loop spawns the server tasks one by one, so it might add
+            # another one while we are already waiting for the previous ones to unwind
+            while tasks := self._server_tasks:
+                self._server_tasks = []
+                for task in tasks:
+                    task.cancel()
+                # cancel() only requests cancellation, wait for task unwind before we shut the http server down,
+                # so that we are not tearing it down underneath a task that is still using it.
+                try:
+                    await wait_for2(asyncio.gather(*tasks, return_exceptions=True), timeout=10)
+                except asyncio.TimeoutError:
+                    # we gave up waiting; better to finish stopping than to stay a half-cancelled server
+                    self.logger.warning("timed out waiting for the swap server tasks to stop")
+                    break
+
+            http_server, self.http_server = self.http_server, None
+            if http_server is not None:
+                await http_server.stop()
+        finally:
+            # Best-effort: on the timeout above we clear it even though a task might still
+            # be running, as staying a server with cancelled tasks would be worse.
+            self.is_server = False
+            self._stopping_server = False
 
     def create_transport(self) -> 'SwapServerTransport':
         from .lnutil import generate_random_keypair
@@ -1861,12 +1915,15 @@ class NostrTransport(SwapServerTransport):
         self.dm_replies = {}  # type: Dict[tuple[str, str], asyncio.Future[dict]]
         self.ssl_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=ca_path)
         self.relay_manager = None  # type: Optional[aionostr.Manager]
+        self._main_loop_task = None  # type: Optional[asyncio.Task]
         self.taskgroup = OldTaskGroup()
         self._last_swapserver_relays = self._load_last_swapserver_relays()  # type: Optional[Sequence[str]]
         self._swap_server_requests = asyncio.Queue(maxsize=5)  # type: asyncio.Queue[dict]
 
     def __enter__(self):
-        asyncio.run_coroutine_threadsafe(self.main_loop(), self.network.asyncio_loop)
+        def start_main_loop():
+            self._main_loop_task = asyncio.create_task(self.main_loop())
+        self.network.asyncio_loop.call_soon_threadsafe(start_main_loop)
         return self
 
     def __exit__(self, ex_type, ex, tb):
@@ -1874,7 +1931,7 @@ class NostrTransport(SwapServerTransport):
         fut.result(timeout=5)
 
     async def __aenter__(self):
-        asyncio.create_task(self.main_loop())
+        self._main_loop_task = asyncio.create_task(self.main_loop())
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -1919,8 +1976,16 @@ class NostrTransport(SwapServerTransport):
         self.logger.info("shutting down nostr transport")
         self.sm.is_initialized.clear()
         self.is_connected.clear()
+        if self._main_loop_task is not None:
+            # note: main_loop is not in the taskgroup below (it owns it), so cancel it here.
+            #       Otherwise it could still be about to connect to the relays, and we would
+            #       not even have a relay_manager to close yet.
+            self._main_loop_task.cancel()
+            self._main_loop_task = None
         await self.taskgroup.cancel_remaining()
-        await self.relay_manager.close()
+        if self.relay_manager is not None:
+            # note: main_loop sets it, and it might not have run yet (or have failed)
+            await self.relay_manager.close()
         self.logger.info("nostr transport shut down")
 
     @property

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ import tempfile
 import shutil
 import functools
 import inspect
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Callable, List
 
 import electrum
 import electrum.logging
@@ -38,6 +38,7 @@ class ElectrumTestCase(unittest.IsolatedAsyncioTestCase, Logger):
     TESTNET = False  # there is also an @as_testnet decorator to run single tests in testnet mode
     REGTEST = False
     TEST_ANCHOR_CHANNELS = True
+    TIME_STEP = 0.01
     WALLET_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_storage_upgrade")
     # maxDiff = None  # for debugging
 
@@ -98,6 +99,11 @@ class ElectrumTestCase(unittest.IsolatedAsyncioTestCase, Logger):
         super().tearDown()
         util._asyncio_event_loop = None  # cleared here, at the ~last possible moment. asyncTearDown is too early.
         self._test_lock.release()
+
+    async def wait_until(self, predicate: Callable[[], bool], *, timeout: int = 20) -> None:
+        async with util.async_timeout(timeout):
+            while not predicate():
+                await asyncio.sleep(self.TIME_STEP)
 
     def create_mock_lnwallet(
         self,

--- a/tests/test_submarine_swaps.py
+++ b/tests/test_submarine_swaps.py
@@ -1,25 +1,30 @@
 import asyncio
 import os
+import socket
 from typing import Optional, Sequence
 from unittest import mock
 
 from electrum_ecc import ECPrivkey
 
-from electrum import bitcoin
+from electrum import bitcoin, util
 from electrum.address_synchronizer import TX_HEIGHT_LOCAL
 from electrum.bitcoin import COIN, DUST_LIMIT_P2WSH
 from electrum.util import bfh, now
 from electrum.crypto import sha256
 from electrum.lnonion import OnionRoutingFailure
+from electrum.lnutil import generate_random_keypair
+from electrum.plugins.swapserver.server import HttpSwapServer
+from electrum.plugins.swapserver.swapserver import SwapServerPlugin
 from electrum.simple_config import SimpleConfig
 from electrum.submarine_swaps import (
-    SwapManager, SwapData, SwapServerTransport, LOCKTIME_DELTA_REFUND,
+    SwapManager, SwapData, NostrTransport, SwapServerTransport, LOCKTIME_DELTA_REFUND,
     MIN_LOCKTIME_DELTA_FOR_CLAIM, SPENDER_FINALITY_DELAY, _construct_swap_scriptcode)
 from electrum.transaction import (
     PartialTransaction, PartialTxOutput, Transaction, TxOutput, TxOutpoint)
 from electrum.txbatcher import TxBatcher
-from electrum.wallet import Standard_Wallet, Wallet
+from electrum.wallet import Standard_Wallet, Wallet, Abstract_Wallet
 
+from . import ElectrumTestCase
 from .toyserver.testcase import ToyServerTestCase
 
 
@@ -634,3 +639,248 @@ class TestSwapClaim(ToyServerTestCase):
         self.assertEqual(1, len(claim_tx.outputs()))
         self.assertEqual(payee_address, claim_tx.outputs()[0].address)
         self.assertEqual(99_000, claim_tx.outputs()[0].value)
+
+
+class TestSwapServerShutdown(ElectrumTestCase):
+    """The swapserver plugin can be enabled and disabled at runtime, so being a server has to
+    be something we can actually stop again.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+
+    def make_swap_manager(self) -> SwapManager:
+        """a SwapManager with no swaps in its db, and no network (unless the test sets one)"""
+        wallet = mock.MagicMock()
+        wallet.config = self.config
+        wallet.db.get_dict.return_value = {}
+        return SwapManager(wallet=wallet, lnworker=mock.MagicMock())
+
+    def make_http_swap_server(self) -> 'HttpSwapServer':
+        wallet = mock.MagicMock()
+        wallet.has_password.return_value = False
+        return HttpSwapServer(self.config, wallet)
+
+    @staticmethod
+    def get_free_port() -> int:
+        with socket.socket() as s:
+            s.bind(('localhost', 0))
+            return s.getsockname()[1]
+
+    async def test_stop_server_survives_a_server_task_erroring_on_cancellation(self):
+        """The server tasks share a taskgroup with the swap invoice payments, and OldTaskGroup
+        cancels the whole group as soon as one task raises. So a server task that errors while
+        being cancelled must not take the invoices we still owe our clients down with it.
+        """
+        sm = self.make_swap_manager()
+        sm.network = mock.Mock(asyncio_loop=util.get_asyncio_loop(), proxy=None)
+        sm.wallet.has_password.return_value = False
+        sm.lnworker.nostr_keypair = generate_random_keypair()
+        self.config.SWAPSERVER_POW_TARGET = 0  # so that we don't grind out a nonce
+        sm.is_server = True
+        invoice_payment_cancelled = asyncio.Event()
+
+        async def pay_invoice_safe():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                invoice_payment_cancelled.set()
+                raise
+
+        async def aexit_that_raises(_self, *args):
+            # __aexit__ waits for the transport to stop with a 5 sec timeout, and stopping it
+            # has to close the relay connections. Both of those can raise while we are cancelled.
+            raise asyncio.TimeoutError("relays did not close in time")
+
+        with (mock.patch.object(NostrTransport, 'main_loop', new=mock.AsyncMock()),
+              mock.patch.object(NostrTransport, '__aexit__', new=aexit_that_raises)):
+            asyncio.create_task(sm.main_loop())
+            await self.wait_until(lambda: len(sm._server_tasks) == 1)
+            # an invoice we still owe a client, as server_add_swap_invoice would have spawned it
+            await sm.taskgroup.spawn(pay_invoice_safe())
+
+            sm.stop_server()
+
+            await asyncio.sleep(0.1)
+            self.assertFalse(invoice_payment_cancelled.is_set())
+            self.assertFalse(sm.taskgroup.joined)  # or nothing can be spawned into it anymore
+
+    async def test_stop_server_cancels_the_server_tasks(self):
+        sm = self.make_swap_manager()
+        sm.network = mock.Mock(asyncio_loop=util.get_asyncio_loop())
+        http_server = mock.AsyncMock()
+        sm.is_server = True
+        sm.http_server = http_server
+        server_task = asyncio.create_task(asyncio.Event().wait())
+        sm._server_tasks.append(server_task)
+
+        sm.stop_server()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await server_task
+        # is_server is the last thing to be cleared, so it tells us the shutdown is done
+        await self.wait_until(lambda: not sm.is_server)
+        # cancelling the task is not enough to stop the http server, see HttpSwapServer.stop
+        http_server.stop.assert_awaited_once()
+        self.assertEqual([], sm._server_tasks)
+        self.assertIsNone(sm.http_server)
+
+    async def test_stop_server_stays_a_server_until_the_shutdown_finished(self):
+        """The transports consult is_server while they are shutting down, to route incoming
+        messages and to publish offers, so it must not be cleared while we still serve.
+        """
+        sm = self.make_swap_manager()
+        sm.network = mock.Mock(asyncio_loop=util.get_asyncio_loop())
+        sm.is_server = True
+        sm.http_server = mock.AsyncMock()
+        unwinding = asyncio.Event()
+        may_finish = asyncio.Event()
+
+        async def server_task():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                unwinding.set()
+                await may_finish.wait()  # a transport that takes a while to shut down
+                raise
+
+        sm._server_tasks.append(asyncio.create_task(server_task()))
+
+        sm.stop_server()
+
+        await unwinding.wait()
+        self.assertTrue(sm.is_server)
+        sm.http_server.stop.assert_not_awaited()
+
+        may_finish.set()
+
+        await self.wait_until(lambda: not sm.is_server)
+
+    def test_stop_server_when_nothing_was_started(self):
+        sm = self.make_swap_manager()
+        sm.is_server = True
+        sm.http_server = mock.AsyncMock()
+        self.assertIsNone(sm.network)
+
+        sm.stop_server()
+
+        self.assertFalse(sm.is_server)
+        self.assertIsNone(sm.http_server)
+
+    async def test_stop_server_stops_the_http_server_only_after_the_tasks_unwound(self):
+        """cancel() only requests cancellation, so we must not tear the http server down while
+        a task that is still running might be in the middle of starting it.
+        """
+        sm = self.make_swap_manager()
+        sm.network = mock.Mock(asyncio_loop=util.get_asyncio_loop())
+        sm.is_server = True
+        # a task that is still suspended when we stop the server, like HttpSwapServer.run
+        # waiting for the wallet to be unlocked
+        server_task = asyncio.create_task(asyncio.Event().wait())
+        sm._server_tasks.append(server_task)
+        tasks_done_when_stopped = None
+
+        async def stop():
+            nonlocal tasks_done_when_stopped
+            tasks_done_when_stopped = server_task.done()
+        sm.http_server = mock.Mock(stop=stop)
+
+        sm.stop_server()
+
+        await self.wait_until(lambda: tasks_done_when_stopped is not None)
+        self.assertTrue(tasks_done_when_stopped)
+
+    async def test_stop_server_cancels_tasks_spawned_while_it_was_stopping(self):
+        """main_loop spawns the server tasks one by one, so it can append another one after we
+        already took them to cancel them. Those must not be left running.
+        """
+        sm = self.make_swap_manager()
+        sm.network = mock.Mock(asyncio_loop=util.get_asyncio_loop())
+        sm.is_server = True
+        sm.http_server = mock.AsyncMock()
+        late_task = None
+
+        async def server_task():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                # as main_loop would, getting to spawn the next server task only now
+                nonlocal late_task
+                late_task = asyncio.create_task(asyncio.Event().wait())
+                sm._server_tasks.append(late_task)
+                raise
+
+        sm._server_tasks.append(asyncio.create_task(server_task()))
+
+        sm.stop_server()
+
+        await self.wait_until(lambda: not sm.is_server)
+        self.assertTrue(late_task.cancelled(), msg="the late task was left running")
+
+    async def test_http_server_stop_releases_the_port(self):
+        self.config.SWAPSERVER_PORT = port = self.get_free_port()
+        http_server = self.make_http_swap_server()
+        await http_server.run()
+        # note: run() returns as soon as the site is up, so we can connect right away
+        _reader, writer = await asyncio.open_connection('localhost', port)
+        writer.close()
+
+        await http_server.stop()
+
+        # note: OSError, not ConnectionRefusedError: localhost can resolve to several addresses,
+        # and asyncio wraps the per-address refusals when all of them fail.
+        with self.assertRaises(OSError):
+            await asyncio.open_connection('localhost', port)
+
+
+class TestSwapServerPlugin(ElectrumTestCase):
+    """The plugin serves swaps with the first wallet the daemon loads."""
+
+    def setUp(self):
+        super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+        self.plugin = SwapServerPlugin(mock.Mock(), self.config, 'swapserver')
+        self.addCleanup(self.plugin.close)  # unregisters the hooks again
+
+    def make_wallet(self, *, has_lightning: bool = True) -> Abstract_Wallet:
+        wallet = mock.MagicMock()
+        wallet.config = self.config
+        wallet.db.get_dict.return_value = {}
+        if not has_lightning:
+            wallet.lnworker = None
+            return wallet
+        wallet.lnworker.swap_manager = SwapManager(wallet=wallet, lnworker=wallet.lnworker)
+        return wallet
+
+    def load_wallet(self, wallet) -> None:
+        self.plugin.daemon_wallet_loaded(mock.Mock(), wallet)
+
+    def test_only_the_first_wallet_serves_swaps(self):
+        wallet1, wallet2 = self.make_wallet(), self.make_wallet()
+
+        self.load_wallet(wallet1)
+        self.load_wallet(wallet2)
+
+        # otherwise we would run a second server, on the same port and nostr identity
+        self.assertTrue(wallet1.lnworker.swap_manager.is_server)
+        self.assertFalse(wallet2.lnworker.swap_manager.is_server)
+
+    def test_wallet_without_lightning_is_skipped(self):
+        wallet1, wallet2 = self.make_wallet(has_lightning=False), self.make_wallet()
+
+        self.load_wallet(wallet1)
+        self.load_wallet(wallet2)
+
+        self.assertTrue(wallet2.lnworker.swap_manager.is_server)
+
+    def test_disabling_the_plugin_stops_the_server(self):
+        wallet = self.make_wallet()
+        self.load_wallet(wallet)
+        sm = wallet.lnworker.swap_manager
+        self.assertTrue(sm.is_server)
+
+        self.plugin.on_close()
+
+        self.assertFalse(sm.is_server)
+        self.assertIsNone(sm.http_server)

--- a/tests/toyserver/testcase.py
+++ b/tests/toyserver/testcase.py
@@ -5,7 +5,7 @@
 import asyncio
 import os
 from dataclasses import dataclass, field
-from typing import Callable, Optional
+from typing import Optional
 from unittest import mock
 
 from electrum import util
@@ -38,7 +38,6 @@ class ToyServerTestCase(ElectrumTestCase):
     and wallets that sync from it.
     """
     REGTEST = True
-    TIME_STEP = 0.01
 
     def setUp(self):
         super().setUp()
@@ -114,11 +113,6 @@ class ToyServerTestCase(ElectrumTestCase):
         await wallet.stop()
 
     # --- chain and wallet helpers ---
-
-    async def wait_until(self, predicate: Callable[[], bool], *, timeout: int = 20) -> None:
-        async with util.async_timeout(timeout):
-            while not predicate():
-                await asyncio.sleep(self.TIME_STEP)
 
     async def sync(self) -> None:
         """wait until all wallets have caught up with the server"""


### PR DESCRIPTION
- `SwapServerPlugin.server` was never set, so the guard on 'use the first wallet loaded' was ineffective
- exclude non-lightning wallets for consideration
- disabling the plugin left the server running
- use `async with` .. in `run_nostr_server()`. non-async would block on `__exit__`, `fut.result(timeout=5)` would time-out since it runs on the `asyncio` thread.