### PR TITLE
lnpeer: split can_update_ctx checks

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1092,19 +1092,13 @@ class Channel(AbstractChannel):
             return False
         return True
 
-    def can_update_ctx(self, *, proposer: HTLCOwner) -> bool:
-        """Whether proposer is allowed to send update_* messages.
-        (update_fee, update_*_htlc)
-        """
-        if not self.can_progress_ctx():
-            return False
-        if proposer == LOCAL:
-            if not self._can_send_ctx_updates:
-                return False
-        return True
+    def can_send_ctx_updates(self) -> bool:
+        """Whether *we* can send update_* messages."""
+        return self.can_progress_ctx() and self._can_send_ctx_updates
 
     def can_send_update_add_htlc(self) -> bool:
-        return self.can_update_ctx(proposer=LOCAL) and self.is_open()
+        """Whether *we* can send update_add_htlc."""
+        return self.can_send_ctx_updates() and self.is_open()
 
     def is_frozen_for_sending(self) -> bool:
         if self.lnworker.uses_trampoline() and not self.lnworker.is_trampoline_peer(self.node_id):
@@ -1134,7 +1128,7 @@ class Channel(AbstractChannel):
         chan_config = self.config[htlc_receiver]
         if self.get_state() != ChannelState.OPEN:
             raise PaymentFailure(f"Channel not open. {self.get_state()!r}")
-        if not self.can_update_ctx(proposer=htlc_proposer):
+        if not self.can_progress_ctx():
             raise PaymentFailure(f"cannot update channel. {self.get_state()!r} {self.peer_state!r}")
         if htlc_proposer == LOCAL:
             if not self.can_send_update_add_htlc():
@@ -1726,7 +1720,7 @@ class Channel(AbstractChannel):
         Action must be initiated by LOCAL.
         """
         self.logger.info("settle_htlc")
-        assert self.can_update_ctx(proposer=LOCAL), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
+        assert self.can_send_ctx_updates(), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
         htlc = self.hm.get_htlc_by_id(REMOTE, htlc_id)
         if htlc.payment_hash != sha256(preimage):
             raise Exception("incorrect preimage for HTLC")
@@ -1744,7 +1738,7 @@ class Channel(AbstractChannel):
         Action must be initiated by REMOTE.
         """
         self.logger.info("receive_htlc_settle")
-        assert self.can_update_ctx(proposer=REMOTE), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
+        assert self.can_progress_ctx(), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
         htlc = self.hm.get_htlc_by_id(LOCAL, htlc_id)
         if htlc.payment_hash != sha256(preimage):
             raise RemoteMisbehaving("received incorrect preimage for HTLC")
@@ -1758,7 +1752,7 @@ class Channel(AbstractChannel):
         Action must be initiated by LOCAL.
         """
         self.logger.info("fail_htlc")
-        assert self.can_update_ctx(proposer=LOCAL), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
+        assert self.can_send_ctx_updates(), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
         with self.db_lock:
             self.hm.send_fail(htlc_id)
 
@@ -1769,7 +1763,7 @@ class Channel(AbstractChannel):
         Action must be initiated by REMOTE.
         """
         self.logger.info("receive_fail_htlc")
-        assert self.can_update_ctx(proposer=REMOTE), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
+        assert self.can_progress_ctx(), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}"
         with self.db_lock:
             self.hm.recv_fail(htlc_id)
         self._receive_fail_reasons[htlc_id] = (error_bytes, reason)
@@ -1803,7 +1797,9 @@ class Channel(AbstractChannel):
         if remainder < 0:
             raise Exception(f"Cannot update_fee. {sender} tried to update fee but they cannot afford it. "
                             f"Their balance would go below reserve: {remainder} msat missing.")
-        assert self.can_update_ctx(proposer=LOCAL if from_us else REMOTE), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}. {from_us=}"
+        assert self.can_progress_ctx(), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}. {from_us=}"
+        if from_us:
+            assert self.can_send_ctx_updates(), f"cannot update channel. {self.get_state()!r} {self.peer_state!r}. {from_us=}"
         with self.db_lock:
             if from_us:
                 self.hm.send_update_fee(feerate)

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1084,13 +1084,19 @@ class Channel(AbstractChannel):
     def set_can_send_ctx_updates(self, b: bool) -> None:
         self._can_send_ctx_updates = b
 
