### PR TITLE
lnpeer: rm early return in send_revoke_and_ack

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1958,7 +1958,9 @@ class Peer(Logger, EventListener):
 
     def maybe_send_commitment(self, chan: Channel) -> bool:
         assert util.get_running_loop() == util.get_asyncio_loop(), f"this must be run on the asyncio thread!"
-        if not chan.can_update_ctx(proposer=LOCAL):
+        # proposer=REMOTE, because commitment_signed only commits changes that were already proposed,
+        # so it must not be gated on chan._can_send_ctx_updates (see send_shutdown).
+        if not chan.can_update_ctx(proposer=REMOTE):
             return False
         # REMOTE should revoke first before we can sign a new ctx
         if chan.hm.is_revack_pending(REMOTE):

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -2039,8 +2039,7 @@ class Peer(Logger, EventListener):
         return htlc
 
     def send_revoke_and_ack(self, chan: Channel) -> None:
-        if not chan.can_update_ctx(proposer=LOCAL):
-            return
+        assert chan.can_update_ctx(proposer=REMOTE)
         self.logger.info(f'send_revoke_and_ack. chan {chan.short_channel_id}. ctn: {chan.get_oldest_unrevoked_ctn(LOCAL)}')
         rev = chan.revoke_current_commitment()
         self.lnworker.save_channel(chan)


### PR DESCRIPTION
This method is a response to us receiving a new commitment, which is gated on `can_update_ctx(proposer=REMOTE)`. We need to send that response. `can_update_ctx(proposer=LOCAL)` is stricter, because _can_send_ctx_updates is set during shutdown.


ref: CLOSE-6
