### PR TITLE
blockchain: move blockchain logic from module to class

### DIFF
--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -125,7 +125,7 @@ class BlockchainManager(Logger):
 
     def _read_blockchains(self):
         best_chain = Blockchain(
-            manager=self,
+            bc_mgr=self,
             forkpoint=0,
             parent=None,
             forkpoint_hash=constants.net.GENESIS,
@@ -166,7 +166,7 @@ class BlockchainManager(Logger):
             self._delete_chain(filename, "cannot find parent for chain")
             return
         b = Blockchain(
-            manager=self,
+            bc_mgr=self,
             forkpoint=forkpoint,
             parent=parent,
             forkpoint_hash=first_hash,
@@ -244,7 +244,7 @@ class Blockchain(Logger):
 
     def __init__(
         self,
-        manager: 'BlockchainManager',
+        bc_mgr: 'BlockchainManager',
         forkpoint: int,
         parent: Optional['Blockchain'],
         forkpoint_hash: str,
@@ -256,7 +256,7 @@ class Blockchain(Logger):
         if 0 < forkpoint <= constants.net.max_checkpoint():
             raise Exception(f"cannot fork below max checkpoint. forkpoint: {forkpoint}")
         Logger.__init__(self)
-        self.manager = manager
+        self.bc_mgr = bc_mgr
         self.forkpoint = forkpoint  # height of first header
         self.parent = parent
         self._forkpoint_hash = forkpoint_hash  # blockhash at forkpoint. "first hash"
@@ -280,12 +280,12 @@ class Blockchain(Logger):
         return mc if mc is not None else self.forkpoint
 
     def get_direct_children(self) -> Sequence['Blockchain']:
-        with self.manager.blockchains_lock:
-            return list(filter(lambda y: y.parent==self, self.manager.blockchains.values()))
+        with self.bc_mgr.blockchains_lock:
+            return list(filter(lambda y: y.parent==self, self.bc_mgr.blockchains.values()))
 
     def get_parent_heights(self) -> Mapping['Blockchain', int]:
         """Returns map: (parent chain -> height of last common block)"""
-        with self.lock, self.manager.blockchains_lock:
+        with self.lock, self.bc_mgr.blockchains_lock:
             result = {self: self.height()}
             chain = self
             while True:
@@ -332,7 +332,7 @@ class Blockchain(Logger):
             raise Exception("forking header does not connect to parent chain")
         forkpoint = header.get('block_height')
         self = Blockchain(
-            manager=parent.manager,
+            bc_mgr=parent.bc_mgr,
             forkpoint=forkpoint,
             parent=parent,
             forkpoint_hash=hash_header(header),
@@ -344,8 +344,8 @@ class Blockchain(Logger):
         # put into global dict. note that in some cases
         # save_header might have already put it there but that's OK
         chain_id = self.get_id()
-        with parent.manager.blockchains_lock:
-            parent.manager.blockchains[chain_id] = self
+        with parent.bc_mgr.blockchains_lock:
+            parent.bc_mgr.blockchains[chain_id] = self
         return self
 
     @with_lock
@@ -397,13 +397,13 @@ class Blockchain(Logger):
     @with_lock
     def path(self) -> Path:
         if self.parent is None:
-            return self.manager.headers_dir / 'blockchain_headers'
+            return self.bc_mgr.headers_dir / 'blockchain_headers'
         else:
             assert self.forkpoint > 0, self.forkpoint
             prev_hash = self._prev_hash.lstrip('0')
             first_hash = self._forkpoint_hash.lstrip('0')
             basename = f'fork2_{self.forkpoint}_{prev_hash}_{first_hash}'
-            return self.manager.forks_dir / basename
+            return self.bc_mgr.forks_dir / basename
 
     @with_lock
     def save_chunk(self, index: int, chunk: bytes):
@@ -411,7 +411,7 @@ class Blockchain(Logger):
         chunk_within_checkpoint_region = index < len(self.checkpoints)
         # chunks in checkpoint region are the responsibility of the 'main chain'
         if chunk_within_checkpoint_region and self.parent is not None:
-            main_chain = self.manager.get_best_chain()
+            main_chain = self.bc_mgr.get_best_chain()
             main_chain.save_chunk(index, chunk)
             return
 
@@ -427,7 +427,7 @@ class Blockchain(Logger):
         self.swap_with_parent()
 
     def swap_with_parent(self) -> None:
-        with self.lock, self.manager.blockchains_lock:
+        with self.lock, self.bc_mgr.blockchains_lock:
             # do the swap; possibly multiple ones
             cnt = 0
             while True:
@@ -436,7 +436,7 @@ class Blockchain(Logger):
                     break
                 # make sure we are making progress
                 cnt += 1
-                if cnt > len(self.manager.blockchains):
+                if cnt > len(self.bc_mgr.blockchains):
                     raise Exception(f'swapping fork with parent too many times: {cnt}')
                 # we might have become the parent of some of our former siblings
                 for old_sibling in old_parent.get_direct_children():
@@ -483,7 +483,7 @@ class Blockchain(Logger):
         self.update_size()
         parent.update_size()
         # update pointers
-        blockchains = self.manager.blockchains
+        blockchains = self.bc_mgr.blockchains
         blockchains.pop(child_old_id, None)
         blockchains.pop(parent_old_id, None)
         blockchains[self.get_id()] = self
@@ -496,7 +496,7 @@ class Blockchain(Logger):
     def assert_headers_file_available(self, path: Path):
         if path.exists():
             return
-        elif not self.manager.headers_dir.exists():
+        elif not self.bc_mgr.headers_dir.exists():
             raise FileNotFoundError('Electrum headers_dir does not exist. Was it deleted while running?')
         else:
             raise FileNotFoundError('Cannot find headers file but headers_dir is there. Should be at {}'.format(path))

--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -103,7 +103,7 @@ _CHAINWORK_CACHE = {
 
 class BlockchainManager(Logger):
 
-    def __init__(self, headers_dir: Path):
+    def __init__(self, *, headers_dir: Path):
         Logger.__init__(self)
         self.headers_dir = headers_dir
         self.forks_dir = headers_dir / 'forks'
@@ -244,6 +244,7 @@ class Blockchain(Logger):
 
     def __init__(
         self,
+        *,
         bc_mgr: 'BlockchainManager',
         forkpoint: int,
         parent: Optional['Blockchain'],

--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -24,18 +24,18 @@ import os
 import threading
 import time
 from typing import Optional, Dict, Mapping, Sequence, TYPE_CHECKING
+from pathlib import Path
 
 from . import util
 from .bitcoin import hash_encode
 from .crypto import sha256d
 from . import constants
 from .util import bfh, with_lock
-from .logging import get_logger, Logger
+from .logging import Logger
 
 if TYPE_CHECKING:
     from .simple_config import SimpleConfig
 
-_logger = get_logger(__name__)
 
 HEADER_SIZE = 80  # bytes
 CHUNK_SIZE = 2016  # num headers in a difficulty retarget period
@@ -79,7 +79,7 @@ def deserialize_header(s: bytes, height: int) -> dict:
     return h
 
 
-def hash_header(header: dict) -> str:
+def hash_header(header: Optional[dict]) -> str:
     if header is None:
         return '0' * 64
     if header.get('prev_block_hash') is None:
@@ -95,96 +95,146 @@ def hash_raw_header(header: bytes) -> str:
 pow_hash_header = hash_header
 
 
-# key: blockhash hex at forkpoint
-# the chain at some key is the best chain that includes the given hash
-blockchains = {}  # type: Dict[str, Blockchain]
-blockchains_lock = threading.RLock()  # lock order: take this last; so after Blockchain.lock
-
-
-def read_blockchains(config: 'SimpleConfig'):
-    best_chain = Blockchain(config=config,
-                            forkpoint=0,
-                            parent=None,
-                            forkpoint_hash=constants.net.GENESIS,
-                            prev_hash=None)
-    blockchains[constants.net.GENESIS] = best_chain
-    # consistency checks
-    if best_chain.height() > constants.net.max_checkpoint():
-        header_after_cp = best_chain.read_header(constants.net.max_checkpoint()+1)
-        if not header_after_cp or not best_chain.can_connect(header_after_cp, check_height=False):
-            _logger.info("[blockchain] deleting best chain. cannot connect header after last cp to last cp.")
-            os.unlink(best_chain.path())
-            best_chain.update_size()
-    # forks
-    fdir = os.path.join(util.get_headers_dir(config), 'forks')
-    util.make_dir(fdir)
-    # files are named as: fork2_{forkpoint}_{prev_hash}_{first_hash}
-    l = filter(lambda x: x.startswith('fork2_') and '.' not in x, os.listdir(fdir))
-    l = sorted(l, key=lambda x: int(x.split('_')[1]))  # sort by forkpoint
-
-    def delete_chain(filename, reason):
-        _logger.info(f"[blockchain] deleting chain {filename}: {reason}")
-        os.unlink(os.path.join(fdir, filename))
-
-    def instantiate_chain(filename):
-        __, forkpoint, prev_hash, first_hash = filename.split('_')
-        forkpoint = int(forkpoint)
-        prev_hash = (64-len(prev_hash)) * "0" + prev_hash  # left-pad with zeroes
-        first_hash = (64-len(first_hash)) * "0" + first_hash
-        # forks below the max checkpoint are not allowed
-        if forkpoint <= constants.net.max_checkpoint():
-            delete_chain(filename, "deleting fork below max checkpoint")
-            return
-        # find parent (sorting by forkpoint guarantees it's already instantiated)
-        for parent in blockchains.values():
-            if parent.check_hash(forkpoint - 1, prev_hash):
-                break
-        else:
-            delete_chain(filename, "cannot find parent for chain")
-            return
-        b = Blockchain(config=config,
-                       forkpoint=forkpoint,
-                       parent=parent,
-                       forkpoint_hash=first_hash,
-                       prev_hash=prev_hash)
-        # consistency checks
-        h = b.read_header(b.forkpoint)
-        if first_hash != hash_header(h):
-            delete_chain(filename, "incorrect first hash for chain")
-            return
-        if not b.parent.can_connect(h, check_height=False):
-            delete_chain(filename, "cannot connect chain to parent")
-            return
-        chain_id = b.get_id()
-        assert first_hash == chain_id, (first_hash, chain_id)
-        blockchains[chain_id] = b
-
-    for filename in l:
-        instantiate_chain(filename)
-
-
-def get_best_chain() -> 'Blockchain':
-    return blockchains[constants.net.GENESIS]
-
-
 # block hash -> chain work; up to and including that block
 _CHAINWORK_CACHE = {
     "0000000000000000000000000000000000000000000000000000000000000000": 0,  # virtual block at height -1
 }  # type: Dict[str, int]
 
 
-def init_headers_file_for_best_chain():
-    b = get_best_chain()
-    filename = b.path()
-    length = HEADER_SIZE * len(constants.net.CHECKPOINTS) * CHUNK_SIZE
-    if not os.path.exists(filename) or os.path.getsize(filename) < length:
-        with open(filename, 'wb') as f:
-            if length > 0:
-                f.seek(length - 1)
-                f.write(b'\x00')
-        util.ensure_sparse_file(filename)
-    with b.lock:
-        b.update_size()
+class BlockchainManager(Logger):
+
+    def __init__(self, headers_dir: Path):
+        Logger.__init__(self)
+        self.headers_dir = headers_dir
+        self.forks_dir = headers_dir / 'forks'
+        util.make_dir(self.forks_dir)
+
+        # key: blockhash hex at forkpoint
+        # the chain at some key is the best chain that includes the given hash
+        self.blockchains = {}  # type: Dict[str, Blockchain]
+        self.blockchains_lock = threading.RLock()  # lock order: take this last; so after Blockchain.lock
+
+        self._read_blockchains()
+        self._init_headers_file_for_best_chain()
+        self.logger.info(f"blockchains {list(map(lambda b: b.forkpoint, self.blockchains.values()))}")
+
+    @classmethod
+    def from_config(cls, config: 'SimpleConfig') -> 'BlockchainManager':
+        headers_dir = util.get_headers_dir(config)
+        return cls(headers_dir=Path(headers_dir))
+
+    def _read_blockchains(self):
+        best_chain = Blockchain(
+            manager=self,
+            forkpoint=0,
+            parent=None,
+            forkpoint_hash=constants.net.GENESIS,
+            prev_hash=None,
+        )
+        self.blockchains[constants.net.GENESIS] = best_chain
+
+        # consistency checks
+        if best_chain.height() > constants.net.max_checkpoint():
+            header_after_cp = best_chain.read_header(constants.net.max_checkpoint()+1)
+            if not header_after_cp or not best_chain.can_connect(header_after_cp, check_height=False):
+                self.logger.warning("[blockchain] deleting best chain. cannot connect header after last cp to last cp.")
+                best_chain.path().unlink()
+                best_chain.update_size()
+
+        # forks
+        # files are named as: fork2_{forkpoint}_{prev_hash}_{first_hash}
+        l = filter(lambda x: x.startswith('fork2_') and '.' not in x, os.listdir(self.forks_dir))
+        l = sorted(l, key=lambda x: int(x.split('_')[1]))  # sort by forkpoint
+
+        for filename in l:
+            self._instantiate_chain(filename)
+
+    def _instantiate_chain(self, filename: str):
+        __, forkpoint, prev_hash, first_hash = filename.split('_')
+        forkpoint = int(forkpoint)
+        prev_hash = (64-len(prev_hash)) * "0" + prev_hash  # left-pad with zeroes
+        first_hash = (64-len(first_hash)) * "0" + first_hash
+        # forks below the max checkpoint are not allowed
+        if forkpoint <= constants.net.max_checkpoint():
+            self._delete_chain(filename, "deleting fork below max checkpoint")
+            return
+        # find parent (sorting by forkpoint guarantees it's already instantiated)
+        for parent in self.blockchains.values():
+            if parent.check_hash(forkpoint - 1, prev_hash):
+                break
+        else:
+            self._delete_chain(filename, "cannot find parent for chain")
+            return
+        b = Blockchain(
+            manager=self,
+            forkpoint=forkpoint,
+            parent=parent,
+            forkpoint_hash=first_hash,
+            prev_hash=prev_hash,
+        )
+        # consistency checks
+        h = b.read_header(b.forkpoint)
+        if first_hash != hash_header(h):
+            self._delete_chain(filename, "incorrect first hash for chain")
+            return
+        if not b.parent.can_connect(h, check_height=False):
+            self._delete_chain(filename, "cannot connect chain to parent")
+            return
+        chain_id = b.get_id()
+        assert first_hash == chain_id, (first_hash, chain_id)
+        self.blockchains[chain_id] = b
+
+    def _delete_chain(self, filename: str, reason: str):
+        self.logger.info(f"[blockchain] deleting chain {filename}: {reason}")
+        file = self.forks_dir / filename
+        file.unlink()
+
+    def _init_headers_file_for_best_chain(self):
+        b = self.get_best_chain()
+        filename = b.path()
+        length = HEADER_SIZE * len(constants.net.CHECKPOINTS) * CHUNK_SIZE
+        if not filename.exists() or filename.stat().st_size < length:
+            with open(filename, 'wb') as f:
+                if length > 0:
+                    f.seek(length - 1)
+                    f.write(b'\x00')
+            util.ensure_sparse_file(filename)
+        with b.lock:
+            b.update_size()
+
+    def get_best_chain(self) -> 'Blockchain':
+        return self.blockchains[constants.net.GENESIS]
+
+    def check_header(self, header: dict) -> Optional['Blockchain']:
+        """Returns any Blockchain that contains header, or None."""
+        if type(header) is not dict:
+            return None
+        with self.blockchains_lock:
+            chains = list(self.blockchains.values())
+        for b in chains:
+            if b.check_header(header):
+                return b
+        return None
+
+    def can_connect(self, header: dict) -> Optional['Blockchain']:
+        """Returns the Blockchain that has a tip that directly links up
+        with header, or None.
+        """
+        with self.blockchains_lock:
+            chains = list(self.blockchains.values())
+        for b in chains:
+            if b.can_connect(header):
+                return b
+        return None
+
+    def get_chains_that_contain_header(self, height: int, header_hash: str) -> Sequence['Blockchain']:
+        """Returns a list of Blockchains that contain header, best chain first."""
+        with self.blockchains_lock:
+            chains = list(self.blockchains.values())
+        chains = [chain for chain in chains
+                  if chain.check_hash(height=height, header_hash=header_hash)]
+        chains = sorted(chains, key=lambda x: x.get_chainwork(), reverse=True)
+        return chains
 
 
 class Blockchain(Logger):
@@ -192,15 +242,21 @@ class Blockchain(Logger):
     Manages blockchain headers and their verification
     """
 
-    def __init__(self, config: 'SimpleConfig', forkpoint: int, parent: Optional['Blockchain'],
-                 forkpoint_hash: str, prev_hash: Optional[str]):
+    def __init__(
+        self,
+        manager: 'BlockchainManager',
+        forkpoint: int,
+        parent: Optional['Blockchain'],
+        forkpoint_hash: str,
+        prev_hash: Optional[str],
+    ):
         assert isinstance(forkpoint_hash, str) and len(forkpoint_hash) == 64, forkpoint_hash
         assert (prev_hash is None) or (isinstance(prev_hash, str) and len(prev_hash) == 64), prev_hash
         # assert (parent is None) == (forkpoint == 0)
         if 0 < forkpoint <= constants.net.max_checkpoint():
             raise Exception(f"cannot fork below max checkpoint. forkpoint: {forkpoint}")
         Logger.__init__(self)
-        self.config = config
+        self.manager = manager
         self.forkpoint = forkpoint  # height of first header
         self.parent = parent
         self._forkpoint_hash = forkpoint_hash  # blockhash at forkpoint. "first hash"
@@ -224,12 +280,12 @@ class Blockchain(Logger):
         return mc if mc is not None else self.forkpoint
 
     def get_direct_children(self) -> Sequence['Blockchain']:
-        with blockchains_lock:
-            return list(filter(lambda y: y.parent==self, blockchains.values()))
+        with self.manager.blockchains_lock:
+            return list(filter(lambda y: y.parent==self, self.manager.blockchains.values()))
 
     def get_parent_heights(self) -> Mapping['Blockchain', int]:
         """Returns map: (parent chain -> height of last common block)"""
-        with self.lock, blockchains_lock:
+        with self.lock, self.manager.blockchains_lock:
             result = {self: self.height()}
             chain = self
             while True:
@@ -275,19 +331,21 @@ class Blockchain(Logger):
         if not parent.can_connect(header, check_height=False):
             raise Exception("forking header does not connect to parent chain")
         forkpoint = header.get('block_height')
-        self = Blockchain(config=parent.config,
-                          forkpoint=forkpoint,
-                          parent=parent,
-                          forkpoint_hash=hash_header(header),
-                          prev_hash=parent.get_hash(forkpoint-1))
+        self = Blockchain(
+            manager=parent.manager,
+            forkpoint=forkpoint,
+            parent=parent,
+            forkpoint_hash=hash_header(header),
+            prev_hash=parent.get_hash(forkpoint-1),
+        )
         self.assert_headers_file_available(parent.path())
         open(self.path(), 'w+').close()
         self.save_header(header)
         # put into global dict. note that in some cases
         # save_header might have already put it there but that's OK
         chain_id = self.get_id()
-        with blockchains_lock:
-            blockchains[chain_id] = self
+        with parent.manager.blockchains_lock:
+            parent.manager.blockchains[chain_id] = self
         return self
 
     @with_lock
@@ -301,7 +359,7 @@ class Blockchain(Logger):
     @with_lock
     def update_size(self) -> None:
         p = self.path()
-        self._size = os.path.getsize(p)//HEADER_SIZE if os.path.exists(p) else 0
+        self._size = os.path.getsize(p)//HEADER_SIZE if p.exists() else 0
 
     @classmethod
     def verify_header(cls, header: dict, prev_hash: str, target: int, expected_header_hash: str=None) -> None:
@@ -337,17 +395,15 @@ class Blockchain(Logger):
             prev_hash = hash_header(header)
 
     @with_lock
-    def path(self):
-        d = util.get_headers_dir(self.config)
+    def path(self) -> Path:
         if self.parent is None:
-            filename = 'blockchain_headers'
+            return self.manager.headers_dir / 'blockchain_headers'
         else:
             assert self.forkpoint > 0, self.forkpoint
             prev_hash = self._prev_hash.lstrip('0')
             first_hash = self._forkpoint_hash.lstrip('0')
             basename = f'fork2_{self.forkpoint}_{prev_hash}_{first_hash}'
-            filename = os.path.join('forks', basename)
-        return os.path.join(d, filename)
+            return self.manager.forks_dir / basename
 
     @with_lock
     def save_chunk(self, index: int, chunk: bytes):
@@ -355,7 +411,7 @@ class Blockchain(Logger):
         chunk_within_checkpoint_region = index < len(self.checkpoints)
         # chunks in checkpoint region are the responsibility of the 'main chain'
         if chunk_within_checkpoint_region and self.parent is not None:
-            main_chain = get_best_chain()
+            main_chain = self.manager.get_best_chain()
             main_chain.save_chunk(index, chunk)
             return
 
@@ -371,7 +427,7 @@ class Blockchain(Logger):
         self.swap_with_parent()
 
     def swap_with_parent(self) -> None:
-        with self.lock, blockchains_lock:
+        with self.lock, self.manager.blockchains_lock:
             # do the swap; possibly multiple ones
             cnt = 0
             while True:
@@ -380,7 +436,7 @@ class Blockchain(Logger):
                     break
                 # make sure we are making progress
                 cnt += 1
-                if cnt > len(blockchains):
+                if cnt > len(self.manager.blockchains):
                     raise Exception(f'swapping fork with parent too many times: {cnt}')
                 # we might have become the parent of some of our former siblings
                 for old_sibling in old_parent.get_direct_children():
@@ -427,6 +483,7 @@ class Blockchain(Logger):
         self.update_size()
         parent.update_size()
         # update pointers
+        blockchains = self.manager.blockchains
         blockchains.pop(child_old_id, None)
         blockchains.pop(parent_old_id, None)
         blockchains[self.get_id()] = self
@@ -436,10 +493,10 @@ class Blockchain(Logger):
     def get_id(self) -> str:
         return self._forkpoint_hash
 
-    def assert_headers_file_available(self, path):
-        if os.path.exists(path):
+    def assert_headers_file_available(self, path: Path):
+        if path.exists():
             return
-        elif not os.path.exists(util.get_headers_dir(self.config)):
+        elif not self.manager.headers_dir.exists():
             raise FileNotFoundError('Electrum headers_dir does not exist. Was it deleted while running?')
         else:
             raise FileNotFoundError('Cannot find headers file but headers_dir is there. Should be at {}'.format(path))
@@ -626,7 +683,7 @@ class Blockchain(Logger):
         work_in_last_partial_chunk = (height % CHUNK_SIZE + 1) * work_in_single_header
         return running_total + work_in_last_partial_chunk
 
-    def can_connect(self, header: dict, *, check_height: bool = True) -> bool:
+    def can_connect(self, header: Optional[dict], *, check_height: bool = True) -> bool:
         if header is None:
             return False
         height = header['block_height']
@@ -669,34 +726,3 @@ class Blockchain(Logger):
             target = self.get_target(index)
             cp.append((h, target))
         return cp
-
-
-def check_header(header: dict) -> Optional[Blockchain]:
-    """Returns any Blockchain that contains header, or None."""
-    if type(header) is not dict:
-        return None
-    with blockchains_lock: chains = list(blockchains.values())
-    for b in chains:
-        if b.check_header(header):
-            return b
-    return None
-
-
-def can_connect(header: dict) -> Optional[Blockchain]:
-    """Returns the Blockchain that has a tip that directly links up
-    with header, or None.
-    """
-    with blockchains_lock: chains = list(blockchains.values())
-    for b in chains:
-        if b.can_connect(header):
-            return b
-    return None
-
-
-def get_chains_that_contain_header(height: int, header_hash: str) -> Sequence[Blockchain]:
-    """Returns a list of Blockchains that contain header, best chain first."""
-    with blockchains_lock: chains = list(blockchains.values())
-    chains = [chain for chain in chains
-              if chain.check_hash(height=height, header_hash=header_hash)]
-    chains = sorted(chains, key=lambda x: x.get_chainwork(), reverse=True)
-    return chains

--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -258,6 +258,8 @@ class Blockchain(Logger):
             raise Exception(f"cannot fork below max checkpoint. forkpoint: {forkpoint}")
         Logger.__init__(self)
         self.bc_mgr = bc_mgr
+        if parent is not None:
+            assert bc_mgr is parent.bc_mgr
         self.forkpoint = forkpoint  # height of first header
         self.parent = parent
         self._forkpoint_hash = forkpoint_hash  # blockhash at forkpoint. "first hash"

--- a/electrum/gui/qml/qeserverlistmodel.py
+++ b/electrum/gui/qml/qeserverlistmodel.py
@@ -92,7 +92,7 @@ class QEServerListModel(QAbstractListModel, QtEventListener):
 
         for chain_id, interfaces in chains.items():
             self._logger.debug(f'chain {chain_id} has {len(interfaces)} interfaces')
-            b = self.network.blockchain_manager.blockchains.get(chain_id)
+            b = self.network.bc_mgr.blockchains.get(chain_id)
             if b is None:
                 continue
 

--- a/electrum/gui/qml/qeserverlistmodel.py
+++ b/electrum/gui/qml/qeserverlistmodel.py
@@ -1,12 +1,15 @@
+from typing import TYPE_CHECKING
+
 from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot
 from PyQt6.QtCore import Qt, QAbstractListModel, QModelIndex
 
 from electrum.logging import get_logger
 from electrum.util import Satoshis
-from electrum.interface import ServerAddr, PREFERRED_NETWORK_PROTOCOL
-from electrum import blockchain
 
 from electrum.gui.common_qt.util import QtEventListener, qt_event_listener
+
+if TYPE_CHECKING:
+    from electrum.network import Network
 
 
 class QEServerListModel(QAbstractListModel, QtEventListener):
@@ -18,7 +21,7 @@ class QEServerListModel(QAbstractListModel, QtEventListener):
     _ROLE_MAP  = dict(zip(_ROLE_KEYS, [bytearray(x.encode()) for x in _ROLE_NAMES]))
     _ROLE_RMAP = dict(zip(_ROLE_NAMES, _ROLE_KEYS))
 
-    def __init__(self, network, parent=None):
+    def __init__(self, network: 'Network', parent=None):
         super().__init__(parent)
 
         self._chaintips = 0
@@ -89,7 +92,7 @@ class QEServerListModel(QAbstractListModel, QtEventListener):
 
         for chain_id, interfaces in chains.items():
             self._logger.debug(f'chain {chain_id} has {len(interfaces)} interfaces')
-            b = blockchain.blockchains.get(chain_id)
+            b = self.network.blockchain_manager.blockchains.get(chain_id)
             if b is None:
                 continue
 

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -154,7 +154,7 @@ class NodesListWidget(QTreeWidget):
         chains = network.get_blockchains()
         n_chains = len(chains)
         for chain_id, interfaces in chains.items():
-            b = self.network.blockchain_manager.blockchains.get(chain_id)
+            b = self.network.bc_mgr.blockchains.get(chain_id)
             if b is None:
                 continue
             name = b.get_name()

--- a/electrum/gui/qt/network_dialog.py
+++ b/electrum/gui/qt/network_dialog.py
@@ -34,7 +34,6 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtGui import QIntValidator
 
 from electrum.i18n import _
-from electrum import blockchain
 from electrum.interface import ServerAddr, PREFERRED_NETWORK_PROTOCOL
 from electrum.network import Network, ProxySettings, is_valid_host, is_valid_port
 from electrum.logging import get_logger
@@ -155,7 +154,7 @@ class NodesListWidget(QTreeWidget):
         chains = network.get_blockchains()
         n_chains = len(chains)
         for chain_id, interfaces in chains.items():
-            b = blockchain.blockchains.get(chain_id)
+            b = self.network.blockchain_manager.blockchains.get(chain_id)
             if b is None:
                 continue
             name = b.get_name()

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -607,7 +607,7 @@ class Interface(Logger):
         assert network.config.path
         self.cert_path = _get_cert_path_for_host(config=network.config, host=self.host)
         self.blockchain = None  # type: Optional[Blockchain]
-        self.blockchain_manager = network.blockchain_manager
+        self.bc_mgr = network.bc_mgr
         self._requested_chunks = set()  # type: Set[int]
         self.network = network
         self.session = None  # type: Optional[NotificationSession]
@@ -798,9 +798,9 @@ class Interface(Logger):
             return
 
         assert self.tip_header
-        chain = self.blockchain_manager.check_header(self.tip_header)
+        chain = self.bc_mgr.check_header(self.tip_header)
         if not chain:
-            self.blockchain = self.blockchain_manager.get_best_chain()
+            self.blockchain = self.bc_mgr.get_best_chain()
         else:
             self.blockchain = chain
         assert self.blockchain is not None
@@ -1240,7 +1240,7 @@ class Interface(Logger):
         )
         header = await self.get_block_header(height, mode=ChainResolutionMode.CATCHUP)
 
-        chain = self.blockchain_manager.check_header(header)
+        chain = self.bc_mgr.check_header(header)
         if chain:
             self.blockchain = chain
             # note: there is an edge case here that is not handled.
@@ -1249,12 +1249,12 @@ class Interface(Logger):
             # this situation resolves itself on the next block
             return ChainResolutionMode.CATCHUP, height+1
 
-        can_connect = self.blockchain_manager.can_connect(header)
+        can_connect = self.bc_mgr.can_connect(header)
         if not can_connect:
             self.logger.info(f"can't connect new block: {height=}")
             height, header, bad, bad_header = await self._search_headers_backwards(height, header=header)
-            chain = self.blockchain_manager.check_header(header)
-            can_connect = self.blockchain_manager.can_connect(header)
+            chain = self.bc_mgr.check_header(header)
+            can_connect = self.bc_mgr.can_connect(header)
             assert chain or can_connect
         if can_connect:
             height += 1
@@ -1285,7 +1285,7 @@ class Interface(Logger):
                 await self._maybe_warm_headers_cache(
                     from_height=good, to_height=bad, mode=ChainResolutionMode.BINARY)
             header = await self.get_block_header(height, mode=ChainResolutionMode.BINARY)
-            chain = self.blockchain_manager.check_header(header)
+            chain = self.bc_mgr.check_header(header)
             if chain:
                 self.blockchain = chain
                 good = height
@@ -1342,8 +1342,8 @@ class Interface(Logger):
                 height = constants.net.max_checkpoint()
                 checkp = True
             header = await self.get_block_header(height, mode=ChainResolutionMode.BACKWARD)
-            chain = self.blockchain_manager.check_header(header)
-            can_connect = self.blockchain_manager.can_connect(header)
+            chain = self.bc_mgr.check_header(header)
+            can_connect = self.bc_mgr.can_connect(header)
             if chain or can_connect:
                 return False
             if checkp:
@@ -1352,8 +1352,8 @@ class Interface(Logger):
 
         bad, bad_header = height, header
         self._assert_header_does_not_check_against_any_chain(bad_header)
-        with self.blockchain_manager.blockchains_lock:
-            chains = list(self.blockchain_manager.blockchains.values())
+        with self.bc_mgr.blockchains_lock:
+            chains = list(self.bc_mgr.blockchains.values())
         local_max = max([0] + [x.height() for x in chains])
         height = min(local_max + 1, height - 1)
         assert height >= 0
@@ -1699,7 +1699,7 @@ class Interface(Logger):
         return [tuple(peer) for peer in peers]
 
     def _assert_header_does_not_check_against_any_chain(self, header: dict) -> None:
-        chain_bad = self.blockchain_manager.check_header(header)
+        chain_bad = self.bc_mgr.check_header(header)
         if chain_bad:
             raise Exception('bad_header must not check!')
 

--- a/electrum/interface.py
+++ b/electrum/interface.py
@@ -607,6 +607,7 @@ class Interface(Logger):
         assert network.config.path
         self.cert_path = _get_cert_path_for_host(config=network.config, host=self.host)
         self.blockchain = None  # type: Optional[Blockchain]
+        self.blockchain_manager = network.blockchain_manager
         self._requested_chunks = set()  # type: Set[int]
         self.network = network
         self.session = None  # type: Optional[NotificationSession]
@@ -797,9 +798,9 @@ class Interface(Logger):
             return
 
         assert self.tip_header
-        chain = blockchain.check_header(self.tip_header)
+        chain = self.blockchain_manager.check_header(self.tip_header)
         if not chain:
-            self.blockchain = blockchain.get_best_chain()
+            self.blockchain = self.blockchain_manager.get_best_chain()
         else:
             self.blockchain = chain
         assert self.blockchain is not None
@@ -1239,7 +1240,7 @@ class Interface(Logger):
         )
         header = await self.get_block_header(height, mode=ChainResolutionMode.CATCHUP)
 
-        chain = blockchain.check_header(header)
+        chain = self.blockchain_manager.check_header(header)
         if chain:
             self.blockchain = chain
             # note: there is an edge case here that is not handled.
@@ -1248,12 +1249,12 @@ class Interface(Logger):
             # this situation resolves itself on the next block
             return ChainResolutionMode.CATCHUP, height+1
 
-        can_connect = blockchain.can_connect(header)
+        can_connect = self.blockchain_manager.can_connect(header)
         if not can_connect:
             self.logger.info(f"can't connect new block: {height=}")
             height, header, bad, bad_header = await self._search_headers_backwards(height, header=header)
-            chain = blockchain.check_header(header)
-            can_connect = blockchain.can_connect(header)
+            chain = self.blockchain_manager.check_header(header)
+            can_connect = self.blockchain_manager.can_connect(header)
             assert chain or can_connect
         if can_connect:
             height += 1
@@ -1272,7 +1273,7 @@ class Interface(Logger):
         chain: Optional[Blockchain],
     ) -> Tuple[int, int, dict]:
         assert bad == bad_header['block_height']
-        _assert_header_does_not_check_against_any_chain(bad_header)
+        self._assert_header_does_not_check_against_any_chain(bad_header)
 
         self.blockchain = chain
         good = height
@@ -1284,7 +1285,7 @@ class Interface(Logger):
                 await self._maybe_warm_headers_cache(
                     from_height=good, to_height=bad, mode=ChainResolutionMode.BINARY)
             header = await self.get_block_header(height, mode=ChainResolutionMode.BINARY)
-            chain = blockchain.check_header(header)
+            chain = self.blockchain_manager.check_header(header)
             if chain:
                 self.blockchain = chain
                 good = height
@@ -1296,7 +1297,7 @@ class Interface(Logger):
 
         if not self.blockchain.can_connect(bad_header, check_height=False):
             raise Exception('unexpected bad header during binary: {}'.format(bad_header))
-        _assert_header_does_not_check_against_any_chain(bad_header)
+        self._assert_header_does_not_check_against_any_chain(bad_header)
 
         self.logger.info(f"binary search exited. good {good}, bad {bad}. {chain=}")
         return good, bad, bad_header
@@ -1309,7 +1310,7 @@ class Interface(Logger):
     ) -> Tuple[ChainResolutionMode, int]:
         assert good + 1 == bad
         assert bad == bad_header['block_height']
-        _assert_header_does_not_check_against_any_chain(bad_header)
+        self._assert_header_does_not_check_against_any_chain(bad_header)
         # 'good' is the height of a block 'good_header', somewhere in self.blockchain.
         # bad_header connects to good_header; bad_header itself is NOT in self.blockchain.
 
@@ -1341,8 +1342,8 @@ class Interface(Logger):
                 height = constants.net.max_checkpoint()
                 checkp = True
             header = await self.get_block_header(height, mode=ChainResolutionMode.BACKWARD)
-            chain = blockchain.check_header(header)
-            can_connect = blockchain.can_connect(header)
+            chain = self.blockchain_manager.check_header(header)
+            can_connect = self.blockchain_manager.can_connect(header)
             if chain or can_connect:
                 return False
             if checkp:
@@ -1350,8 +1351,9 @@ class Interface(Logger):
             return True
 
         bad, bad_header = height, header
-        _assert_header_does_not_check_against_any_chain(bad_header)
-        with blockchain.blockchains_lock: chains = list(blockchain.blockchains.values())
+        self._assert_header_does_not_check_against_any_chain(bad_header)
+        with self.blockchain_manager.blockchains_lock:
+            chains = list(self.blockchain_manager.blockchains.values())
         local_max = max([0] + [x.height() for x in chains])
         height = min(local_max + 1, height - 1)
         assert height >= 0
@@ -1365,7 +1367,7 @@ class Interface(Logger):
             height -= delta
             delta *= 2
 
-        _assert_header_does_not_check_against_any_chain(bad_header)
+        self._assert_header_does_not_check_against_any_chain(bad_header)
         self.logger.info(f"exiting backward mode at {height}")
         return height, header, bad, bad_header
 
@@ -1696,11 +1698,10 @@ class Interface(Logger):
                     raise RequestCorrupted(f"peer feature should be str, got {feat!r}")
         return [tuple(peer) for peer in peers]
 
-
-def _assert_header_does_not_check_against_any_chain(header: dict) -> None:
-    chain_bad = blockchain.check_header(header)
-    if chain_bad:
-        raise Exception('bad_header must not check!')
+    def _assert_header_does_not_check_against_any_chain(self, header: dict) -> None:
+        chain_bad = self.blockchain_manager.check_header(header)
+        if chain_bad:
+            raise Exception('bad_header must not check!')
 
 
 def sanitize_tx_broadcast_response(server_msg) -> str:

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -348,11 +348,11 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         self.config = config
         self.daemon = daemon
 
-        self.blockchain_manager = BlockchainManager.from_config(self.config)
+        self.bc_mgr = BlockchainManager.from_config(self.config)
         self._blockchain_preferred_block = self.config.BLOCKCHAIN_PREFERRED_BLOCK  # type: Optional[Dict[str, Any]]
         if self._blockchain_preferred_block is None:
             self._set_preferred_chain(None)
-        self._blockchain = self.blockchain_manager.get_best_chain()
+        self._blockchain = self.bc_mgr.get_best_chain()
 
         self._allowed_protocols = {PREFERRED_NETWORK_PROTOCOL}
 
@@ -860,8 +860,8 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         if pref_height == 0:
             return
         # maybe try switching chains; starting with most desirable first
-        matching_chains = self.blockchain_manager.get_chains_that_contain_header(pref_height, pref_hash)
-        chains_to_try = list(matching_chains) + [self.blockchain_manager.get_best_chain()]
+        matching_chains = self.bc_mgr.get_chains_that_contain_header(pref_height, pref_hash)
+        chains_to_try = list(matching_chains) + [self.bc_mgr.get_best_chain()]
         for rank, chain in enumerate(chains_to_try):
             # check if main interface is already on this fork
             if self.interface.blockchain == chain:
@@ -1148,8 +1148,8 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
 
     def get_blockchains(self) -> Mapping[str, Sequence[Interface]]:
         out = {}  # blockchain_id -> list(interfaces)
-        with self.blockchain_manager.blockchains_lock:
-            blockchain_items = list(self.blockchain_manager.blockchains.items())
+        with self.bc_mgr.blockchains_lock:
+            blockchain_items = list(self.bc_mgr.blockchains.items())
         with self.interfaces_lock:
             interfaces_values = list(self.interfaces.values())
         for chain_id, bc in blockchain_items:
@@ -1172,7 +1172,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         self.config.BLOCKCHAIN_PREFERRED_BLOCK = self._blockchain_preferred_block
 
     async def follow_chain_given_id(self, chain_id: str) -> None:
-        bc = self.blockchain_manager.blockchains.get(chain_id)
+        bc = self.bc_mgr.blockchains.get(chain_id)
         if not bc:
             raise Exception('blockchain {} not found'.format(chain_id))
         self._set_preferred_chain(bc)

--- a/electrum/network.py
+++ b/electrum/network.py
@@ -47,10 +47,9 @@ from .util import (
     NetworkRetryManager, error_text_str_to_safe_str, detect_tor_socks_proxy
 )
 from . import constants
-from . import blockchain
 from . import dns_hacks
 from .transaction import Transaction
-from .blockchain import Blockchain
+from .blockchain import Blockchain, BlockchainManager
 from .interface import (
     Interface, PREFERRED_NETWORK_PROTOCOL, RequestTimedOut, NetworkTimeout, BUCKET_NAME_OF_ONION_SERVERS,
     NetworkException, RequestCorrupted, ServerAddr, TxBroadcastError, KNOWN_ELEC_PROTOCOL_TRANSPORTS,
@@ -349,13 +348,11 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         self.config = config
         self.daemon = daemon
 
-        blockchain.read_blockchains(self.config)
-        blockchain.init_headers_file_for_best_chain()
-        self.logger.info(f"blockchains {list(map(lambda b: b.forkpoint, blockchain.blockchains.values()))}")
-        self._blockchain_preferred_block = self.config.BLOCKCHAIN_PREFERRED_BLOCK  # type: Dict[str, Any]
+        self.blockchain_manager = BlockchainManager.from_config(self.config)
+        self._blockchain_preferred_block = self.config.BLOCKCHAIN_PREFERRED_BLOCK  # type: Optional[Dict[str, Any]]
         if self._blockchain_preferred_block is None:
             self._set_preferred_chain(None)
-        self._blockchain = blockchain.get_best_chain()
+        self._blockchain = self.blockchain_manager.get_best_chain()
 
         self._allowed_protocols = {PREFERRED_NETWORK_PROTOCOL}
 
@@ -863,8 +860,8 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         if pref_height == 0:
             return
         # maybe try switching chains; starting with most desirable first
-        matching_chains = blockchain.get_chains_that_contain_header(pref_height, pref_hash)
-        chains_to_try = list(matching_chains) + [blockchain.get_best_chain()]
+        matching_chains = self.blockchain_manager.get_chains_that_contain_header(pref_height, pref_hash)
+        chains_to_try = list(matching_chains) + [self.blockchain_manager.get_best_chain()]
         for rank, chain in enumerate(chains_to_try):
             # check if main interface is already on this fork
             if self.interface.blockchain == chain:
@@ -1151,8 +1148,10 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
 
     def get_blockchains(self) -> Mapping[str, Sequence[Interface]]:
         out = {}  # blockchain_id -> list(interfaces)
-        with blockchain.blockchains_lock: blockchain_items = list(blockchain.blockchains.items())
-        with self.interfaces_lock: interfaces_values = list(self.interfaces.values())
+        with self.blockchain_manager.blockchains_lock:
+            blockchain_items = list(self.blockchain_manager.blockchains.items())
+        with self.interfaces_lock:
+            interfaces_values = list(self.interfaces.values())
         for chain_id, bc in blockchain_items:
             r = list(filter(lambda i: i.blockchain==bc, interfaces_values))
             if r:
@@ -1173,7 +1172,7 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
         self.config.BLOCKCHAIN_PREFERRED_BLOCK = self._blockchain_preferred_block
 
     async def follow_chain_given_id(self, chain_id: str) -> None:
-        bc = blockchain.blockchains.get(chain_id)
+        bc = self.blockchain_manager.blockchains.get(chain_id)
         if not bc:
             raise Exception('blockchain {} not found'.format(chain_id))
         self._set_preferred_chain(bc)

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -28,10 +28,10 @@ import os
 import sys
 import re
 import subprocess
-from pathlib import Path
 from collections import defaultdict, OrderedDict
 from concurrent.futures.process import ProcessPoolExecutor
 import typing
+from pathlib import Path
 from typing import (
     NamedTuple, Union, TYPE_CHECKING, Tuple, Optional, Callable, Any, Sequence, Dict, Generic, TypeVar, List, Iterable,
     Set, Awaitable

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -27,6 +27,8 @@ import logging
 import os
 import sys
 import re
+import subprocess
+from pathlib import Path
 from collections import defaultdict, OrderedDict
 from concurrent.futures.process import ProcessPoolExecutor
 import typing
@@ -549,14 +551,18 @@ def android_data_dir():
     return PythonActivity.mActivity.getFilesDir().getPath() + '/data'
 
 
-def ensure_sparse_file(filename):
+def ensure_sparse_file(file_path: str | Path):
     # On modern Linux, no need to do anything.
     # On Windows, need to explicitly mark file.
     if os.name == "nt":
         try:
-            os.system('fsutil sparse setflag "{}" 1'.format(filename))
-        except Exception as e:
-            _logger.info(f'error marking file {filename} as sparse: {e}')
+            subprocess.run(
+                ['fsutil', 'sparse', 'setflag', file_path, '1'],
+                check=True,
+                capture_output=True,
+            )
+        except (subprocess.CalledProcessError, OSError) as e:
+            _logger.warning(f'error marking file {file_path} as sparse: {e}')
 
 
 def get_headers_dir(config):

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -58,15 +58,15 @@ class TestBlockchain(ElectrumTestCase):
         super().setUp()
         self.data_dir = Path(self.electrum_path)
         self.config = SimpleConfig({'electrum_path': self.data_dir})
-        self.blockchain_manager = BlockchainManager.from_config(self.config)
+        self.bc_mgr = BlockchainManager.from_config(self.config)
 
     def _append_header(self, chain: Blockchain, header: dict):
         self.assertTrue(chain.can_connect(header))
         chain.save_header(header)
 
     def test_get_height_of_last_common_block_with_chain(self):
-        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            manager=self.blockchain_manager, forkpoint=0, parent=None,
+        self.bc_mgr.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            bc_mgr=self.bc_mgr, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
         self._append_header(chain_u, self.HEADERS['A'])
@@ -121,8 +121,8 @@ class TestBlockchain(ElectrumTestCase):
         self.assertEqual(8, chain_z.get_height_of_last_common_block_with_chain(chain_l))
 
     def test_parents_after_forking(self):
-        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            manager=self.blockchain_manager, forkpoint=0, parent=None,
+        self.bc_mgr.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            bc_mgr=self.bc_mgr, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
         self._append_header(chain_u, self.HEADERS['A'])
@@ -167,8 +167,8 @@ class TestBlockchain(ElectrumTestCase):
         self.assertEqual(None,    chain_z.parent)
 
     def test_forking_and_swapping(self):
-        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            manager=self.blockchain_manager, forkpoint=0, parent=None,
+        self.bc_mgr.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            bc_mgr=self.bc_mgr, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
 
@@ -189,7 +189,7 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_l, self.HEADERS['J'])
 
         # do checks
-        self.assertEqual(2, len(self.blockchain_manager.blockchains))
+        self.assertEqual(2, len(self.bc_mgr.blockchains))
         self.assertEqual(1, len(os.listdir(self.data_dir / "forks")))
         self.assertEqual(0, chain_u.forkpoint)
         self.assertEqual(None, chain_u.parent)
@@ -207,7 +207,7 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_l, self.HEADERS['K'])
 
         # chains were swapped, do checks
-        self.assertEqual(2, len(self.blockchain_manager.blockchains))
+        self.assertEqual(2, len(self.bc_mgr.blockchains))
         self.assertEqual(1, len(os.listdir(self.data_dir / "forks")))
         self.assertEqual(6, chain_u.forkpoint)
         self.assertEqual(chain_l, chain_u.parent)
@@ -236,7 +236,7 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_z, self.HEADERS['Z'])
 
         # chain_z became best chain, do checks
-        self.assertEqual(3, len(self.blockchain_manager.blockchains))
+        self.assertEqual(3, len(self.bc_mgr.blockchains))
         self.assertEqual(2, len(os.listdir(self.data_dir / "forks")))
         self.assertEqual(0, chain_z.forkpoint)
         self.assertEqual(None, chain_z.parent)
@@ -267,8 +267,8 @@ class TestBlockchain(ElectrumTestCase):
         self.assertEqual(hash_header(self.HEADERS['Z']), chain_z.get_hash(13))
 
     def test_doing_multiple_swaps_after_single_new_header(self):
-        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            manager=self.blockchain_manager, forkpoint=0, parent=None,
+        self.bc_mgr.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            bc_mgr=self.bc_mgr, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
 
@@ -284,7 +284,7 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_u, self.HEADERS['R'])
         self._append_header(chain_u, self.HEADERS['S'])
 
-        self.assertEqual(1, len(self.blockchain_manager.blockchains))
+        self.assertEqual(1, len(self.bc_mgr.blockchains))
         self.assertEqual(0, len(os.listdir(self.data_dir / "forks")))
 
         chain_l = chain_u.fork(self.HEADERS['G'])
@@ -294,14 +294,14 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_l, self.HEADERS['K'])
         # now chain_u is best chain, but it's tied with chain_l
 
-        self.assertEqual(2, len(self.blockchain_manager.blockchains))
+        self.assertEqual(2, len(self.bc_mgr.blockchains))
         self.assertEqual(1, len(os.listdir(self.data_dir / "forks")))
 
         chain_z = chain_l.fork(self.HEADERS['M'])
         self._append_header(chain_z, self.HEADERS['N'])
         self._append_header(chain_z, self.HEADERS['X'])
 
-        self.assertEqual(3, len(self.blockchain_manager.blockchains))
+        self.assertEqual(3, len(self.bc_mgr.blockchains))
         self.assertEqual(2, len(os.listdir(self.data_dir / "forks")))
 
         # chain_z became best chain, do checks
@@ -337,11 +337,11 @@ class TestBlockchain(ElectrumTestCase):
     def get_chains_that_contain_header_helper(self, header: dict):
         height = header['block_height']
         header_hash = hash_header(header)
-        return self.blockchain_manager.get_chains_that_contain_header(height, header_hash)
+        return self.bc_mgr.get_chains_that_contain_header(height, header_hash)
 
     def test_get_chains_that_contain_header(self):
-        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            manager=self.blockchain_manager, forkpoint=0, parent=None,
+        self.bc_mgr.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            bc_mgr=self.bc_mgr, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
         self._append_header(chain_u, self.HEADERS['A'])

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -1,11 +1,10 @@
-import shutil
-import tempfile
+from pathlib import Path
 import os
 
-from electrum import constants, blockchain
+from electrum import constants
 from electrum.simple_config import SimpleConfig
-from electrum.blockchain import Blockchain, deserialize_header, hash_header, InvalidHeader
-from electrum.util import bfh, make_dir
+from electrum.blockchain import Blockchain, deserialize_header, hash_header, InvalidHeader, BlockchainManager
+from electrum.util import bfh
 
 from . import ElectrumTestCase
 
@@ -57,18 +56,17 @@ class TestBlockchain(ElectrumTestCase):
 
     def setUp(self):
         super().setUp()
-        self.data_dir = self.electrum_path
-        make_dir(os.path.join(self.data_dir, 'forks'))
+        self.data_dir = Path(self.electrum_path)
         self.config = SimpleConfig({'electrum_path': self.data_dir})
-        blockchain.blockchains = {}
+        self.blockchain_manager = BlockchainManager.from_config(self.config)
 
     def _append_header(self, chain: Blockchain, header: dict):
         self.assertTrue(chain.can_connect(header))
         chain.save_header(header)
 
     def test_get_height_of_last_common_block_with_chain(self):
-        blockchain.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            config=self.config, forkpoint=0, parent=None,
+        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            manager=self.blockchain_manager, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
         self._append_header(chain_u, self.HEADERS['A'])
@@ -123,8 +121,8 @@ class TestBlockchain(ElectrumTestCase):
         self.assertEqual(8, chain_z.get_height_of_last_common_block_with_chain(chain_l))
 
     def test_parents_after_forking(self):
-        blockchain.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            config=self.config, forkpoint=0, parent=None,
+        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            manager=self.blockchain_manager, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
         self._append_header(chain_u, self.HEADERS['A'])
@@ -169,8 +167,8 @@ class TestBlockchain(ElectrumTestCase):
         self.assertEqual(None,    chain_z.parent)
 
     def test_forking_and_swapping(self):
-        blockchain.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            config=self.config, forkpoint=0, parent=None,
+        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            manager=self.blockchain_manager, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
 
@@ -191,37 +189,37 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_l, self.HEADERS['J'])
 
         # do checks
-        self.assertEqual(2, len(blockchain.blockchains))
-        self.assertEqual(1, len(os.listdir(os.path.join(self.data_dir, "forks"))))
+        self.assertEqual(2, len(self.blockchain_manager.blockchains))
+        self.assertEqual(1, len(os.listdir(self.data_dir / "forks")))
         self.assertEqual(0, chain_u.forkpoint)
         self.assertEqual(None, chain_u.parent)
         self.assertEqual(constants.net.GENESIS, chain_u._forkpoint_hash)
         self.assertEqual(None, chain_u._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "blockchain_headers"), chain_u.path())
+        self.assertEqual(self.data_dir / "blockchain_headers", chain_u.path())
         self.assertEqual(10 * 80, os.stat(chain_u.path()).st_size)
         self.assertEqual(6, chain_l.forkpoint)
         self.assertEqual(chain_u, chain_l.parent)
         self.assertEqual(hash_header(self.HEADERS['G']), chain_l._forkpoint_hash)
         self.assertEqual(hash_header(self.HEADERS['F']), chain_l._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "forks", "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_711a2e2a701354121a33660f45c9f9f3c4bbdb4441114c39ca837f6e7f689ee1"), chain_l.path())
+        self.assertEqual(self.data_dir / "forks" / "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_711a2e2a701354121a33660f45c9f9f3c4bbdb4441114c39ca837f6e7f689ee1", chain_l.path())
         self.assertEqual(4 * 80, os.stat(chain_l.path()).st_size)
 
         self._append_header(chain_l, self.HEADERS['K'])
 
         # chains were swapped, do checks
-        self.assertEqual(2, len(blockchain.blockchains))
-        self.assertEqual(1, len(os.listdir(os.path.join(self.data_dir, "forks"))))
+        self.assertEqual(2, len(self.blockchain_manager.blockchains))
+        self.assertEqual(1, len(os.listdir(self.data_dir / "forks")))
         self.assertEqual(6, chain_u.forkpoint)
         self.assertEqual(chain_l, chain_u.parent)
         self.assertEqual(hash_header(self.HEADERS['O']), chain_u._forkpoint_hash)
         self.assertEqual(hash_header(self.HEADERS['F']), chain_u._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "forks", "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_aff81830e28e01ef7d23277c56779a6b93f251a2d50dcc09d7c87d119e1e8ab"), chain_u.path())
+        self.assertEqual(self.data_dir / "forks" / "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_aff81830e28e01ef7d23277c56779a6b93f251a2d50dcc09d7c87d119e1e8ab", chain_u.path())
         self.assertEqual(4 * 80, os.stat(chain_u.path()).st_size)
         self.assertEqual(0, chain_l.forkpoint)
         self.assertEqual(None, chain_l.parent)
         self.assertEqual(constants.net.GENESIS, chain_l._forkpoint_hash)
         self.assertEqual(None, chain_l._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "blockchain_headers"), chain_l.path())
+        self.assertEqual(self.data_dir / "blockchain_headers", chain_l.path())
         self.assertEqual(11 * 80, os.stat(chain_l.path()).st_size)
         for b in (chain_u, chain_l):
             self.assertTrue(all([b.can_connect(b.read_header(i), check_height=False) for i in range(b.height())]))
@@ -238,25 +236,25 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_z, self.HEADERS['Z'])
 
         # chain_z became best chain, do checks
-        self.assertEqual(3, len(blockchain.blockchains))
-        self.assertEqual(2, len(os.listdir(os.path.join(self.data_dir, "forks"))))
+        self.assertEqual(3, len(self.blockchain_manager.blockchains))
+        self.assertEqual(2, len(os.listdir(self.data_dir / "forks")))
         self.assertEqual(0, chain_z.forkpoint)
         self.assertEqual(None, chain_z.parent)
         self.assertEqual(constants.net.GENESIS, chain_z._forkpoint_hash)
         self.assertEqual(None, chain_z._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "blockchain_headers"), chain_z.path())
+        self.assertEqual(self.data_dir / "blockchain_headers", chain_z.path())
         self.assertEqual(14 * 80, os.stat(chain_z.path()).st_size)
         self.assertEqual(9, chain_l.forkpoint)
         self.assertEqual(chain_z, chain_l.parent)
         self.assertEqual(hash_header(self.HEADERS['J']), chain_l._forkpoint_hash)
         self.assertEqual(hash_header(self.HEADERS['I']), chain_l._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "forks", "fork2_9_2874a1277687ab8042eff9916256b860a5b0a08b0038456c5a4a37d3bdf3656a_6e1acd473503ce0ee3cee916ca07db2f656b48baf8968f999189545316423bbb"), chain_l.path())
+        self.assertEqual(self.data_dir / "forks" / "fork2_9_2874a1277687ab8042eff9916256b860a5b0a08b0038456c5a4a37d3bdf3656a_6e1acd473503ce0ee3cee916ca07db2f656b48baf8968f999189545316423bbb", chain_l.path())
         self.assertEqual(3 * 80, os.stat(chain_l.path()).st_size)
         self.assertEqual(6, chain_u.forkpoint)
         self.assertEqual(chain_z, chain_u.parent)
         self.assertEqual(hash_header(self.HEADERS['O']), chain_u._forkpoint_hash)
         self.assertEqual(hash_header(self.HEADERS['F']), chain_u._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "forks", "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_aff81830e28e01ef7d23277c56779a6b93f251a2d50dcc09d7c87d119e1e8ab"), chain_u.path())
+        self.assertEqual(self.data_dir / "forks" / "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_aff81830e28e01ef7d23277c56779a6b93f251a2d50dcc09d7c87d119e1e8ab", chain_u.path())
         self.assertEqual(7 * 80, os.stat(chain_u.path()).st_size)
         for b in (chain_u, chain_l, chain_z):
             self.assertTrue(all([b.can_connect(b.read_header(i), check_height=False) for i in range(b.height())]))
@@ -269,8 +267,8 @@ class TestBlockchain(ElectrumTestCase):
         self.assertEqual(hash_header(self.HEADERS['Z']), chain_z.get_hash(13))
 
     def test_doing_multiple_swaps_after_single_new_header(self):
-        blockchain.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            config=self.config, forkpoint=0, parent=None,
+        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            manager=self.blockchain_manager, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
 
@@ -286,8 +284,8 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_u, self.HEADERS['R'])
         self._append_header(chain_u, self.HEADERS['S'])
 
-        self.assertEqual(1, len(blockchain.blockchains))
-        self.assertEqual(0, len(os.listdir(os.path.join(self.data_dir, "forks"))))
+        self.assertEqual(1, len(self.blockchain_manager.blockchains))
+        self.assertEqual(0, len(os.listdir(self.data_dir / "forks")))
 
         chain_l = chain_u.fork(self.HEADERS['G'])
         self._append_header(chain_l, self.HEADERS['H'])
@@ -296,34 +294,34 @@ class TestBlockchain(ElectrumTestCase):
         self._append_header(chain_l, self.HEADERS['K'])
         # now chain_u is best chain, but it's tied with chain_l
 
-        self.assertEqual(2, len(blockchain.blockchains))
-        self.assertEqual(1, len(os.listdir(os.path.join(self.data_dir, "forks"))))
+        self.assertEqual(2, len(self.blockchain_manager.blockchains))
+        self.assertEqual(1, len(os.listdir(self.data_dir / "forks")))
 
         chain_z = chain_l.fork(self.HEADERS['M'])
         self._append_header(chain_z, self.HEADERS['N'])
         self._append_header(chain_z, self.HEADERS['X'])
 
-        self.assertEqual(3, len(blockchain.blockchains))
-        self.assertEqual(2, len(os.listdir(os.path.join(self.data_dir, "forks"))))
+        self.assertEqual(3, len(self.blockchain_manager.blockchains))
+        self.assertEqual(2, len(os.listdir(self.data_dir / "forks")))
 
         # chain_z became best chain, do checks
         self.assertEqual(0, chain_z.forkpoint)
         self.assertEqual(None, chain_z.parent)
         self.assertEqual(constants.net.GENESIS, chain_z._forkpoint_hash)
         self.assertEqual(None, chain_z._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "blockchain_headers"), chain_z.path())
+        self.assertEqual(self.data_dir / "blockchain_headers", chain_z.path())
         self.assertEqual(12 * 80, os.stat(chain_z.path()).st_size)
         self.assertEqual(9, chain_l.forkpoint)
         self.assertEqual(chain_z, chain_l.parent)
         self.assertEqual(hash_header(self.HEADERS['J']), chain_l._forkpoint_hash)
         self.assertEqual(hash_header(self.HEADERS['I']), chain_l._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "forks", "fork2_9_2874a1277687ab8042eff9916256b860a5b0a08b0038456c5a4a37d3bdf3656a_6e1acd473503ce0ee3cee916ca07db2f656b48baf8968f999189545316423bbb"), chain_l.path())
+        self.assertEqual(self.data_dir / "forks" / "fork2_9_2874a1277687ab8042eff9916256b860a5b0a08b0038456c5a4a37d3bdf3656a_6e1acd473503ce0ee3cee916ca07db2f656b48baf8968f999189545316423bbb", chain_l.path())
         self.assertEqual(2 * 80, os.stat(chain_l.path()).st_size)
         self.assertEqual(6, chain_u.forkpoint)
         self.assertEqual(chain_z, chain_u.parent)
         self.assertEqual(hash_header(self.HEADERS['O']), chain_u._forkpoint_hash)
         self.assertEqual(hash_header(self.HEADERS['F']), chain_u._prev_hash)
-        self.assertEqual(os.path.join(self.data_dir, "forks", "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_aff81830e28e01ef7d23277c56779a6b93f251a2d50dcc09d7c87d119e1e8ab"), chain_u.path())
+        self.assertEqual(self.data_dir / "forks" / "fork2_6_5c400c7966145d56291080b6482716a16aa644eefe590f984c1da0ee46ed33b8_aff81830e28e01ef7d23277c56779a6b93f251a2d50dcc09d7c87d119e1e8ab", chain_u.path())
         self.assertEqual(5 * 80, os.stat(chain_u.path()).st_size)
 
         self.assertEqual(constants.net.GENESIS, chain_z.get_hash(0))
@@ -339,11 +337,11 @@ class TestBlockchain(ElectrumTestCase):
     def get_chains_that_contain_header_helper(self, header: dict):
         height = header['block_height']
         header_hash = hash_header(header)
-        return blockchain.get_chains_that_contain_header(height, header_hash)
+        return self.blockchain_manager.get_chains_that_contain_header(height, header_hash)
 
     def test_get_chains_that_contain_header(self):
-        blockchain.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
-            config=self.config, forkpoint=0, parent=None,
+        self.blockchain_manager.blockchains[constants.net.GENESIS] = chain_u = Blockchain(
+            manager=self.blockchain_manager, forkpoint=0, parent=None,
             forkpoint_hash=constants.net.GENESIS, prev_hash=None)
         open(chain_u.path(), 'w+').close()
         self._append_header(chain_u, self.HEADERS['A'])

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -5,7 +5,7 @@ from typing import List
 
 from electrum import constants
 from electrum.simple_config import SimpleConfig
-from electrum import blockchain
+from electrum.blockchain import BlockchainManager
 from electrum.interface import Interface, ServerAddr, ChainResolutionMode
 from electrum.crypto import sha256
 from electrum.util import OldTaskGroup
@@ -19,9 +19,10 @@ CRM = ChainResolutionMode
 
 class MockBlockchain:
 
-    def __init__(self, headers: List[str]):
+    def __init__(self, headers: List[str], manager: 'BlockchainManager'):
         self._headers = headers
         self.forkpoint = len(headers)
+        self.manager = manager
 
     def height(self) -> int:
         return len(self._headers) - 1
@@ -45,11 +46,11 @@ class MockBlockchain:
         if not parent.can_connect(header, check_height=False):
             raise Exception("forking header does not connect to parent chain")
         forkpoint = header.get('block_height')
-        self = MockBlockchain(parent._headers[:forkpoint])
+        self = MockBlockchain(parent._headers[:forkpoint], parent.manager)
         self.save_header(header)
         chain_id = header['mock']['id']
-        with blockchain.blockchains_lock:
-            blockchain.blockchains[chain_id] = self
+        with self.manager.blockchains_lock:
+            self.manager.blockchains[chain_id] = self
         return self
 
 
@@ -57,6 +58,7 @@ class MockNetwork:
 
     def __init__(self, config: SimpleConfig):
         self.config = config
+        self.blockchain_manager = BlockchainManager.from_config(config)
         self.asyncio_loop = util.get_asyncio_loop()
         self.taskgroup = OldTaskGroup()
         self.proxy = None
@@ -96,7 +98,6 @@ class TestHeaderChainResolution(ElectrumTestCase):
         constants.BitcoinMainnet.set_as_network()
 
     def tearDown(self):
-        blockchain.blockchains = {}
         super().tearDown()
 
     async def asyncSetUp(self):
@@ -110,43 +111,43 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 6
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 6, 'mock': {CRM.CATCHUP:1, 'id': '06a', 'prev_id': '05a'}})
         res = await ifa.sync_until(ifa.tip)
         self.assertEqual((CRM.CATCHUP, 7), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 1)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
 
     async def test_catchup_already_up_to_date(self):
         """Single chain, local chain tip already matches server tip."""
         ifa = self.interface
         ifa.tip = 5
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 5, 'mock': {CRM.CATCHUP:1, 'id': '05a', 'prev_id': '04a'}})
         res = await ifa.sync_until(ifa.tip)
         self.assertEqual((CRM.CATCHUP, 6), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 1)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
 
     async def test_catchup_client_ahead_of_lagging_server(self):
         """Single chain, server is lagging."""
         ifa = self.interface
         ifa.tip = 3
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 3, 'mock': {CRM.CATCHUP:1, 'id': '03a', 'prev_id': '02a'}})
         res = await ifa.sync_until(ifa.tip)
         self.assertEqual((CRM.CATCHUP, 4), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 1)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
 
     async def test_catchup_fast_forward(self):
         """Single chain, but client is behind. The client's height is 5, server is already on block 12.
@@ -154,8 +155,8 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 12
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 12, 'mock': {CRM.CATCHUP:1, 'id': '12a', 'prev_id': '11a'}})
@@ -166,7 +167,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=9)
         self.assertEqual((CRM.CATCHUP, 10), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 1)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
 
     async def test_fork(self):
         """client starts on main chain, has no knowledge of any fork.
@@ -176,8 +177,8 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 8
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 8, 'mock': {CRM.CATCHUP:1, 'id': '08b', 'prev_id': '07b'}})
@@ -187,7 +188,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=7)
         self.assertEqual((CRM.FORK, 8), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 2)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
 
     async def test_can_connect_during_backward(self):
         """client starts on main chain. client already knows about another fork, which has local height 4.
@@ -197,10 +198,10 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 8
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
-            "03b": MockBlockchain(["00a", "01a", "02a", "03b", "04b"]),
+            "03b": MockBlockchain(["00a", "01a", "02a", "03b", "04b"], ifa.blockchain_manager),
         }
         ifa.q.put_nowait({'block_height': 8, 'mock': {CRM.CATCHUP:1, 'id': '08b', 'prev_id': '07b'}})
         ifa.q.put_nowait({'block_height': 7, 'mock': {CRM.BACKWARD:1, 'id': '07b', 'prev_id': '06b'}})
@@ -209,7 +210,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=6)
         self.assertEqual((CRM.CATCHUP, 7), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 2)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
 
     async def test_chain_false_during_binary(self):
         """client starts on main chain, has no knowledge of any fork.
@@ -219,8 +220,8 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 8
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 8, 'mock': {CRM.CATCHUP:1, 'id': '08b', 'prev_id': '07b'}})
@@ -234,7 +235,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=6)
         self.assertEqual((CRM.CATCHUP, 7), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 2)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
 
     async def test_chain_true_during_binary(self):
         """client starts on main chain. client already knows about another fork, which has local height 10.
@@ -244,10 +245,10 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 20
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a", "13a", "14a"])
-        blockchain.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a", "13a", "14a"], ifa.blockchain_manager)
+        ifa.blockchain_manager.blockchains = {
             "00a": ifa.blockchain,
-            "07b": MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07b", "08b", "09b", "10b"]),
+            "07b": MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07b", "08b", "09b", "10b"], ifa.blockchain_manager),
         }
         ifa.q.put_nowait({'block_height': 20, 'mock': {CRM.CATCHUP:1, 'id': '20b', 'prev_id': '19b'}})
         ifa.q.put_nowait({'block_height': 15, 'mock': {CRM.BACKWARD:1, 'id': '15b', 'prev_id': '14b'}})
@@ -261,7 +262,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=13)
         self.assertEqual((CRM.CATCHUP, 14), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(blockchain.blockchains), 2)
