### PR TITLE
wallet: don't remove ln xprv from wallet backup

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -513,7 +513,6 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             for chan_id, chan in self.lnworker.channels.items():
                 channel_backups[chan_id.hex()] = self.lnworker.create_channel_backup(chan_id)
             new_db.put('channels', None)
-            new_db.put('lightning_privkey2', None)
         new_db.set_modified(True)
         new_db.write()
         return new_path


### PR DESCRIPTION
Fixes the same issue described in https://github.com/spesmilo/electrum/issues/7513 for non-deterministic lightning wallets.