### PR TITLE
swaps: fix history for refunded submarine payment

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -1698,6 +1698,8 @@ class SwapManager(Logger):
                     # address again from accounting addresses so the refund tx is not incorrectly
                     # shown in the wallet history as tx spending from this wallet
                     self.wallet._accounting_addresses.discard(swap.lockup_address)
+                    del d[txid]  # neither funding nor refund tx belongs in our history
+                    continue
                 # add the funding tx to the group as the total amount of the group would
                 # otherwise be ~2x the actual payment as the claim tx gets counted as negative
                 # value (as it sends from the wallet/accounting address balance)


### PR DESCRIPTION
Remove the claim txid from the wallet history if claim tx is a refund tx of the swap provider during a submarine payment. This was already the intention of the code but the missing `continue` made it a no-op as the accounting address was re-added below.