+        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -19,10 +19,10 @@ CRM = ChainResolutionMode
 
 class MockBlockchain:
 
-    def __init__(self, headers: List[str], manager: 'BlockchainManager'):
+    def __init__(self, headers: List[str], bc_mgr: 'BlockchainManager'):
         self._headers = headers
         self.forkpoint = len(headers)
-        self.manager = manager
+        self.bc_mgr = bc_mgr
 
     def height(self) -> int:
         return len(self._headers) - 1
@@ -46,11 +46,11 @@ class MockBlockchain:
         if not parent.can_connect(header, check_height=False):
             raise Exception("forking header does not connect to parent chain")
         forkpoint = header.get('block_height')
-        self = MockBlockchain(parent._headers[:forkpoint], parent.manager)
+        self = MockBlockchain(parent._headers[:forkpoint], parent.bc_mgr)
         self.save_header(header)
         chain_id = header['mock']['id']
-        with self.manager.blockchains_lock:
-            self.manager.blockchains[chain_id] = self
+        with self.bc_mgr.blockchains_lock:
+            self.bc_mgr.blockchains[chain_id] = self
         return self
 
 
@@ -58,7 +58,7 @@ class MockNetwork:
 
     def __init__(self, config: SimpleConfig):
         self.config = config
-        self.blockchain_manager = BlockchainManager.from_config(config)
+        self.bc_mgr = BlockchainManager.from_config(config)
         self.asyncio_loop = util.get_asyncio_loop()
         self.taskgroup = OldTaskGroup()
         self.proxy = None