-    def can_update_ctx(self, *, proposer: HTLCOwner) -> bool:
-        """Whether proposer is allowed to send commitment_signed, revoke_and_ack,
-        and update_* messages.
-        """
+    def can_progress_ctx(self) -> bool:
+        """Whether chan is in a state that generally allows signing new commitments or revoking them."""
         if self.get_state() not in (ChannelState.OPEN, ChannelState.SHUTDOWN):
             return False
         if self.peer_state != PeerState.GOOD:
+            return False
+        return True
+
+    def can_update_ctx(self, *, proposer: HTLCOwner) -> bool:
+        """Whether proposer is allowed to send update_* messages.
+        (update_fee, update_*_htlc)
+        """
+        if not self.can_progress_ctx():
             return False
         if proposer == LOCAL:
             if not self._can_send_ctx_updates:

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1949,7 +1949,7 @@ class Peer(Logger, EventListener):
         htlc_id = payload["id"]
         reason = payload["reason"]
         self.logger.info(f"on_update_fail_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}")
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_update_fail_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
@@ -2077,7 +2077,7 @@ class Peer(Logger, EventListener):
         payment_hash = sha256(preimage)
         htlc_id = payload["id"]
         self.logger.info(f"on_update_fulfill_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}")
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_update_fulfill_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
@@ -2089,7 +2089,7 @@ class Peer(Logger, EventListener):
         failure_code = payload["failure_code"]
         self.logger.info(f"on_update_fail_malformed_htlc. chan {chan.get_id_for_log()}. "
                          f"htlc_id {htlc_id}. failure_code={failure_code}")
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_update_fail_malformed_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
@@ -2115,7 +2115,7 @@ class Peer(Logger, EventListener):
         self.logger.info(f"on_update_add_htlc. chan {chan.short_channel_id}. htlc={str(htlc)}")
         if chan.get_state() != ChannelState.OPEN:
             raise RemoteMisbehaving(f"received update_add_htlc while chan.get_state() != OPEN. state was {chan.get_state()!r}")
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_update_add_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
@@ -2319,7 +2319,7 @@ class Peer(Logger, EventListener):
             if chan is None:
                 # this htlc belongs to another peer and has to be settled in their htlc_switch
                 continue
-            if not chan.can_update_ctx(proposer=LOCAL):
+            if not chan.can_send_ctx_updates():
                 continue
             self.logger.info(f"fulfill htlc: {chan.short_channel_id}. {htlc_id=}. {payment_hash.hex()=}")
             if chan.hm.was_htlc_preimage_released(htlc_id=htlc_id, htlc_proposer=REMOTE):
@@ -2362,7 +2362,7 @@ class Peer(Logger, EventListener):
             if chan is None:
                 # this htlc belongs to another peer and has to be settled in their htlc_switch
                 continue
-            if not chan.can_update_ctx(proposer=LOCAL):
+            if not chan.can_send_ctx_updates():
                 continue
             assert chan.hm.is_htlc_irrevocably_added_yet(htlc_proposer=REMOTE, htlc_id=htlc_id)
             if chan.hm.was_htlc_failed(htlc_id=htlc_id, htlc_proposer=REMOTE):
@@ -2405,7 +2405,7 @@ class Peer(Logger, EventListener):
 
     def fail_htlc(self, *, chan: Channel, htlc_id: int, error_bytes: bytes):
         self.logger.info(f"fail_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}.")
