### PR TITLE
qt/qml: handle RuntimeError when accessing deleted QObject

### DIFF
--- a/electrum/gui/common_qt/util.py
+++ b/electrum/gui/common_qt/util.py
@@ -1,19 +1,38 @@
 import queue
 import sys
+from contextlib import contextmanager
 from functools import wraps
-from typing import Optional, NamedTuple, Callable
+from typing import Optional, NamedTuple, Callable, Iterator
 import os.path
 
-from PyQt6 import QtGui
-from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6 import QtGui, sip
+from PyQt6.QtCore import Qt, QThread, QObject, pyqtSignal
 from PyQt6.QtGui import QColor, QPen, QPaintDevice, QFontDatabase, QImage
 import qrcode
 
 from electrum.i18n import _
-from electrum.logging import Logger
+from electrum.logging import Logger, get_logger
 from electrum.util import EventListener, event_listener
 
+_logger = get_logger(__name__)
+
 _cached_font_ids: dict[str, int] = {}
+
+
+@contextmanager
+def ignore_if_destroyed(qobj: QObject) -> Iterator[None]:
+    """
+    Objects owned by qt (e.g. a child of a dialog) or by QML are destroyed as soon as the user
+    closes the dialog, while threads and tasks may still hold a reference to the python wrapper,
+    and writing a property or emitting a signal on it then raises RuntimeError.
+    Any other RuntimeError is re-raised.
+    """
+    try:
+        yield
+    except RuntimeError:
+        if not sip.isdeleted(qobj):
+            raise
+        _logger.debug(f'{type(qobj).__name__} has been destroyed, ignoring')
 
 
 def get_font_id(filename: str) -> int:

--- a/electrum/gui/qml/qechanneldetails.py
+++ b/electrum/gui/qml/qechanneldetails.py
@@ -11,7 +11,7 @@ from electrum.lnutil import LOCAL, REMOTE
 from electrum.lnchannel import ChanCloseOption, ChannelState, AbstractChannel, Channel, ChannelBackup
 from electrum.util import format_short_id, event_listener
 
-from electrum.gui.common_qt.util import QtEventListener
+from electrum.gui.common_qt.util import QtEventListener, ignore_if_destroyed
 
 from .auth import AuthMixin, auth_protect
 from .qewallet import QEWallet
@@ -285,17 +285,15 @@ class QEChannelDetails(AuthMixin, QObject, QtEventListener):
     def do_close_channel(self, closetype: str):
         channel_id = self._channel.channel_id
 
+        @ignore_if_destroyed(self)
         def handle_result(success: bool, msg: str = ''):
-            try:
-                if success:
-                    self.channelCloseSuccess.emit()
-                else:
-                    self.channelCloseFailed.emit(msg)
+            if success:
+                self.channelCloseSuccess.emit()
+            else:
+                self.channelCloseFailed.emit(msg)
 
-                self._is_closing = False
-                self.isClosingChanged.emit()
-            except RuntimeError:  # QEChannelDetails might be deleted at this point if the user closed the dialog.
-                pass
+            self._is_closing = False
+            self.isClosingChanged.emit()
 
         def do_close():
             try:

--- a/electrum/gui/qml/qechannelopener.py
+++ b/electrum/gui/qml/qechannelopener.py
@@ -4,10 +4,12 @@ from asyncio.exceptions import TimeoutError
 from typing import Optional
 import electrum_ecc as ecc
 
+from PyQt6 import sip
 from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject, QVariant
 
 from electrum.i18n import _
 from electrum.gui import messages
+from electrum.gui.common_qt.util import ignore_if_destroyed
 from electrum.util import bfh
 from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.lntransport import extract_nodeid, ConnStringFormatError
@@ -230,6 +232,7 @@ class QEChannelOpener(QObject, AuthMixin):
         funding_sat = funding_tx.output_value_for_address(DummyAddress.CHANNEL)
         lnworker = self._wallet.wallet.lnworker
 
+        @ignore_if_destroyed(self)
         def open_thread():
             error = None
             try:
@@ -253,6 +256,8 @@ class QEChannelOpener(QObject, AuthMixin):
             except (CancelledError, TimeoutError):
                 error = _('Could not connect to channel peer')
             except Exception as e:
+                if isinstance(e, RuntimeError) and sip.isdeleted(self):
+                    return  # qt object already deleted
                 error = str(e)
                 if not error:
                     error = repr(e)
@@ -290,6 +295,7 @@ class QEChannelOpener(QObject, AuthMixin):
                 self._amount.satsInt = amount if amount else 0
             finally:
                 self._updating_max = False
-                self.validate()
+                with ignore_if_destroyed(self):
+                    self.validate()
 
         threading.Thread(target=calc_max, daemon=True).start()

--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -20,7 +20,7 @@ from electrum.bitcoin import COIN, address_to_script
 from electrum.payment_identifier import PaymentIdentifier, PaymentIdentifierState, PaymentIdentifierType
 from electrum.util import event_listener, now, InvoiceError
 