@@ -111,43 +111,43 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 6
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 6, 'mock': {CRM.CATCHUP:1, 'id': '06a', 'prev_id': '05a'}})
         res = await ifa.sync_until(ifa.tip)
         self.assertEqual((CRM.CATCHUP, 7), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 1)
 
     async def test_catchup_already_up_to_date(self):
         """Single chain, local chain tip already matches server tip."""
         ifa = self.interface
         ifa.tip = 5
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 5, 'mock': {CRM.CATCHUP:1, 'id': '05a', 'prev_id': '04a'}})
         res = await ifa.sync_until(ifa.tip)
         self.assertEqual((CRM.CATCHUP, 6), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 1)
 
     async def test_catchup_client_ahead_of_lagging_server(self):
         """Single chain, server is lagging."""
         ifa = self.interface
         ifa.tip = 3
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 3, 'mock': {CRM.CATCHUP:1, 'id': '03a', 'prev_id': '02a'}})
         res = await ifa.sync_until(ifa.tip)
         self.assertEqual((CRM.CATCHUP, 4), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 1)
 
     async def test_catchup_fast_forward(self):
         """Single chain, but client is behind. The client's height is 5, server is already on block 12.
@@ -155,8 +155,8 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 12
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 12, 'mock': {CRM.CATCHUP:1, 'id': '12a', 'prev_id': '11a'}})
@@ -167,7 +167,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=9)
         self.assertEqual((CRM.CATCHUP, 10), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 1)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 1)
 
     async def test_fork(self):
         """client starts on main chain, has no knowledge of any fork.
