### PR TITLE
lnworker: keep watchtower sync alive on invalid get_ctn replies

### DIFF
--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1182,9 +1182,14 @@ class LNWallet(Logger):
                     watchtower.add_method('get_ctn')
                     watchtower.add_method('add_sweep_tx')
                     for chan in self.channels.values():
-                        await self.sync_channel_with_watchtower(chan, watchtower)
+                        try:
+                            await self.sync_channel_with_watchtower(chan, watchtower)
+                        except Exception:
+                            self.logger.exception(f'could not sync channel {chan.funding_outpoint} with watchtower')
             except aiohttp.ClientError:
                 self.logger.info(f'could not contact remote watchtower {watchtower_url}')
+            except Exception:
+                self.logger.exception(f'could not sync with remote watchtower {watchtower_url}')
 
     def get_watchtower_ctn(self, channel_point):
         return self.watchtower_ctns.get(channel_point)
@@ -1194,6 +1199,9 @@ class LNWallet(Logger):
         addr = chan.get_funding_address()
         current_ctn = chan.get_oldest_unrevoked_ctn(REMOTE)
         watchtower_ctn = await watchtower.get_ctn(outpoint, addr)
+        if type(watchtower_ctn) is not int or watchtower_ctn < 0:
+            self.logger.warning(f'watchtower get_ctn returned invalid ctn {watchtower_ctn!r} for {outpoint}')
+            return
         for ctn in range(watchtower_ctn + 1, current_ctn):
             sweeptxs = chan.create_sweeptxs_for_watchtower(ctn)
             for tx in sweeptxs:


### PR DESCRIPTION
## Summary
- Validate `get_ctn` from a remote watchtower (must be a non-negative `int`) before feeding it to `range()` / `assert ctn >= 0`.
- Catch per-channel and unexpected errors inside the `while True` sync loop so one bad reply cannot kill watchtower updates for the rest of the session.

A JSON-RPC `get_ctn` result was used unvalidated. A negative or non-int value (including HTTP non-200 returning an `'Error: …'` string) escaped the loop's `except aiohttp.ClientError`. The coroutine is spawned once in `start_network`, so syncing then stopped for all channels until restart.

## Tests

Optional tests live on a separate branch, not in this PR: [watchtower_invalid_ctn-test](https://github.com/rdymac/electrum/tree/watchtower_invalid_ctn-test). Pull that if you want the unit tests as well.


## Comments already received on the suggested fix

`util.py:763` already has `is_non_negative_integer`, and `lnworker.py:38` already imports from `.util`.

```
is_non_negative_integer(True)  -> True     # bool subclasses int
```

`is_integer` is just `isinstance(val, int)`, so the helper accepts `True`/`False`. `type(watchtower_ctn) is not int` rejects them. A watchtower answering JSON `true` would otherwise become `range(2, n)` silently treated as ctn=1.

Suggested in-code comment:
python
```
# note: `type(x) is int` rather than isinstance/is_non_negative_integer:
#       bool subclasses int, and a JSON `true` would otherwise be read as ctn=1
if type(watchtower_ctn) is not int or watchtower_ctn < 0:
```