### PR TITLE
tests: Unskip, repair and make discoverable tests under TestChanReserve

### DIFF
--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -865,7 +865,6 @@ class TestChanReserve(ElectrumTestCase):
         self.alice_channel = alice_channel
         self.bob_channel = bob_channel
 
-    @unittest.skip("broken probably because we haven't implemented detecting when we come out of a situation where we violate reserve")
     def test_part1(self):
         # Add an HTLC that will increase Bob's balance. This should succeed,
         # since Alice stays above her channel reserve, and Bob increases his

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -905,7 +905,7 @@ class TestChanReserve(ElectrumTestCase):
         with self.assertRaises(lnutil.RemoteMisbehaving):
             self.alice_channel.receive_htlc(htlc)
 
-    def part2(self):
+    def test_part2(self):
         paymentPreimage = b"\x01" * 32
         paymentHash = bitcoin.sha256(paymentPreimage)
         # Now we'll add HTLC of 3.5 BTC to Alice's commitment, this should put
@@ -913,11 +913,12 @@ class TestChanReserve(ElectrumTestCase):
         #
         # Resulting balances:
         #	Alice:	1.5
-        #	Bob:	9.5
+        #	Bob:	5.0
         htlc = UpdateAddHtlc(
             payment_hash=paymentHash,
             amount_msat=int(3.5 * one_bitcoin_in_msat),
             cltv_abs=5,
+            timestamp=0,
         )
         self.alice_channel.add_htlc(htlc)
         self.bob_channel.receive_htlc(htlc)
@@ -925,14 +926,18 @@ class TestChanReserve(ElectrumTestCase):
         # Alice's balance all the way down to her channel reserve, but since
         # she is the initiator the additional transaction fee makes her
         # balance dip below.
-        htlc = dataclasses.replace(htlc, amount_msat=one_bitcoin_in_msat)
+        htlc = dataclasses.replace(
+            htlc,
+            payment_hash=bitcoin.sha256(32 * b'\x02'),
+            amount_msat=one_bitcoin_in_msat,
+        )
         with self.assertRaises(lnutil.PaymentFailure):
             self.alice_channel.add_htlc(htlc)
         with self.assertRaises(lnutil.RemoteMisbehaving):
             self.bob_channel.receive_htlc(htlc)
 
-    def part3(self):
-        # Add a HTLC of 2 BTC to Alice, and the settle it.
+    async def test_part3(self):
+        # Add a HTLC of 2 BTC to Alice, and then settle it.
         # Resulting balances:
         #	Alice:	3.0
         #	Bob:	7.0
@@ -947,31 +952,37 @@ class TestChanReserve(ElectrumTestCase):
         alice_idx = self.alice_channel.add_htlc(htlc).htlc_id
         bob_idx = self.bob_channel.receive_htlc(htlc).htlc_id
         force_state_transition(self.alice_channel, self.bob_channel)
-        self.check_bals(one_bitcoin_in_msat * 3
-                        - self.alice_channel.get_next_fee(LOCAL),
-                        one_bitcoin_in_msat * 5)
+        self.check_bals(one_bitcoin_in_msat * 3, one_bitcoin_in_msat * 5)
+        # The HTLC is still in-flight, so Bob's balance is unchanged and still
+        # below his channel reserve: he cannot send anything.
+        self.assertEqual(0, self.bob_channel.available_to_spend(LOCAL))
         self.bob_channel.settle_htlc(paymentPreimage, bob_idx)
         self.alice_channel.receive_htlc_settle(paymentPreimage, alice_idx)
         force_state_transition(self.alice_channel, self.bob_channel)
-        self.check_bals(one_bitcoin_in_msat * 3
-                        - self.alice_channel.get_next_fee(LOCAL),
-                        one_bitcoin_in_msat * 7)
+        self.check_bals(one_bitcoin_in_msat * 3, one_bitcoin_in_msat * 7)
         # And now let Bob add an HTLC of 1 BTC. This will take Bob's balance
         # all the way down to his channel reserve, but since he is not paying
         # the fee this is okay.
