### PR TITLE
config: make sure running the unittests can never mutate prod config

### DIFF
--- a/electrum/simple_config.py
+++ b/electrum/simple_config.py
@@ -24,6 +24,7 @@ _logger = get_logger(__name__)
 
 FINAL_CONFIG_VERSION = 3
 
+_RUNNING_UNITTESTS = False
 
 _config_var_from_key = {}  # type: Dict[str, 'ConfigVar']
 
@@ -236,6 +237,9 @@ class SimpleConfig(Logger):
         # Otherwise use the user's default data directory.
         path = self.get('electrum_path') or self.user_dir()
         make_dir(path, allow_symlink=False)
+        if _RUNNING_UNITTESTS:
+            path = os.path.join(path, "unittests")
+            make_dir(path, allow_symlink=False)
         return path
 
     @classmethod

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,6 +30,7 @@ FAST_TESTS = False
 electrum.logging._configure_stderr_logging(verbosity="*")
 
 electrum.util.AS_LIB_USER_I_WANT_TO_MANAGE_MY_OWN_ASYNCIO_LOOP = True
+electrum.simple_config._RUNNING_UNITTESTS = True
 
 
 class ElectrumTestCase(unittest.IsolatedAsyncioTestCase, Logger):

--- a/tests/plugins/test_timelock_recovery.py
+++ b/tests/plugins/test_timelock_recovery.py
@@ -22,7 +22,7 @@ class TestTimelockRecovery(ElectrumTestCase):
         super(TestTimelockRecovery, self).setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-        self.wallet_path = os.path.join(self.electrum_path, "timelock_recovery_wallet")
+        self.wallet_path = os.path.join(self.config.get_datadir_wallet_path(), "timelock_recovery_wallet")
 
         self._saved_stdout = sys.stdout
         self._stdout_buffer = StringIO()

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -56,8 +56,8 @@ class TestBlockchain(ElectrumTestCase):
 
     def setUp(self):
         super().setUp()
-        self.data_dir = Path(self.electrum_path)
-        self.config = SimpleConfig({'electrum_path': self.data_dir})
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+        self.data_dir = Path(self.config.path)
         self.bc_mgr = BlockchainManager.from_config(self.config)
 
     def _append_header(self, chain: Blockchain, header: dict):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -193,7 +193,7 @@ class TestCommandsTestnet(ElectrumTestCase):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
         self.config.NETWORK_OFFLINE = True
-        shutil.copytree(os.path.join(os.path.dirname(__file__), "fiat_fx_data"), os.path.join(self.electrum_path, "cache"))
+        shutil.copytree(os.path.join(os.path.dirname(__file__), "fiat_fx_data"), os.path.join(self.config.path, "cache"))
         self.config.FX_EXCHANGE = "BitFinex"
         self.config.FX_CURRENCY = "EUR"
         self._default_default_timezone = electrum.util.DEFAULT_TIMEZONE

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -14,7 +14,7 @@ class TestContacts(ElectrumTestCase):
     def setUp(self):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-        self.wallet_path = os.path.join(self.electrum_path, "somewallet1")
+        self.wallet_path = os.path.join(self.config.get_datadir_wallet_path(), "somewallet1")
 
     async def test_saving_contacts(self):
         text = 'cross end slow expose giraffe fuel track awake turtle capital ranch pulp'

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -21,8 +21,8 @@ class TestWalletPaymentRequests(ElectrumTestCase):
     def setUp(self):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-        self.wallet1_path = os.path.join(self.electrum_path, "somewallet1")
-        self.wallet2_path = os.path.join(self.electrum_path, "somewallet2")
+        self.wallet1_path = os.path.join(self.config.get_datadir_wallet_path(), "somewallet1")
+        self.wallet2_path = os.path.join(self.config.get_datadir_wallet_path(), "somewallet2")
         self._orig_get_cur_time = BaseInvoice._get_cur_time
 
     def tearDown(self):
@@ -264,7 +264,7 @@ class TestOutgoingInvoicesPaidCache(ElectrumTestCase):
     def setUp(self):
         super().setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
-        self.wallet_path = os.path.join(self.electrum_path, "outgoing_inv_wallet")
+        self.wallet_path = os.path.join(self.config.get_datadir_wallet_path(), "outgoing_inv_wallet")
 
     def _make_wallet(self):
         # Seed matches the funding tx output below (see TestWalletPaymentRequests.create_wallet2).

--- a/tests/test_simple_config.py
+++ b/tests/test_simple_config.py
@@ -107,7 +107,7 @@ class Test_SimpleConfig(ElectrumTestCase):
                               read_user_dir_function=read_user_dir)
         config.save_user_config()
         contents = None
-        with open(os.path.join(self.electrum_dir, "config"), "r") as f:
+        with open(os.path.join(config.path, "config"), "r") as f:
             contents = f.read()
         result = ast.literal_eval(contents)
         result.pop('config_version', None)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -45,7 +45,7 @@ class WalletTestCase(ElectrumTestCase):
         super(WalletTestCase, self).setUp()
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
 
-        self.wallet_path = os.path.join(self.electrum_path, "somewallet")
+        self.wallet_path = os.path.join(self.config.get_datadir_wallet_path(), "somewallet")
 
         self._saved_stdout = sys.stdout
         self._stdout_buffer = StringIO()
@@ -245,8 +245,8 @@ class TestHistoryExport(ElectrumTestCase):
         self.patch_timezone.start()
         time.tzset()
         super(TestHistoryExport, self).setUp()
-        shutil.copytree(Path(__file__).parent / "fiat_fx_data", Path(self.electrum_path) / "cache")
         self.config = SimpleConfig({'electrum_path': self.electrum_path})
+        shutil.copytree(Path(__file__).parent / "fiat_fx_data", Path(self.config.path) / "cache")
 
     def tearDown(self):
         super(TestHistoryExport, self).tearDown()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -51,7 +51,7 @@ class WizardTestCase(ElectrumTestCase):
             'electrum_path': self.electrum_path,
             'enable_plugin_trustedcoin': True,
         })
-        self.wallet_path = os.path.join(self.electrum_path, "somewallet")
+        self.wallet_path = os.path.join(self.config.get_datadir_wallet_path(), "somewallet")
         self.plugins = Plugins(self.config, gui_name='cmdline')
         self.plugins.load_plugin_by_name('trustedcoin')
         # note: hw plugins are loaded on-demand


### PR DESCRIPTION
related: https://github.com/spesmilo/electrum/pull/10883

Running the unittests must never mutate the mainnet/production config file (or other files in the datadir) of a dev machine. I am not sure how exactly to prevent that, but this is one approach.

The idea is that a test case constructing e.g. a config file should use a tempfolder for it (and then clean-up after itself), however in case that is accidentally not done, we should have a belt-and-suspenders last-resort protection. In this PR I propose using e.g. `/home/user/.electrum/unittests/config` instead of `/home/user/.electrum/config`: we always know we are in a unittest context, and if so, we add an extra level of nesting.