### PR TITLE
plugin: trezor: fix usage with passphrase

### DIFF
--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -110,25 +110,21 @@ class TrezorClientBase(HardwareClientBase, Logger):
         if self._session is None:
             assert self.handler is not None, "No UI handler for session"
             self.pair_if_needed()
+            self.client.ensure_unlocked()  # unlock device so features are populated and we know about passphrase
 
-            # If needed, unlock the device (triggering PIN entry dialog for legacy model).
-            with self.client.get_session(passphrase=PassphraseSetting.STANDARD_WALLET) as session:
-                session.ensure_unlocked()
-
-            passphrase = PassphraseSetting.STANDARD_WALLET  # (empty passphrase)
-            if self.client.features.passphrase_protection:
-                passphrase = self.get_passphrase(Capability.PassphraseEntry in self.client.features.capabilities)
-
-            # Then, derive a session for this wallet (possibly with a passphrase)
-            if passphrase == PassphraseSetting.STANDARD_WALLET:
-                self._session = session  # reuse the session above to avoid re-derivation
-                self.logger.info("Opened standard %s", self._session)
+            features = self.client.features
+            if not features.passphrase_protection:
+                passphrase = PassphraseSetting.STANDARD_WALLET  # (empty passphrase)
+            elif features.passphrase_always_on_device:
+                # the device asks for the passphrase itself, prompting in electrum as well would make the user enter it twice
+                passphrase = PassphraseSetting.ON_DEVICE
             else:
-                self._session = self.client.get_session(passphrase)
-                self.logger.info("Re-opened passphrase %s", self._session)
+                passphrase = self.get_passphrase(Capability.PassphraseEntry in features.capabilities)
+
+            self._session = self.client.get_session(passphrase=passphrase)
+            self.logger.info(f"Opened {self._session} ({features.passphrase_protection=}, on_device={passphrase is PassphraseSetting.ON_DEVICE})")
 
         return self._session
-
 
     def run_flow(self, message=None, creating_wallet=False):
         if self.in_flow:

--- a/electrum/plugins/trezor/qt.py
+++ b/electrum/plugins/trezor/qt.py
@@ -506,9 +506,12 @@ class SettingsDialog(WindowModalDialog):
                     raise RuntimeError("Device not connected")
                 if method:
                     getattr(client, method)(*args, **kw_args)
-                if unpair_after:
-                    devmgr.unpair_id(device_id)
-                return client.features
+                try:
+                    features = client.features  # some features are set None after unpairing, so store them first
+                finally:  # always clean up
+                    if unpair_after:
+                        devmgr.unpair_id(device_id)
+                return features
 
             thread.add(task, on_success=update)
 
@@ -531,7 +534,8 @@ class SettingsDialog(WindowModalDialog):
 
             device_label.setText(features.label)
             pin_set_label.setText(noyes[features.pin_protection])
-            passphrases_label.setText(disen[features.passphrase_protection])
+            passphrase_protection = features.passphrase_protection  # might be None if device is locked
+            passphrases_label.setText(disen[passphrase_protection] if passphrase_protection is not None else _("Unknown"))
             bl_hash_label.setText(bl_hash)
             label_edit.setText(features.label)
             device_id_label.setText(features.device_id)
@@ -541,7 +545,8 @@ class SettingsDialog(WindowModalDialog):
             clear_pin_warning.setVisible(features.pin_protection)
             pin_button.setText(setchange[features.pin_protection])
             pin_msg.setVisible(not features.pin_protection)
-            passphrase_button.setText(endis[features.passphrase_protection])
+            passphrase_button.setText(endis[bool(passphrase_protection)])
+            passphrase_button.setEnabled(passphrase_protection is not None)
             language_label.setText(features.language)
 
         def set_label_enabled():


### PR DESCRIPTION
Fixes 3 issues when using passphrases with Trezor hww:
1. V1 devices with `passphrase_always_on_device` would
    require the passphrase to be entered twice, see https://github.com/spesmilo/electrum/issues/10868
2. THP devices (Safe 7) with `passphrase_always_on_device` couldn't be unlocked at all
3. The settings dialog would raise after disabling the passphrase (https://github.com/spesmilo/electrum/commit/5796dec1cbd3f61ef76c944192f65d3b3eee75ce)