@@ -177,8 +177,8 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 8
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 8, 'mock': {CRM.CATCHUP:1, 'id': '08b', 'prev_id': '07b'}})
@@ -188,7 +188,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=7)
         self.assertEqual((CRM.FORK, 8), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 2)
 
     async def test_can_connect_during_backward(self):
         """client starts on main chain. client already knows about another fork, which has local height 4.
@@ -198,10 +198,10 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 8
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
-            "03b": MockBlockchain(["00a", "01a", "02a", "03b", "04b"], ifa.blockchain_manager),
+            "03b": MockBlockchain(["00a", "01a", "02a", "03b", "04b"], ifa.bc_mgr),
         }
         ifa.q.put_nowait({'block_height': 8, 'mock': {CRM.CATCHUP:1, 'id': '08b', 'prev_id': '07b'}})
         ifa.q.put_nowait({'block_height': 7, 'mock': {CRM.BACKWARD:1, 'id': '07b', 'prev_id': '06b'}})
@@ -210,7 +210,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=6)
         self.assertEqual((CRM.CATCHUP, 7), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 2)
 
     async def test_chain_false_during_binary(self):
         """client starts on main chain, has no knowledge of any fork.
@@ -220,8 +220,8 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 8
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
         }
         ifa.q.put_nowait({'block_height': 8, 'mock': {CRM.CATCHUP:1, 'id': '08b', 'prev_id': '07b'}})