-        assert chan.can_update_ctx(proposer=LOCAL), f"cannot send updates: {chan.short_channel_id}"
+        assert chan.can_send_ctx_updates(), f"cannot send updates: {chan.short_channel_id}"
         self.received_htlcs_pending_removal.add((chan, htlc_id))
         chan.fail_htlc(htlc_id)
         self.send_message(
@@ -2418,7 +2418,7 @@ class Peer(Logger, EventListener):
 
     def fail_malformed_htlc(self, *, chan: Channel, htlc_id: int, reason: OnionParsingError):
         self.logger.info(f"fail_malformed_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}.")
-        assert chan.can_update_ctx(proposer=LOCAL), f"cannot send updates: {chan.short_channel_id}"
+        assert chan.can_send_ctx_updates(), f"cannot send updates: {chan.short_channel_id}"
         if not (reason.code & OnionFailureCodeMetaFlag.BADONION and len(reason.data) == 32):
             raise Exception(f"unexpected reason when sending 'update_fail_malformed_htlc': {reason!r}")
         self.received_htlcs_pending_removal.add((chan, htlc_id))
@@ -2452,7 +2452,7 @@ class Peer(Logger, EventListener):
         await self.taskgroup.spawn(async_wrapper)
 
     def on_update_fee(self, chan: Channel, payload):
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_update_fee. illegal action. "
                 f"chan={chan.get_id_for_log()}. {chan.get_state()=!r}. {chan.peer_state=!r}")
@@ -2464,7 +2464,7 @@ class Peer(Logger, EventListener):
         """
         called when our fee estimates change
         """
-        if not chan.can_update_ctx(proposer=LOCAL):
+        if not chan.can_send_ctx_updates():
             return
         if chan.get_state() != ChannelState.OPEN:
             return
@@ -2874,7 +2874,7 @@ class Peer(Logger, EventListener):
         #    and not added to any set.
         #    Each htlc is only supposed to go through this first loop once when being received.
         for chan_id, chan in self.channels.items():
-            if not chan.can_update_ctx(proposer=LOCAL):
+            if not chan.can_send_ctx_updates():
                 continue
             self.maybe_send_commitment(chan)
             unfulfilled = chan.unfulfilled_htlcs

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1951,9 +1951,9 @@ class Peer(Logger, EventListener):
         self.logger.info(f"on_update_fail_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}")
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_update_fail_htlc. dropping message. illegal action. "
+                f"on_update_fail_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received update_fail_htlc when not allowed")
         chan.receive_fail_htlc(htlc_id, error_bytes=reason)  # TODO handle exc and maybe fail channel (e.g. bad htlc_id)
 
     def maybe_send_commitment(self, chan: Channel) -> bool:
@@ -2054,9 +2054,9 @@ class Peer(Logger, EventListener):
         self.logger.info(f'on_commitment_signed. chan {chan.short_channel_id}. ctn: {chan.get_next_ctn(LOCAL)}.')
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_commitment_signed. dropping message. illegal action. "
+                f"on_commitment_signed. illegal action. "
                 f"chan={chan.get_id_for_log()}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received commitment_signed when not allowed")
         # make sure there were changes to the ctx, otherwise the remote peer is misbehaving
         if not chan.has_pending_changes(LOCAL):
             # TODO if feerate changed A->B->A; so there were updates but the value is identical,
@@ -2080,9 +2080,9 @@ class Peer(Logger, EventListener):
         self.logger.info(f"on_update_fulfill_htlc. chan {chan.short_channel_id}. htlc_id {htlc_id}")
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_update_fulfill_htlc. dropping message. illegal action. "
+                f"on_update_fulfill_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received update_fulfill_htlc when not allowed")
         chan.receive_htlc_settle(preimage, htlc_id)  # TODO handle exc and maybe fail channel (e.g. bad htlc_id)
 
     def on_update_fail_malformed_htlc(self, chan: Channel, payload):
@@ -2092,9 +2092,9 @@ class Peer(Logger, EventListener):
                          f"htlc_id {htlc_id}. failure_code={failure_code}")
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_update_fail_malformed_htlc. dropping message. illegal action. "
+                f"on_update_fail_malformed_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received update_fail_malformed_htlc when not allowed")
         if failure_code & OnionFailureCodeMetaFlag.BADONION == 0:
             self.schedule_force_closing(chan.channel_id)
             raise RemoteMisbehaving(f"received update_fail_malformed_htlc with unexpected failure code: {failure_code}")
