### PR TITLE
lnpeer: fix wedged peer connections

### DIFF
--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -225,7 +225,10 @@ class Peer(Logger, EventListener):
         if time.time() - self.last_message_time > 30:
             self.send_message('ping', num_pong_bytes=4, byteslen=4)
             self.pong_event.clear()
-            await self.pong_event.wait()
+            try:
+                await util.wait_for2(self.pong_event.wait(), LN_P2P_NETWORK_TIMEOUT)
+            except asyncio.TimeoutError as e:
+                raise GracefulDisconnect("pong timed out") from e
 
     async def _process_message(self, message: bytes) -> None:
         try:
@@ -566,12 +569,20 @@ class Peer(Logger, EventListener):
                 await util.wait_for2(self.initialized, LN_P2P_NETWORK_TIMEOUT)
             except Exception as e:
                 raise GracefulDisconnect(f"Failed to initialize: {e!r}") from e
+            await group.spawn(self._monitor_connection())
             await group.spawn(self._query_gossip())
             await group.spawn(self._process_gossip())
             await group.spawn(self._send_own_gossip())
             await group.spawn(self._forward_gossip())
             if self.network.lngossip != self.lnworker:
                 await group.spawn(self.htlc_switch())
+
+    async def _monitor_connection(self):
+        # this mirrors Interface.monitor_connection.
+        while True:
+            await asyncio.sleep(1)
+            if self.transport.is_closing():
+                raise GracefulDisconnect('transport was closed')
 
     async def _process_gossip(self):
         while True:

--- a/electrum/lntransport.py
+++ b/electrum/lntransport.py
@@ -291,6 +291,9 @@ class LNTransportBase:
     def close(self):
         self.writer.close()
 
+    def is_closing(self) -> bool:
+        return self.writer.is_closing()
+
     def remote_pubkey(self) -> Optional[bytes]:
         raise NotImplementedError()
 

--- a/tests/lnhelpers.py
+++ b/tests/lnhelpers.py
@@ -313,6 +313,9 @@ class MockTransport:
     def name(self):
         return self._name
 
+    def is_closing(self) -> bool:
+        return False
+
     async def read_messages(self):
         while True:
             data = await self.queue.get()


### PR DESCRIPTION
On android, when the app is suspended in the background long enough that LN peer sockets die, electrum failed to recover these wedged connections. On desktop, the same issue occurs when suspending the system.

- add timeout on ping messages. avoid wait forever on a dead socket
- ~add timeout on channel_reestablish response message, avoid staying in state REESTABLISHING forever~
- add connection monitor task on Peer taskgroup, similar to Interface.

<!--
Please read this before opening the PR:

Every line of this diff will be reviewed by hand by a human. A pull request
that its own author cannot explain costs the maintainers more time than it
saves, so:

  * You may use whatever tools you like to WRITE code, but you must
    UNDERSTAND the result, and be able to explain it in your own words.
  * The description below must be handwritten by you. Do not paste text
    produced by an LLM/AI assistant. Reviewing AI-written prose to find out
    what a patch is supposed to do is a burden we are not willing to carry.
  * If you cannot explain the change in your own words, please do NOT open a
    pull request. Open an issue instead (handwritten too) describing the
    problem you ran into. A clear bug report is genuinely useful to us; a
    patch nobody can explain is not.

Pull requests ignoring the above may be closed without further discussion.
-->