### PR TITLE
qml: prevent concurrent biometric auth requests

### DIFF
--- a/electrum/gui/qml/components/main.qml
+++ b/electrum/gui/qml/components/main.qml
@@ -703,12 +703,14 @@ ApplicationWindow
         function onWalletRequiresPassword(name, path) {
             console.log('wallet requires password')
             if (Biometrics.isAvailable && Biometrics.isEnabled && !app._loadingWalletContext) {
-                app._pendingBiometricAuth = {
-                    action: 'load_wallet',
-                    name: name,
-                    path: path
+                if (!app._pendingBiometricAuth) {
+                    app._pendingBiometricAuth = {
+                        action: 'load_wallet',
+                        name: name,
+                        path: path
+                    }
+                    Biometrics.unlock()
                 }
-                Biometrics.unlock()
             } else {
                 showOpenWalletDialog(name, path)
             }
@@ -838,12 +840,14 @@ ApplicationWindow
 
         if (method !== 'wallet_password_only') {
             if (Biometrics.isAvailable && Biometrics.isEnabled) {
-                app._pendingBiometricAuth = {
-                    qtobject: qtobject,
-                    method: method,
-                    authMessage: authMessage
+                if (!app._pendingBiometricAuth) {
+                    app._pendingBiometricAuth = {
+                        qtobject: qtobject,
+                        method: method,
+                        authMessage: authMessage
+                    }
+                    Biometrics.unlock(authMessage)
                 }
-                Biometrics.unlock(authMessage)
                 return
             }
         }

--- a/electrum/gui/qml/qebiometrics.py
+++ b/electrum/gui/qml/qebiometrics.py
@@ -88,6 +88,7 @@ class QEBiometrics(AuthMixin, QObject):
             data=unified_wallet_password.encode('utf-8'),
         )
         encrypted_password_bundle = f"{iv.hex()}:{wrapped_wallet_password.hex()}"
+        assert self._current_action is None, "not overriding biometric auth pw during pending activity result"
         self.config.WALLET_ANDROID_BIOMETRIC_AUTH_WRAPPED_WALLET_PASSWORD = encrypted_password_bundle
         self._start_activity(BiometricAction.ENCRYPT, data=wrap_key.hex())
 
@@ -128,6 +129,7 @@ class QEBiometrics(AuthMixin, QObject):
         self._start_activity(BiometricAction.DECRYPT, data=encrypted_wrap_key, auth_message=auth_message)
 
     def _start_activity(self, action: BiometricAction, data: str, auth_message: str = None):
+        assert self._current_action is None, f"don't run concurrent activities: {self._current_action=} {action=}"
         self._current_action = action
 
         _logger.debug(f"_start_activity: {action.value}, {len(data)=}")
@@ -164,6 +166,7 @@ class QEBiometrics(AuthMixin, QObject):
 
         try:
             self.unbind()
+            assert action is not None, f"received activity {resultCode=} for {requestCode=} without pending action"
             if resultCode == -1: # RESULT_OK
                 data = intent.getStringExtra(jString("data"))
                 if action == BiometricAction.ENCRYPT:


### PR DESCRIPTION
Don't allow initiating a new biometric auth request if there is still a pending one.
I assume this can happen if the phone is slow to
open the biometric auth prompt after the user requested auth, giving them enough time to e.g. click on the wallet again and request a second auth.

Fixes https://github.com/spesmilo/electrum/issues/10916

