### PR TITLE
Surface passphrase support for Electrum seeds and use “BIP39 Passphrase” consistently. Closes #10797

### DIFF
--- a/electrum/gui/qml/components/wizard/WCConfirmExt.qml
+++ b/electrum/gui/qml/components/wizard/WCConfirmExt.qml
@@ -49,14 +49,14 @@ WizardComponent {
             Label {
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
-                text: qsTr('Please enter your custom word(s) a second time:')
+                text: qsTr('Please enter your custom Passphrase a second time:')
             }
 
             TextField {
                 id: customwordstext
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                placeholderText: qsTr('Enter your custom word(s) here')
+                placeholderText: qsTr('Enter your custom Passphrase')
                 inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                 onTextChanged: checkValid()
             }

--- a/electrum/gui/qml/components/wizard/WCCreateSeed.qml
+++ b/electrum/gui/qml/components/wizard/WCCreateSeed.qml
@@ -14,7 +14,8 @@ WizardComponent {
     function apply() {
         wizard_data['seed'] = seedtext.text
         wizard_data['seed_variant'] = 'electrum' // generated seed always electrum variant
-        wizard_data['seed_extend'] = true  // true so we get forwarded to the passphrase page
+        wizard_data['seed_extend'] = extendcb.checked
+        wizard_data['seed_extra_words'] = extendcb.checked ? customwordstext.text : ''
     }
 
     function setWarningText(numwords) {
@@ -68,6 +69,35 @@ WizardComponent {
                     height: parent.height * 2/3
                     visible: seedtext.text == ''
                 }
+            }
+
+            ElCheckBox {
+                id: extendcb
+                Layout.fillWidth: true
+                enabled: seedtext.text != ''
+                text: qsTr('Extend this seed with custom words')
+                onCheckedChanged: checkIsLast()
+            }
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                visible: extendcb.checked
+                text: [
+                    qsTr('You may extend your seed with custom words.'),
+                    qsTr('Your seed extension must be saved together with your seed.'),
+                    qsTr('Note that this is NOT your encryption password.'),
+                    qsTr('If you do not know what this is, leave this field empty.'),
+                ].join(' ')
+            }
+
+            TextField {
+                id: customwordstext
+                Layout.fillWidth: true
+                visible: extendcb.checked
+                placeholderText: qsTr('Enter your custom word(s)')
+                inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+                onTextChanged: checkIsLast()
             }
 
             Component.onCompleted : {

--- a/electrum/gui/qml/components/wizard/WCCreateSeed.qml
+++ b/electrum/gui/qml/components/wizard/WCCreateSeed.qml
@@ -18,22 +18,6 @@ WizardComponent {
         wizard_data['seed_extra_words'] = extendcb.checked ? customwordstext.text : ''
     }
 
-    function setWarningText(numwords) {
-        var t = [
-            '<p>',
-            qsTr('Please save these %1 words on paper (order is important).').arg(numwords),
-            qsTr('This seed will allow you to recover your wallet in case of computer failure.'),
-            '</p>',
-            '<b>' + qsTr('WARNING') + ':</b>',
-            '<ul>',
-            '<li>' + qsTr('Never disclose your seed.') + '</li>',
-            '<li>' + qsTr('Never type it on a website.') + '</li>',
-            '<li>' + qsTr('Do not store it electronically.') + '</li>',
-            '</ul>'
-        ]
-        warningtext.text = t.join(' ')
-    }
-
     Flickable {
         anchors.fill: parent
         contentHeight: mainLayout.height
@@ -44,13 +28,6 @@ WizardComponent {
             id: mainLayout
             width: parent.width
             columns: 1
-
-            InfoTextArea {
-                id: warningtext
-                Layout.fillWidth: true
-                backgroundColor: constants.darkerDialogBackground
-                iconStyle: InfoTextArea.IconStyle.Warn
-            }
 
             Label {
                 Layout.topMargin: constants.paddingMedium
@@ -75,7 +52,7 @@ WizardComponent {
                 id: extendcb
                 Layout.fillWidth: true
                 enabled: seedtext.text != ''
-                text: qsTr('Extend this seed with custom words')
+                text: qsTr('Extend this seed with a Passphrase')
                 onCheckedChanged: checkIsLast()
             }
 
@@ -84,9 +61,9 @@ WizardComponent {
                 wrapMode: Text.Wrap
                 visible: extendcb.checked
                 text: [
-                    qsTr('You may extend your seed with custom words.'),
-                    qsTr('Your seed extension must be saved together with your seed.'),
-                    qsTr('Note that this is NOT your encryption password.'),
+                    qsTr('You may extend your seed with a Passphrase (e.g. password manager generated passphrase, custom words, a combination of both...).'),
+                    qsTr("You will need to save both your seed and the extension Passphrase together."),
+                    qsTr('Note that this is NOT your wallet file encryption password.'),
                     qsTr('If you do not know what this is, leave this field empty.'),
                 ].join(' ')
             }
@@ -94,14 +71,36 @@ WizardComponent {
             TextField {
                 id: customwordstext
                 Layout.fillWidth: true
+                Layout.topMargin: constants.paddingXSmall
                 visible: extendcb.checked
-                placeholderText: qsTr('Enter your custom word(s)')
+                placeholderText: qsTr('Enter your custom Passphrase')
                 inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                 onTextChanged: checkIsLast()
             }
 
-            Component.onCompleted : {
-                setWarningText(12)
+            InfoTextArea {
+                Layout.fillWidth: true
+                Layout.topMargin: constants.paddingSmall
+                backgroundColor: constants.darkerDialogBackground
+                iconStyle: InfoTextArea.IconStyle.Warn
+                text: {
+                    var n = seedtext.text.split(' ').filter(Boolean).length || 12
+                    var save = extendcb.checked
+                        ? qsTr('Please save these %1 words and your custom Passphrase on paper (order is important).').arg(n)
+                        : qsTr('Please save these %1 words on paper (order is important).').arg(n)
+                    return [
+                        '<p>',
+                        save,
+                        qsTr('This seed will allow you to recover your wallet in case of computer failure.'),
+                        '</p>',
+                        '<b>' + qsTr('WARNING') + ':</b>',
+                        '<ul>',
+                        '<li>' + qsTr('Never disclose your seed.') + '</li>',
+                        '<li>' + qsTr('Never type it on a website.') + '</li>',
+                        '<li>' + qsTr('Do not store it electronically.') + '</li>',
+                        '</ul>'
+                    ].join(' ')
+                }
             }
         }
     }
@@ -114,7 +113,6 @@ WizardComponent {
         id: bitcoin
         onGeneratedSeedChanged: {
             seedtext.text = generatedSeed
-            setWarningText(generatedSeed.split(' ').length)
         }
     }
 }

--- a/electrum/gui/qml/components/wizard/WCEnterExt.qml
+++ b/electrum/gui/qml/components/wizard/WCEnterExt.qml
@@ -14,15 +14,18 @@ WizardComponent {
     valid: true
 
     property int cosigner: 0
+    property string seedVariant: ''
+
+    title: seedVariant == 'bip39' ? qsTr('BIP39 Passphrase') : qsTr('Seed Extension')
 
     function apply() {
-        var seed_extend = extendcb.checked
+        // page is only shown after the user opted in on the seed page
         if (cosigner) {
-            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extend'] = seed_extend
-            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extra_words'] = seed_extend ? customwordstext.text : ''
+            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extend'] = true
+            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extra_words'] = customwordstext.text
         } else {
-            wizard_data['seed_extend'] = seed_extend
-            wizard_data['seed_extra_words'] = seed_extend ? customwordstext.text : ''
+            wizard_data['seed_extend'] = true
+            wizard_data['seed_extra_words'] = customwordstext.text
         }
     }
 
@@ -30,17 +33,12 @@ WizardComponent {
         valid = false
         validationtext.text = ''
 
-        if (extendcb.checked && customwordstext.text == '') {
-            return
-        } else {
-            // passphrase is either disabled or filled with text
-            apply()
-            if (cosigner && wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_variant'] == 'electrum') {
-                // check if master keys are not duplicated after entering passphrase
-                if (wiz.hasDuplicateMasterKeys(wizard_data)) {
-                    validationtext.text = qsTr('Error: duplicate master public key')
-                    return
-                }
+        apply()
+        if (cosigner && wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_variant'] == 'electrum') {
+            // check if master keys are not duplicated after entering passphrase
+            if (wiz.hasDuplicateMasterKeys(wizard_data)) {
+                validationtext.text = qsTr('Error: duplicate master public key')
+                return
             }
         }
         valid = true
@@ -69,29 +67,29 @@ WizardComponent {
             Label {
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
-                text: [
-                    qsTr('You may extend your seed with custom words.'),
-                    qsTr('Your seed extension must be saved together with your seed.'),
-                    qsTr('Note that this is NOT your encryption password.'),
-                    '<br/>',
-                    qsTr('Do not enable it unless you know what it does!'),
-                ].join(' ')
-            }
-
-            ElCheckBox {
-                id: extendcb
-                Layout.columnSpan: 2
-                Layout.fillWidth: true
-                text: qsTr('Extend seed with custom words')
-                onCheckedChanged: checkValid()
+                text: seedVariant == 'bip39'
+                    ? [
+                        qsTr('Enter an optional BIP39 passphrase.'),
+                        qsTr('Each passphrase derives a different wallet.'),
+                        qsTr('This is sometimes incorrectly called the "25th word".'),
+                        qsTr('Note that this is NOT your encryption password.'),
+                        qsTr('If you do not know what this is, leave this field empty.'),
+                    ].join(' ')
+                    : [
+                        qsTr('You may extend your seed with custom words.'),
+                        qsTr('Your seed extension must be saved together with your seed.'),
+                        qsTr('Note that this is NOT your encryption password.'),
+                        qsTr('If you do not know what this is, leave this field empty.'),
+                    ].join(' ')
             }
 
             TextField {
                 id: customwordstext
-                visible: extendcb.checked  // users confuse this with the seed re-entry if shown
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                placeholderText: qsTr('Enter your custom word(s)')
+                placeholderText: seedVariant == 'bip39'
+                    ? qsTr('Enter your BIP39 passphrase')
+                    : qsTr('Enter your custom word(s)')
                 inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                 onTextChanged: startValidationTimer()
             }
@@ -115,6 +113,10 @@ WizardComponent {
             if ('multisig_current_cosigner' in wizard_data)
                 cosigner = wizard_data['multisig_current_cosigner']
         }
+        if (cosigner)
+            seedVariant = wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_variant']
+        else
+            seedVariant = wizard_data['seed_variant']
         checkValid()
     }
 }

--- a/electrum/gui/qml/components/wizard/WCEnterExt.qml
+++ b/electrum/gui/qml/components/wizard/WCEnterExt.qml
@@ -76,9 +76,9 @@ WizardComponent {
                         qsTr('If you do not know what this is, leave this field empty.'),
                     ].join(' ')
                     : [
-                        qsTr('You may extend your seed with custom words.'),
-                        qsTr('Your seed extension must be saved together with your seed.'),
-                        qsTr('Note that this is NOT your encryption password.'),
+                        qsTr('You may extend your seed with a Passphrase (e.g. password manager generated passphrase, custom words, a combination of both...).'),
+                        qsTr("You will need to save both your seed and the extension Passphrase together."),
+                        qsTr('Note that this is NOT your wallet file encryption password.'),
                         qsTr('If you do not know what this is, leave this field empty.'),
                     ].join(' ')
             }
@@ -88,8 +88,8 @@ WizardComponent {
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
                 placeholderText: seedVariant == 'bip39'
-                    ? qsTr('Enter your BIP39 passphrase')
-                    : qsTr('Enter your custom word(s)')
+                    ? qsTr('Enter your BIP39 Passphrase')
+                    : qsTr('Enter your custom Passphrase')
                 inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                 onTextChanged: startValidationTimer()
             }

--- a/electrum/gui/qml/components/wizard/WCHaveSeed.qml
+++ b/electrum/gui/qml/components/wizard/WCHaveSeed.qml
@@ -28,12 +28,12 @@ WizardComponent {
             wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed'] = seedtext.text
             wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_variant'] = seed_variant_cb.currentValue
             wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_type'] = _seedType
-            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extend'] = _canPassphrase
+            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extend'] = extendcb.checked
         } else {
             wizard_data['seed'] = seedtext.text
             wizard_data['seed_variant'] = seed_variant_cb.currentValue
             wizard_data['seed_type'] = _seedType
-            wizard_data['seed_extend'] = _canPassphrase
+            wizard_data['seed_extend'] = extendcb.checked
 
             // determine script type from electrum seed type
             // (used to limit script type options for bip39 cosigners)
@@ -74,6 +74,7 @@ WizardComponent {
         _validationMessage = verifyResult.message
         _seedType = verifyResult.type
         _canPassphrase = verifyResult.can_passphrase
+        syncExtControls()
 
         if (!cosigner || !verifyResult.valid) {
             _seedValid = verifyResult.valid
@@ -96,6 +97,39 @@ WizardComponent {
         }
 
         valid = _seedValid
+    }
+
+    function syncExtControls() {
+        var variant = seed_variant_cb.currentValue
+        if (variant == 'bip39') {
+            extendcb.text = qsTr('Use a BIP39 passphrase')
+            extreason.text = ''
+            if (!seedtext.text.trim()) {
+                extendcb.checked = false
+                extendcb.enabled = false
+            } else {
+                extendcb.enabled = true
+            }
+            return
+        }
+        extendcb.text = qsTr('Extend this seed with custom words')
+        if (!_seedType) {
+            extendcb.checked = false
+            extendcb.enabled = false
+            extreason.text = ''
+            return
+        }
+        if (!_canPassphrase) {
+            extendcb.checked = false
+            extendcb.enabled = false
+            if (_seedType == 'old')
+                extreason.text = qsTr('Old Electrum seeds have no extra word.')
+            else
+                extreason.text = qsTr('This seed cannot be extended with an extra word.')
+            return
+        }
+        extendcb.enabled = true
+        extreason.text = ''
     }
 
     Flickable {
@@ -183,6 +217,15 @@ WizardComponent {
                     checkIsLast()
                     checkValid()
                 }
+                delegate: ItemDelegate {
+                    width: seed_variant_cb.width
+                    text: modelData.text
+                    // grey BIP39 only after an Electrum version actually decodes
+                    enabled: !(modelData.value == 'bip39'
+                               && seed_variant_cb.currentValue == 'electrum'
+                               && root._seedType
+                               && root._seedType != 'old')
+                }
             }
 
             InfoTextArea {
@@ -214,6 +257,23 @@ WizardComponent {
                     startValidationTimer()
                 }
             }
+
+            ElCheckBox {
+                id: extendcb
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                enabled: false
+                text: qsTr('Extend this seed with custom words')
+                onCheckedChanged: checkIsLast()
+            }
+
+            Label {
+                id: extreason
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                visible: text
+            }
         }
     }
 
@@ -221,6 +281,7 @@ WizardComponent {
         valid = false
         root._seedType = ''
         root._validationMessage = ''
+        syncExtControls()
         validationTimer.restart()
     }
 
@@ -230,7 +291,7 @@ WizardComponent {
         repeat: false
         onTriggered: {
             checkValid()
-            // checkIsLast depends on 'seed_extend'(_canPassphrase) getting set in apply()
+            // checkIsLast depends on seed_extend from the on-page checkbox
             checkIsLast()
         }
     }

--- a/electrum/gui/qml/components/wizard/WCHaveSeed.qml
+++ b/electrum/gui/qml/components/wizard/WCHaveSeed.qml
@@ -114,7 +114,7 @@ WizardComponent {
             }
             return
         }
-        extendcb.text = qsTr('Extend this seed with custom words')
+        extendcb.text = qsTr('Extend this seed with a Passphrase')
         if (!_seedType) {
             extendcb.checked = false
             extendcb.enabled = false
@@ -265,7 +265,7 @@ WizardComponent {
                 Layout.columnSpan: 2
                 Layout.fillWidth: true
                 enabled: false
-                text: qsTr('Extend this seed with custom words')
+                text: qsTr('Extend this seed with a Passphrase')
                 onCheckedChanged: checkIsLast()
             }
 
@@ -291,9 +291,9 @@ WizardComponent {
                         qsTr('If you do not know what this is, leave this field empty.'),
                     ].join(' ')
                     : [
-                        qsTr('You may extend your seed with custom words.'),
-                        qsTr('Your seed extension must be saved together with your seed.'),
-                        qsTr('Note that this is NOT your encryption password.'),
+                        qsTr('You may extend your seed with a Passphrase (e.g. password manager generated passphrase, custom words, a combination of both...).'),
+                        qsTr("You will need to save both your seed and the extension Passphrase together."),
+                        qsTr('Note that this is NOT your wallet file encryption password.'),
                         qsTr('If you do not know what this is, leave this field empty.'),
                     ].join(' ')
             }
@@ -304,8 +304,8 @@ WizardComponent {
                 Layout.fillWidth: true
                 visible: extendcb.checked && extendcb.enabled
                 placeholderText: seed_variant_cb.currentValue == 'bip39'
-                    ? qsTr('Enter your BIP39 passphrase')
-                    : qsTr('Enter your custom word(s)')
+                    ? qsTr('Enter your BIP39 Passphrase')
+                    : qsTr('Enter your custom Passphrase')
                 inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                 onTextChanged: checkIsLast()
             }

--- a/electrum/gui/qml/components/wizard/WCHaveSeed.qml
+++ b/electrum/gui/qml/components/wizard/WCHaveSeed.qml
@@ -29,11 +29,13 @@ WizardComponent {
             wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_variant'] = seed_variant_cb.currentValue
             wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_type'] = _seedType
             wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extend'] = extendcb.checked
+            wizard_data['multisig_cosigner_data'][cosigner.toString()]['seed_extra_words'] = extendcb.checked ? customwordstext.text : ''
         } else {
             wizard_data['seed'] = seedtext.text
             wizard_data['seed_variant'] = seed_variant_cb.currentValue
             wizard_data['seed_type'] = _seedType
             wizard_data['seed_extend'] = extendcb.checked
+            wizard_data['seed_extra_words'] = extendcb.checked ? customwordstext.text : ''
 
             // determine script type from electrum seed type
             // (used to limit script type options for bip39 cosigners)
@@ -273,6 +275,39 @@ WizardComponent {
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
                 visible: text
+            }
+
+            Label {
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                visible: extendcb.checked && extendcb.enabled
+                text: seed_variant_cb.currentValue == 'bip39'
+                    ? [
+                        qsTr('Enter an optional BIP39 passphrase.'),
+                        qsTr('Each passphrase derives a different wallet.'),
+                        qsTr('This is sometimes incorrectly called the "25th word".'),
+                        qsTr('Note that this is NOT your encryption password.'),
+                        qsTr('If you do not know what this is, leave this field empty.'),
+                    ].join(' ')
+                    : [
+                        qsTr('You may extend your seed with custom words.'),
+                        qsTr('Your seed extension must be saved together with your seed.'),
+                        qsTr('Note that this is NOT your encryption password.'),
+                        qsTr('If you do not know what this is, leave this field empty.'),
+                    ].join(' ')
+            }
+
+            TextField {
+                id: customwordstext
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                visible: extendcb.checked && extendcb.enabled
+                placeholderText: seed_variant_cb.currentValue == 'bip39'
+                    ? qsTr('Enter your BIP39 passphrase')
+                    : qsTr('Enter your custom word(s)')
+                inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+                onTextChanged: checkIsLast()
             }
         }
     }

--- a/electrum/gui/qt/seed_dialog.py
+++ b/electrum/gui/qt/seed_dialog.py
@@ -151,6 +151,10 @@ class SeedWidget(QWidget):
         self.is_ext = False
         self.cb_ext = None
         self.ext_reason_label = None
+        self.ext_box = None
+        self.ext_edit = None
+        self.ext_help = None
+        self.ext_issue4566 = None
         if options:
             # Options is only for BIP39/SLIP39; extra-word lives on this page
             if 'bip39' in options or 'slip39' in options:
@@ -164,6 +168,24 @@ class SeedWidget(QWidget):
                 vbox.addWidget(self.cb_ext)
                 self.ext_reason_label = WWLabel('')
                 vbox.addWidget(self.ext_reason_label)
+                self.ext_box = QWidget()
+                ext_vbox = QVBoxLayout(self.ext_box)
+                ext_vbox.setContentsMargins(0, 0, 0, 0)
+                self.ext_help = WWLabel('')
+                self.ext_edit = QLineEdit()
+                self.ext_edit.textChanged.connect(self._on_ext_text)
+                ext_warn = WWLabel('\n'.join([
+                    _('Note that this is NOT your encryption password.'),
+                    _('If you do not know what this is, leave this field empty.'),
+                ]))
+                self.ext_issue4566 = WWLabel(MSG_PASSPHRASE_WARN_ISSUE4566)
+                self.ext_issue4566.setVisible(False)
+                ext_vbox.addWidget(self.ext_help)
+                ext_vbox.addWidget(self.ext_edit)
+                ext_vbox.addWidget(ext_warn)
+                ext_vbox.addWidget(self.ext_issue4566)
+                self.ext_box.setVisible(False)
+                vbox.addWidget(self.ext_box)
                 self._update_ext_controls()
         if passphrase:
             hbox = QHBoxLayout()
@@ -360,7 +382,21 @@ class SeedWidget(QWidget):
 
     def _on_ext_toggled(self, checked):
         self.is_ext = checked
+        if self.ext_box:
+            self.ext_box.setVisible(bool(checked) and self.cb_ext.isEnabled())
         self.updated.emit()
+
+    def _on_ext_text(self, text: str):
+        if self.ext_issue4566 and self.seed_type == 'bip39':
+            self.ext_issue4566.setVisible(text != ' '.join(text.split()))
+        elif self.ext_issue4566:
+            self.ext_issue4566.setVisible(False)
+        self.updated.emit()
+
+    def get_seed_extra_words(self) -> str:
+        if not self.is_ext or not self.ext_edit:
+            return ''
+        return self.ext_edit.text()
 
     def _electrum_version_detected(self) -> bool:
         if self.seed_type != 'electrum':
@@ -377,14 +413,33 @@ class SeedWidget(QWidget):
         self.cb_ext.blockSignals(False)
         self.is_ext = checked
 
+    def _sync_ext_box(self):
+        if self.ext_box:
+            self.ext_box.setVisible(bool(self.is_ext) and self.cb_ext.isEnabled())
+
     def _update_ext_controls(self):
         if self.cb_ext is None:
             return
         seed_text = self.seed_e.text().strip()
         if self.seed_type == 'bip39':
             self.cb_ext.setText(_('Use a BIP39 passphrase'))
+            if self.ext_help:
+                self.ext_help.setText('\n'.join([
+                    _('Enter an optional BIP39 passphrase.'),
+                    _('Each passphrase derives a different wallet.'),
+                    _('This is sometimes incorrectly called the "25th word".'),
+                ]))
+            if self.ext_edit:
+                self.ext_edit.setPlaceholderText(_('Enter your BIP39 passphrase'))
         else:
             self.cb_ext.setText(_('Extend this seed with custom words'))
+            if self.ext_help:
+                self.ext_help.setText('\n'.join([
+                    _('You may extend your seed with custom words.'),
+                    _('Your seed extension must be saved together with your seed.'),
+                ]))
+            if self.ext_edit:
+                self.ext_edit.setPlaceholderText(_('Enter your custom word(s)'))
         if self.seed_type in ('bip39', 'slip39'):
             self.ext_reason_label.setText('')
             if not seed_text:
@@ -392,12 +447,14 @@ class SeedWidget(QWidget):
                 self.cb_ext.setEnabled(False)
             else:
                 self.cb_ext.setEnabled(True)
+            self._sync_ext_box()
             return
         stype = calc_seed_type(self.get_seed())
         if not stype:
             self._set_ext_checked(False)
             self.cb_ext.setEnabled(False)
             self.ext_reason_label.setText('')
+            self._sync_ext_box()
             return
         if not can_seed_have_passphrase(self.get_seed()):
             self._set_ext_checked(False)
@@ -406,9 +463,11 @@ class SeedWidget(QWidget):
                 self.ext_reason_label.setText(_('Old Electrum seeds have no extra word.'))
             else:
                 self.ext_reason_label.setText(_('This seed cannot be extended with an extra word.'))
+            self._sync_ext_box()
             return
         self.cb_ext.setEnabled(True)
         self.ext_reason_label.setText('')
+        self._sync_ext_box()
 
     def update_share_buttons(self):
         if self.seed_type != 'slip39':

--- a/electrum/gui/qt/seed_dialog.py
+++ b/electrum/gui/qt/seed_dialog.py
@@ -32,7 +32,7 @@ from PyQt6.QtWidgets import (QVBoxLayout, QCheckBox, QHBoxLayout, QLineEdit,
                              QWidget, QPushButton)
 
 from electrum.i18n import _
-from electrum.mnemonic import Mnemonic, calc_seed_type, is_any_2fa_seed_type
+from electrum.mnemonic import Mnemonic, calc_seed_type, is_any_2fa_seed_type, can_seed_have_passphrase
 from electrum import old_mnemonic
 from electrum import slip39
 from electrum.util import ChoiceItem
@@ -149,10 +149,22 @@ class SeedWidget(QWidget):
 
         # options
         self.is_ext = False
+        self.cb_ext = None
+        self.ext_reason_label = None
         if options:
-            opt_button = EnterButton(_('Options'), self.seed_options)
-            hbox.addWidget(opt_button)
+            # Options is only for BIP39/SLIP39; extra-word lives on this page
+            if 'bip39' in options or 'slip39' in options:
+                opt_button = EnterButton(_('Options'), self.seed_options)
+                hbox.addWidget(opt_button)
             vbox.addLayout(hbox)
+            if 'ext' in options:
+                self.cb_ext = QCheckBox(_('Extend this seed with custom words'))
+                self.cb_ext.setEnabled(False)
+                self.cb_ext.toggled.connect(self._on_ext_toggled)
+                vbox.addWidget(self.cb_ext)
+                self.ext_reason_label = WWLabel('')
+                vbox.addWidget(self.ext_reason_label)
+                self._update_ext_controls()
         if passphrase:
             hbox = QHBoxLayout()
             passphrase_e = QLineEdit()
@@ -194,10 +206,13 @@ class SeedWidget(QWidget):
         dialog.setWindowTitle(_("Seed Options"))
         vbox = QVBoxLayout(dialog)
 
-        if 'ext' in self.options:
-            cb_ext = QCheckBox(_('Extend this seed with custom words'))
-            cb_ext.setChecked(self.is_ext)
-            vbox.addWidget(cb_ext)
+        def _sync_variant_enabled():
+            if self._electrum_version_detected():
+                seed_type_choice.set_item_enabled('bip39', False)
+                seed_type_choice.set_item_enabled('slip39', False)
+            else:
+                seed_type_choice.set_item_enabled('bip39', True)
+                seed_type_choice.set_item_enabled('slip39', True)
 
         def on_selected(idx):
             self.seed_type = seed_type_choice.selected_key
@@ -207,19 +222,19 @@ class SeedWidget(QWidget):
             self.on_edit()
             self.update_share_buttons()
             self.initialize_completer()
+            _sync_variant_enabled()
 
         if len(self.seed_types) > 1:
             seed_type_choice = ChoiceWidget(message=_('Seed type'), choices=self.seed_types, default_key=self.seed_type)
             seed_type_choice.itemSelected.connect(on_selected)
             vbox.addWidget(seed_type_choice)
+            _sync_variant_enabled()
 
         vbox.addLayout(Buttons(OkButton(dialog)))
 
         if not dialog.exec():
             return None
 
-        if 'ext' in self.options:
-            self.is_ext = cb_ext.isChecked()
         if len(self.seed_types) > 1:
             self.seed_type = seed_type_choice.selected_key
 
@@ -333,6 +348,7 @@ class SeedWidget(QWidget):
                 self.seed_warning.setText("")
 
         self.seed_type_label.setText(label)
+        self._update_ext_controls()
         self.validChanged.emit(valid)
 
         # disable suggestions if user already typed an unknown word
@@ -341,6 +357,58 @@ class SeedWidget(QWidget):
                 self.seed_e.disable_suggestions()
                 return
         self.seed_e.enable_suggestions()
+
+    def _on_ext_toggled(self, checked):
+        self.is_ext = checked
+        self.updated.emit()
+
+    def _electrum_version_detected(self) -> bool:
+        if self.seed_type != 'electrum':
+            return False
+        stype = calc_seed_type(self.get_seed())
+        return bool(stype) and stype != 'old'
+
+    def _set_ext_checked(self, checked: bool):
+        if self.cb_ext is None:
+            self.is_ext = checked
+            return
+        self.cb_ext.blockSignals(True)
+        self.cb_ext.setChecked(checked)
+        self.cb_ext.blockSignals(False)
+        self.is_ext = checked
+
+    def _update_ext_controls(self):
+        if self.cb_ext is None:
+            return
+        seed_text = self.seed_e.text().strip()
+        if self.seed_type == 'bip39':
+            self.cb_ext.setText(_('Use a BIP39 passphrase'))
+        else:
+            self.cb_ext.setText(_('Extend this seed with custom words'))
+        if self.seed_type in ('bip39', 'slip39'):
+            self.ext_reason_label.setText('')
+            if not seed_text:
+                self._set_ext_checked(False)
+                self.cb_ext.setEnabled(False)
+            else:
+                self.cb_ext.setEnabled(True)
+            return
+        stype = calc_seed_type(self.get_seed())
+        if not stype:
+            self._set_ext_checked(False)
+            self.cb_ext.setEnabled(False)
+            self.ext_reason_label.setText('')
+            return
+        if not can_seed_have_passphrase(self.get_seed()):
+            self._set_ext_checked(False)
+            self.cb_ext.setEnabled(False)
+            if stype == 'old':
+                self.ext_reason_label.setText(_('Old Electrum seeds have no extra word.'))
+            else:
+                self.ext_reason_label.setText(_('This seed cannot be extended with an extra word.'))
+            return
+        self.cb_ext.setEnabled(True)
+        self.ext_reason_label.setText('')
 
     def update_share_buttons(self):
         if self.seed_type != 'slip39':

--- a/electrum/gui/qt/seed_dialog.py
+++ b/electrum/gui/qt/seed_dialog.py
@@ -155,6 +155,7 @@ class SeedWidget(QWidget):
         self.ext_edit = None
         self.ext_help = None
         self.ext_issue4566 = None
+        self.ext_save_hint = None
         if options:
             # Options is only for BIP39/SLIP39; extra-word lives on this page
             if 'bip39' in options or 'slip39' in options:
@@ -162,7 +163,7 @@ class SeedWidget(QWidget):
                 hbox.addWidget(opt_button)
             vbox.addLayout(hbox)
             if 'ext' in options:
-                self.cb_ext = QCheckBox(_('Extend this seed with custom words'))
+                self.cb_ext = QCheckBox(_('Extend this seed with a Passphrase'))
                 self.cb_ext.setEnabled(False)
                 self.cb_ext.toggled.connect(self._on_ext_toggled)
                 vbox.addWidget(self.cb_ext)
@@ -175,7 +176,7 @@ class SeedWidget(QWidget):
                 self.ext_edit = QLineEdit()
                 self.ext_edit.textChanged.connect(self._on_ext_text)
                 ext_warn = WWLabel('\n'.join([
-                    _('Note that this is NOT your encryption password.'),
+                    _('Note that this is NOT your wallet file encryption password.'),
                     _('If you do not know what this is, leave this field empty.'),
                 ]))
                 self.ext_issue4566 = WWLabel(MSG_PASSPHRASE_WARN_ISSUE4566)
@@ -186,6 +187,9 @@ class SeedWidget(QWidget):
                 ext_vbox.addWidget(self.ext_issue4566)
                 self.ext_box.setVisible(False)
                 vbox.addWidget(self.ext_box)
+                vbox.addSpacing(font_height() // 2)
+                self.ext_save_hint = WWLabel('')
+                vbox.addWidget(self.ext_save_hint)
                 self._update_ext_controls()
         if passphrase:
             hbox = QHBoxLayout()
@@ -216,7 +220,9 @@ class SeedWidget(QWidget):
         self.seed_status = WWLabel('')
         vbox.addWidget(self.seed_status)
         self.seed_warning = WWLabel('')
-        if msg:
+        if msg and self.ext_save_hint is not None:
+            pass  # create-seed wizard: backup warning is the local text under the passphrase box
+        elif msg:
             self.seed_warning.setText(seed_warning_msg(seed))
         else:
             self.update_seed_warning()
@@ -384,6 +390,7 @@ class SeedWidget(QWidget):
         self.is_ext = checked
         if self.ext_box:
             self.ext_box.setVisible(bool(checked) and self.cb_ext.isEnabled())
+        self._update_ext_save_hint()
         self.updated.emit()
 
     def _on_ext_text(self, text: str):
@@ -413,9 +420,34 @@ class SeedWidget(QWidget):
         self.cb_ext.blockSignals(False)
         self.is_ext = checked
 
+    def _update_ext_save_hint(self):
+        if not self.ext_save_hint:
+            return
+        if not self.msg:
+            self.ext_save_hint.setText('')
+            return
+        n = len(self.seed_e.text().split())
+        if self.is_ext:
+            save_line = _("Please save these {0} words and your custom Passphrase on paper (order is important). ").format(n)
+        else:
+            save_line = _("Please save these {0} words on paper (order is important). ").format(n)
+        self.ext_save_hint.setText(''.join([
+            "<p>",
+            save_line,
+            _("This seed will allow you to recover your wallet in case of computer failure."),
+            "</p>",
+            "<b>" + _("WARNING") + ":</b>",
+            "<ul>",
+            "<li>" + _("Never disclose your seed.") + "</li>",
+            "<li>" + _("Never type it on a website.") + "</li>",
+            "<li>" + _("Do not store it electronically.") + "</li>",
+            "</ul>",
+        ]))
+
     def _sync_ext_box(self):
         if self.ext_box:
             self.ext_box.setVisible(bool(self.is_ext) and self.cb_ext.isEnabled())
+        self._update_ext_save_hint()
 
     def _update_ext_controls(self):
         if self.cb_ext is None:
@@ -430,16 +462,16 @@ class SeedWidget(QWidget):
                     _('This is sometimes incorrectly called the "25th word".'),
                 ]))
             if self.ext_edit:
-                self.ext_edit.setPlaceholderText(_('Enter your BIP39 passphrase'))
+                self.ext_edit.setPlaceholderText(_('Enter your BIP39 Passphrase'))
         else:
-            self.cb_ext.setText(_('Extend this seed with custom words'))
+            self.cb_ext.setText(_('Extend this seed with a Passphrase'))
             if self.ext_help:
                 self.ext_help.setText('\n'.join([
-                    _('You may extend your seed with custom words.'),
-                    _('Your seed extension must be saved together with your seed.'),
+                    _('You may extend your seed with a Passphrase (e.g. password manager generated passphrase, custom words, a combination of both...).'),
+                    _("You will need to save both your seed and the extension Passphrase together."),
                 ]))
             if self.ext_edit:
-                self.ext_edit.setPlaceholderText(_('Enter your custom word(s)'))
+                self.ext_edit.setPlaceholderText(_('Enter your custom Passphrase'))
         if self.seed_type in ('bip39', 'slip39'):
             self.ext_reason_label.setText('')
             if not seed_text:

--- a/electrum/gui/qt/seed_dialog.py
+++ b/electrum/gui/qt/seed_dialog.py
@@ -56,10 +56,15 @@ MSG_PASSPHRASE_WARN_ISSUE4566 = _("Warning") + ": "\
                                   "same wallet as newer versions or other software.")
 
 
-def seed_warning_msg(seed):
+def seed_warning_msg(seed, passphrase: str = ''):
+    n = len(seed.split())
+    if passphrase:
+        save_line = _("Please save these {0} words on paper and your seed extension Passphrase (order is important). ").format(n)
+    else:
+        save_line = _("Please save these {0} words on paper (order is important). ").format(n)
     return ''.join([
         "<p>",
-        _("Please save these {0} words on paper (order is important). "),
+        save_line,
         _("This seed will allow you to recover your wallet in case "
           "of computer failure."),
         "</p>",
@@ -69,7 +74,7 @@ def seed_warning_msg(seed):
         "<li>" + _("Never type it on a website.") + "</li>",
         "<li>" + _("Do not store it electronically.") + "</li>",
         "</ul>"
-    ]).format(len(seed.split()))
+    ])
 
 
 class SeedWidget(QWidget):
