### PR TITLE
wallet: fix sweeping with imported address watch only wallet

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2698,7 +2698,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             is_mine = self._learn_derivation_path_for_address_from_txinout(txin, address)
         if not is_mine:
             return
-        txin.script_descriptor = self.get_script_descriptor_for_address(address)
+        if desc := self.get_script_descriptor_for_address(address):
+            txin.script_descriptor = desc
         txin.is_mine = True
         self._add_txinout_derivation_info(txin, address, only_der_suffix=only_der_suffix)
         txin.block_height = self.adb.get_tx_height(txin.prevout.txid.hex()).height()

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -4046,8 +4046,11 @@ class Imported_Wallet(Simple_Wallet):
         else:
             raise BitcoinException(str(bad_keys[0][1]))
 
-    def get_txin_type(self, address):
-        return self.db.get_imported_address(address).get('type', 'address')
+    def get_txin_type(self, address) -> str:
+        x = self.db.get_imported_address(address)
+        if x is None:
+            return 'unknown'
+        return x.get('type', 'address')
 
     @profiler
     def try_detecting_internal_addresses_corruption(self):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -376,9 +376,13 @@ class TestCreateRestoreWallet(WalletTestCase):
         wallet = d['wallet']  # type: Imported_Wallet
         self.assertEqual('bc1q2ccr34wzep58d4239tl3x3734ttle92a8srmuw', wallet.get_receiving_addresses()[0])
         self.assertEqual(2, len(wallet.get_receiving_addresses()))
+        # we don't know the script type of an imported address
+        self.assertEqual('address', wallet.get_txin_type('bc1qnp78h78vp92pwdwq5xvh8eprlga5q8gu66960c'))
         # also test addr deletion
         wallet.delete_address('bc1qnp78h78vp92pwdwq5xvh8eprlga5q8gu66960c')
         self.assertEqual(1, len(wallet.get_receiving_addresses()))
+        # querying an address that is not is_mine
+        self.assertEqual('unknown', wallet.get_txin_type('bc1qnp78h78vp92pwdwq5xvh8eprlga5q8gu66960c'))
 
     async def test_restore_wallet_from_text_privkeys(self):
         text = 'p2wpkh:L4jkdiXszG26SUYvwwJhzGwg37H2nLhrbip7u6crmgNeJysv5FHL p2wpkh:L24GxnN7NNUAfCXA6hFzB1jt59fYAAiFZMcLaJ2ZSawGpM3uqhb1'

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -12,7 +12,7 @@ from electrum.storage import WalletStorage
 from electrum import SimpleConfig
 from electrum import util
 from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_UNCONF_PARENT, TX_HEIGHT_LOCAL, TX_HEIGHT_FUTURE
