### PR TITLE
lnwatcher/qt: fix regressed pending force close warning

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -2732,7 +2732,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
             warning = ''.join([
                 _("Are you sure you want to close Electrum?"),
                 '\n\n',
-                _("An ongoing operation requires you to stay online."),
+                _("An ongoing operation requires you to stay online:"),
                 '\n',
                 warning
             ])
@@ -2764,7 +2764,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.closing_warning_callbacks.append(warning_callback)
 
     def _check_ongoing_force_closures(self) -> Optional[str]:
-        from electrum.lnutil import MIN_FINAL_CLTV_DELTA_ACCEPTED
         if not self.wallet.has_lightning():
             return None
         if not self.network:
@@ -2772,8 +2771,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         force_closes = self.wallet.lnworker.lnwatcher.get_pending_force_closes()
         if not force_closes:
             return
-        # fixme: this is inaccurate, we need local_height - cltv_of_htlc
-        cltv_delta = MIN_FINAL_CLTV_DELTA_ACCEPTED
+        # the htlc that expires first determines how long we can stay offline
+        cltv = min(force_closes.values())
+        cltv_delta = max(cltv - self.wallet.adb.get_local_height(), 0)
         msg = '\n\n'.join([
             _("Pending channel force-close"),
             messages.MSG_FORCE_CLOSE_WARNING.format(cltv_delta),

--- a/electrum/lnsweep.py
+++ b/electrum/lnsweep.py
@@ -46,6 +46,7 @@ class SweepInfo(NamedTuple):
     can_be_batched: bool # todo: this could be more fine-grained
     dust_override: bool
     expiry_height: Optional[int] = None  # first height at which we will not start sweeping this utxo
+    their_cltv_abs: Optional[int] = None  # counterparties timeout spend height, at this height sweeping becomes a race
 
     def is_anchor(self):
         return self.name in ['local_anchor', 'remote_anchor']
@@ -411,6 +412,7 @@ def sweep_our_ctx(
             txs[prevout] = SweepInfo(
                 name=name,
                 our_cltv_abs=htlc_tx.locktime,
+                their_cltv_abs=htlc.cltv_abs if htlc_direction == RECEIVED else 0,
                 txin=htlc_tx.inputs()[0],
                 txout=htlc_tx.outputs()[0],
                 can_be_batched=False,  # both parties can spend
@@ -786,6 +788,7 @@ def sweep_their_ctx(
             txs[prevout] = SweepInfo(
                 name=f'their_ctx_htlc_{ctx_output_idx}{"_for_revoked_ctx" if is_revocation else ""}',
                 our_cltv_abs=cltv_abs,
+                their_cltv_abs=0 if is_received_htlc else htlc.cltv_abs,
                 txin=txin,
                 txout=None,
                 can_be_batched=False,   # both parties can spend

--- a/electrum/lnsweep.py
+++ b/electrum/lnsweep.py
@@ -39,8 +39,8 @@ HTLCTX_INPUT_OUTPUT_INDEX = 0
 
 class SweepInfo(NamedTuple):
     name: str
-    cltv_abs: Optional[int] # set to None only if the script has no cltv
-    # TODO add asserts that cltv_abs is block-based (see NLOCKTIME_BLOCKHEIGHT_MAX)
+    our_cltv_abs: Optional[int] # set to None only if the script has no cltv
+    # TODO add asserts that our_cltv_abs is block-based (see NLOCKTIME_BLOCKHEIGHT_MAX)
     txin: PartialTxInput
     txout: Optional[PartialTxOutput]  # only for first-stage htlc tx
     can_be_batched: bool # todo: this could be more fine-grained
@@ -274,7 +274,7 @@ def sweep_their_htlctx_justice(
             prevout = htlc_tx.txid() + f':{output_idx}'
             index_to_sweepinfo[prevout] = SweepInfo(
                 name=f'second-stage-htlc:{output_idx}',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=False,
@@ -352,7 +352,7 @@ def sweep_our_ctx(
         if txin := sweep_ctx_anchor(ctx=ctx, multisig_key=our_conf.multisig_key):
             txs[txin.prevout.to_str()] = SweepInfo(
                 name='local_anchor',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=True,
@@ -374,7 +374,7 @@ def sweep_our_ctx(
             prevout = ctx.txid() + ':%d'%output_idx
             txs[prevout] = SweepInfo(
                 name='our_ctx_to_local',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=True,
@@ -410,7 +410,7 @@ def sweep_our_ctx(
             prevout = ctx.txid() + f':{ctx_output_idx}'
             txs[prevout] = SweepInfo(
                 name=name,
-                cltv_abs=htlc_tx.locktime,
+                our_cltv_abs=htlc_tx.locktime,
                 txin=htlc_tx.inputs()[0],
                 txout=htlc_tx.outputs()[0],
                 can_be_batched=False,  # both parties can spend
@@ -437,7 +437,7 @@ def sweep_our_ctx(
                     prevout = actual_htlc_tx.txid() + f':{output_idx}'
                     txs[prevout] = SweepInfo(
                         name=f'second-stage-htlc:{output_idx}',
-                        cltv_abs=0,
+                        our_cltv_abs=0,
                         txin=sweep_txin,
                         txout=None,
                         # this is safe to batch, we are the only ones who can spend
@@ -623,7 +623,7 @@ def sweep_their_ctx_to_remote_backup(
         if txin := sweep_ctx_anchor(ctx=ctx, multisig_key=our_ms_funding_keypair):
             txs[txin.prevout.to_str()] = SweepInfo(
                 name='remote_anchor',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=True,
@@ -644,7 +644,7 @@ def sweep_their_ctx_to_remote_backup(
         ):
             txs[prevout] = SweepInfo(
                 name='their_ctx_to_remote_backup',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=True,
@@ -702,7 +702,7 @@ def sweep_their_ctx(
         if txin := sweep_ctx_anchor(ctx=ctx, multisig_key=our_conf.multisig_key):
             txs[txin.prevout.to_str()] = SweepInfo(
                 name='remote_anchor',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=True,
@@ -715,7 +715,7 @@ def sweep_their_ctx(
         if txin := sweep_their_ctx_justice(chan, ctx, per_commitment_secret):
             txs[txin.prevout.to_str()] = SweepInfo(
                 name='to_local_for_revoked_ctx',
-                cltv_abs=None,
+                our_cltv_abs=None,
                 txin=txin,
                 txout=None,
                 can_be_batched=False,
@@ -746,7 +746,7 @@ def sweep_their_ctx(
                 # todo: we might not want to sweep this at all, if we add it to the wallet addresses
                 txs[prevout] = SweepInfo(
                     name='their_ctx_to_remote',
-                    cltv_abs=None,
+                    our_cltv_abs=None,
                     txin=txin,
                     txout=None,
                     can_be_batched=True,
@@ -785,7 +785,7 @@ def sweep_their_ctx(
         ):
             txs[prevout] = SweepInfo(
                 name=f'their_ctx_htlc_{ctx_output_idx}{"_for_revoked_ctx" if is_revocation else ""}',
-                cltv_abs=cltv_abs,
+                our_cltv_abs=cltv_abs,
                 txin=txin,
                 txout=None,
                 can_be_batched=False,   # both parties can spend

--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -325,9 +325,9 @@ class LNWatcher(Logger, EventListener):
         (we are waiting for ctx to be confirmed and there are received htlcs)
         """
         if is_local_ctx and sweep_info.name == 'received-htlc':
-            cltv = sweep_info.our_cltv_abs
-            assert cltv is not None, f"missing cltv for {sweep_info}"
-            if self.adb.get_local_height() > cltv + REDEEM_AFTER_DOUBLE_SPENT_DELAY:
+            their_cltv = sweep_info.their_cltv_abs
+            assert their_cltv is not None, f"missing cltv for {sweep_info}"
+            if self.adb.get_local_height() > their_cltv + REDEEM_AFTER_DOUBLE_SPENT_DELAY:
                 # We had plenty of time to sweep. The remote also had time to time out the htlc.
                 # Maybe its value has been ~dust at current and past fee levels (every time we checked).
                 # We should not keep warning the user forever.

--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -34,7 +34,7 @@ class LNWatcher(Logger, EventListener):
         self.callbacks = {}  # type: Dict[str, Callable[[], Awaitable[None]]]  # address -> lambda function
         self.network = None
         self.register_callbacks()
-        self._pending_force_closes = set()
+        self._pending_force_closes = {}  # type: Dict['AbstractChannel', int]  # chan -> lowest remote htlc timeout height
         self.taskgroup = OldTaskGroup()
         self._last_callback_trigger_ts = 0
 
@@ -183,7 +183,7 @@ class LNWatcher(Logger, EventListener):
             closing_height=closing_height,
             keep_watching=keep_watching)
         if closing_height.conf > 0:
-            self._pending_force_closes.discard(chan)
+            self._pending_force_closes.pop(chan, None)
         await self.lnworker.handle_onchain_state(chan)
 
     async def sweep_commitment_transaction(self, funding_outpoint: str, closing_tx: Transaction) -> bool:
@@ -202,6 +202,7 @@ class LNWatcher(Logger, EventListener):
         if not chan:
             return False
         local_height = self.adb.get_local_height()
+        self._pending_force_closes.pop(chan, None)  # recomputed below
         # detect who closed and get information about how to claim outputs
         is_local_ctx, sweep_info_dict = chan.get_ctx_sweep_info(closing_tx)
         # note: we need to keep watching *at least* until the closing tx is deeply mined,
@@ -254,8 +255,8 @@ class LNWatcher(Logger, EventListener):
             )
         return keep_watching
 
-    def get_pending_force_closes(self):
-        return self._pending_force_closes
+    def get_pending_force_closes(self) -> Dict['AbstractChannel', int]:
+        return dict(self._pending_force_closes)
 
     def maybe_redeem(self, sweep_info: 'SweepInfo') -> bool:
         """ returns 'keep_watching' """
@@ -321,7 +322,7 @@ class LNWatcher(Logger, EventListener):
         is_local_ctx: bool,
         sweep_info: 'SweepInfo',
     ) -> None:
-        """Adds chan into set of ongoing force-closures if the user should keep the wallet open, waiting for it.
+        """Adds chan into dict of ongoing force-closures if the user should keep the wallet open, waiting for it.
         (we are waiting for ctx to be confirmed and there are received htlcs)
         """
         if is_local_ctx and sweep_info.name == 'received-htlc':
@@ -334,4 +335,7 @@ class LNWatcher(Logger, EventListener):
                 return
             tx_mined_status = self.adb.get_tx_height(spender_txid)
             if tx_mined_status.height() == TX_HEIGHT_LOCAL:
-                self._pending_force_closes.add(chan)
+                self._pending_force_closes[chan] = min(
+                    their_cltv,
+                    self._pending_force_closes.get(chan, their_cltv),  # collect lowest timeout (if multiple htlcs exist)
+                )

--- a/electrum/lnwatcher.py
+++ b/electrum/lnwatcher.py
@@ -325,7 +325,7 @@ class LNWatcher(Logger, EventListener):
         (we are waiting for ctx to be confirmed and there are received htlcs)
         """
         if is_local_ctx and sweep_info.name == 'received-htlc':
-            cltv = sweep_info.cltv_abs
+            cltv = sweep_info.our_cltv_abs
             assert cltv is not None, f"missing cltv for {sweep_info}"
             if self.adb.get_local_height() > cltv + REDEEM_AFTER_DOUBLE_SPENT_DELAY:
                 # We had plenty of time to sweep. The remote also had time to time out the htlc.

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -651,6 +651,7 @@ class SwapManager(Logger):
         sweep_info = SweepInfo(
             txin=txin,
             our_cltv_abs=locktime,
+            their_cltv_abs=swap.locktime if swap.is_reverse else 0,
             txout=None,
             name=name,
             can_be_batched=can_be_batched,

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -650,7 +650,7 @@ class SwapManager(Logger):
         can_be_batched = True
         sweep_info = SweepInfo(
             txin=txin,
-            cltv_abs=locktime,
+            our_cltv_abs=locktime,
             txout=None,
             name=name,
             can_be_batched=can_be_batched,

--- a/electrum/txbatcher.py
+++ b/electrum/txbatcher.py
@@ -174,7 +174,7 @@ class TxBatcher(Logger):
     async def _maybe_redeem_legacy_htlcs(self, sweep_info: 'SweepInfo') -> None:
         assert sweep_info.csv_delay == 0
         local_height = self.wallet.network.get_local_height()
-        wanted_height = sweep_info.cltv_abs
+        wanted_height = sweep_info.our_cltv_abs
         if wanted_height - local_height > 0:
             return
         outpoint = sweep_info.txin.prevout.to_str()
@@ -186,7 +186,7 @@ class TxBatcher(Logger):
             if tx_mined_status.height() not in [TX_HEIGHT_LOCAL, TX_HEIGHT_FUTURE]:
                 return
         self.logger.info(f'will broadcast standalone tx {sweep_info.name}')
-        tx = PartialTransaction.from_io([sweep_info.txin], [sweep_info.txout], locktime=sweep_info.cltv_abs, version=2)
+        tx = PartialTransaction.from_io([sweep_info.txin], [sweep_info.txout], locktime=sweep_info.our_cltv_abs, version=2)
         self.wallet.sign_transaction(tx, password=None, ignore_warnings=True)
         if await self.wallet.network.try_broadcasting(tx, sweep_info.name):
             self.wallet.adb.add_transaction(tx)
@@ -548,10 +548,10 @@ class TxBatch(Logger):
         locktime = base_tx.locktime if base_tx else None
         # sort inputs so that txin-txout pairs are first
         for sweep_info in sorted(to_sweep, key=lambda x: not bool(x.txout)):
-            if sweep_info.cltv_abs is not None:
-                if locktime is None or locktime < sweep_info.cltv_abs:  # FIXME height vs timestamp confusion
+            if sweep_info.our_cltv_abs is not None:
+                if locktime is None or locktime < sweep_info.our_cltv_abs:  # FIXME height vs timestamp confusion
                     # nLockTime must be greater than or equal to the stack operand.
-                    locktime = sweep_info.cltv_abs
+                    locktime = sweep_info.our_cltv_abs
             inputs.append(copy.deepcopy(sweep_info.txin))
             if sweep_info.txout:
                 outputs.append(sweep_info.txout)
@@ -619,8 +619,8 @@ class TxBatch(Logger):
         wanted_height_cltv = None
         wanted_height_csv = None
         local_height = self.wallet.network.get_local_height()
-        if sweep_info.cltv_abs:
-            wanted_height_cltv = sweep_info.cltv_abs
+        if sweep_info.our_cltv_abs:
+            wanted_height_cltv = sweep_info.our_cltv_abs
             if wanted_height_cltv - local_height > 0:
                 can_broadcast = False
         prev_height = self.wallet.adb.get_tx_height(prev_txid).height()

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -685,6 +685,15 @@ class TestChannel(ElectrumTestCase):
         bob_channel.htlc_settle_time[bob_htlc_id] = int(time.time()) - 60
         self.assertTrue(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
 
+        # if bob force-closes, the sweep info for the received htlc must expose the correct cltv heights for both sides.
+        bob_lnwallet.save_preimage(htlc.payment_hash, preimage, mark_as_public=True)
+        is_local_ctx, sweep_info_dict = bob_channel.get_ctx_sweep_info(bob_channel.force_close_tx())
+        self.assertTrue(is_local_ctx)
+        sweep_infos = [si for si in sweep_info_dict.values() if si.name == 'received-htlc']
+        self.assertEqual(1, len(sweep_infos))
+        self.assertEqual(0, sweep_infos[0].our_cltv_abs)
+        self.assertEqual(htlc.cltv_abs, sweep_infos[0].their_cltv_abs)
+
 
 class TestChannelNoAnchors(TestChannel):
     assert TestChannel.TEST_ANCHOR_CHANNELS is True

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -694,6 +694,31 @@ class TestChannel(ElectrumTestCase):
         self.assertEqual(0, sweep_infos[0].our_cltv_abs)
         self.assertEqual(htlc.cltv_abs, sweep_infos[0].their_cltv_abs)
 
+        # while the htlc-success tx is not broadcast yet, the user must be warned to stay online
+        lnwatcher = bob_lnwallet.lnwatcher
+        with mock.patch.object(lnwatcher.adb, 'get_local_height', return_value=htlc.cltv_abs - 1):
+            lnwatcher.maybe_add_pending_forceclose(
+                chan=bob_channel,
+                spender_txid=None,
+                is_local_ctx=is_local_ctx,
+                sweep_info=sweep_infos[0],
+            )
+        self.assertEqual({bob_channel: htlc.cltv_abs}, lnwatcher.get_pending_force_closes())
+        # but not forever: once alice had plenty of time to time out the htlc, we stop warning
+        lnwatcher._pending_force_closes.clear()
+        with mock.patch.object(
+            lnwatcher.adb,
+            'get_local_height',
+            return_value=htlc.cltv_abs + lnutil.REDEEM_AFTER_DOUBLE_SPENT_DELAY + 1,
+        ):
+            lnwatcher.maybe_add_pending_forceclose(
+                chan=bob_channel,
+                spender_txid=None,
+                is_local_ctx=is_local_ctx,
+                sweep_info=sweep_infos[0],
+            )
+        self.assertEqual({}, lnwatcher.get_pending_force_closes())
+
 
 class TestChannelNoAnchors(TestChannel):
     assert TestChannel.TEST_ANCHOR_CHANNELS is True

--- a/tests/test_txbatcher.py
+++ b/tests/test_txbatcher.py
@@ -83,7 +83,7 @@ txin._trusted_value_sats = SWAPDATA.onchain_amount
 txin, locktime = SwapManager.create_claim_txin(txin=txin, swap=SWAPDATA)
 SWAP_SWEEP_INFO = SweepInfo(
     txin=txin,
-    cltv_abs=locktime,
+    our_cltv_abs=locktime,
     txout=None,
     name='swap claim',
     can_be_batched=True,
@@ -106,7 +106,7 @@ chan_multisig_key = lnutil.Keypair(
 anchor_txin = sweep_ctx_anchor(ctx=anchor_chan_ctx, multisig_key=chan_multisig_key)
 ANCHOR_SWEEP_INFO = SweepInfo(
     name='local_anchor',
-    cltv_abs=None,
+    our_cltv_abs=None,
     txin=anchor_txin,
     txout=None,
     can_be_batched=True,


### PR DESCRIPTION
The warning dialog supposed to be shown when we wait for a ctx to get confirmed so we don't miss claiming the htlc was not shown anymore due to a regression from f337b4782d. 
We were looking at our cltv (which is 0) instead of the remote one, and always considered the htlc too old for the warning.
Also now shows the exact remaining blocks in the warning dialog instead of the constant, resolving a `fixme` comment.