@@ -223,7 +228,7 @@ class SeedWidget(QWidget):
         if msg and self.ext_save_hint is not None:
             pass  # create-seed wizard: backup warning is the local text under the passphrase box
         elif msg:
-            self.seed_warning.setText(seed_warning_msg(seed))
+            self.seed_warning.setText(seed_warning_msg(seed, passphrase or ''))
         else:
             self.update_seed_warning()
 

--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -575,6 +575,12 @@ class ChoiceWidget(QWidget):
             if key == c.key:
                 self.group.button(i).click()
 
+    def set_item_enabled(self, key, enabled: bool):
+        for i, c in enumerate(self.choices):
+            if c.key == key:
+                self.group.button(i).setEnabled(enabled)
+                return
+
 
 class ResizableStackedWidget(QWidget):
     """Simple alternative to QStackedWidget, as QStackedWidget always resizes to the largest

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -461,6 +461,7 @@ class WCCreateSeed(WalletWizardComponent):
             self.wizard_data['seed'] = self.seed
             self.wizard_data['seed_type'] = self.seed_type
             self.wizard_data['seed_extend'] = self.seed_widget.is_ext
+            self.wizard_data['seed_extra_words'] = self.seed_widget.get_seed_extra_words()
             self.wizard_data['seed_variant'] = 'electrum'
 
     def create_seed(self):
@@ -671,6 +672,7 @@ class WCHaveSeed(WalletWizardComponent, Logger):
         else:
             cosigner_data['seed_type'] = self.seed_widget.seed_type
         cosigner_data['seed_extend'] = self.seed_widget.is_ext if self.can_passphrase else False
+        cosigner_data['seed_extra_words'] = self.seed_widget.get_seed_extra_words() if cosigner_data['seed_extend'] else ''
 
 
 class WCScriptAndDerivation(WalletWizardComponent, Logger):

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -530,11 +530,11 @@ class WCEnterExt(WalletWizardComponent, Logger):
         else:
             self.title = _('Seed Extension')
             message = '\n'.join([
-                _('You may extend your seed with custom words.'),
-                _('Your seed extension must be saved together with your seed.'),
+                _('You may extend your seed with a Passphrase (e.g. password manager generated passphrase, custom words, a combination of both...).'),
+                _("You will need to save both your seed and the extension Passphrase together."),
             ])
         warning = '\n'.join([
-            _('Note that this is NOT your encryption password.'),
+            _('Note that this is NOT your wallet file encryption password.'),
             _('If you do not know what this is, leave this field empty.'),
         ])
 
@@ -573,6 +573,7 @@ class WCConfirmExt(WalletWizardComponent):
             _('Please type it here.'),
         ])
         self.ext_edit = SeedExtensionEdit(self, message=message)
+        self.ext_edit.line.setPlaceholderText(_('Enter your custom Passphrase'))
         self.ext_edit.textEdited.connect(self.on_text_edited)
         self.layout().addWidget(self.ext_edit)
         self.layout().addStretch(1)

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -513,11 +513,25 @@ class WCEnterExt(WalletWizardComponent, Logger):
     def __init__(self, parent, wizard):
         WalletWizardComponent.__init__(self, parent, wizard, title=_('Seed Extension'))
         Logger.__init__(self)
+        self.ext_edit = None
+        self.warn_label = None
 
-        message = '\n'.join([
-            _('You may extend your seed with custom words.'),
-            _('Your seed extension must be saved together with your seed.'),
-        ])
+    def on_ready(self):
+        wdata = self.wizard.current_cosigner(self.wizard_data)
+        is_bip39 = wdata.get('seed_variant') == 'bip39'
+        if is_bip39:
+            self.title = _('BIP39 Passphrase')
+            message = '\n'.join([
+                _('Enter an optional BIP39 passphrase.'),
+                _('Each passphrase derives a different wallet.'),
+                _('This is sometimes incorrectly called the "25th word".'),
+            ])
+        else:
+            self.title = _('Seed Extension')
+            message = '\n'.join([
+                _('You may extend your seed with custom words.'),
+                _('Your seed extension must be saved together with your seed.'),
+            ])
         warning = '\n'.join([
             _('Note that this is NOT your encryption password.'),
             _('If you do not know what this is, leave this field empty.'),
@@ -530,8 +544,6 @@ class WCEnterExt(WalletWizardComponent, Logger):
         self.warn_label = IconLabel(reverse=True, hide_if_empty=True)
         self.warn_label.setIcon(read_QIcon('warning.png'))
         self.layout().addWidget(self.warn_label)
-
-    def on_ready(self):
         self.validate()
 
     def on_text_edited(self, text):
@@ -549,7 +561,7 @@ class WCEnterExt(WalletWizardComponent, Logger):
 
     def apply(self):
         cosigner_data = self.wizard.current_cosigner(self.wizard_data)
-        cosigner_data['seed_extra_words'] = self.ext_edit.text()
+        cosigner_data['seed_extra_words'] = self.ext_edit.text() if self.ext_edit else ''
 
 
 class WCConfirmExt(WalletWizardComponent):

--- a/electrum/plugins/trustedcoin/trustedcoin.py
+++ b/electrum/plugins/trustedcoin/trustedcoin.py
@@ -598,7 +598,7 @@ class TrustedCoinPlugin(BasePlugin):
                         else 'trustedcoin_have_seed'
             },
             'trustedcoin_create_seed': {
-                'next': lambda d: 'trustedcoin_create_ext' if wizard.wants_ext(d) else 'trustedcoin_confirm_seed',
+                'next': 'trustedcoin_confirm_seed',
             },
             'trustedcoin_create_ext': {
                 'next': 'trustedcoin_confirm_seed',
@@ -610,7 +610,7 @@ class TrustedCoinPlugin(BasePlugin):
                 'next': 'trustedcoin_tos',
             },
             'trustedcoin_have_seed': {
-                'next': lambda d: 'trustedcoin_have_ext' if wizard.wants_ext(d) else 'trustedcoin_keep_disable',
+                'next': 'trustedcoin_keep_disable',
             },
             'trustedcoin_have_ext': {
                 'next': 'trustedcoin_keep_disable',

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -726,7 +726,7 @@ class NewWalletWizard(KeystoreWizard):
                     #       TODO we should normalize them, but it only makes sense if we also do a walletDB-upgrade.
                     addresses[addr] = {}
         elif data['keystore_type'] in ['createseed', 'haveseed']:
-            seed_extension = data['seed_extra_words'] if data['seed_extend'] else ''
+            seed_extension = data.get('seed_extra_words', '') if data.get('seed_extend') else ''
             if data['seed_type'] in ['old', 'standard', 'segwit']:
                 self._logger.debug('creating keystore from electrum seed')
                 k = keystore.from_seed(data['seed'], passphrase=seed_extension, for_multisig=data['wallet_type'] == 'multisig')

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -212,9 +212,10 @@ class KeystoreWizard(AbstractWizard):
                 'next': self.on_keystore_type
             },
             'enter_seed': {
-                'next': lambda d: 'enter_ext' if self.wants_ext(d) else 'script_and_derivation',
-                'accept': lambda d: None if (self.wants_ext(d) or self.needs_derivation_path(d)) else self.update_keystore(d),
-                'last': lambda d: not self.wants_ext(d) and not self.needs_derivation_path(d),
+                # extra words are typed on this page
+                'next': 'script_and_derivation',
+                'accept': lambda d: None if self.needs_derivation_path(d) else self.update_keystore(d),
+                'last': lambda d: not self.needs_derivation_path(d),
             },
             'enter_ext': {
                 'next': 'script_and_derivation',
@@ -425,7 +426,8 @@ class NewWalletWizard(KeystoreWizard):
                 'next': self.on_keystore_type
             },
             'create_seed': {
-                'next': lambda d: 'create_ext' if self.wants_ext(d) else 'confirm_seed',
+                # extra words are typed on this page; confirm_ext still follows confirm_seed
+                'next': 'confirm_seed',
             },
             'create_ext': {
                 'next': 'confirm_seed',
@@ -441,10 +443,11 @@ class NewWalletWizard(KeystoreWizard):
                 'last': lambda d: self.is_single_password() and not self.is_multisig(d)
             },
             'have_seed': {
-                'next': lambda d: 'have_ext' if self.wants_ext(d) else self.on_have_or_confirm_seed(d),
-                'accept': lambda d: None if self.wants_ext(d) else self.maybe_master_pubkey(d),
+                # extra words are typed on this page
+                'next': self.on_have_or_confirm_seed,
+                'accept': self.maybe_master_pubkey,
                 'last': lambda d: self.is_single_password() and not
-                                    (self.needs_derivation_path(d) or self.is_multisig(d) or self.wants_ext(d)),
+                                    (self.needs_derivation_path(d) or self.is_multisig(d)),
             },
             'have_ext': {
                 'next': self.on_have_or_confirm_seed,
@@ -476,9 +479,9 @@ class NewWalletWizard(KeystoreWizard):
                 'last': lambda d: self.is_single_password() and self.last_cosigner(d)
             },
             'multisig_cosigner_seed': {
-                'next': lambda d: 'multisig_cosigner_have_ext' if self.wants_ext(d) else self.on_have_cosigner_seed(d),
+                'next': self.on_have_cosigner_seed,
                 'last': lambda d: self.is_single_password() and self.last_cosigner(d) and not
-                                  (self.needs_derivation_path(d) or self.wants_ext(d)),
+                                  self.needs_derivation_path(d),
             },
             'multisig_cosigner_have_ext': {
                 'next': self.on_have_cosigner_seed,

--- a/electrum/wizard.py
+++ b/electrum/wizard.py
@@ -292,7 +292,15 @@ class KeystoreWizard(AbstractWizard):
 
     def wants_ext(self, wizard_data: dict) -> bool:
         wdata = self.current_cosigner(wizard_data)
-        return 'seed_variant' in wdata and wdata['seed_extend']
+        if not ('seed_variant' in wdata and wdata['seed_extend']):
+            return False
+        if wdata.get('seed_variant') != 'electrum':
+            return True
+        # old / incomplete electrum seeds must not get an extra-word page
+        try:
+            return can_seed_have_passphrase(wdata.get('seed', ''))
+        except Exception:
+            return False
 
     def is_multisig(self, wizard_data: dict) -> bool:
         return wizard_data['wallet_type'] == 'multisig'

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -622,15 +622,7 @@ class WalletWizardTestCase(WizardTestCase):
             'seed': 'powerful random nobody notice nothing important anyway look away hidden message over',
             'seed_type': 'old', 'seed_extend': True, 'seed_variant': 'electrum'})
         v = w.resolve_next(v.view, d)
-        # FIXME this diverges from the actual GUIs :(
-        #  the GUIs do validation using wizard.validate_seed() and don't go to 'have_ext' for next view.
-        #  the validation should be moved to the base impl!
-        self.assertEqual('have_ext', v.view)
-
-        d.update({'seed_extra_words': UNICODE_HORROR})
-        with self.assertRaises(Exception) as ctx:
-            v = w.resolve_next(v.view, d)
-        self.assertTrue("cannot have passphrase" in ctx.exception.args[0])
+        self._set_password_and_check_address(v=v, w=w, recv_addr="1FJEEB8ihPMbzs2SkLmr37dHyRFzakqUmo")
 
     async def test_create_standard_wallet_haveseed_electrum(self):
         w = self._wizard_for(wallet_type='standard')

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -220,11 +220,8 @@ class KeystoreWizardTestCase(WizardTestCase):
         myxpub = 'zpub6oLFCUpqxT8BUzy8g5miUuRofPZ46ZjjvZfcfH7qJanRM7aRYGpNX4uBGtcJRbgcKbi7dYkiiPw1GB2sc3SufyDcZskuQEWp5jBwbNcj1VL'
         d.update({
             'seed': myseed, 'seed_type': 'segwit', 'seed_extend': True, 'seed_variant': 'electrum',
+            'seed_extra_words': mypassphrase,
         })
-        self.assertFalse(w.is_last_view(v.view, d))
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('enter_ext', v.view)
-        d.update({'seed_extra_words': mypassphrase})
         self.assertTrue(w.is_last_view(v.view, d))
         w.resolve_next(v.view, d)
         ks, ishww = w._result
@@ -324,11 +321,9 @@ class KeystoreWizardTestCase(WizardTestCase):
         d.update({
             'seed': 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
             'seed_type': 'bip39', 'seed_extend': True, 'seed_variant': 'bip39',
+            'seed_extra_words': 'abc',
         })
         self.assertFalse(w.is_last_view(v.view, d))
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('enter_ext', v.view)
-        d.update({'seed_extra_words': 'abc'})
         v = w.resolve_next(v.view, d)
 
         self.assertEqual('script_and_derivation', v.view)
@@ -556,11 +551,8 @@ class WalletWizardTestCase(WizardTestCase):
 
         d.update({
             'seed': '9dk', 'seed_type': 'segwit', 'seed_extend': True, 'seed_variant': 'electrum',
+            'seed_extra_words': UNICODE_HORROR,
         })
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('create_ext', v.view)
-
-        d.update({'seed_extra_words': UNICODE_HORROR})
         v = w.resolve_next(v.view, d)
         self.assertEqual('confirm_seed', v.view)
 
@@ -650,11 +642,8 @@ class WalletWizardTestCase(WizardTestCase):
         v = w.resolve_next(v.view, d)
         self.assertEqual('have_seed', v.view)
 
-        d.update({'seed': '9dk', 'seed_type': 'segwit', 'seed_extend': True, 'seed_variant': 'electrum'})
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('have_ext', v.view)
-
-        d.update({'seed_extra_words': UNICODE_HORROR})
+        d.update({'seed': '9dk', 'seed_type': 'segwit', 'seed_extend': True, 'seed_variant': 'electrum',
+                  'seed_extra_words': UNICODE_HORROR})
         v = w.resolve_next(v.view, d)
         self._set_password_and_check_address(v=v, w=w, recv_addr="bc1qgvx24uzdv4mapfmtlu8azty5fxdcw9ghxu4pr4")
 
@@ -704,11 +693,8 @@ class WalletWizardTestCase(WizardTestCase):
         self.assertEqual('have_seed', v.view)
 
         d.update({'seed': 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-                  'seed_type': 'bip39', 'seed_extend': True, 'seed_variant': 'bip39'})
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('have_ext', v.view)
-
-        d.update({'seed_extra_words': UNICODE_HORROR})
+                  'seed_type': 'bip39', 'seed_extend': True, 'seed_variant': 'bip39',
+                  'seed_extra_words': UNICODE_HORROR})
         v = w.resolve_next(v.view, d)
         self.assertEqual('script_and_derivation', v.view)
 
@@ -764,11 +750,8 @@ class WalletWizardTestCase(WizardTestCase):
         ]
         encrypted_seed = slip39.recover_ems(mnemonics)
 
-        d.update({'seed': encrypted_seed, 'seed_variant': 'slip39', 'seed_type': 'slip39', 'seed_extend': True})
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('have_ext', v.view)
-
-        d.update({'seed_extra_words': 'TREZOR'})
+        d.update({'seed': encrypted_seed, 'seed_variant': 'slip39', 'seed_type': 'slip39', 'seed_extend': True,
+                  'seed_extra_words': 'TREZOR'})
         v = w.resolve_next(v.view, d)
         self.assertEqual('script_and_derivation', v.view)
 
@@ -875,10 +858,8 @@ class WalletWizardTestCase(WizardTestCase):
         d.update({
             'seed': 'oblige basket safe educate whale bacon celery demand novel slice various awkward',
             'seed_type': '2fa', 'seed_extend': True, 'seed_variant': 'electrum',
+            'seed_extra_words': UNICODE_HORROR,
         })
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('trustedcoin_have_ext', v.view)
-        d.update({'seed_extra_words': UNICODE_HORROR})
         v = w.resolve_next(v.view, d)
         self.assertEqual('trustedcoin_keep_disable', v.view)
         d.update({'trustedcoin_keepordisable': 'keep'})
@@ -1009,11 +990,7 @@ class WalletWizardTestCase(WizardTestCase):
 
         d.update({
             'seed': '9dk',
-            'seed_variant': 'electrum', 'seed_type': 'segwit', 'seed_extend': True})
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('have_ext', v.view)
-
-        d.update({
+            'seed_variant': 'electrum', 'seed_type': 'segwit', 'seed_extend': True,
             'seed_extra_words': UNICODE_HORROR,
             'multisig_master_pubkey': 'Zpub6zAYrXzLbLwWFCkahiB3fQz4KMUm68RsoGVHkM5aBjzHBGnQ9orvy7PKuFvMj4gyJXhFW5uFzHBgDDYFEPS75b3ADq3yvtuEJF86ZgLLyeL'})
         v = w.resolve_next(v.view, d)
@@ -1085,11 +1062,7 @@ class WalletWizardTestCase(WizardTestCase):
 
         d['multisig_cosigner_data']['5'].update({
             'seed': 'abandon bike',
-            'seed_variant': 'electrum', 'seed_type': 'segwit', 'seed_extend': True})
-        v = w.resolve_next(v.view, d)
-        self.assertEqual('multisig_cosigner_have_ext', v.view)
-
-        d['multisig_cosigner_data']['5'].update({
+            'seed_variant': 'electrum', 'seed_type': 'segwit', 'seed_extend': True,
             'seed_extra_words': UNICODE_HORROR})
         v = w.resolve_next(v.view, d)
         self.assertEqual('multisig_cosigner_keystore', v.view)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -622,6 +622,8 @@ class WalletWizardTestCase(WizardTestCase):
             'seed': 'powerful random nobody notice nothing important anyway look away hidden message over',
             'seed_type': 'old', 'seed_extend': True, 'seed_variant': 'electrum'})
         v = w.resolve_next(v.view, d)
+        # GUI unchecks the box; even if seed_extend is still True, skip have_ext.
+        self.assertEqual('wallet_password', v.view)
         self._set_password_and_check_address(v=v, w=w, recv_addr="1FJEEB8ihPMbzs2SkLmr37dHyRFzakqUmo")
 
     async def test_create_standard_wallet_haveseed_electrum(self):


### PR DESCRIPTION
These changes try to make the use of a seed extension aka Passphrase more user-friendly. As shown from recent events having a custom Passphrase extending a seed is a great idea for funds safety. I didn't even know Electrum seeds supported this despite it has been there for years. I remember myself creating a BIP39 seed in a different wallet software just to be able to restore it inside Electrum + a Passphrase to make it stronger.

I also tackled this request https://github.com/spesmilo/electrum/issues/10797 for clearer BIP39 Passphrase wording. cc @MatheyBTC @SomberNight 

I dev built and tested the flows, but please feel free to test these changes if you see them worthy of a merge.

```
python -m pytest tests/test_wizard.py tests/test_mnemonic.py -q --tb=short
50 passed, 45 subtests passed
```

I tried to add clear copy and easy wording for users, also tried to improve the UX by not separating the Passphrase creation from the seed step itself, IMO this is better for understanding the importance of the seed+Passphrase despite the amount of words and lines needed to educate users.