@@ -235,7 +235,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=6)
         self.assertEqual((CRM.CATCHUP, 7), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 2)
 
     async def test_chain_true_during_binary(self):
         """client starts on main chain. client already knows about another fork, which has local height 10.
@@ -245,10 +245,10 @@ class TestHeaderChainResolution(ElectrumTestCase):
         """
         ifa = self.interface
         ifa.tip = 20
-        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a", "13a", "14a"], ifa.blockchain_manager)
-        ifa.blockchain_manager.blockchains = {
+        ifa.blockchain = MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07a", "08a", "09a", "10a", "11a", "12a", "13a", "14a"], ifa.bc_mgr)
+        ifa.bc_mgr.blockchains = {
             "00a": ifa.blockchain,
-            "07b": MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07b", "08b", "09b", "10b"], ifa.blockchain_manager),
+            "07b": MockBlockchain(["00a", "01a", "02a", "03a", "04a", "05a", "06a", "07b", "08b", "09b", "10b"], ifa.bc_mgr),
         }
         ifa.q.put_nowait({'block_height': 20, 'mock': {CRM.CATCHUP:1, 'id': '20b', 'prev_id': '19b'}})
         ifa.q.put_nowait({'block_height': 15, 'mock': {CRM.BACKWARD:1, 'id': '15b', 'prev_id': '14b'}})
@@ -262,7 +262,7 @@ class TestHeaderChainResolution(ElectrumTestCase):
         res = await ifa.sync_until(ifa.tip, next_height=13)
         self.assertEqual((CRM.CATCHUP, 14), res)
         self.assertEqual(ifa.q.qsize(), 0)
-        self.assertEqual(len(ifa.blockchain_manager.blockchains), 2)
+        self.assertEqual(len(ifa.bc_mgr.blockchains), 2)
 
 
 if __name__ == "__main__":

--- a/tests/toyserver/toynetwork.py
+++ b/tests/toyserver/toynetwork.py
@@ -26,8 +26,7 @@ class ToyNetwork:
         self.config = config
         self.asyncio_loop = util.get_asyncio_loop()
         self.taskgroup = OldTaskGroup()
-        blockchain.read_blockchains(self.config)
-        blockchain.init_headers_file_for_best_chain()
+        self.blockchain_manager = blockchain.BlockchainManager.from_config(self.config)
         self.proxy = None
         self.debug = True
         self.bhi_lock = asyncio.Lock()

--- a/tests/toyserver/toynetwork.py
+++ b/tests/toyserver/toynetwork.py
@@ -26,7 +26,7 @@ class ToyNetwork:
         self.config = config
         self.asyncio_loop = util.get_asyncio_loop()
         self.taskgroup = OldTaskGroup()
-        self.blockchain_manager = blockchain.BlockchainManager.from_config(self.config)
+        self.bc_mgr = blockchain.BlockchainManager.from_config(self.config)
         self.proxy = None
         self.debug = True
         self.bhi_lock = asyncio.Lock()


### PR DESCRIPTION
Move the blockchain logic in `blockchain.py` from the module level
into a `BlockchainManager` class whose instance is owned by the `Network`.

This separates the blockchain handling from the process and allows
to have different blockchain setups in the same process, which can
e.g. be used in unittests, as those might simulate different
"users" in a single process.