### PR TITLE
bip32: reject master key with non-zero child/fingerprint

### DIFF
--- a/electrum/bip32.py
+++ b/electrum/bip32.py
@@ -154,6 +154,9 @@ class BIP32Node(NamedTuple):
         xtype = headers_inv[header]
         if not allow_custom_headers and xtype != "standard":
             raise ValueError(f"only standard xpub/xprv allowed. found custom xtype={xtype}")
+        if depth == 0 and (child_number != bytes(4) or fingerprint != bytes(4)):
+            raise BitcoinException('Invalid extended key: a depth-0 (master) key must have '
+                                   'zero child number and zero parent fingerprint')
         if is_private:
             if xkey[13 + 32] != 0:
                 raise BitcoinException('Invalid extended private key: '

--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -776,6 +776,19 @@ class Test_xprv_xpub(ElectrumTestCase):
             with self.assertRaises(BitcoinException):
                 BIP32Node.from_xkey(invalid)
 
+    def test_bip32_from_xkey_depth0_with_nonzero_child_or_fingerprint(self):
+        # BIP32 requires a depth-0 (master) key to have child number 0 and parent fingerprint 0.
+        for invalid in (
+            # BIP32 test vector 5: zero depth with non-zero parent fingerprint
+            "xprv9s2SPatNQ9Vc6GTbVMFPFo7jsaZySyzk7L8n2uqKXJen3KUmvQNTuLh3fhZMBoG3G4ZW1N2kZuHEPY53qmbZzCHshoQnNf4GvELZfqTUrcv",
+            "xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ",
+            # BIP32 test vector: zero depth with non-zero index
+            "xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN",
+            "xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8",
+        ):
+            with self.assertRaises(BitcoinException):
+                BIP32Node.from_xkey(invalid)
+
     def test_is_bip32_derivation(self):
         self.assertTrue(is_bip32_derivation("m/0'/1"))
         self.assertTrue(is_bip32_derivation("m/0'/0'"))


### PR DESCRIPTION
BIP-32 mentions [here](https://github.com/bitcoin/bips/blob/7fe0b034ec967b52a5a28276419117326df93263/bip-0032.mediawiki?plain=1#L133-L134) that the fingerprint of the parent's key and child number must be four zero bytes for master keys: 

> ===Serialization format===
>
> Extended public and private keys are serialized as follows:
> * ...
> * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
> * 4 bytes: child number. This is ser<sub>32</sub>(i) for i in x<sub>i</sub> = x<sub>par</sub>/i, with x<sub>i</sub> the key being serialized. (0x00000000 if master key)

Together with #10880, electrum now covers all invalid BIP-32 test vectors.

_This was found with differential fuzzing and embit in my [fuzz branch](https://github.com/ekzyis/electrum/tree/fuzz)._