-        htlc = dataclasses.replace(htlc, amount_msat=one_bitcoin_in_msat)
+        self.assertEqual(one_bitcoin_in_msat, self.bob_channel.available_to_spend(LOCAL))
+        htlc = dataclasses.replace(
+            htlc,
+            payment_hash=bitcoin.sha256(32 * b'\x02'),
+            amount_msat=one_bitcoin_in_msat,
+        )
         self.bob_channel.add_htlc(htlc)
         self.alice_channel.receive_htlc(htlc)
         force_state_transition(self.alice_channel, self.bob_channel)
-        self.check_bals(one_bitcoin_in_msat * 3 \
-                        - self.alice_channel.get_next_fee(LOCAL),
-                        one_bitcoin_in_msat * 6)
+        self.check_bals(one_bitcoin_in_msat * 3, one_bitcoin_in_msat * 6)
+        self.assertEqual(0, self.bob_channel.available_to_spend(LOCAL))
 
-    def check_bals(self, amt1, amt2):
-        self.assertEqual(self.alice_channel.available_to_spend(LOCAL), amt1)
-        self.assertEqual(self.bob_channel.available_to_spend(REMOTE), amt1)
-        self.assertEqual(self.alice_channel.available_to_spend(REMOTE), amt2)
-        self.assertEqual(self.bob_channel.available_to_spend(LOCAL), amt2)
+    def check_bals(self, amt1: int, amt2: int) -> None:
+        """Assert Alice's (amt1) and Bob's (amt2) balance in msat, as seen by
+        both channels. HTLCs that are still in-flight count towards neither.
+        """
+        self.assertEqual(amt1, self.alice_channel.balance_minus_outgoing_htlcs(LOCAL))
+        self.assertEqual(amt1, self.bob_channel.balance_minus_outgoing_htlcs(REMOTE))
+        self.assertEqual(amt2, self.alice_channel.balance_minus_outgoing_htlcs(REMOTE))
+        self.assertEqual(amt2, self.bob_channel.balance_minus_outgoing_htlcs(LOCAL))
 
 
 class TestChanReserveNoAnchors(TestChanReserve):

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -887,20 +887,15 @@ class TestChanReserve(ElectrumTestCase):
         # even though the channel reserves are not met.
         force_state_transition(self.alice_channel, self.bob_channel)
 
-        aliceSelfBalance = self.alice_channel.balance(LOCAL)\
-                - lnchannel.htlcsum(self.alice_channel.hm.htlcs_by_direction(LOCAL, SENT).values())
-        bobBalance = self.bob_channel.balance(REMOTE)\
-                - lnchannel.htlcsum(self.alice_channel.hm.htlcs_by_direction(REMOTE, SENT).values())
-        self.assertEqual(aliceSelfBalance, one_bitcoin_in_msat*4.5)
-        self.assertEqual(bobBalance, one_bitcoin_in_msat*5)
+        self.check_bals(int(4.5 * one_bitcoin_in_msat), one_bitcoin_in_msat * 5)
         # Now let Bob try to add an HTLC. This should fail, since it will
         # decrease his balance, which is already below the channel reserve.
         #
         # Resulting balances:
         #	Alice:	4.5
         #	Bob:	5.0
+        htlc = dataclasses.replace(htlc, payment_hash=bitcoin.sha256(32 * b'\x02'))
         with self.assertRaises(lnutil.PaymentFailure):
-            htlc = dataclasses.replace(htlc, payment_hash=bitcoin.sha256(32 * b'\x02'))
             self.bob_channel.add_htlc(htlc)
         with self.assertRaises(lnutil.RemoteMisbehaving):
             self.alice_channel.receive_htlc(htlc)


### PR DESCRIPTION
`TestChanReserve` currently has 3 tests, one skipped (`part_1`) and the remaining two tests  (`part_2` and `part_3`) were not discoverable by pytest since they were written because both were written as normal functions without being prefixed with `test_` This PR makes the tests discoverable, fixes the breaking chages in part 1,2,3 and makes additional changes to make the tests more meaningful.

```shell
❯ pytest tests/test_lnchannel.py -v 
=============================================================== 31 passed, 2 skipped in 3.86s ================================================================

``` 