### PR TITLE
fee_policy: don't quantize explicitly set feerates

### DIFF
--- a/electrum/fee_policy.py
+++ b/electrum/fee_policy.py
@@ -265,7 +265,9 @@ class FeePolicy(Logger):
             else:
                 raise NoDynamicFeeEstimates()
 
-        return self.estimate_fee_for_feerate(fee_per_kb=fee_per_kb, size=size)
+        # a feerate explicitly set by the user is honored at its full precision
+        quantize = self.method != FeeMethod.FEERATE
+        return self.estimate_fee_for_feerate(fee_per_kb=fee_per_kb, size=size, quantize=quantize)
 
     @classmethod
     def estimate_fee_for_feerate(
@@ -273,14 +275,16 @@ class FeePolicy(Logger):
         *,
         fee_per_kb: Union[int, float, Decimal],
         size: Union[int, float, Decimal],
+        quantize: bool = True,
     ) -> int:
         # note: 'size' is in vbytes
         size = Decimal(size)
         fee_per_kb = Decimal(fee_per_kb)
         fee_per_byte = fee_per_kb / 1000
-        # to be consistent with what is displayed in the GUI,
-        # the calculation needs to use the same precision:
-        fee_per_byte = quantize_feerate(fee_per_byte)
+        if quantize:
+            # to be consistent with what is displayed in the GUI,
+            # the calculation needs to use the same precision:
+            fee_per_byte = quantize_feerate(fee_per_byte)
         return math.ceil(fee_per_byte * size)
 
 

--- a/tests/test_fee_policy.py
+++ b/tests/test_fee_policy.py
@@ -1,4 +1,4 @@
-from electrum.fee_policy import FeeHistogram
+from electrum.fee_policy import FeeHistogram, FeePolicy
 
 from . import ElectrumTestCase
 
@@ -53,3 +53,18 @@ class Test_FeeHistogram(ElectrumTestCase):
         self.assertEqual(36495000, mempool_fees.fee_to_depth(0.5))
 
 
+class Test_FeePolicy(ElectrumTestCase):
+
+    def test_estimate_fee_honors_explicit_feerate(self):
+        # an explicitly set feerate should be used at its full (sat/kvB) precision,
+        # instead of being rounded to FEERATE_PRECISION decimal places
+        self.assertEqual(45, FeePolicy('feerate:450').estimate_fee(100))    # 0.45 sat/vB
+        self.assertEqual(64, FeePolicy('feerate:450').estimate_fee(141))    # ceil(63.45)
+        self.assertEqual(125, FeePolicy('feerate:1250').estimate_fee(100))  # 1.25 sat/vB
+        self.assertEqual(40, FeePolicy('feerate:400').estimate_fee(100))    # 0.4 sat/vB
+
+    def test_estimate_fee_for_feerate_quantizes_by_default(self):
+        # estimates not explicitly set by the user keep being quantized,
+        # to stay consistent with what is displayed in the GUI
+        self.assertEqual(40, FeePolicy.estimate_fee_for_feerate(fee_per_kb=450, size=100))
+        self.assertEqual(120, FeePolicy.estimate_fee_for_feerate(fee_per_kb=1250, size=100))


### PR DESCRIPTION
`estimate_fee()` rounds the feerate to `FEERATE_PRECISION` (1 decimal place, half-down) before computing the fee, so `payto --feerate 0.45` pays 0.4 sat/vB and `--feerate 3.75` (the example from #4259) pays 3.7, with no indication that the requested rate was not used.

The rounding was added in f12798e91 for consistency with the GUI display, but both GUIs already constrain feerate input to one decimal place before the policy is constructed, so for `FeeMethod.FEERATE` it only affected CLI- and
config-originated rates. ETA and mempool based estimates keep being quantized. Since 58af1c493 lowered the supported relay floor to 0.1 sat/vB, one-decimal granularity is coarsest exactly where these rates now live.

Note: `bump_fee`/`dscancel` have their own `quantize_feerate` call (which also feeds the new-vs-old rate sanity check); deliberately left untouched here.