-from electrum.gui.common_qt.util import QtEventListener
+from electrum.gui.common_qt.util import QtEventListener, ignore_if_destroyed
 
 from .qetypes import QEAmount
 from .qewallet import QEWallet
@@ -442,6 +442,7 @@ class QEInvoice(QObject, QtEventListener):
 
         self._updating_max = True
 
+        @ignore_if_destroyed(self)
         def calc_max(address):
             try:
                 outputs = [PartialTxOutput(scriptpubkey=address_to_script(address), value='!')]

--- a/electrum/gui/qml/qetxfinalizer.py
+++ b/electrum/gui/qml/qetxfinalizer.py
@@ -21,7 +21,7 @@ from electrum.fee_policy import FeePolicy, FeeMethod
 from electrum.network import NetworkException
 
 from electrum.gui import messages
-from electrum.gui.common_qt.util import QtEventListener
+from electrum.gui.common_qt.util import QtEventListener, ignore_if_destroyed
 
 from .qewallet import QEWallet
 from .qetypes import QEAmount
@@ -1161,6 +1161,7 @@ class QETxSweepFinalizer(QETxFinalizer):
     def update_privkeys(self):
         privkeys = keystore.get_private_keys(self._private_keys)
 
+        @ignore_if_destroyed(self)
         def fetch_privkeys_info():
             try:
                 self._txins = self._wallet.wallet.network.run_from_another_thread(sweep_preparations(privkeys, self._wallet.wallet.network))

--- a/electrum/gui/qt/wizard/wallet.py
+++ b/electrum/gui/qt/wizard/wallet.py
@@ -25,6 +25,7 @@ from electrum import WalletStorage, mnemonic, keystore
 from electrum.wallet_db import WalletDB
 from electrum.wizard import NewWalletWizard, KeystoreWizard, WizardViewState
 
+from electrum.gui.common_qt.util import ignore_if_destroyed
 from electrum.gui.qt.bip39_recovery_dialog import Bip39RecoveryDialog
 from electrum.gui.qt.password_dialog import PasswordLayout, PW_NEW, MSG_ENTER_PASSWORD, PasswordLayoutForHW
 from electrum.gui.qt.seed_dialog import SeedWidget, MSG_PASSPHRASE_WARN_ISSUE4566, KeysWidget
@@ -1175,6 +1176,7 @@ class WCChooseHWDevice(WalletWizardComponent, Logger):
         self.busy_msg = _('Scanning devices...')
         self.busy = True
 
+        @ignore_if_destroyed(self)
         def scan_task():
             # check available plugins
             supported_plugins = self.plugins.get_hardware_support()

--- a/electrum/hw_wallet/qt.py
+++ b/electrum/hw_wallet/qt.py
@@ -36,7 +36,7 @@ from electrum.logging import Logger
 from electrum.util import UserCancelled, UserFacingException, ChoiceItem
 from electrum.plugin import hook
 
-from electrum.gui.common_qt.util import TaskThread
+from electrum.gui.common_qt.util import TaskThread, ignore_if_destroyed
 from electrum.gui.qt.password_dialog import PasswordLayout, PW_PASSPHRASE
 from electrum.gui.qt.util import (
     read_QIcon, WWLabel, OkButton, WindowModalDialog, Buttons, CancelButton, char_width_in_lineedit, PasswordLineEdit,
@@ -181,10 +181,11 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
         # window-modal dialog each time is slow and visibly janky on macOS
         # (the modal "sheet" animates closed/open between outputs). See #10718.
         if self.dialog is not None and self._dialog_on_cancel == on_cancel:
-            self._dialog_label.setText(msg)
-            if not self.dialog.isVisible():  # e.g. was hidden by a user "cancel"
-                self.dialog.show()
-            return
+            with ignore_if_destroyed(self.dialog):
+                self._dialog_label.setText(msg)
+                if not self.dialog.isVisible():  # e.g. was hidden by a user "cancel"
+                    self.dialog.show()
+                return  # dialog gets rebuild if a RuntimeError was raised and the return is skipped
         self.clear_dialog()
         title = self.MESSAGE_DIALOG_TITLE
         if title is None:
@@ -207,7 +208,8 @@ class QtHandlerBase(HardwareHandlerBase, QObject, Logger):
 
     def clear_dialog(self):
         if self.dialog:
-            self.dialog.accept()
+            with ignore_if_destroyed(self.dialog):
+                self.dialog.accept()
             self.dialog = None
             self._dialog_label = None
             self._dialog_on_cancel = None


### PR DESCRIPTION
Handle `RuntimeError` raised inside threads and tasks when accessing an object owned by Qt/QML which has already been deleted before the job finished its execution. 
We already handle it in some parts of the code, but these parts were not yet caught.

Fixes https://github.com/spesmilo/electrum/issues/4193
Fixes https://github.com/spesmilo/electrum/issues/8995
Fixes https://github.com/spesmilo/electrum/issues/10886 
Fixes https://github.com/spesmilo/electrum/issues/10887