### PR TITLE
util, swaps: fix nostr announcement PoW mining

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -450,6 +450,7 @@ class SwapManager(Logger):
             self.config.SWAPSERVER_POW_TARGET,
         )
         self.logger.debug(f"Found {pow_amount} bits of work for Nostr announcement.")
+        assert pow_amount >= self.config.SWAPSERVER_POW_TARGET, pow_amount
         self.config.SWAPSERVER_ANN_POW_NONCE = nonce
 
     async def pay_invoice(self, key):

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -2420,10 +2420,10 @@ def nostr_pow_worker(nonce, nostr_pubk, target_bits, hash_function, hash_len_bit
             digest = hash_function(hash_preimage + nonce.to_bytes(32, 'big')).digest()
             if int.from_bytes(digest, 'big') < (1 << (hash_len_bits - target_bits)):
                 shutdown.set()
-                return hash, nonce
+                return nonce
             nonce += 1
         if shutdown.is_set():
-            return None, None
+            return None
 
 
 async def gen_nostr_ann_pow(nostr_pubk: bytes, target_bits: int) -> Tuple[int, int]:
@@ -2456,10 +2456,15 @@ async def gen_nostr_ann_pow(nostr_pubk: bytes, target_bits: int) -> Tuple[int, i
             if start_nonce > max_nonce:  # make sure we don't go over the max_nonce
                 start_nonce = random.randint(0, int(max_nonce * 0.75))
 
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        hash_res, nonce_res = done.pop().result()
+        # workers that observe the shutdown event return None; their results can be
+        # delivered before the winner's own result, so wait for all workers and
+        # collect the result that carries a nonce.
+        done, _pending = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+        nonce_res = next((n for n in (fut.result() for fut in done) if n is not None), None)
         executor.shutdown(wait=False, cancel_futures=True)
 
+    if nonce_res is None:
+        raise Exception("nostr announcement PoW mining failed: no worker returned a nonce")
     return nonce_res, get_nostr_ann_pow_amount(nostr_pubk, nonce_res)
 
 


### PR DESCRIPTION
Fixes #10858

## Summary

Three defects in the swapserver nostr announcement PoW path, all introduced in `947094c1b` (PR #9551):

1. `nostr_pow_worker` returned the builtin `hash` instead of the sha256 `digest` of the winning preimage.
2. `gen_nostr_ann_pow` collected the result via `done.pop()` on the unordered set returned by `asyncio.wait(FIRST_COMPLETED)`. Workers that observe the shutdown event return early at their next 1M-hash block boundary, and their results can be delivered to the event loop before the winner's own result (independent channels: manager socket vs executor result pipe), so the freshly-mined winning nonce could be silently discarded.
3. `set_nostr_proof_of_work` stored the returned nonce without checking `pow_amount >= SWAPSERVER_POW_TARGET`.

## Changes (electrum/util.py + electrum/submarine_swaps.py)

- `nostr_pow_worker`: return only the winning `nonce` — the digest was never used by the caller (it is recomputed via `get_nostr_ann_pow_amount`), so the return value is removed entirely
- `gen_nostr_ann_pow`: wait for all workers (`ALL_COMPLETED`), collect the first result carrying a nonce, raise if none does
- `set_nostr_proof_of_work`: assert the achieved work meets `SWAPSERVER_POW_TARGET` before storing the nonce

## Impact

If the race in (2) hits, the winning nonce is discarded and the stored nonce reads as the default `0`: the announcement is then published with insufficient PoW and every client silently discards it (`too low pow`) — the swapserver looks healthy in its own logs but is undiscoverable over nostr until it re-mines.

~~An earlier version of this description claimed the race outcome would be persisted as `None`, and that the next `publish_offer` would then raise `TypeError: hex(None)` outside its try/except, killing `run_nostr_server`.~~

**Correction:** that chain was wrong — assigning `None` to a ConfigVar deletes the key, the read falls back to the default `0`, and `hex(0)` works fine, so nothing crashes. Thanks to @f321x for the REPL check that caught this.

## Testing

- Adjacent suites: `python -m pytest tests/test_util.py tests/test_submarine_swaps.py` — all green
- The deterministic repro suite from #10858 stays on the `nostr-pow-bug-repro` branch (per review, the in-tree module was overkill for this fix size)