-from electrum.wallet import (sweep, Multisig_Wallet, Standard_Wallet, Imported_Wallet,
+from electrum.wallet import (sweep, sweep_preparations, Multisig_Wallet, Standard_Wallet, Imported_Wallet,
                              Abstract_Wallet, CannotBumpFee, BumpFeeStrategy,
                              TransactionPotentiallyDangerousException,
                              TransactionDangerousException,
@@ -2583,6 +2583,23 @@ class TestWalletSending(ElectrumTestCase):
                          str(tx_copy))
         self.assertEqual('e02641928e5394332eec0a36c196f1e30e2b8645ebbeef89d6cc27bf237ae548', tx_copy.txid())
         self.assertEqual('b062d2e19880c66b36e80b823c2d00a2769658d1e574ff854dab15efd8fd7da8', tx_copy.wtxid())
+
+        # a watch only wallet with imported address must still be able to sweep the address
+        # (see https://github.com/spesmilo/electrum/issues/10891)
+        swept_addr = 'tb1q6vu7lmtu6hfg6vvetjh3pwyh82dp83jkm6rf05'
+        wallet = WalletIntegrityHelper.create_imported_wallet(config=self.config, privkeys=False)
+        wallet.import_addresses([swept_addr])
+        self.assertTrue(wallet.is_mine(swept_addr))
+        self.assertIsNone(wallet.get_script_descriptor_for_address(swept_addr))
+        coins, keypairs = await sweep_preparations(privkeys, network=network)
+        tx = wallet.make_unsigned_transaction(
+            coins=coins,
+            outputs=[PartialTxOutput.from_address_and_value(dest_addr, value='!')],
+            fee_policy=FixedFeePolicy(500),
+            is_sweep=True,
+        )
+        tx.sign(keypairs)
+        self.assertTrue(tx.is_complete())
 
     async def test_coinjoin_between_two_p2wpkh_electrum_seeds(self):
         wallet1 = WalletIntegrityHelper.create_standard_wallet(

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -2576,30 +2576,33 @@ class TestWalletSending(ElectrumTestCase):
         privkeys = ['p2wpkh:cV2BvgtpLNX328m4QrhqycBGA6EkZUFfHM9kKjVXjfyD53uNfC4q',]
         network = NetworkMock()
         dest_addr = 'tb1qhuy2e45lrdcp9s4ezeptx5kwxcnahzgpar9scc'
-        tx = await sweep(privkeys, network=network, to_address=dest_addr, fee_policy=FixedFeePolicy(500), locktime=2420010, tx_version=2)
 
-        tx_copy = tx_from_any(tx.serialize())
-        self.assertEqual('02000000000101e328aeb4f9dc1b85a2709ce59b0478a15ed9fb5e7f84fb62422f99b8cd6ad7010000000000fdffffff01087e010000000000160014bf08acd69f1b7012c2b91642b352ce3627db89010247304402204993099c4663d92ef4c9a28b3f45a40a6585754fe22ecfdc0a76c43fda7c9d04022006a75e0fd3ad1862d8e81015a71d2a1489ec7a9264e6e63b8fe6bb90c27e799b0121038ca94e7c715152fd89803c2a40a934c7c4035fb87b3cba981cd1e407369cfe312aed2400',
-                         str(tx_copy))
-        self.assertEqual('e02641928e5394332eec0a36c196f1e30e2b8645ebbeef89d6cc27bf237ae548', tx_copy.txid())
-        self.assertEqual('b062d2e19880c66b36e80b823c2d00a2769658d1e574ff854dab15efd8fd7da8', tx_copy.wtxid())
+        with self.subTest(msg="simple sweep"):
+            tx = await sweep(privkeys, network=network, to_address=dest_addr, fee_policy=FixedFeePolicy(500), locktime=2420010, tx_version=2)
 
-        # a watch only wallet with imported address must still be able to sweep the address
-        # (see https://github.com/spesmilo/electrum/issues/10891)
-        swept_addr = 'tb1q6vu7lmtu6hfg6vvetjh3pwyh82dp83jkm6rf05'
-        wallet = WalletIntegrityHelper.create_imported_wallet(config=self.config, privkeys=False)
-        wallet.import_addresses([swept_addr])
-        self.assertTrue(wallet.is_mine(swept_addr))
-        self.assertIsNone(wallet.get_script_descriptor_for_address(swept_addr))
-        coins, keypairs = await sweep_preparations(privkeys, network=network)
-        tx = wallet.make_unsigned_transaction(
-            coins=coins,
-            outputs=[PartialTxOutput.from_address_and_value(dest_addr, value='!')],
-            fee_policy=FixedFeePolicy(500),
-            is_sweep=True,
-        )
-        tx.sign(keypairs)
-        self.assertTrue(tx.is_complete())
+            tx_copy = tx_from_any(tx.serialize())
+            self.assertEqual('02000000000101e328aeb4f9dc1b85a2709ce59b0478a15ed9fb5e7f84fb62422f99b8cd6ad7010000000000fdffffff01087e010000000000160014bf08acd69f1b7012c2b91642b352ce3627db89010247304402204993099c4663d92ef4c9a28b3f45a40a6585754fe22ecfdc0a76c43fda7c9d04022006a75e0fd3ad1862d8e81015a71d2a1489ec7a9264e6e63b8fe6bb90c27e799b0121038ca94e7c715152fd89803c2a40a934c7c4035fb87b3cba981cd1e407369cfe312aed2400',
+                             str(tx_copy))
+            self.assertEqual('e02641928e5394332eec0a36c196f1e30e2b8645ebbeef89d6cc27bf237ae548', tx_copy.txid())
+            self.assertEqual('b062d2e19880c66b36e80b823c2d00a2769658d1e574ff854dab15efd8fd7da8', tx_copy.wtxid())
+
+        with self.subTest(msg="watch-only wallet self-sweep"):
+            # a watch only wallet with imported address must still be able to self-sweep the address (though kind of pointless)
+            # (see https://github.com/spesmilo/electrum/issues/10891)
+            swept_addr = 'tb1q6vu7lmtu6hfg6vvetjh3pwyh82dp83jkm6rf05'
+            wallet = WalletIntegrityHelper.create_imported_wallet(config=self.config, privkeys=False)
+            wallet.import_addresses([swept_addr])
+            self.assertTrue(wallet.is_mine(swept_addr))
+            self.assertIsNone(wallet.get_script_descriptor_for_address(swept_addr))
+            coins, keypairs = await sweep_preparations(privkeys, network=network)
+            tx = wallet.make_unsigned_transaction(
+                coins=coins,
+                outputs=[PartialTxOutput.from_address_and_value(dest_addr, value='!')],
+                fee_policy=FixedFeePolicy(500),
+                is_sweep=True,
+            )
+            tx.sign(keypairs)
+            self.assertTrue(tx.is_complete())
 
     async def test_coinjoin_between_two_p2wpkh_electrum_seeds(self):
         wallet1 = WalletIntegrityHelper.create_standard_wallet(


### PR DESCRIPTION
Don't override a txin descriptor with None when trying to sweep a
key on an imported address watch only wallet which contains the address
to be swept from.

Fixes https://github.com/spesmilo/electrum/issues/10891