### PR TITLE
github: add anti-slop PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Please read this before opening the PR:
+
+Every line of this diff will be reviewed by hand by a human. A pull request
+that its own author cannot explain costs the maintainers more time than it
+saves, so:
+
+  * You may use whatever tools you like to WRITE code, but you must
+    UNDERSTAND the result, and be able to explain it in your own words.
+  * The description below must be handwritten by you. Do not paste text
+    produced by an LLM/AI assistant. Reviewing AI-written prose to find out
+    what a patch is supposed to do is a burden we are not willing to carry.
+  * If you cannot explain the change in your own words, please do NOT open a
+    pull request. Open an issue instead (handwritten too) describing the
+    problem you ran into. A clear bug report is genuinely useful to us; a
+    patch nobody can explain is not.
+
+Pull requests ignoring the above may be closed without further discussion.
+-->


### PR DESCRIPTION
Adds a PR template which asks the creator of a PR for a handwritten description and understanding of the patch. 
This hopefully reduces the amount of fully generated PRs whose underlying issues could be solved more efficient if the author just opened an Issue and let us fix the issue instead of going back-and-forth with the author to clean it up.