### PR TITLE
lnpeer: drop support for legacy closing fee negotiation

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -53,7 +53,9 @@ from .lntransport import LNTransport, LNTransportBase, LightningPeerConnectionCl
 from .lnmsg import encode_msg, decode_msg, UnknownOptionalMsgType, FailedToParseMsg
 from .interface import GracefulDisconnect
 from .invoices import PR_PAID
-from .fee_policy import FEE_LN_ETA_TARGET, FEERATE_PER_KW_MIN_RELAY_LIGHTNING, FEERATE_MAX_DYNAMIC
+from .fee_policy import (
+    FEE_LN_ETA_TARGET, FEERATE_PER_KW_MIN_RELAY_LIGHTNING, FEERATE_MAX_DYNAMIC, FEE_LN_MINIMUM_ETA_TARGET, FEERATE_DEFAULT_RELAY,
+)
 from .channel_db import FLAG_DIRECTION
 
 if TYPE_CHECKING:
@@ -64,6 +66,9 @@ if TYPE_CHECKING:
 
 
 LN_P2P_NETWORK_TIMEOUT = 20
+
+
+class CoopCloseFailure(Exception): pass
 
 
 class Peer(Logger, EventListener):
@@ -2622,8 +2627,9 @@ class Peer(Logger, EventListener):
         # Note: A malicious Electrum server can make us pay high closing fees, capped only by FEERATE_MAX_DYNAMIC
         # The same issue exists with commitment transactions; we only make sure it is not worse here.
         config = self.config
+        is_initiator = chan.constraints.is_initiator
         our_fee = None
-        if config.TEST_SHUTDOWN_FEE:
+        if config.TEST_SHUTDOWN_FEE is not None:
             our_fee = config.TEST_SHUTDOWN_FEE
         else:
             fee_rate_per_kb = self.network.fee_estimates.eta_target_to_fee(FEE_LN_ETA_TARGET)
