### PR TITLE
tests: onion_message: do not mutate mainnet config file

### DIFF
--- a/tests/qml/test_qml_qeconfig.py
+++ b/tests/qml/test_qml_qeconfig.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import tempfile
 from typing import TYPE_CHECKING
 
 from electrum import SimpleConfig
@@ -12,7 +15,16 @@ if TYPE_CHECKING:
 class TestConfig(QETestCase):
     @classmethod
     def setUpClass(cls):
-        QEConfig(SimpleConfig())
+        super().setUpClass()
+        cls._unittest_base_path = tempfile.mkdtemp(prefix="electrum-unittest-base-")
+        electrum_path = os.path.join(cls._unittest_base_path, "electrum")
+        config = SimpleConfig({'electrum_path': electrum_path})
+        QEConfig(config)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls._unittest_base_path)
+        super().tearDownClass()
 
     def setUp(self):
         super().setUp()

--- a/tests/test_lnutil.py
+++ b/tests/test_lnutil.py
@@ -1163,7 +1163,7 @@ class TestLNUtil(ElectrumTestCase):
         )
 
     async def test_payment_fee_budget(self):
-        config = SimpleConfig()
+        config = SimpleConfig({'electrum_path': self.electrum_path})
         # test value above cutoff
         invoice_amount_msat = 1_000_000 * 1000
         budget = PaymentFeeBudget.from_invoice_amount(

--- a/tests/test_onion_message.py
+++ b/tests/test_onion_message.py
@@ -265,10 +265,10 @@ class TestOnionMessage(ElectrumTestCase):
 
 
 class MockNetwork:
-    def __init__(self):
+    def __init__(self, *, config: SimpleConfig):
         self.asyncio_loop = get_asyncio_loop()
         self.taskgroup = OldTaskGroup()
-        self.config = SimpleConfig()
+        self.config = config
         self.config.EXPERIMENTAL_LN_FORWARD_PAYMENTS = True
 
 
@@ -300,6 +300,7 @@ class TestOnionMessageManager(ElectrumTestCase):
 
     def setUp(self):
         super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
         def keypair(privkey: ECPrivkey):
             priv = privkey.get_secret_bytes()
@@ -368,7 +369,7 @@ class TestOnionMessageManager(ElectrumTestCase):
         self.assertEqual(t6_result, ({'path_id': {'data': b'electrum' + rkey}}, {}))
 
     async def test_request_and_reply(self):
-        n = MockNetwork()
+        n = MockNetwork(config=self.config)
         lnw = self.create_mock_lnwallet(name='test_request_and_reply')
 
         # mock add_peer for direct connection fallback
@@ -426,7 +427,7 @@ class TestOnionMessageManager(ElectrumTestCase):
             await lnw.stop()
 
     async def test_forward(self):
-        n = MockNetwork()
+        n = MockNetwork(config=self.config)
         lnw = self.create_mock_lnwallet(name='alice')
         lnw.node_keypair = self.alice
 
@@ -463,7 +464,7 @@ class TestOnionMessageManager(ElectrumTestCase):
         self.assertTrue(self.was_sent)
 
     async def test_receive_unsolicited(self):
-        n = MockNetwork()
+        n = MockNetwork(config=self.config)
         lnw = self.create_mock_lnwallet(name='dave')
         lnw.node_keypair = self.dave
 


### PR DESCRIPTION
`test_onion_message.py` was setting `config.EXPERIMENTAL_LN_FORWARD_PAYMENTS = True` on my mainnet config...
and I only noticed because we started logging a warning in https://github.com/spesmilo/electrum/pull/10837

This is just a minimal surface-level patch to fix the immediate issue.
See https://github.com/spesmilo/electrum/pull/10884 for one idea re adding generic future prevention.