### PR TITLE
qml: fix paying multi-output invoices

### DIFF
--- a/electrum/gui/qml/components/InvoiceDialog.qml
+++ b/electrum/gui/qml/components/InvoiceDialog.qml
@@ -22,7 +22,7 @@ ElDialog {
 
     padding: 0
 
-    property bool _canMax: invoice.invoiceType == Invoice.OnchainInvoice
+    property bool _canMax: invoice.invoiceType == Invoice.OnchainInvoice && invoice.outputs.length == 1
 
     property var _invoice_amount: invoice.amount  // type: Amount
 
@@ -75,7 +75,7 @@ ElDialog {
                 Label {
                     Layout.columnSpan: 2
                     Layout.topMargin: constants.paddingSmall
-                    visible: invoice.invoiceType == Invoice.OnchainInvoice
+                    visible: invoice.invoiceType == Invoice.OnchainInvoice && invoice.outputs.length == 1
                     text: qsTr('Address')
                     color: Material.accentColor
                 }
@@ -83,7 +83,7 @@ ElDialog {
                 DialogHighlightPane {
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
-                    visible: invoice.invoiceType == Invoice.OnchainInvoice
+                    visible: invoice.invoiceType == Invoice.OnchainInvoice && invoice.outputs.length == 1
                     leftPadding: constants.paddingMedium
 
                     RowLayout {
@@ -104,6 +104,56 @@ ElDialog {
                                     text: invoice.address
                                 })
                                 dialog.open()
+                            }
+                        }
+                    }
+                }
+
+                Label {
+                    Layout.columnSpan: 2
+                    Layout.topMargin: constants.paddingSmall
+                    visible: invoice.outputs.length > 1
+                    text: qsTr('Outputs (%1)').arg(invoice.outputs.length)
+                    color: Material.accentColor
+                }
+
+                Repeater {
+                    model: invoice.outputs.length > 1
+                        ? invoice.outputs
+                        : undefined
+
+                    DialogHighlightPane {
+                        Layout.columnSpan: 2
+                        Layout.fillWidth: true
+                        leftPadding: constants.paddingMedium
+
+                        ColumnLayout {
+                            width: parent.width
+                            spacing: 0
+                            Label {
+                                Layout.fillWidth: true
+                                text: modelData.address
+                                font.pixelSize: constants.fontSizeMedium
+                                font.family: FixedFont
+                                wrapMode: Text.Wrap
+                            }
+                            RowLayout {
+                                Layout.alignment: Qt.AlignRight
+                                Label {
+                                    text: !modelData.is_max
+                                        ? Config.formatSats(modelData.value)
+                                        : modelData.value == '!'
+                                            ? qsTr('Max')
+                                            : modelData.value
+                                    font.pixelSize: constants.fontSizeMedium
+                                    font.family: FixedFont
+                                }
+                                Label {
+                                    visible: !modelData.is_max
+                                    text: Config.baseUnit
+                                    font.pixelSize: constants.fontSizeMedium
+                                    color: Material.accentColor
+                                }
                             }
                         }
                     }
@@ -507,7 +557,7 @@ ElDialog {
     }
 
     Component.onCompleted: {
-        if (invoice.amount.isEmpty && invoice.status != Invoice.Expired) {
+        if (invoice.amount.isEmpty && invoice.status != Invoice.Expired && invoice.outputs.length <= 1) {
             amountContainer.editmode = true
         } else if (invoice.amount.isMax) {
             amountMax.checked = true

--- a/electrum/gui/qml/components/WalletMainView.qml
+++ b/electrum/gui/qml/components/WalletMainView.qml
@@ -105,8 +105,10 @@ Item {
 
     function payOnchain(invoicedialog, invoice) {
         var dialog = confirmPaymentDialog.createObject(mainView, {
+                invoice: invoice,
                 address: invoice.address,
-                satoshis: invoice.amountOverride.isEmpty
+                // the amount override does not apply to multi-output invoices
+                satoshis: (invoice.outputs.length > 1 || invoice.amountOverride.isEmpty)
                     ? invoice.amount
                     : invoice.amountOverride,
                 message: invoice.message
@@ -670,10 +672,13 @@ Item {
         id: confirmPaymentDialog
         ConfirmTxDialog {
             id: _confirmPaymentDialog
+
+            property QtObject invoice
             title: qsTr('Confirm Payment')
             finalizer: TxFinalizer {
                 wallet: Daemon.currentWallet
                 canRbf: true
+                invoice: _confirmPaymentDialog.invoice
                 onFinished: (signed, saved, complete) => {
                     if (!complete) {
                         var msg

--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -18,7 +18,7 @@ from electrum.lnurl import LNURL6Data
 from electrum.lnchannel import PeerState, ChannelState
 from electrum.bitcoin import COIN, address_to_script
 from electrum.payment_identifier import PaymentIdentifier, PaymentIdentifierState, PaymentIdentifierType
-from electrum.util import event_listener, now, InvoiceError
+from electrum.util import event_listener, now, parse_max_spend, InvoiceError
 
 from electrum.gui.common_qt.util import QtEventListener
 
@@ -167,6 +167,19 @@ class QEInvoice(QObject, QtEventListener):
     def address(self):
         return self._effectiveInvoice.get_address() if self._effectiveInvoice else ''
 
+    @pyqtProperty('QVariantList', notify=invoiceChanged)
+    def outputs(self):
+        if not self._effectiveInvoice or self.invoiceType != QEInvoice.Type.OnchainInvoice:
+            return []
+        outputs = []
+        for o in self._effectiveInvoice.get_outputs():
+            outputs.append({
+                'address': o.get_ui_address_str(),
+                'value': o.value,
+                'is_max': bool(parse_max_spend(o.value))
+            })
+        return outputs
+
     @pyqtProperty(QEAmount, notify=invoiceChanged)
     def amount(self):
         if not self._effectiveInvoice:
@@ -291,6 +304,9 @@ class QEInvoice(QObject, QtEventListener):
         lnworker = self._wallet.wallet.lnworker
         return (lnworker.lnpeermgr.get_node_alias(node_id) if lnworker else None) or node_id.hex()
 
+    def get_effective_invoice(self) -> Optional[Invoice]:
+        return self._effectiveInvoice
+
     def set_effective_invoice(self, invoice: Invoice):
         self._paid_in_this_session = False
         self._effectiveInvoice = invoice
@@ -302,6 +318,9 @@ class QEInvoice(QObject, QtEventListener):
                 self.setInvoiceType(QEInvoice.Type.LightningInvoice)
             else:
                 self.setInvoiceType(QEInvoice.Type.OnchainInvoice)
+                if len(invoice.get_outputs()) > 1:
+                    # amount override does not apply to multi-output invoices
+                    self._amountOverride.clear()
             self._isSaved = self._wallet.wallet.get_invoice(invoice.get_id()) is not None
 
         self.set_lnprops()
@@ -340,6 +359,14 @@ class QEInvoice(QObject, QtEventListener):
 
         amount = self.amountOverride if not self.amountOverride.isEmpty else self.amount
 
+        is_multi_output = (self.invoiceType == QEInvoice.Type.OnchainInvoice
+                           and len(self._effectiveInvoice.get_outputs()) > 1)
+        if is_multi_output:
+            # the amount override does not apply to multi-output invoices: the pay
+            # path spends to the invoice outputs as-is. If their amount is
+            # unspecified (all zero-value outputs), the invoice cannot be paid.
+            amount = self.amount
+
         # Invalid and LNURLPayRequest have no _effectiveInvoice, so payability cannot be determined.
         is_directly_payable = self.invoiceType in [
             QEInvoice.Type.LightningInvoice, QEInvoice.Type.OnchainInvoice]
@@ -351,7 +378,8 @@ class QEInvoice(QObject, QtEventListener):
         userinfo_status = QEInvoice.UserinfoStatus.Info
         try:
             if self.amount.isEmpty:
-                userinfo = _('Enter the amount you want to send')
+                userinfo = (_('Invoice has no amount') if is_multi_output
+                            else _('Enter the amount you want to send'))
 
             status = self.status
 
@@ -436,6 +464,10 @@ class QEInvoice(QObject, QtEventListener):
             return
 
         assert self.invoiceType == QEInvoice.Type.OnchainInvoice
+
+        if len(self._effectiveInvoice.get_outputs()) > 1:
+            self._logger.debug('updateMaxAmount not supported for multi-output invoices')
+            return
 
         # only single address invoice supported
         invoice_address = self._effectiveInvoice.get_address()

--- a/electrum/gui/qml/qetxfinalizer.py
+++ b/electrum/gui/qml/qetxfinalizer.py
@@ -24,6 +24,7 @@ from electrum.gui import messages
 from electrum.gui.common_qt.util import QtEventListener
 
 from .qewallet import QEWallet
+from .qeinvoice import QEInvoice
 from .qetypes import QEAmount
 
 if TYPE_CHECKING:
@@ -407,6 +408,7 @@ class QETxFinalizer(TxFeeSlider):
         self.f_accept = accept
 
         self._address = ''
+        self._invoice = None  # type: Optional[QEInvoice]
         self._amount = QEAmount()
         self._effectiveAmount = QEAmount()
         self._extraFee = QEAmount()
@@ -422,6 +424,19 @@ class QETxFinalizer(TxFeeSlider):
         if self._address != address:
             self._address = address
             self.addressChanged.emit()
+
+    invoiceChanged = pyqtSignal()
+    @pyqtProperty(QVariant, notify=invoiceChanged)
+    def invoice(self) -> Optional[QEInvoice]:
+        return self._invoice
+
+    @invoice.setter
+    def invoice(self, invoice: QEInvoice):
+        assert invoice is None or isinstance(invoice, QEInvoice)
+        if self._invoice != invoice:
+            self._invoice = invoice
+            self.update()
+            self.invoiceChanged.emit()
 
     amountChanged = pyqtSignal()
     @pyqtProperty(QVariant, notify=amountChanged)
@@ -474,7 +489,16 @@ class QETxFinalizer(TxFeeSlider):
         else:
             # default impl
             coins = self._wallet.wallet.get_spendable_coins(None)
-            outputs = [PartialTxOutput.from_address_and_value(self.address, amount)]
+            invoice = self._invoice.get_effective_invoice() if self._invoice else None
+            invoice_outputs = invoice.get_outputs() if invoice and not invoice.is_lightning() else []
+            if len(invoice_outputs) > 1:
+                # multi-output ("pay to many") invoice: pay all invoice outputs
+                outputs = invoice_outputs
+            else:
+                # single-output invoices use (address, amount), as amount may differ
+                # from the invoice output value (zero-amount invoices, and lightning
+                # invoices paid via their onchain fallback address)
+                outputs = [PartialTxOutput.from_address_and_value(self.address, amount)]
             tx = self._wallet.wallet.make_unsigned_transaction(
                 coins=coins,
                 outputs=outputs,

--- a/tests/qml/test_qml_qetxfinalizer.py
+++ b/tests/qml/test_qml_qetxfinalizer.py
@@ -1,0 +1,234 @@
+import gc
+import time
+from collections import Counter
+from decimal import Decimal
+
+from electrum import constants, keystore
+from electrum.bolt11 import BOLT11Addr, encode_bolt11_invoice
+from electrum.invoices import Invoice
+from electrum.simple_config import SimpleConfig
+from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED
+from electrum.transaction import PartialTxOutput, Transaction
+
+from electrum.gui.qml.qewallet import QEWallet
+from electrum.gui.qml.qeinvoice import QEInvoice
+from electrum.gui.qml.qetxfinalizer import QETxFinalizer
+from electrum.gui.qml.qetypes import QEAmount
+
+from .. import ElectrumTestCase
+from ..test_bolt11 import PRIVKEY, RHASH, PAYMENT_SECRET
+from ..test_wallet_vertical import WalletIntegrityHelper
+
+
+class TestQmlMultiOutputInvoice(ElectrumTestCase):
+    """Tests the pay path used by the QML gui with multi-output (paytomany) invoices,
+    driving the same python objects the QML flow uses:
+    WalletMainView.payOnchain() -> ConfirmTxDialog -> QETxFinalizer.make_tx()
+    """
+    TESTNET = True
+
+    # p2wpkh wallet with a single 1_000_000 sat utxo (same fixture as TestWalletSending)
+    SEED_FUNDED = 'bitter grass shiver impose acquire brush forget axis eager alone wine silver'
+    SEED_RECIPIENT = 'cycle rocket west magnet parrot shuffle foot correct salt library feed song'
+    FUNDING_TX = '01000000014576dacce264c24d81887642b726f5d64aa7825b21b350c7b75a57f337da6845010000006b483045022100a3f8b6155c71a98ad9986edd6161b20d24fad99b6463c23b463856c0ee54826d02200f606017fd987696ebbe5200daedde922eee264325a184d5bbda965ba5160821012102e5c473c051dae31043c335266d0ef89c1daab2f34d885cc7706b267f3269c609ffffffff0240420f00000000001600148a28bddb7f61864bdcf58b2ad13d5aeb3abc3c42a2ddb90e000000001976a914c384950342cb6f8df55175b48586838b03130fad88ac00000000'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # collect the QObject wrappers when the class is done: once a later test
+        # creates a QCoreApplication, lingering ones become uncollectable and
+        # keep their wallets alive (breaking the gc checks in test_daemon.py)
+        cls.addClassCleanup(gc.collect)
+
+    def setUp(self):
+        super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+        self.config.FEE_POLICY = 'fixed:5000'
+
+    def _create_funded_wallet(self):
+        ks = keystore.from_seed(self.SEED_FUNDED, passphrase='', for_multisig=False)
+        wallet = WalletIntegrityHelper.create_standard_wallet(ks, gap_limit=2, config=self.config)
+        wallet.adb.receive_tx_callback(Transaction(self.FUNDING_TX), tx_height=TX_HEIGHT_UNCONFIRMED)
+        return wallet
+
+    def _recipient_addresses(self, n):
+        ks = keystore.from_seed(self.SEED_RECIPIENT, passphrase='', for_multisig=False)
+        w2 = WalletIntegrityHelper.create_standard_wallet(ks, gap_limit=max(n, 2), config=self.config)
+        return w2.get_receiving_addresses()[:n]
+
+    def _qeinvoice_for_saved_invoice(self, wallet, invoice):
+        wallet.save_invoice(invoice)
+        qew = QEWallet(wallet)
+        self.addCleanup(qew.unregister_callbacks)
+        qei = QEInvoice()
+        self.addCleanup(qei.unregister_callbacks)
+        qei.wallet = qew
+        qei.key = invoice.get_id()
+        return qew, qei
+
+    def _finalizer_for_saved_invoice(self, wallet, invoice):
+        """Wire up QEWallet/QEInvoice/QETxFinalizer the way WalletMainView.payOnchain()
+        and ConfirmTxDialog wire them for a saved invoice."""
+        qew, qei = self._qeinvoice_for_saved_invoice(wallet, invoice)
+        fin = QETxFinalizer()
+        fin.wallet = qew
+        fin.address = qei.address
+        fin.invoice = qei
+        return qei, fin
+
+    def _assert_tx_pays_outputs(self, tx, outputs):
+        """every given output must appear in the tx (compared as multisets,
+        so duplicate addresses are not collapsed)"""
+        tx_outputs = Counter((o.address, o.value) for o in tx.outputs())
+        expected = Counter((o.address, o.value) for o in outputs)
+        self.assertEqual(Counter(), expected - tx_outputs,
+                         f'invoice outputs not paid correctly: {tx.outputs()}')
+
+    async def test_make_tx_pays_all_outputs_of_multi_output_invoice(self):
+        wallet = self._create_funded_wallet()
+        addrs = self._recipient_addresses(3)
+        values = [100_000, 150_000, 200_000]
+        outputs = [PartialTxOutput.from_address_and_value(a, v) for a, v in zip(addrs, values)]
+        invoice = wallet.create_invoice(outputs=outputs, message='batch', URI=None)
+        qei, fin = self._finalizer_for_saved_invoice(wallet, invoice)
+
+        tx = fin.make_tx(sum(values))
+
+        self._assert_tx_pays_outputs(tx, outputs)
+
+    async def test_make_tx_pays_duplicate_address_outputs_separately(self):
+        # paytomany invoices can pay the same address on multiple lines; the tx
+        # must contain each output (make_unsigned_transaction does not merge
+        # duplicate outputs by default)
+        wallet = self._create_funded_wallet()
+        addr = self._recipient_addresses(1)[0]
+        outputs = [
+            PartialTxOutput.from_address_and_value(addr, 100_000),
+            PartialTxOutput.from_address_and_value(addr, 150_000),
+        ]
+        invoice = wallet.create_invoice(outputs=outputs, message='dup', URI=None)
+        qei, fin = self._finalizer_for_saved_invoice(wallet, invoice)
+
+        tx = fin.make_tx(250_000)
+
+        self._assert_tx_pays_outputs(tx, outputs)
+
+    async def test_make_tx_lightning_invoice_paid_via_fallback_uses_address_and_amount(self):
+        # a lightning invoice paid onchain via its fallback address must keep the
+        # (address, amount) path; the amount comes from the finalizer (it can
+        # legitimately differ from the invoice amount), not from get_outputs()
+        wallet = self._create_funded_wallet()
+        fallback = self._recipient_addresses(1)[0]
+        lnaddr = BOLT11Addr(
+            date=int(time.time()),
+            paymenthash=RHASH, payment_secret=PAYMENT_SECRET,
+            amount=Decimal('0.003'),
+            net=constants.BitcoinTestnet,
+            tags=[('f', fallback), ('d', 'ln fallback'), ('9', 0x28200)])
+        invoice = Invoice.from_bech32(encode_bolt11_invoice(lnaddr, PRIVKEY))
+        qei, fin = self._finalizer_for_saved_invoice(wallet, invoice)
+
+        tx = fin.make_tx(200_000)
+
+        paid = {o.address: o.value for o in tx.outputs()}
+        self.assertEqual(200_000, paid.get(fallback))
+
+    async def test_update_rebuilds_tx_when_invoice_set_after_wallet(self):
+        # in ConfirmTxDialog the finalizer's wallet binding triggers the first
+        # update() before the invoice property lands, so setting the invoice
+        # must rebuild the tx, or the collapsed single-output tx gets signed
+        wallet = self._create_funded_wallet()
+        addrs = self._recipient_addresses(3)
+        values = [100_000, 150_000, 200_000]
+        outputs = [PartialTxOutput.from_address_and_value(a, v) for a, v in zip(addrs, values)]
+        invoice = wallet.create_invoice(outputs=outputs, message='batch', URI=None)
+        qew, qei = self._qeinvoice_for_saved_invoice(wallet, invoice)
+
+        fin = QETxFinalizer()
+        fin.address = qei.address
+        fin.amount = QEAmount(amount_sat=sum(values))
+        fin.wallet = qew  # triggers update() while invoice is not set yet
+        fin.invoice = qei
+
+        self.assertTrue(fin.valid)
+        self._assert_tx_pays_outputs(fin._tx, outputs)
+
+    async def test_make_tx_pays_all_outputs_of_multiline_max_invoice(self):
+        wallet = self._create_funded_wallet()
+        addrs = self._recipient_addresses(2)
+        outputs = [
+            PartialTxOutput.from_address_and_value(addrs[0], 100_000),
+            PartialTxOutput.from_address_and_value(addrs[1], '!'),
+        ]
+        invoice = wallet.create_invoice(outputs=outputs, message='batch max', URI=None)
+        qei, fin = self._finalizer_for_saved_invoice(wallet, invoice)
+
+        tx = fin.make_tx('!')
+
+        paid = {o.address: o.value for o in tx.outputs()}
+        self.assertEqual(2, len(tx.outputs()), f'expected no change output: {paid}')
+        self.assertEqual(100_000, paid.get(addrs[0]))
+        self.assertEqual(1_000_000 - 100_000 - 5000, paid.get(addrs[1]))
+
+    async def test_make_tx_zero_amount_invoice_still_uses_override_amount(self):
+        # zero-amount invoices carry value=0 outputs; the amount the user entered
+        # arrives via the amount override, so the address+amount path must be kept
+        wallet = self._create_funded_wallet()
+        addr = self._recipient_addresses(1)[0]
+        outputs = [PartialTxOutput.from_address_and_value(addr, 0)]
+        invoice = wallet.create_invoice(outputs=outputs, message='no amount', URI=None)
+        qei, fin = self._finalizer_for_saved_invoice(wallet, invoice)
+
+        tx = fin.make_tx(300_000)
+
+        paid = {o.address: o.value for o in tx.outputs()}
+        self.assertEqual(300_000, paid.get(addr))
+
+    async def test_amountless_multi_output_invoice_cannot_be_paid(self):
+        # the desktop multiline parser accepts zero-value lines, so a saved
+        # multi-output invoice can have an unspecified amount. An amount entered
+        # by the user must not make it payable: the pay path spends to the
+        # invoice outputs as-is, which would silently discard the entered amount
+        wallet = self._create_funded_wallet()
+        addrs = self._recipient_addresses(2)
+        outputs = [PartialTxOutput.from_address_and_value(a, 0) for a in addrs]
+        invoice = wallet.create_invoice(outputs=outputs, message='no amounts', URI=None)
+        qew, qei = self._qeinvoice_for_saved_invoice(wallet, invoice)
+
+        qei.amountOverride = QEAmount(amount_sat=300_000)  # as if entered by the user
+
+        self.assertFalse(qei.canPay)
+
+    async def test_amount_override_cleared_when_multi_output_invoice_loaded(self):
+        # the QEInvoice instance is shared between subsequently viewed invoices;
+        # an amount override left over from a previously viewed zero-amount
+        # invoice must not be applied to a multi-output invoice
+        wallet = self._create_funded_wallet()
+        addrs = self._recipient_addresses(2)
+        outputs = [PartialTxOutput.from_address_and_value(a, v) for a, v in zip(addrs, [100_000, 150_000])]
+        invoice = wallet.create_invoice(outputs=outputs, message='batch', URI=None)
+        wallet.save_invoice(invoice)
+        qew = QEWallet(wallet)
+        self.addCleanup(qew.unregister_callbacks)
+        qei = QEInvoice()
+        self.addCleanup(qei.unregister_callbacks)
+        qei.wallet = qew
+        qei.amountOverride = QEAmount(amount_sat=123_000)  # stale, from a previously viewed invoice
+
+        qei.key = invoice.get_id()
+
+        self.assertTrue(qei.amountOverride.isEmpty)
+
+    async def test_qeinvoice_exposes_outputs_for_display(self):
+        wallet = self._create_funded_wallet()
+        addrs = self._recipient_addresses(3)
+        values = [100_000, '!', '2!']
+        outputs = [PartialTxOutput.from_address_and_value(a, v) for a, v in zip(addrs, values)]
+        invoice = wallet.create_invoice(outputs=outputs, message='batch', URI=None)
+        qew, qei = self._qeinvoice_for_saved_invoice(wallet, invoice)
+
+        outs = qei.outputs
+        self.assertEqual(3, len(outs))
+        self.assertEqual(addrs, [o['address'] for o in outs])
+        self.assertEqual(values, [o['value'] for o in outs])
+        self.assertEqual([False, True, True], [o['is_max'] for o in outs])


### PR DESCRIPTION
Paying a multi-output ("pay to many") onchain invoice from the QML gui builds a transaction that sends the **entire invoice total to the first output's address**: the first recipient is overpaid, the others receive nothing — and the invoice then remains marked Unpaid, since onchain paid-detection requires every output to be satisfied.

The QML gui assumed onchain invoices have a single output, in two places:

1. `WalletMainView.payOnchain()` passes only `(invoice.address, invoice.amount)` to the finalizer, and `QETxFinalizer.make_tx()` rebuilds `[PartialTxOutput.from_address_and_value(self.address, amount)]` — where `address` is `invoice.get_address()` (the first output) and `amount` is the invoice total.
2. `InvoiceDialog` only displays the first output's address, so there is no way to notice before confirming.

To reproduce: on desktop Qt, Send tab → "Pay to many" with several `address, amount` lines → Save invoice; open the same wallet with `electrum -g qml` (or on Android) and pay the saved invoice from the invoice list. The resulting tx has a single output paying the full total to the first address.

The fix makes the finalizer spend to the invoice outputs as-is when the invoice has more than one output — matching the qt gui, which already pays `invoice.outputs`, and following the direction of the existing TODO in `gui/qt/send_tab.py` ("instead of passing outputs, use an invoice instead"). Single-output invoices keep the existing `(address, amount)` path, since the paid amount can legitimately differ from the invoice output value (zero-amount invoices, lightning invoices paid via their onchain fallback). It keeps `make_unsigned_transaction`'s default `merge_duplicate_outputs=False`, as the QML gui has no UI for `WALLET_MERGE_DUPLICATE_OUTPUTS`; happy to pass the config through like qt's send tab if preferred.

`InvoiceDialog` now lists all outputs with their amounts (a lightweight list rather than `controls/TxOutput`, which needs tx-level model roles and can't render `'!'` values), and the "Max" option is hidden for multi-output invoices, as amountOverride/updateMaxAmount only support a single address. The amount override does not apply to multi-output invoices at all: the pay path spends to the outputs as-is, so a leftover override is cleared on load, the amount editor is not offered, and an amountless multi-output invoice — all zero-value outputs, which the desktop multiline parser permits — cannot be paid. An entered amount can thus never silently diverge from what the tx pays.

`ConfirmTxDialog` needs no changes: it already renders the built tx's outputs, so the confirmation screen shows all recipients before signing.

<details>
<summary>Before / after screenshots (same invoices, desktop QML, testnet)</summary>

3-output invoice, before / after:

<img width="300" alt="invoice-dialog-multi-output-BEFORE" src="https://github.com/user-attachments/assets/22b6bc33-2dca-44b1-be15-017417187d94" /> <img width="300" alt="invoice-dialog-multi-output" src="https://github.com/user-attachments/assets/2d19c9d8-54ac-434d-b7e3-36604060b3fe" />

Invoice with a `'!'` line, before / after:

<img width="300" alt="invoice-dialog-max-BEFORE" src="https://github.com/user-attachments/assets/bd5aae21-ed61-44a1-9f5f-47d3d93d9500" /> <img width="300" alt="invoice-dialog-max" src="https://github.com/user-attachments/assets/37e8c7fc-1591-4d3d-87c6-cc1895b925c6" />
</details>

Includes tests driving the same python objects the QML flow uses (`QEInvoice`/`QETxFinalizer`), covering: multi-output payment, duplicate-address outputs, a `'!'` max line, weighted-max display values, the zero-amount override path, a lightning invoice paid via its onchain fallback address, and that the finalizer rebuilds its tx when the invoice property is set after the wallet binding has already triggered the first update(). They are async tests on `ElectrumTestCase` (same as `test_qml_qetransactionlistmodel.py`) rather than the existing `QETestCase` in `tests/qml/qt_util.py`, as they need wallet fixtures and asyncio support that harness doesn't provide; happy to move them onto the refactored harness once #10699 lands.

Tested on desktop QML (`-g qml`) on testnet, and on an arm64 Android 16 device with a debug testnet apk carrying this fix:

<details>
<summary>Device screenshots (Android 16)</summary>

<img width="300" alt="device-invoice-dialog-multi-output" src="https://github.com/user-attachments/assets/585fc75d-2c72-4d5d-a5d8-03ddca878eb9" /> <img width="300" alt="device-invoice-dialog-max" src="https://github.com/user-attachments/assets/9afd7113-906e-458f-ad90-afe47713c038" />
</details>

Note: this overlaps textually with #10723 (`QETxFinalizer.__init__`/`make_tx` and `WalletMainView.payOnchain`) — happy to rebase on top of it or vice versa, whichever lands first.

The QML gui still cannot *create* multi-output invoices; this only fixes displaying and paying ones that already exist in the wallet. Groundwork for #8624, but stands alone as a bug fix.