### PR TITLE
electrum-env script: fix instructions for -hw deps

### DIFF
--- a/electrum-env
+++ b/electrum-env
@@ -8,7 +8,7 @@
 # By default, not all optional dependencies are installed.
 # E.g. for hardware wallet support, do:
 # $ source ./env/bin/activate
-# $ pip install -r contrib/deterministic-build/requirements-hw.txt
+# $ pip install --no-dependencies -r contrib/deterministic-build/requirements-hw.txt
 # $ deactivate
 
 set -e


### PR DESCRIPTION
`--no-deps` is needed since the introduction of ghost.txt
(ref commit 74615623ebb23b3a772e3ca2e9ba5167590c8c1f)

```
Collecting platformdirs>=4.4.0 (from trezor==0.20.1->-r contrib/deterministic-build/requirements-hw.txt (line 486))
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    platformdirs>=4.4.0 from https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl (from trezor==0.20.1->-r contrib/deterministic-build/requirements-hw.txt (line 486))
```