@@ -2637,19 +2643,29 @@ class Peer(Logger, EventListener):
             our_fee = fee_rate_per_kb * closing_tx.estimated_size() // 1000
         # max value
         max_fee = min(our_fee * 2, FEERATE_MAX_DYNAMIC * closing_tx.estimated_size() // 1000)
-        our_fee = min(our_fee, max_fee)
         # make sure fee is payable by initiator
-        affordable = chan.balance(LOCAL if chan.constraints.is_initiator else REMOTE) // 1000
-        our_fee = min(our_fee, affordable)
+        affordable = chan.balance(LOCAL if is_initiator else REMOTE) // 1000
         max_fee = min(max_fee, affordable)
         # min value. We aim at a fee between next block inclusion and some lower value.
-        min_fee = our_fee // 2
+        fee_rate_per_kb = self.network.fee_estimates.eta_target_to_fee(FEE_LN_MINIMUM_ETA_TARGET) or FEERATE_DEFAULT_RELAY
+        superlow_min_fee = fee_rate_per_kb * closing_tx.estimated_size() // 1000
+        if is_initiator:
+            min_fee = our_fee // 2
+            min_fee = max(min_fee, superlow_min_fee)
+        else:
+            # The sending node, if it is not the funder:
+            # SHOULD set min_fee_satoshis to a fairly low value
+            min_fee = superlow_min_fee
+        # ensure order
+        min_fee = min(min_fee, max_fee)  # note: if min_fee was > max_fee, the tx might not relay... unclear what to do.
+        our_fee = max(min_fee, our_fee)
+        our_fee = min(our_fee, max_fee)
+        assert min_fee <= our_fee <= max_fee
         if config.TEST_SHUTDOWN_FEE_RANGE:
             our_fee_range = config.TEST_SHUTDOWN_FEE_RANGE
         else:
             our_fee_range = {'min_fee_satoshis': min_fee, 'max_fee_satoshis': max_fee}
         self.logger.info(f"Our fee range: {our_fee_range} and fee: {our_fee}")
-        assert our_fee_range['min_fee_satoshis'] <= our_fee <= our_fee_range['max_fee_satoshis']
         return our_fee, our_fee_range
 
     @log_exceptions
@@ -2698,14 +2714,14 @@ class Peer(Logger, EventListener):
                 cs_payload = await self.wait_for_message('closing_signed', chan.channel_id)
             except asyncio.exceptions.TimeoutError:
                 self.schedule_force_closing(chan.channel_id)
-                raise Exception("closing_signed not received, force closing.")
+                raise CoopCloseFailure("closing_signed not received, force closing.")
             their_fee = cs_payload['fee_satoshis']
             their_fee_range = cs_payload['closing_signed_tlvs'].get('fee_range')
             their_sig = cs_payload['signature']
             # legacy negotiation is no longer supported
             if their_fee_range is None:
                 self.schedule_force_closing(chan.channel_id)
-                raise Exception(f"Their fee range missing, force closing.")
+                raise CoopCloseFailure(f"Their fee range missing, force closing.")
             # perform checks
             our_sig, closing_tx = chan.make_closing_tx(our_scriptpubkey, their_scriptpubkey, fee_sat=their_fee, drop_remote=False)
             if verify_signature(closing_tx, their_sig):
@@ -2717,7 +2733,7 @@ class Peer(Logger, EventListener):
                 else:
                     # this can happen if we consider our output too valuable to drop,
                     # but the remote drops it because it violates their dust limit
-                    raise Exception('failed to verify their signature')
+                    raise CoopCloseFailure('failed to verify their signature')
             # at this point we know how the closing tx looks like
             # check that their output is above their scriptpubkey's network dust limit
             to_remote_set = closing_tx.get_output_idxs_from_scriptpubkey(their_scriptpubkey)
@@ -2732,13 +2748,12 @@ class Peer(Logger, EventListener):
             fee_range_sent = our_fee_range and (is_initiator or (their_previous_fee is not None))
 
             # The sending node, if it is not the funder:
-            if not is_initiator and not self.config.TEST_SHUTDOWN_FEE_RANGE:
+            if not is_initiator:
                 # SHOULD set max_fee_satoshis to at least the max_fee_satoshis received
+                # note: we are submissive with the "max" but not with the "min" value.
                 our_fee_range['max_fee_satoshis'] = max(their_fee_range['max_fee_satoshis'], our_fee_range['max_fee_satoshis'])
-                # SHOULD set min_fee_satoshis to a fairly low value
-                our_fee_range['min_fee_satoshis'] = min(their_fee_range['min_fee_satoshis'], our_fee_range['min_fee_satoshis'])
                 # Note: the BOLT describes what the sending node SHOULD do.
-                # However, this assumes that we have decided to send 'funding_signed' in response to their fee_range.
+                # However, this assumes that we have decided to send 'closing_signed' in response to their fee_range.
                 # In practice, we might prefer to fail the channel in some cases (TODO)
 
             # the receiving node, if fee_satoshis matches its previously sent fee_range,
@@ -2755,14 +2770,14 @@ class Peer(Logger, EventListener):
                     # TODO: the receiving node should first send a warning, and fail the channel
                     # only if it doesn't receive a satisfying fee_range after a reasonable amount of time
                     self.schedule_force_closing(chan.channel_id)
-                    raise Exception("There is no overlap between between their and our fee range.")
+                    raise CoopCloseFailure("There is no overlap between their and our fee range.")
                 # otherwise, if it is the funder
                 if is_initiator:
                     # if fee_satoshis is not in the overlap between the sent and received fee_range:
                     if not (overlap_min <= their_fee <= overlap_max):
                         # MUST fail the channel
                         self.schedule_force_closing(chan.channel_id)
-                        raise Exception("Their fee is not in the overlap region, we force closed.")
+                        raise CoopCloseFailure("Their fee is not in the overlap region, we force closed.")
                     # otherwise, MUST reply with the same fee_satoshis.
                     our_fee = their_fee
                 # otherwise (it is not the funder):
@@ -2771,14 +2786,14 @@ class Peer(Logger, EventListener):
                     if fee_range_sent:
                         # fee_satoshis is not the same as the value we sent, we MUST fail the channel
                         self.schedule_force_closing(chan.channel_id)
-                        raise Exception("Expected the same fee as ours, we force closed.")
+                        raise CoopCloseFailure("Expected the same fee as ours, we force closed.")
                     # otherwise:
                     # MUST propose a fee_satoshis in the overlap between received and (about-to-be) sent fee_range.
                     our_fee = (overlap_min + overlap_max) // 2
 
             return our_fee, our_fee_range
 
-        # Fee negotiation: both parties exchange 'funding_signed' messages.
+        # Fee negotiation: both parties exchange 'closing_signed' messages.
         # The funder sends the first message, the non-funder sends the last message.
         # In the 'modern' case, at most 3 messages are exchanged, because choose_new_fee of the funder either returns their_fee or fails
         their_fee = None

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -53,7 +53,7 @@ from .lntransport import LNTransport, LNTransportBase, LightningPeerConnectionCl
 from .lnmsg import encode_msg, decode_msg, UnknownOptionalMsgType, FailedToParseMsg
 from .interface import GracefulDisconnect
 from .invoices import PR_PAID
-from .fee_policy import FEE_LN_ETA_TARGET, FEERATE_PER_KW_MIN_RELAY_LIGHTNING
+from .fee_policy import FEE_LN_ETA_TARGET, FEERATE_PER_KW_MIN_RELAY_LIGHTNING, FEERATE_MAX_DYNAMIC
 from .channel_db import FLAG_DIRECTION
 
 if TYPE_CHECKING:
@@ -2617,8 +2617,10 @@ class Peer(Logger, EventListener):
         # can fulfill or fail htlcs. cannot add htlcs, because state != OPEN
         chan.set_can_send_ctx_updates(True)
 
-    def get_shutdown_fee_range(self, chan, closing_tx, is_local):
-        """ return the closing fee and fee range we initially try to enforce """
+    def get_shutdown_fee_range(self, chan, closing_tx, is_local) -> Tuple[int, dict]:
+        """ return our closing fee, and the fee range we initially want to enforce. """
+        # Note: A malicious Electrum server can make us pay high closing fees, capped only by FEERATE_MAX_DYNAMIC
+        # The same issue exists with commitment transactions; we only make sure it is not worse here.
         config = self.config
         our_fee = None
         if config.TEST_SHUTDOWN_FEE:
@@ -2628,24 +2630,26 @@ class Peer(Logger, EventListener):
             if fee_rate_per_kb is None:  # fallback
                 from .fee_policy import FeePolicy
                 fee_rate_per_kb = FeePolicy(config.FEE_POLICY).fee_per_kb(self.network)
-            if fee_rate_per_kb is not None:
-                our_fee = fee_rate_per_kb * closing_tx.estimated_size() // 1000
-            # TODO: anchors: remove this, as commitment fee rate can be below chain head fee rate?
-            # BOLT2: The sending node MUST set fee less than or equal to the base fee of the final ctx
-            max_fee = chan.get_latest_fee(LOCAL if is_local else REMOTE)
-            if our_fee is None:  # fallback
+            if fee_rate_per_kb is None:  # fallback
                 self.logger.warning(f"got no fee estimates for co-op close! falling back to chan.get_latest_fee")
-                our_fee = max_fee
-            our_fee = min(our_fee, max_fee)
-        # config modern_fee_negotiation can be set in tests
-        if config.TEST_SHUTDOWN_LEGACY:
-            our_fee_range = None
-        elif config.TEST_SHUTDOWN_FEE_RANGE:
+                feerate_per_kw = chan.get_latest_feerate(LOCAL if is_local else REMOTE)
+                fee_rate_per_kb = 4 * feerate_per_kw
+            our_fee = fee_rate_per_kb * closing_tx.estimated_size() // 1000
+        # max value
+        max_fee = min(our_fee * 2, FEERATE_MAX_DYNAMIC * closing_tx.estimated_size() // 1000)
+        our_fee = min(our_fee, max_fee)
+        # make sure fee is payable by initiator
+        affordable = chan.balance(LOCAL if chan.constraints.is_initiator else REMOTE) // 1000
+        our_fee = min(our_fee, affordable)
+        max_fee = min(max_fee, affordable)
+        # min value. We aim at a fee between next block inclusion and some lower value.
+        min_fee = our_fee // 2
+        if config.TEST_SHUTDOWN_FEE_RANGE:
             our_fee_range = config.TEST_SHUTDOWN_FEE_RANGE
         else:
-            # we aim at a fee between next block inclusion and some lower value
-            our_fee_range = {'min_fee_satoshis': our_fee // 2, 'max_fee_satoshis': our_fee * 2}
+            our_fee_range = {'min_fee_satoshis': min_fee, 'max_fee_satoshis': max_fee}
         self.logger.info(f"Our fee range: {our_fee_range} and fee: {our_fee}")
+        assert our_fee_range['min_fee_satoshis'] <= our_fee <= our_fee_range['max_fee_satoshis']
         return our_fee, our_fee_range
 
     @log_exceptions
@@ -2671,10 +2675,7 @@ class Peer(Logger, EventListener):
 
         def send_closing_signed(our_fee, our_fee_range, drop_remote):
             nonlocal our_sig, closing_tx
-            if our_fee_range:
-                closing_signed_tlvs = {'fee_range': our_fee_range}
-            else:
-                closing_signed_tlvs = {}
+            closing_signed_tlvs = {'fee_range': our_fee_range}
             our_sig, closing_tx = chan.make_closing_tx(our_scriptpubkey, their_scriptpubkey, fee_sat=our_fee, drop_remote=drop_remote)
             self.logger.info(f"Sending fee range: {closing_signed_tlvs} and fee: {our_fee}")
             self.send_message(
@@ -2701,6 +2702,10 @@ class Peer(Logger, EventListener):
             their_fee = cs_payload['fee_satoshis']
             their_fee_range = cs_payload['closing_signed_tlvs'].get('fee_range')
             their_sig = cs_payload['signature']
+            # legacy negotiation is no longer supported
+            if their_fee_range is None:
+                self.schedule_force_closing(chan.channel_id)
+                raise Exception(f"Their fee range missing, force closing.")
             # perform checks
             our_sig, closing_tx = chan.make_closing_tx(our_scriptpubkey, their_scriptpubkey, fee_sat=their_fee, drop_remote=False)
             if verify_signature(closing_tx, their_sig):
@@ -2727,7 +2732,7 @@ class Peer(Logger, EventListener):
             fee_range_sent = our_fee_range and (is_initiator or (their_previous_fee is not None))
 
             # The sending node, if it is not the funder:
-            if our_fee_range and their_fee_range and not is_initiator and not self.config.TEST_SHUTDOWN_FEE_RANGE:
+            if not is_initiator and not self.config.TEST_SHUTDOWN_FEE_RANGE:
                 # SHOULD set max_fee_satoshis to at least the max_fee_satoshis received
                 our_fee_range['max_fee_satoshis'] = max(their_fee_range['max_fee_satoshis'], our_fee_range['max_fee_satoshis'])
                 # SHOULD set min_fee_satoshis to a fairly low value
@@ -2742,7 +2747,7 @@ class Peer(Logger, EventListener):
                 our_fee = their_fee
 
             # the receiving node, if the message contains a fee_range
-            elif our_fee_range and their_fee_range:
+            else:
                 overlap_min = max(our_fee_range['min_fee_satoshis'], their_fee_range['min_fee_satoshis'])
                 overlap_max = min(our_fee_range['max_fee_satoshis'], their_fee_range['max_fee_satoshis'])
                 # if there is no overlap between that and its own fee_range
@@ -2770,18 +2775,6 @@ class Peer(Logger, EventListener):
                     # otherwise:
                     # MUST propose a fee_satoshis in the overlap between received and (about-to-be) sent fee_range.
                     our_fee = (overlap_min + overlap_max) // 2
-            else:
-                # otherwise, if fee_satoshis is not strictly between its last-sent fee_satoshis
-                # and its previously-received fee_satoshis, UNLESS it has since reconnected:
-                if their_previous_fee and not (min(our_fee, their_previous_fee) < their_fee < max(our_fee, their_previous_fee)):
-                    # SHOULD fail the connection.
-                    raise Exception('Their fee is not between our last sent and their last sent fee.')
-                # accept their fee if they are very close
-                if abs(their_fee - our_fee) < 2:
-                    our_fee = their_fee
-                else:
-                    # this will be "strictly between" (as in BOLT2) previous values because of the above
-                    our_fee = (our_fee + their_fee) // 2
 
             return our_fee, our_fee_range
 

--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -793,7 +793,6 @@ Warning: setting this to too low will result in lots of payment failures."""),
     TEST_FORCE_DISABLE_MPP = ConfigVar('test_force_disable_mpp', default=False, type_=bool)
     TEST_SHUTDOWN_FEE = ConfigVar('test_shutdown_fee', default=None, type_=int)
     TEST_SHUTDOWN_FEE_RANGE = ConfigVar('test_shutdown_fee_range', default=None)
-    TEST_SHUTDOWN_LEGACY = ConfigVar('test_shutdown_legacy', default=False, type_=bool)
     TEST_LN_OPEN_SRK_CHANNELS = ConfigVar('test_ln_open_srk_channels', default=False, type_=bool)
 
     # fee_policy is a dict: fee_policy_name -> fee_policy_descriptor

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -1277,12 +1277,6 @@ class TestPeerDirect(TestPeer):
             self.logger.debug(f"test_mpp_cleanup_after_expiry: {use_trampoline=}")
             await run_test(use_trampoline)
 
-    async def test_legacy_shutdown_low(self):
-        await self._test_shutdown(alice_fee=100, bob_fee=150)
-
-    async def test_legacy_shutdown_high(self):
-        await self._test_shutdown(alice_fee=2000, bob_fee=100)
-
     async def test_modern_shutdown_with_overlap(self):
         await self._test_shutdown(
             alice_fee=1,
@@ -1304,7 +1298,7 @@ class TestPeerDirect(TestPeer):
         # note: "Task exception was never retrieved" for "Exception: There is no overlap [...]"
         #       is because we don't start peer.main_loop and hence peer.taskgroup is never joined.
 
-    async def _test_shutdown(self, alice_fee, bob_fee, alice_fee_range=None, bob_fee_range=None):
+    async def _test_shutdown(self, alice_fee, bob_fee, alice_fee_range, bob_fee_range):
         graph = self.prepare_chans_and_peers_in_graph(self.GRAPH_DEFINITIONS['single_chan'])
         p1, p2 = graph.peers.values()
         w1, w2 = graph.workers.values()
@@ -1312,14 +1306,8 @@ class TestPeerDirect(TestPeer):
         bob_channel = graph.channels[('bob', 'alice')][0]
         w1.network.config.TEST_SHUTDOWN_FEE = alice_fee
         w2.network.config.TEST_SHUTDOWN_FEE = bob_fee
-        if alice_fee_range is not None:
-            w1.network.config.TEST_SHUTDOWN_FEE_RANGE = alice_fee_range
-        else:
-            w1.network.config.TEST_SHUTDOWN_LEGACY = True
-        if bob_fee_range is not None:
-            w2.network.config.TEST_SHUTDOWN_FEE_RANGE = bob_fee_range
-        else:
-            w2.network.config.TEST_SHUTDOWN_LEGACY = True
+        w1.network.config.TEST_SHUTDOWN_FEE_RANGE = alice_fee_range
+        w2.network.config.TEST_SHUTDOWN_FEE_RANGE = bob_fee_range
         w2.enable_htlc_settle = False
         lnaddr, pay_req = self.prepare_invoice(w2)
         async def pay():

--- a/tests/test_lnpeer.py
+++ b/tests/test_lnpeer.py
@@ -11,7 +11,7 @@ import concurrent
 from concurrent import futures
 from functools import lru_cache
 from unittest import mock
-from typing import Iterable, NamedTuple, Tuple, List, Dict, Sequence, Mapping
+from typing import Iterable, NamedTuple, Tuple, List, Dict, Sequence, Mapping, Optional
 from types import MappingProxyType
 import time
 import statistics
@@ -33,6 +33,7 @@ from electrum.bitcoin import sha256
 from electrum.transaction import Transaction
 from electrum.util import NetworkRetryManager, bfh, OldTaskGroup, EventListener, InvoiceError
 from electrum.lnpeer import Peer
+from electrum.lnpeer import CoopCloseFailure
 from electrum.lntransport import LNPeerAddr
 from electrum.crypto import privkey_to_pubkey
 from electrum.lnutil import Keypair, PaymentFailure, LnFeatures, HTLCOwner, PaymentFeeBudget, RECEIVED
@@ -1278,27 +1279,52 @@ class TestPeerDirect(TestPeer):
             await run_test(use_trampoline)
 
     async def test_modern_shutdown_with_overlap(self):
-        await self._test_shutdown(
-            alice_fee=1,
-            bob_fee=200,
-            alice_fee_range={'min_fee_satoshis': 1, 'max_fee_satoshis': 10},
-            bob_fee_range={'min_fee_satoshis': 10, 'max_fee_satoshis': 300})
-
-    @mock.patch('electrum.lnpeer.LN_P2P_NETWORK_TIMEOUT', 0.05)
-    async def test_modern_shutdown_no_overlap(self):
-        with self.assertLogs('electrum', level='ERROR') as logs:
-            with self.assertRaisesRegex(Exception, "closing_signed not received"):
-                await self._test_shutdown(
+        for alice_closes in [True, False]:
+            with self.subTest(alice_closes=alice_closes):
+                chan_ab, chan_ba, coop_fail = await self._test_shutdown(
                     alice_fee=1,
                     bob_fee=200,
                     alice_fee_range={'min_fee_satoshis': 1, 'max_fee_satoshis': 10},
-                    bob_fee_range={'min_fee_satoshis': 50, 'max_fee_satoshis': 300})
-        self.assertTrue(any(("bob->alice" in msg and "There is no overlap between between their and our fee range." in msg) for msg in logs.output))
-        self.assertTrue(any(("alice->bob" in msg and "closing_signed not received, force closing." in msg) for msg in logs.output))
-        # note: "Task exception was never retrieved" for "Exception: There is no overlap [...]"
-        #       is because we don't start peer.main_loop and hence peer.taskgroup is never joined.
+                    bob_fee_range={'min_fee_satoshis': 10, 'max_fee_satoshis': 300},
+                    alice_closes=alice_closes,
+                )
+                await asyncio.sleep(0.1)  # FIXME test is a bit fragile...
+                self.assertIsNone(coop_fail)
+                self.assertEqual((chan_ab._state, chan_ba._state), (ChannelState.CLOSING, ChannelState.CLOSING))
 
-    async def _test_shutdown(self, alice_fee, bob_fee, alice_fee_range, bob_fee_range):
+    @mock.patch('electrum.lnpeer.LN_P2P_NETWORK_TIMEOUT', 0.05)
+    async def test_modern_shutdown_no_overlap(self):
+        for alice_closes in [True, False]:
+            with self.subTest(alice_closes=alice_closes):
+                with self.assertLogs('electrum', level='ERROR') as logs:
+                    chan_ab, chan_ba, coop_fail = await self._test_shutdown(
+                        alice_fee=1,
+                        bob_fee=200,
+                        alice_fee_range={'min_fee_satoshis': 1, 'max_fee_satoshis': 10},
+                        bob_fee_range={'min_fee_satoshis': 50, 'max_fee_satoshis': 300},
+                        alice_closes=alice_closes,
+                    )
+                    await asyncio.sleep(0.1)  # FIXME test is a bit fragile...
+                self.assertIsInstance(coop_fail, CoopCloseFailure)
+                if alice_closes:
+                    assert "closing_signed not received" in str(coop_fail)
+                else:
+                    assert "There is no overlap between their and our fee range" in str(coop_fail)
+        self.assertTrue(any(("bob->alice" in msg and "There is no overlap between their and our fee range." in msg) for msg in logs.output))
+        self.assertTrue(any(("alice->bob" in msg and "closing_signed not received, force closing." in msg) for msg in logs.output))
+        # note: "Task exception was never retrieved" for the other CoopCloseFailure
+        #       is because we don't start peer.main_loop and hence peer.taskgroup is never joined.
+        self.assertEqual((chan_ab._state, chan_ba._state), (ChannelState.FORCE_CLOSING, ChannelState.FORCE_CLOSING))
+
+    async def _test_shutdown(
+        self,
+        *,
+        alice_fee: int,
+        bob_fee: int,
+        alice_fee_range: dict,
+        bob_fee_range: dict,
+        alice_closes: bool,  # who sends "shutdown" first
+    ) -> tuple[Channel, Channel, Optional[CoopCloseFailure]]:
         graph = self.prepare_chans_and_peers_in_graph(self.GRAPH_DEFINITIONS['single_chan'])
         p1, p2 = graph.peers.values()
         w1, w2 = graph.workers.values()
@@ -1323,15 +1349,24 @@ class TestPeerDirect(TestPeer):
                    min_final_cltv_delta=lnaddr.get_min_final_cltv_delta(),
                    payment_secret=lnaddr.payment_secret)
             await p2.received_commitsig_event.wait()
-            # alice closes
-            await p1.close_channel(alice_channel.channel_id)
-            gath.cancel()
+            # start mutual close
+            p_shutdown_sender = p1 if alice_closes else p2
+            await p_shutdown_sender.close_channel(alice_channel.channel_id)
+            raise SuccessfulTest()
         async def set_settle():
             await asyncio.sleep(0.1)
             w2.enable_htlc_settle = True
         gath = asyncio.gather(pay(), set_settle(), p1._message_loop(), p2._message_loop(), p1.htlc_switch(), p2.htlc_switch())
-        with self.assertRaises(asyncio.CancelledError):
+
+        coop_close_failure = None
+        try:
             await gath
+        except SuccessfulTest:
+            pass
+        except CoopCloseFailure as e:
+            coop_close_failure = e
+
+        return alice_channel, bob_channel, coop_close_failure
 
     async def test_warning(self):
         graph = self.prepare_chans_and_peers_in_graph(self.GRAPH_DEFINITIONS['single_chan'])


### PR DESCRIPTION
Note that BOLT2 used to bound fee_satoshis by the base fee of the final ctx, but that requirement was removed in lightning/bolts#847.

Also fix the "strictly between" check, which was skipped when their previously proposed fee was 0.