### PR TITLE
bip32: reject extended private key with non-zero key prefix

### DIFF
--- a/electrum/bip32.py
+++ b/electrum/bip32.py
@@ -155,6 +155,9 @@ class BIP32Node(NamedTuple):
         if not allow_custom_headers and xtype != "standard":
             raise ValueError(f"only standard xpub/xprv allowed. found custom xtype={xtype}")
         if is_private:
+            if xkey[13 + 32] != 0:
+                raise BitcoinException('Invalid extended private key: '
+                                       'key data must be prefixed with 0x00')
             eckey = ecc.ECPrivkey(xkey[13 + 33:])
         else:
             eckey = ecc.ECPubkey(xkey[13 + 32:])

--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -763,6 +763,19 @@ class Test_xprv_xpub(ElectrumTestCase):
         self.assertEqual(bytes.fromhex("03f18e53f3386a5f9a9d2c369ad3b84b429eb397b4bc69ce600f2d833b54ba32f4"),
                          bip32node2.eckey.get_public_key_bytes(compressed=True))
 
+    def test_bip32_from_xkey_private_key_bad_prefix(self):
+        # A private extended key's key field must be 0x00 || ser256(k).
+        for invalid in (
+            # BIP32 test vector 5: prvkey version / pubkey mismatch
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGTQQD3dC4H2D5GBj7vWvSQaaBv5cxi9gafk7NF3pnBju6dwKvH"
+            # BIP32 test vector 5: invalid prvkey prefix 04
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ",
+            # BIP32 test vector 5: invalid prvkey prefix 01
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fEQ3Qen6J",
+        ):
+            with self.assertRaises(BitcoinException):
+                BIP32Node.from_xkey(invalid)
+
     def test_is_bip32_derivation(self):
         self.assertTrue(is_bip32_derivation("m/0'/1"))
         self.assertTrue(is_bip32_derivation("m/0'/0'"))


### PR DESCRIPTION
BIP-32 mentions [here](https://github.com/bitcoin/bips/blob/7fe0b034ec967b52a5a28276419117326df93263/bip-0032.mediawiki?plain=1#L136) that private key data must start with 0x00:

> ===Serialization format===
>
>Extended public and private keys are serialized as follows:
> * ...
> * 33 bytes: the public key or private key data (ser<sub>P</sub>(K) for public keys, **0x00 || ser<sub>256</sub>(k) for private keys**)

Electrum does currently not check that prefix. [Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/bf8402c8803f085a50df96cb7956033cd252e9ab/src/key.cpp#L420) and [embit](https://github.com/diybitcoinhardware/embit/blob/eb6104fd85d3becabba628756cd5e1b75619f3a1/src/embit/bip32.py#L118) do.

_This was found with differential fuzzing and embit in my [fuzz branch](https://github.com/ekzyis/electrum/tree/fuzz)._