@@ -2118,9 +2118,9 @@ class Peer(Logger, EventListener):
             raise RemoteMisbehaving(f"received update_add_htlc while chan.get_state() != OPEN. state was {chan.get_state()!r}")
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_update_add_htlc. dropping message. illegal action. "
+                f"on_update_add_htlc. illegal action. "
                 f"chan={chan.get_id_for_log()}. {htlc_id=}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received update_add_htlc when not allowed")
         if cltv_abs > bitcoin.NLOCKTIME_BLOCKHEIGHT_MAX:
             self.schedule_force_closing(chan.channel_id)
             raise RemoteMisbehaving(f"received update_add_htlc with {cltv_abs=} > BLOCKHEIGHT_MAX")
@@ -2436,9 +2436,9 @@ class Peer(Logger, EventListener):
         self.logger.info(f'on_revoke_and_ack. chan {chan.short_channel_id}. ctn: {chan.get_oldest_unrevoked_ctn(REMOTE)}')
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_revoke_and_ack. dropping message. illegal action. "
+                f"on_revoke_and_ack. illegal action. "
                 f"chan={chan.get_id_for_log()}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received revack when not allowed")
         rev = RevokeAndAck(payload["per_commitment_secret"], payload["next_per_commitment_point"])
         chan.receive_revocation(rev)
         self.lnworker.save_channel(chan)
@@ -2455,9 +2455,9 @@ class Peer(Logger, EventListener):
     def on_update_fee(self, chan: Channel, payload):
         if not chan.can_update_ctx(proposer=REMOTE):
             self.logger.warning(
-                f"on_update_fee. dropping message. illegal action. "
+                f"on_update_fee. illegal action. "
                 f"chan={chan.get_id_for_log()}. {chan.get_state()=!r}. {chan.peer_state=!r}")
-            return
+            raise RemoteMisbehaving("received update_fee when not allowed")
         feerate = payload["feerate_per_kw"]
         chan.update_fee(feerate, False)
 

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -1958,7 +1958,7 @@ class Peer(Logger, EventListener):
 
     def maybe_send_commitment(self, chan: Channel) -> bool:
         assert util.get_running_loop() == util.get_asyncio_loop(), f"this must be run on the asyncio thread!"
-        if not chan.can_update_ctx(proposer=LOCAL):
+        if not chan.can_progress_ctx():
             return False
         # REMOTE should revoke first before we can sign a new ctx
         if chan.hm.is_revack_pending(REMOTE):
@@ -2039,8 +2039,7 @@ class Peer(Logger, EventListener):
         return htlc
 
     def send_revoke_and_ack(self, chan: Channel) -> None:
-        if not chan.can_update_ctx(proposer=LOCAL):
-            return
+        assert chan.can_progress_ctx(), chan.get_state()
         self.logger.info(f'send_revoke_and_ack. chan {chan.short_channel_id}. ctn: {chan.get_oldest_unrevoked_ctn(LOCAL)}')
         rev = chan.revoke_current_commitment()
         self.lnworker.save_channel(chan)
@@ -2052,7 +2051,7 @@ class Peer(Logger, EventListener):
 
     def on_commitment_signed(self, chan: Channel, payload) -> None:
         self.logger.info(f'on_commitment_signed. chan {chan.short_channel_id}. ctn: {chan.get_next_ctn(LOCAL)}.')
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_commitment_signed. illegal action. "
                 f"chan={chan.get_id_for_log()}. {chan.get_state()=!r}. {chan.peer_state=!r}")
@@ -2434,7 +2433,7 @@ class Peer(Logger, EventListener):
 
     def on_revoke_and_ack(self, chan: Channel, payload) -> None:
         self.logger.info(f'on_revoke_and_ack. chan {chan.short_channel_id}. ctn: {chan.get_oldest_unrevoked_ctn(REMOTE)}')
-        if not chan.can_update_ctx(proposer=REMOTE):
+        if not chan.can_progress_ctx():
             self.logger.warning(
                 f"on_revoke_and_ack. illegal action. "
                 f"chan={chan.get_id_for_log()}. {chan.get_state()=!r}. {chan.peer_state=!r}")


### PR DESCRIPTION
see individual commit messages

commit `lnpeer: when sending commitsig/revack, ignore _can_send_ctx_updates`  is an alternative to https://github.com/spesmilo/electrum/pull/10892
