### PR TITLE
add sanity check: wallet.config == lnworker.config == network.config

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -204,6 +204,7 @@ class AddressSynchronizer(Logger, EventListener):
         assert self.network is None, "already started"
         self.network = network
         if self.network is not None:
+            assert network.config is self.config
             self.synchronizer = Synchronizer(self)
             self.verifier = SPV(self.network, self)
             self.asyncio_loop = network.asyncio_loop

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -424,6 +424,7 @@ class LNPeerManager(Logger, EventListener, NetworkRetryManager[LNPeerAddr]):
         assert network
         assert self.network is None, "already started"
         self.network = network
+        assert network.config is self.config
         self._add_peers_from_config()
         asyncio.run_coroutine_threadsafe(self.main_loop(), get_asyncio_loop())
         if listen:
@@ -1211,6 +1212,7 @@ class LNWallet(Logger):
             self.logger.info("taskgroup stopped.")
 
     def start_network(self, network: 'Network'):
+        assert network.config is self.config
         asyncio.run_coroutine_threadsafe(self.main_loop(), get_asyncio_loop())
         self.lnpeermgr.start_network(network, listen=True)
         self.lnwatcher.start_network(network)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -681,6 +681,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self.taskgroup = OldTaskGroup()
         self.network = network
         if network:
+            assert network.config is self.config
             asyncio.run_coroutine_threadsafe(self.main_loop(), self.network.asyncio_loop)
             self.adb.start_network(network)
             if self.lnworker:


### PR DESCRIPTION
useful for unit tests where it is easy to slip-up and break this invariant when creating a MockNetwork

ref https://github.com/spesmilo/electrum/pull/10852#discussion_r3796948136