### PR TITLE
refactor coin filtering, combine frozen and coincontrol into new class CoinFilter

### DIFF
--- a/electrum/coinfilter.py
+++ b/electrum/coinfilter.py
@@ -1,0 +1,433 @@
+# Copyright (C) 2026 The Electrum developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENCE or http://www.opensource.org/licenses/mit-license.php
+
+import threading
+import weakref
+from typing import TYPE_CHECKING, Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Union
+
+from . import util
+from .i18n import _
+from .logging import Logger
+from .util import EventListener, event_listener, UserFacingException
+from .transaction import PartialTxInput, TxOutpoint
+from .address_synchronizer import TX_HEIGHT_FUTURE
+
+if TYPE_CHECKING:
+    from .wallet import Abstract_Wallet
+    from .transaction import Transaction
+
+
+CoinType = Union[str, TxOutpoint, PartialTxInput]
+
+
+def outpoint_str(coin: CoinType) -> str:
+    if isinstance(coin, str):
+        return coin
+    if isinstance(coin, TxOutpoint):
+        return coin.to_str()
+    if isinstance(coin, PartialTxInput):
+        return coin.prevout.to_str()
+    raise TypeError(f"cannot interpret {type(coin)} as a coin")
+
+
+class CoinControlStatus(NamedTuple):
+    is_active: bool
+    num_selected: int  # selected outpoints that are still unspent
+    num_usable: int    # selected AND passing the policy filters
+    num_total: int     # all wallet utxos
+    value_sat: int     # sum of the usable ones
+
+
+class CoinFilter(Logger, EventListener):
+    """Owns the decision of which coins are usable/spendable.
+
+    Three layers, applied in this order:
+      1. existence:   is it an unspent is_mine utxo?  (delegated to adb)
+      2. policy:      frozen addr/coin, maturity, confirmed_only, nonlocal_only
+      3. user intent: `domain`, and the manual "coin control" selection
+
+    The selection is stored as bare outpoint strings and is combined with
+    the live policy-filtered utxo set on every read.
+    """
+
+    def __init__(self, wallet: 'Abstract_Wallet'):
+        # weak ref. we are owned by the wallet, so we must not keep it alive
+        self._wallet = weakref.ref(wallet)
+        Logger.__init__(self)
+        self.db = wallet.db
+        self.config = wallet.config
+        self.lock = threading.RLock()
+
+        self._frozen_addresses = set(self.db.get('frozen_addresses', []))
+        self._frozen_coins = self.db.get_dict('frozen_coins')  # type: Dict[str, bool]
+
+        # coin control. in-memory only.
+        self._selection = set()  # type: Set[str]
+
+        self.register_callbacks()
+
+    @property
+    def wallet(self) -> 'Abstract_Wallet':
+        wallet = self._wallet()
+        if wallet is None:
+            raise RuntimeError("CoinFilter used after its wallet was garbage-collected")
+        return wallet
+
+    def diagnostic_name(self):
+        # must not raise.
+        wallet = self._wallet()
+        return wallet.diagnostic_name() if wallet is not None else ""
+
+    def stop(self) -> None:
+        self.unregister_callbacks()
+
+    @property
+    def adb(self):
+        return self.wallet.adb
+
+    def get_utxos(self, domain: Optional[Iterable[str]] = None, **kwargs) -> Sequence[PartialTxInput]:
+        if domain is None:
+            domain = self.wallet.get_addresses()
+        return self.adb.get_utxos(domain=domain, **kwargs)
+
+    def get_spendable_coins(
+            self,
+            domain: Optional[Iterable[str]] = None,
+            *,
+            nonlocal_only: bool = False,
+            confirmed_only: bool = None,
+            ignore_coin_control: bool = False,
+    ) -> Sequence[PartialTxInput]:
+        """The coins we are allowed to spend.
+
+        confirmed_only: tri-state, None defers to config
+        ignore_coin_control: skip the user's manual selection.
+        """
+        with self.lock:
+            frozen_addresses = self._frozen_addresses.copy()
+            selection = None if ignore_coin_control else self._selection.copy()
+        if confirmed_only is None:
+            confirmed_only = self.config.WALLET_SPEND_CONFIRMED_ONLY
+        utxos = self.get_utxos(
+            domain=domain,
+            excluded_addresses=frozen_addresses,
+            mature_only=True,
+            confirmed_funding_only=confirmed_only,
+            nonlocal_only=nonlocal_only,
+        )
+        utxos = [utxo for utxo in utxos if not self.is_frozen_coin(utxo)]
+        if selection:
+            # note: compose with the filters above, never replace them. this is
+            # what keeps a coin that was frozen *after* being selected, or one
+            # excluded by confirmed_only/nonlocal_only, out of the spend set.
+            utxos = [utxo for utxo in utxos if utxo.prevout.to_str() in selection]
+        return utxos
+
+    def get_coins_for_outpoints(
+            self,
+            outpoints: Iterable[CoinType],
+            *,
+            domain: Optional[Iterable[str]] = None,
+            **kwargs,
+    ) -> Sequence[PartialTxInput]:
+        """Resolve an explicit list of outpoints to spendable coins.
+
+        Used for one-shot overrides such as the CLI's --from_coins. Ignores
+        any stored coin control selection. Raises if an outpoint is unknown
+        or unspendable. Duplicates are dropped, keeping first-seen order:
+        returning a coin twice would build a tx spending it twice.
+        """
+        wanted = []  # type: List[str]
+        seen = set()  # type: Set[str]
+        for op in outpoints:
+            op = outpoint_str(op)
+            if op not in seen:
+                seen.add(op)
+                wanted.append(op)
+        coins = self.get_spendable_coins(domain, ignore_coin_control=True, **kwargs)
+        by_outpoint = {coin.prevout.to_str(): coin for coin in coins}
+        for op in wanted:
+            if op not in by_outpoint:
+                raise UserFacingException(
+                    _("Unknown or unspendable coin: {}").format(op))
+        return [by_outpoint[op] for op in wanted]
+
+    def is_frozen_address(self, addr: str) -> bool:
+        return addr in self._frozen_addresses
+
+    def is_frozen_coin(self, utxo: PartialTxInput) -> bool:
+        prevout_str = utxo.prevout.to_str()
+        frozen = self._frozen_coins.get(prevout_str, None)
+        # frozen is a tri-state, True/False if the user explicitly set it,
+        # None otherwise.
+        if frozen is not None:  # user has explicitly set the state
+            return bool(frozen)
+        # State not set. We implicitly mark certain coins as frozen:
+        tx_mined_status = self.adb.get_tx_height(utxo.prevout.txid.hex())
+        if tx_mined_status.height() == TX_HEIGHT_FUTURE:
+            return True
+        if self._is_coin_small_and_unconfirmed(utxo):
+            return True
+        addr = utxo.address
+        assert addr is not None
+        if self.config.WALLET_FREEZE_REUSED_ADDRESS_UTXOS and self.adb.is_used_as_from_address(addr):
+            return True
+        return False
+
+    def _is_coin_small_and_unconfirmed(self, utxo: PartialTxInput) -> bool:
+        """If true, the coin should not be spent.
+        The idea here is that an attacker might send us a UTXO in a
+        large low-fee unconfirmed tx that will ~never confirm. If we
+        spend it as part of a tx ourselves, that too will not confirm
+        (unless we use a high fee, but that might not be worth it for
+        a small value UTXO).
+        In particular, this test triggers for large "dusting transactions"
+        that are used for advertising purposes by some entities.
+        see #6960
+        """
+        # confirmed UTXOs are fine; check this first for performance:
+        block_height = utxo.block_height
+        assert block_height is not None
+        if block_height > 0:
+            return False
+        # exempt large value UTXOs
+        value_sats = utxo.value_sats()
+        assert value_sats is not None
+        threshold = self.config.WALLET_UNCONF_UTXO_FREEZE_THRESHOLD_SAT
+        if value_sats >= threshold:
+            return False
+        # if funding tx has any is_mine input, then UTXO is fine
+        funding_tx = self.db.get_transaction(utxo.prevout.txid.hex())
+        if funding_tx is None:
+            # we should typically have the funding tx available;
+            # might not have it e.g. while not up_to_date
+            return True
+        if any(self.wallet.is_mine(self.adb.get_txin_address(txin))
+               for txin in funding_tx.inputs()):
+            return False
+        return True
+
+    def filter_frozen(self, coins: Sequence[PartialTxInput]) -> List[PartialTxInput]:
+        return [utxo for utxo in coins
+                if (not self.is_frozen_address(utxo.address)
+                    and not self.is_frozen_coin(utxo))]
+
+    def set_frozen_state_of_addresses(
+        self,
+        addrs: Iterable[str],
+        freeze: bool,
+        *,
+        write_to_disk: bool = True,
+    ) -> bool:
+        """Set frozen state of the addresses to FREEZE, True or False"""
+        addrs = list(addrs)
+        if all(self.wallet.is_mine(addr) for addr in addrs):
+            with self.lock:
+                if freeze:
+                    self._frozen_addresses |= set(addrs)
+                else:
+                    self._frozen_addresses -= set(addrs)
+                self.db.put('frozen_addresses', list(self._frozen_addresses))
+            self._notify_frozen_changed(addresses=set(addrs), outpoints=set())
+            if write_to_disk:
+                self.wallet.save_db()
+            return True
+        return False
+
+    def set_frozen_state_of_coins(
+        self,
+        utxos: Iterable[str],
+        freeze: Optional[bool],  # tri-state
+        *,
+        write_to_disk: bool = True,
+    ) -> None:
+        """Set frozen state of the utxos to `freeze`, True or False (or None).
+        A value of True/False means the user explicitly set if the coin should be frozen.
+        In contrast, None is the default "unset" state. If unset, is_frozen_coin()
+        can decide whether a coin should be frozen.
+        """
+        utxos = [outpoint_str(utxo) for utxo in utxos]
+        # basic sanity check that input is not garbage: (see if raises)
+        [TxOutpoint.from_str(utxo) for utxo in utxos]
+        assert freeze in (None, False, True), f"{freeze=!r}"
+        with self.lock:
+            for utxo in utxos:
+                if freeze is None:
+                    self._frozen_coins.pop(utxo, None)
+                else:
+                    self._frozen_coins[utxo] = bool(freeze)
+        self._notify_frozen_changed(addresses=set(), outpoints=set(utxos))
+        if write_to_disk:
+            self.wallet.save_db()
+
+    def get_frozen_balance(self) -> tuple[int, int, int]:
+        with self.lock:
+            frozen_addresses = self._frozen_addresses.copy()
+        # note: for coins, use is_frozen_coin instead of _frozen_coins,
+        #       as latter only contains *manually* frozen ones
+        frozen_coins = {utxo.prevout.to_str() for utxo in self.get_utxos()
+                        if self.is_frozen_coin(utxo)}
+        if not frozen_coins:  # shortcut
+            return self.adb.get_balance(frozen_addresses)
+        c1, u1, x1 = self.wallet.get_balance()
+        c2, u2, x2 = self.wallet.get_balance(
+            excluded_addresses=frozen_addresses,
+            excluded_coins=frozen_coins,
+        )
+        return c1-c2, u1-u2, x1-x2
+
+    def get_frozen_balance_str(self) -> Optional[str]:
+        frozen_bal = sum(self.get_frozen_balance())
+        if not frozen_bal:
+            return None
+        return self.config.format_amount_and_units(frozen_bal)
+
+    def is_coin_control_active(self) -> bool:
+        with self.lock:
+            return bool(self._selection)
+
+    def get_selection(self) -> Set[str]:
+        """The raw stored outpoints. Not filtered; for display/introspection."""
+        with self.lock:
+            return set(self._selection)
+
+    def is_selected(self, coin: CoinType) -> bool:
+        with self.lock:
+            return outpoint_str(coin) in self._selection
+
+    def _selectable_outpoints(self) -> Set[str]:
+        """Coins that may be added to the selection: currently unspent and not
+        frozen. Deliberately laxer than get_spendable_coins() -- an unconfirmed
+        coin can be selected even while WALLET_SPEND_CONFIRMED_ONLY is set; the
+        read-time filter drops it and the status reports num_usable < num_selected.
+        """
+        return {utxo.prevout.to_str() for utxo in self.filter_frozen(self.get_utxos())}
+
+    def select_coins(self, coins: Iterable[CoinType], *, strict: bool = False) -> Set[str]:
+        """Add coins to the selection. Returns the outpoints actually added.
+
+        Silently skips outpoints that are not currently spendable, unless
+        `strict`, in which case it raises. (Returning the added set is what lets
+        the GUI warn rather than crash; see #10206.)
+        """
+        wanted = {outpoint_str(c) for c in coins}
+        if not wanted:
+            return set()
+        selectable = self._selectable_outpoints()
+        rejected = wanted - selectable
+        if rejected and strict:
+            raise UserFacingException(
+                _("Cannot select coin, it is unknown, already spent or frozen: {}")
+                .format(sorted(rejected)[0]))
+        with self.lock:
+            added = (wanted - rejected) - self._selection
+            self._selection |= added
+        if added:
+            self._notify_coin_control_changed(added=added, removed=set(), reason='user')
+        return added
+
+    def deselect_coins(self, coins: Iterable[CoinType]) -> Set[str]:
+        wanted = {outpoint_str(c) for c in coins}
+        with self.lock:
+            removed = wanted & self._selection
+            self._selection -= removed
+        if removed:
+            self._notify_coin_control_changed(added=set(), removed=removed, reason='user')
+        return removed
+
+    def set_selection(self, coins: Iterable[CoinType]) -> Set[str]:
+        """Replace the selection wholesale."""
+        wanted = {outpoint_str(c) for c in coins} & self._selectable_outpoints()
+        with self.lock:
+            added = wanted - self._selection
+            removed = self._selection - wanted
+            self._selection = set(wanted)
+        if added or removed:
+            self._notify_coin_control_changed(added=added, removed=removed, reason='user')
+        return added
+
+    def clear_selection(self) -> None:
+        with self.lock:
+            removed = set(self._selection)
+            self._selection.clear()
+        if removed:
+            self._notify_coin_control_changed(added=set(), removed=removed, reason='cleared')
+
+    def toggle_selection(self, coins: Iterable[CoinType]) -> Set[str]:
+        """If coin control is active, turn it off; otherwise select `coins`."""
+        if self.is_coin_control_active():
+            self.clear_selection()
+            return set()
+        return self.select_coins(coins)
+
+    def select_addresses(self, addrs: Iterable[str]) -> Set[str]:
+        coins = self.get_spendable_coins(list(addrs), ignore_coin_control=True)
+        return self.select_coins(coins)
+
+    def deselect_addresses(self, addrs: Iterable[str]) -> Set[str]:
+        outpoints = {utxo.prevout.to_str() for utxo in self.get_utxos(list(addrs))}
+        return self.deselect_coins(outpoints & self.get_selection())
+
+    def get_coin_control_status(self) -> CoinControlStatus:
+        """Everything a frontend needs to render the coin-control indicator."""
+        all_utxos = self.get_utxos()
+        with self.lock:
+            selection = self._selection.copy()
+        if not selection:
+            return CoinControlStatus(
+                is_active=False, num_selected=0, num_usable=0,
+                num_total=len(all_utxos), value_sat=0)
+        unspent = {utxo.prevout.to_str() for utxo in all_utxos}
+        usable = self.get_spendable_coins()
+        return CoinControlStatus(
+            is_active=True,
+            num_selected=len(selection & unspent),
+            num_usable=len(usable),
+            num_total=len(all_utxos),
+            value_sat=sum(utxo.value_sats() for utxo in usable),
+        )
+
+    def _discard(self, outpoints: Set[str], *, reason: str) -> None:
+        with self.lock:
+            removed = outpoints & self._selection
+            self._selection -= removed
+        if removed:
+            self._notify_coin_control_changed(added=set(), removed=removed, reason=reason)
+
+    def _notify_coin_control_changed(self, *, added: Set[str], removed: Set[str], reason: str) -> None:
+        self.logger.debug(f'coin control changed ({reason}): +{len(added)} -{len(removed)}')
+        util.trigger_callback('coin_control_changed', self.wallet, added, removed, reason)
+
+    def _notify_frozen_changed(self, *, addresses: Set[str], outpoints: Set[str]) -> None:
+        util.trigger_callback('frozen_state_changed', self.wallet, addresses, outpoints)
+
+    def _is_our_adb(self, adb) -> bool:
+        wallet = self._wallet()
+        return wallet is not None and adb == wallet.adb
+
+    @event_listener
+    def on_event_adb_added_tx(self, adb, tx_hash: str, tx: 'Transaction'):
+        if not self._is_our_adb(adb):
+            return
+        with self.lock:
+            if not self._selection:
+                return
+            spent = {txin.prevout.to_str() for txin in tx.inputs()} & self._selection
+        if spent:
+            # drop only the coins that were actually spent, and keep the rest of the selection.
+            # clearing everything would silently turn coin control off and let the next send
+            # draw from the whole wallet.
+            self._discard(spent, reason='spent')
+
+    @event_listener
+    def on_event_adb_removed_tx(self, adb, txid: str, tx: Optional['Transaction']):
+        if not self._is_our_adb(adb):
+            return
+        with self.lock:
+            if not self._selection:
+                return
+            # the *funding* tx of a selected coin is gone, so the coin no longer exists
+            gone = {op for op in self._selection if op.startswith(txid + ':')}
+        if gone:
+            self._discard(gone, reason='removed')

--- a/electrum/commands.py
+++ b/electrum/commands.py
@@ -493,11 +493,14 @@ class Commands(Logger):
     async def listunspent(self, wallet: Abstract_Wallet = None):
         """List unspent outputs. Returns the list of unspent transaction
         outputs in your wallet."""
+        coinfilter = wallet.coinfilter
         coins = []
         for txin in wallet.get_utxos():
             d = txin.to_json()
             v = d.pop("value_sats")
             d["value"] = format_satoshis(v)
+            d["frozen"] = coinfilter.is_frozen_coin(txin) or coinfilter.is_frozen_address(txin.address)
+            d["selected"] = coinfilter.is_selected(txin)
             coins.append(d)
         return coins
 
@@ -681,6 +684,44 @@ class Commands(Logger):
         """
         wallet.set_frozen_state_of_coins([coin], False)
         return True
+
+    @command('w')
+    async def select_utxo(self, coins, wallet: Abstract_Wallet = None):
+        """
+        Add UTXOs to the coin control selection. While the selection is non-empty,
+        only the selected coins are used to fund new transactions.
+
+        arg:json:coins:list of outpoints, each in the <txid:index> format
+        """
+        added = wallet.coinfilter.select_coins(coins, strict=True)
+        return sorted(added)
+
+    @command('w')
+    async def unselect_utxo(self, coins=None, wallet: Abstract_Wallet = None):
+        """
+        Remove UTXOs from the coin control selection. Without arguments, clears
+        the whole selection and thus turns coin control off.
+
+        arg:json:coins:list of outpoints; omit to clear the entire selection
+        """
+        coinfilter = wallet.coinfilter
+        if coins is None:
+            coinfilter.clear_selection()
+            return True
+        return sorted(coinfilter.deselect_coins(coins))
+
+    @command('w')
+    async def list_selected_utxos(self, wallet: Abstract_Wallet = None):
+        """List the coin control selection, and whether it is currently active."""
+        coinfilter = wallet.coinfilter
+        status = coinfilter.get_coin_control_status()
+        return {
+            'active': status.is_active,
+            'selected': sorted(coinfilter.get_selection()),
+            'num_usable': status.num_usable,
+            'num_total': status.num_total,
+            'value': format_satoshis(status.value_sat),
+        }
 
     @command('wp')
     async def getprivatekeys(self, address, password=None, wallet: Abstract_Wallet = None):
@@ -1024,9 +1065,11 @@ class Commands(Logger):
             address = await self._resolver(address, wallet)
             amount_sat = satoshis_or_max(amount)
             final_outputs.append(PartialTxOutput.from_address_and_value(address, amount_sat))
-        coins = wallet.get_spendable_coins(domain_addr)
         if domain_coins is not None:
-            coins = [coin for coin in coins if (coin.prevout.to_str() in domain_coins)]
+            coins = wallet.coinfilter.get_coins_for_outpoints(
+                domain_coins, domain=domain_addr)
+        else:
+            coins = wallet.get_spendable_coins(domain_addr)
         tx = wallet.make_unsigned_transaction(
             outputs=final_outputs,
             fee_policy=fee_policy,
@@ -1087,9 +1130,10 @@ class Commands(Logger):
             except transaction.SerializationError as e:
                 raise UserFacingException(f"Failed to deserialize transaction: {e}") from e
         domain_coins = from_coins.split(',') if from_coins else None
-        coins = wallet.get_spendable_coins(None)
         if domain_coins is not None:
-            coins = [coin for coin in coins if (coin.prevout.to_str() in domain_coins)]
+            coins = wallet.coinfilter.get_coins_for_outpoints(domain_coins)
+        else:
+            coins = wallet.get_spendable_coins(None)
         tx.add_info_from_wallet(wallet)
         await tx.add_info_from_network(self.network)
         new_tx = wallet.bump_fee(

--- a/electrum/gui/qml/qeaddresslistmodel.py
+++ b/electrum/gui/qml/qeaddresslistmodel.py
@@ -138,6 +138,12 @@ class QEAddressCoinListModel(QAbstractListModel, QtEventListener):
         if wallet == self.wallet:
             self.setDirty()
 
+    @qt_event_listener
+    def on_event_frozen_state_changed(self, wallet, addresses, outpoints):
+        # the 'held' role of both addresses and coins depends on the frozen state
+        if wallet == self.wallet:
+            self.setDirty()
+
     def rowCount(self, index):
         return len(self._items)
 

--- a/electrum/gui/qml/qeinvoice.py
+++ b/electrum/gui/qml/qeinvoice.py
@@ -446,8 +446,8 @@ class QEInvoice(QObject, QtEventListener):
         def calc_max(address):
             try:
                 outputs = [PartialTxOutput(scriptpubkey=address_to_script(address), value='!')]
-                make_tx = lambda fee_policy, *, confirmed_only=False: self._wallet.wallet.make_unsigned_transaction(
-                    coins=self._wallet.wallet.get_spendable_coins(None),
+                make_tx = lambda fee_policy, *, confirmed_only=None: self._wallet.wallet.make_unsigned_transaction(
+                    coins=self._wallet.wallet.get_spendable_coins(None, confirmed_only=confirmed_only),
                     outputs=outputs,
                     fee_policy=fee_policy,
                     is_sweep=False)

--- a/electrum/gui/qml/qewallet.py
+++ b/electrum/gui/qml/qewallet.py
@@ -241,6 +241,12 @@ class QEWallet(AuthMixin, QObject, QtEventListener):
             if not self.synchronizing:
                 self.historyModel.initModel()  # refresh if dirty
 
+    @qt_event_listener
+    def on_event_frozen_state_changed(self, wallet, addresses, outpoints):
+        if wallet == self.wallet:
+            # frozenBalance, isLowReserve and the piechart all depend on the frozen set
+            self.balanceChanged.emit()
+
     @event_listener
     def on_event_channel(self, wallet, channel):
         if wallet == self.wallet:

--- a/electrum/gui/qt/address_list.py
+++ b/electrum/gui/qt/address_list.py
@@ -25,7 +25,7 @@
 
 import enum
 from enum import IntEnum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Sequence
 
 from PyQt6.QtCore import Qt, QPersistentModelIndex, QModelIndex
 from PyQt6.QtGui import QStandardItemModel, QStandardItem, QFont
@@ -37,6 +37,8 @@ from electrum.plugin import run_hook
 from electrum.bitcoin import is_address
 from electrum.wallet import InternalAddressCorruption
 from electrum.simple_config import SimpleConfig
+
+from electrum.gui.common_qt.util import QtEventListener, qt_event_listener
 
 from .util import MONOSPACE_FONT, ColorScheme, webopen
 from .my_treeview import MyTreeView, MySortModel
@@ -77,7 +79,7 @@ class AddressTypeFilter(IntEnum):
         }[self]
 
 
-class AddressList(MyTreeView):
+class AddressList(MyTreeView, QtEventListener):
 
     class Columns(MyTreeView.BaseColumnsEnum):
         TYPE = enum.auto()
@@ -121,6 +123,18 @@ class AddressList(MyTreeView):
         self.sortByColumn(self.Columns.TYPE, Qt.SortOrder.AscendingOrder)
         if self.config:
             self.configvar_show_toolbar = self.config.cv.GUI_QT_ADDRESSES_TAB_SHOW_TOOLBAR
+        self.register_callbacks()
+        self.destroyed.connect(lambda: self.unregister_callbacks())
+
+    @qt_event_listener
+    def on_event_frozen_state_changed(self, wallet, addresses, outpoints):
+        if wallet != self.wallet:
+            return
+        self.refresh_all()  # frozen addresses are painted blue
+
+    def set_frozen_state_of_addresses(self, addrs: Sequence[str], freeze: bool) -> None:
+        self.wallet.set_frozen_state_of_addresses(addrs, freeze)
+        self.selectionModel().clearSelection()
 
     def on_double_click(self, idx):
         addr = self.get_role_data_for_current_item(col=0, role=self.ROLE_ADDRESS_STR)
@@ -328,24 +342,27 @@ class AddressList(MyTreeView):
                 menu.addAction(_("View on block explorer"), lambda: webopen(addr_URL))
 
             if not self.wallet.is_frozen_address(addr):
-                act = menu.addAction(_("Freeze"), lambda: self.main_window.set_frozen_state_of_addresses([addr], True))
+                act = menu.addAction(_("Freeze"), lambda: self.set_frozen_state_of_addresses([addr], True))
             else:
-                act = menu.addAction(_("Unfreeze"), lambda: self.main_window.set_frozen_state_of_addresses([addr], False))
+                act = menu.addAction(_("Unfreeze"), lambda: self.set_frozen_state_of_addresses([addr], False))
             act.setToolTip(MSG_FREEZE_ADDRESS)
 
         else:
             # multiple items selected
-            act = menu.addAction(_("Freeze"), lambda: self.main_window.set_frozen_state_of_addresses(addrs, True))
+            act = menu.addAction(_("Freeze"), lambda: self.set_frozen_state_of_addresses(addrs, True))
             act.setToolTip(MSG_FREEZE_ADDRESS)
-            act = menu.addAction(_("Unfreeze"), lambda: self.main_window.set_frozen_state_of_addresses(addrs, False))
+            act = menu.addAction(_("Unfreeze"), lambda: self.set_frozen_state_of_addresses(addrs, False))
             act.setToolTip(MSG_FREEZE_ADDRESS)
 
-        coins = self.wallet.get_spendable_coins(addrs)
+        coinfilter = self.wallet.coinfilter
+        # ignore coin_control, we want to know which coins *could* be added,
+        # independently of what is selected right now.
+        coins = coinfilter.get_spendable_coins(addrs, ignore_coin_control=True)
         if coins:
-            if self.main_window.utxo_list.are_in_coincontrol(coins):
-                menu.addAction(_("Remove from coin control"), lambda: self.main_window.utxo_list.remove_from_coincontrol(coins))
+            if all(coinfilter.is_selected(utxo) for utxo in coins):
+                menu.addAction(_("Remove from coin control"), lambda: coinfilter.deselect_addresses(addrs))
             else:
-                menu.addAction(_("Add to coin control"), lambda: self.main_window.utxo_list.add_to_coincontrol(coins))
+                menu.addAction(_("Add to coin control"), lambda: coinfilter.select_addresses(addrs))
 
         run_hook('receive_menu', menu, addrs, self.wallet)
         self.open_menu(menu, position)

--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -579,6 +579,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
     def on_event_recently_opened_wallets_update(self, *args):
         self.update_recently_opened_menu()
 
+    @qt_event_listener
+    def on_event_coin_control_changed(self, wallet, *args):
+        if wallet == self.wallet:
+            self.update_coincontrol_bar()
+
+    @qt_event_listener
+    def on_event_frozen_state_changed(self, wallet, *args):
+        if wallet == self.wallet:
+            self.update_status()  # updates frozen balance in piechart and coincontrol bar
+
     def close_wallet(self):
         if self.wallet:
             self.logger.info(f'close_wallet {self.wallet.storage.get_path()}')
@@ -1117,6 +1127,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.tasks_label.setText(name)
         self.tasks_label.setVisible(num_tasks > 0)
 
+        self.update_coincontrol_bar()
+
     def num_tasks(self):
         # For the moment, all the coroutines in this set are outgoing LN payments,
         # so we can use this to disable buttons for rebalance/swap suggestions
@@ -1415,18 +1427,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.notify(_('Payment failed') + '\n\n' + description + '\n\n' + reason)
 
     def get_coins(self, **kwargs) -> Sequence[PartialTxInput]:
-        coins = self.get_manually_selected_coins()
-        if coins is not None:
-            return coins
-        else:
-            return self.wallet.get_spendable_coins(None, **kwargs)
-
-    def get_manually_selected_coins(self) -> Optional[Sequence[PartialTxInput]]:
-        """Return a list of selected coins or None.
-        Note: None means selection is not being used,
-              while an empty sequence means the user specifically selected that.
-        """
-        return self.utxo_list.get_spend_list()
+        return self.wallet.get_spendable_coins(None, **kwargs)
 
     def broadcast_or_show(self, tx: Transaction, *, invoice: 'Invoice' = None):
         if not tx.is_complete():
@@ -1573,18 +1574,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         else:
             if pi.error:
                 self.show_error(str(pi.error))
-
-    def set_frozen_state_of_addresses(self, addrs, freeze: bool):
-        self.wallet.set_frozen_state_of_addresses(addrs, freeze)
-        self.address_list.refresh_all()
-        self.utxo_list.refresh_all()
-        self.address_list.selectionModel().clearSelection()
-
-    def set_frozen_state_of_coins(self, utxos: Sequence[PartialTxInput], freeze: bool):
-        utxos_str = {utxo.prevout.to_str() for utxo in utxos}
-        self.wallet.set_frozen_state_of_coins(utxos_str, freeze)
-        self.utxo_list.refresh_all()
-        self.utxo_list.selectionModel().clearSelection()
 
     def create_list_tab(self, l):
         w = QWidget()
@@ -1880,12 +1869,24 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         self.coincontrol_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         sb.addWidget(self.coincontrol_label)
 
-        clear_cc_button = EnterButton(_('Reset'), lambda: self.utxo_list.clear_coincontrol())
+        clear_cc_button = EnterButton(_('Reset'), lambda: self.wallet.coinfilter.clear_selection())
         clear_cc_button.setStyleSheet("margin-right: 5px;")
         sb.addPermanentWidget(clear_cc_button)
 
         sb.setVisible(False)
         return sb
+
+    def update_coincontrol_bar(self):
+        # get_coin_control_status walks all utxos, so shortcut the inactive case.
+        coinfilter = self.wallet.coinfilter
+        status = coinfilter.get_coin_control_status() if coinfilter.is_coin_control_active() else None
+        if status and status.is_active:
+            amount_str = self.format_amount_and_units(status.value_sat)
+            num_outputs_str = _("{} outputs available ({} total)").format(
+                status.num_usable, status.num_total)
+            self.set_coincontrol_msg(_("Coin control active") + f': {num_outputs_str}, {amount_str}')
+        else:
+            self.set_coincontrol_msg(None)
 
     def set_coincontrol_msg(self, msg: Optional[str]) -> None:
         if not msg:

--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -251,9 +251,9 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
         outputs = pi.get_onchain_outputs('!')
         if not outputs:
             return
-        make_tx = lambda fee_policy, *, confirmed_only=False: self.wallet.make_unsigned_transaction(
+        make_tx = lambda fee_policy, *, confirmed_only=None: self.wallet.make_unsigned_transaction(
             fee_policy=fee_policy,
-            coins=self.window.get_coins(),
+            coins=self.window.get_coins(confirmed_only=confirmed_only),
             outputs=outputs,
             is_sweep=False)
         try:

--- a/electrum/gui/qt/utxo_list.py
+++ b/electrum/gui/qt/utxo_list.py
@@ -23,7 +23,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Optional, List, Dict, Sequence, Set, TYPE_CHECKING
+from typing import List, Dict, Sequence, TYPE_CHECKING
 import enum
 import copy
 
@@ -38,6 +38,8 @@ from electrum.lnutil import MIN_FUNDING_SAT
 from electrum.util import profiler
 from electrum.plugin import run_hook
 
+from electrum.gui.common_qt.util import QtEventListener, qt_event_listener
+
 from .util import ColorScheme, MONOSPACE_FONT
 from .my_treeview import MyTreeView, MySortModel
 from .new_channel_dialog import NewChannelDialog
@@ -47,8 +49,7 @@ if TYPE_CHECKING:
     from .main_window import ElectrumWindow
 
 
-class UTXOList(MyTreeView):
-    _spend_set: Set[str]  # coins selected by the user to spend from
+class UTXOList(MyTreeView, QtEventListener):
     _utxo_dict: Dict[str, PartialTxInput]  # coin name -> coin
 
     class Columns(MyTreeView.BaseColumnsEnum):
@@ -77,7 +78,6 @@ class UTXOList(MyTreeView):
             main_window=main_window,
             stretch_column=self.stretch_column,
         )
-        self._spend_set = set()
         self._utxo_dict = {}
         self.wallet = self.main_window.wallet
         self.std_model = QStandardItemModel(self)
@@ -86,6 +86,27 @@ class UTXOList(MyTreeView):
         self.setModel(self.proxy)
         self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setSortingEnabled(True)
+        self.register_callbacks()
+        self.destroyed.connect(lambda: self.unregister_callbacks())
+
+    @qt_event_listener
+    def on_event_coin_control_changed(self, wallet, *args):
+        if wallet == self.wallet:
+            self.refresh_all()
+
+    @qt_event_listener
+    def on_event_frozen_state_changed(self, wallet, *args):
+        if wallet == self.wallet:
+            self.refresh_all()
+
+    def set_frozen_state_of_coins(self, utxos: Sequence[PartialTxInput], freeze: bool) -> None:
+        utxos_str = {utxo.prevout.to_str() for utxo in utxos}
+        self.wallet.set_frozen_state_of_coins(utxos_str, freeze)
+        self.selectionModel().clearSelection()
+
+    def set_frozen_state_of_addresses(self, addrs: Sequence[str], freeze: bool) -> None:
+        self.wallet.set_frozen_state_of_addresses(addrs, freeze)
+        self.selectionModel().clearSelection()
 
     def create_toolbar(self, config):
         toolbar, menu = self.create_toolbar_with_menu('')
@@ -100,10 +121,11 @@ class UTXOList(MyTreeView):
 
     @profiler(min_threshold=0.05)
     def update(self):
-        # not calling maybe_defer_update() as it interferes with coincontrol status bar
+        if self.maybe_defer_update():
+            return
         self.proxy.setDynamicSortFilter(False)  # temp. disable re-sorting after every change
         utxos = self.wallet.get_utxos()
-        self._maybe_reset_coincontrol(utxos)
+        self._maybe_close_stale_menu(utxos)
         self._utxo_dict = dict([(utxo.prevout.to_str(), utxo) for utxo in utxos])
         self.std_model.clear()
         self.update_headers(self.__class__.headers)
@@ -130,20 +152,7 @@ class UTXOList(MyTreeView):
         self.filter()
         self.proxy.setDynamicSortFilter(True)
         self.sortByColumn(self.Columns.OUTPOINT, Qt.SortOrder.DescendingOrder)
-        self.update_coincontrol_bar()
         self.num_coins_label.setText(_('{} unspent transaction outputs').format(len(utxos)))
-
-    def update_coincontrol_bar(self):
-        # update coincontrol status bar
-        if bool(self._spend_set):
-            coins = [self._utxo_dict[x] for x in self._spend_set]
-            coins = self._filter_frozen_coins(coins)
-            amount = sum(x.value_sats() for x in coins)
-            amount_str = self.main_window.format_amount_and_units(amount)
-            num_outputs_str = _("{} outputs available ({} total)").format(len(coins), len(self._utxo_dict))
-            self.main_window.set_coincontrol_msg(_("Coin control active") + f': {num_outputs_str}, {amount_str}')
-        else:
-            self.main_window.set_coincontrol_msg(None)
 
     def refresh_row(self, key, row):
         assert row is not None
@@ -160,7 +169,7 @@ class UTXOList(MyTreeView):
         )
         utxo_item[self.Columns.OUTPOINT].setData(sort_key, self.ROLE_SORT_ORDER)
         SELECTED_TO_SPEND_TOOLTIP = _('Coin selected to be spent')
-        if key in self._spend_set:
+        if self.wallet.coinfilter.is_selected(key):
             tooltip = key + "\n" + SELECTED_TO_SPEND_TOOLTIP
             color = ColorScheme.GREEN.as_color(True)
         else:
@@ -182,65 +191,43 @@ class UTXOList(MyTreeView):
         items = self.selected_in_column(self.Columns.OUTPOINT)
         return [x.data(self.ROLE_PREVOUT_STR) for x in items]
 
-    def _filter_frozen_coins(self, coins: List[PartialTxInput]) -> List[PartialTxInput]:
-        coins = [utxo for utxo in coins
-                 if (not self.wallet.is_frozen_address(utxo.address) and
-                     not self.wallet.is_frozen_coin(utxo))]
-        return coins
-
     def are_in_coincontrol(self, coins: List[PartialTxInput]) -> bool:
-        return all([utxo.prevout.to_str() in self._spend_set for utxo in coins])
+        coinfilter = self.wallet.coinfilter
+        return all(coinfilter.is_selected(utxo) for utxo in coins)
 
     def add_to_coincontrol(self, coins: List[PartialTxInput]):
-        assert all(utxo.prevout.to_str() in self._utxo_dict for utxo in coins) # see issue 10206
-        coins = self._filter_frozen_coins(coins)
-        for utxo in coins:
-            self._spend_set.add(utxo.prevout.to_str())
-        self._refresh_coincontrol()
+        # NOTE: select_coins() silently skips coins that are unknown/spent/frozen,
+        # which is what we want here (see issue 10206).
+        self.wallet.coinfilter.select_coins(coins)
+        self._clear_row_selection()
 
     def remove_from_coincontrol(self, coins: List[PartialTxInput]):
-        for utxo in coins:
-            self._spend_set.remove(utxo.prevout.to_str())
-        self._refresh_coincontrol()
+        self.wallet.coinfilter.deselect_coins(coins)
+        self._clear_row_selection()
 
     def clear_coincontrol(self):
-        self._spend_set.clear()
-        self._refresh_coincontrol()
+        self.wallet.coinfilter.clear_selection()
+        self._clear_row_selection()
 
     def add_selection_to_coincontrol(self):
-        if bool(self._spend_set):
-            self.clear_coincontrol()
-            return
+        coinfilter = self.wallet.coinfilter
         selected = self.get_selected_outpoints()
-        coins = [self._utxo_dict[name] for name in selected]
-        if not coins:
+        if not coinfilter.is_coin_control_active() and not selected:
             self.main_window.show_error(_('You need to select coins from the list first.\nUse ctrl+left mouse button to select multiple items'))
             return
-        self.add_to_coincontrol(coins)
+        coinfilter.toggle_selection(selected)
+        self._clear_row_selection()
 
-    def _refresh_coincontrol(self):
-        self.refresh_all()
-        self.update_coincontrol_bar()
+    def _clear_row_selection(self):
         self.selectionModel().clearSelection()
 
-    def get_spend_list(self) -> Optional[Sequence[PartialTxInput]]:
-        if not bool(self._spend_set):
-            return None
-        utxos = [self._utxo_dict[x] for x in self._spend_set]
-        return copy.deepcopy(utxos)  # copy so that side-effects don't affect utxo_dict
-
-    def _maybe_reset_coincontrol(self, current_wallet_utxos: Sequence[PartialTxInput]) -> None:
-        if not self._spend_set and not self._currently_open_menu:
+    def _maybe_close_stale_menu(self, current_wallet_utxos: Sequence[PartialTxInput]) -> None:
+        # if we spent one of the qt-highlighted UTXOs, close context-menu.
+        if not self._currently_open_menu:
             return
         utxo_set = {utxo.prevout.to_str() for utxo in current_wallet_utxos}
-        if self._currently_open_menu:
-            # if we spent one of the qt-highlighted UTXOs, close context-menu
-            if not all(prevout_str in utxo_set for prevout_str in self.get_selected_outpoints()):
-                self.close_menu()
-        if self._spend_set:
-            # if we spent one of the green-marked UTXOs, just reset selection
-            if not all([prevout_str in utxo_set for prevout_str in self._spend_set]):
-                self._spend_set.clear()
+        if not all(prevout_str in utxo_set for prevout_str in self.get_selected_outpoints()):
+            self.close_menu()
 
     def can_swap_coins(self, coins):
         # fixme: min and max_amounts are known only after first request
@@ -309,7 +296,7 @@ class UTXOList(MyTreeView):
         # use copies, avoid mutating
         coins = copy.deepcopy(coins)
 
-        unfrozen_coins = self._filter_frozen_coins(coins)
+        unfrozen_coins = self.wallet.coinfilter.filter_frozen(coins)
         menu = QMenu()
         menu.setSeparatorsCollapsible(True)  # consecutive separators are merged together
 
@@ -348,14 +335,14 @@ class UTXOList(MyTreeView):
             menu_freeze = menu.addMenu(_("Freeze"))
             menu_freeze.setToolTipsVisible(True)
             if not self.wallet.is_frozen_coin(utxo):
-                act = menu_freeze.addAction(_("Freeze Coin"), lambda: self.main_window.set_frozen_state_of_coins([utxo], True))
+                act = menu_freeze.addAction(_("Freeze Coin"), lambda: self.set_frozen_state_of_coins([utxo], True))
             else:
-                act = menu_freeze.addAction(_("Unfreeze Coin"), lambda: self.main_window.set_frozen_state_of_coins([utxo], False))
+                act = menu_freeze.addAction(_("Unfreeze Coin"), lambda: self.set_frozen_state_of_coins([utxo], False))
             act.setToolTip(MSG_FREEZE_COIN)
             if not self.wallet.is_frozen_address(addr):
-                act = menu_freeze.addAction(_("Freeze Address"), lambda: self.main_window.set_frozen_state_of_addresses([addr], True))
+                act = menu_freeze.addAction(_("Freeze Address"), lambda: self.set_frozen_state_of_addresses([addr], True))
             else:
-                act = menu_freeze.addAction(_("Unfreeze Address"), lambda: self.main_window.set_frozen_state_of_addresses([addr], False))
+                act = menu_freeze.addAction(_("Unfreeze Address"), lambda: self.set_frozen_state_of_addresses([addr], False))
             act.setToolTip(MSG_FREEZE_ADDRESS)
         elif len(coins) > 1:  # multiple items selected
             menu.addSeparator()
@@ -365,16 +352,16 @@ class UTXOList(MyTreeView):
             menu_freeze = menu.addMenu(_("Freeze"))
             menu_freeze.setToolTipsVisible(True)
             if not all(is_coin_frozen):
-                act = menu_freeze.addAction(_("Freeze Coins"), lambda: self.main_window.set_frozen_state_of_coins(coins, True))
+                act = menu_freeze.addAction(_("Freeze Coins"), lambda: self.set_frozen_state_of_coins(coins, True))
                 act.setToolTip(MSG_FREEZE_COIN)
             if any(is_coin_frozen):
-                act = menu_freeze.addAction(_("Unfreeze Coins"), lambda: self.main_window.set_frozen_state_of_coins(coins, False))
+                act = menu_freeze.addAction(_("Unfreeze Coins"), lambda: self.set_frozen_state_of_coins(coins, False))
                 act.setToolTip(MSG_FREEZE_COIN)
             if not all(is_addr_frozen):
-                act = menu_freeze.addAction(_("Freeze Addresses"), lambda: self.main_window.set_frozen_state_of_addresses(addrs, True))
+                act = menu_freeze.addAction(_("Freeze Addresses"), lambda: self.set_frozen_state_of_addresses(addrs, True))
                 act.setToolTip(MSG_FREEZE_ADDRESS)
             if any(is_addr_frozen):
-                act = menu_freeze.addAction(_("Unfreeze Addresses"), lambda: self.main_window.set_frozen_state_of_addresses(addrs, False))
+                act = menu_freeze.addAction(_("Unfreeze Addresses"), lambda: self.set_frozen_state_of_addresses(addrs, False))
                 act.setToolTip(MSG_FREEZE_ADDRESS)
 
         run_hook('qt_utxo_menu', menu, coins, self.wallet)

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1567,6 +1567,7 @@ class LNWallet(Logger):
                 public=False,
                 opening_base_fee_msat=channel_opening_base_fee_msat,
                 password=password,
+                get_coins=partial(self.wallet.get_spendable_coins, ignore_coin_control=True)
             )
             async def wait_for_channel():
                 while not next_chan.is_open():
@@ -1647,9 +1648,11 @@ class LNWallet(Logger):
             public: bool = False,
             zeroconf: bool = False,
             opening_base_fee_msat: Optional[int] = None,
-            password=None):
+            password=None,
+            get_coins: Callable[..., Sequence[PartialTxInput]] = None,
+    ):
         self.wallet.unlock(password)
-        coins = self.wallet.get_spendable_coins(None)
+        coins = get_coins() if get_coins else self.wallet.get_spendable_coins()
         node_id = peer.pubkey
         fee_policy = FeePolicy(self.config.FEE_POLICY)
         funding_tx = self.mktx_for_open_channel(

--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -1342,7 +1342,8 @@ class SwapManager(Logger):
         """ for server """
         self.percentage = Decimal(self.config.SWAPSERVER_FEE_MILLIONTHS) / 10000  # type: ignore
         self._min_amount = MIN_SWAP_AMOUNT_SAT  # FIXME: adapt to mining fee environment
-        oc_balance_sat: int = self.wallet.get_spendable_balance_sat()
+        # ignore coin_control. advertised amount must not depend on a local UI coin selection.
+        oc_balance_sat: int = self.wallet.get_spendable_balance_sat(ignore_coin_control=True)
         MAX_SWAP_AMT = bitcoin.COIN // 10  # just to minimise accidental damage. not enforced client-side
         max_forward: int = min(int(self.lnworker.num_sats_can_receive()), oc_balance_sat, MAX_SWAP_AMT)
         max_reverse: int = min(int(self.lnworker.num_sats_can_send()), MAX_SWAP_AMT)

--- a/electrum/txbatcher.py
+++ b/electrum/txbatcher.py
@@ -566,7 +566,7 @@ class TxBatch(Logger):
         outputs += to_pay
         inputs += self._create_inputs_from_tx_change(self._parent_tx) if self._parent_tx else []
         # create tx
-        coins = self.wallet.get_spendable_coins(nonlocal_only=True)
+        coins = self.wallet.get_spendable_coins(nonlocal_only=True, ignore_coin_control=True)
         tx = self.wallet.make_unsigned_transaction(
             coins=coins,
             fee_policy=self.fee_policy,

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -85,6 +85,7 @@ from .lnutil import MIN_FUNDING_SAT, RECEIVED, SENT
 from .lntransport import extract_nodeid
 from .descriptor import Descriptor
 from .txbatcher import TxBatcher
+from .coinfilter import CoinFilter
 from .submarine_swaps import MIN_SWAP_AMOUNT_SAT
 
 if TYPE_CHECKING:
@@ -443,15 +444,14 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self.use_change            = db.get('use_change', True)
         self.multiple_change       = db.get('multiple_change', False)
         self._labels               = db.get_dict('labels')
-        self._frozen_addresses     = set(db.get('frozen_addresses', []))
-        self._frozen_coins         = db.get_dict('frozen_coins')  # type: Dict[str, bool]
         self.fiat_value            = db.get_dict('fiat_value')
         self._receive_requests     = db.get_dict('payment_requests')  # type: Dict[str, Request]
         self._invoices             = db.get_dict('invoices')  # type: Dict[str, Invoice]
         self._reserved_addresses   = set(db.get('reserved_addresses', []))
         self._num_parents          = db.get_dict('num_parents')
 
-        self._freeze_lock = threading.RLock()  # for mutating/iterating frozen_{addresses,coins}
+        # owns frozen state, the coin-control selection, and the spendable-coin query
+        self.coinfilter = CoinFilter(self)
 
         self.load_keystore()
         self.txbatcher = TxBatcher(self)
@@ -591,6 +591,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     async def stop(self):
         """Stop all networking and save DB to disk."""
         self.unregister_callbacks()
+        self.coinfilter.stop()
         try:
             async with ignore_after(5):
                 if self.lnworker:
@@ -698,6 +699,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     def clear_history(self):
         self.adb.clear_history()
         self._paid_invoice_keys_cache.clear()
+        self.coinfilter.clear_selection()
         self.save_db()
 
     def start_network(self, network: 'Network'):
@@ -1151,9 +1153,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             domain: Optional[Iterable[str]] = None,
             **kwargs,
     ) -> Sequence[PartialTxInput]:
-        if domain is None:
-            domain = self.get_addresses()
-        return self.adb.get_utxos(domain=domain, **kwargs)
+        return self.coinfilter.get_utxos(domain, **kwargs)
 
     def get_spendable_coins(
             self,
@@ -1161,20 +1161,17 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             *,
             nonlocal_only: bool = False,
             confirmed_only: bool = None,
+            ignore_coin_control: bool = False,
     ) -> Sequence[PartialTxInput]:
-        with self._freeze_lock:
-            frozen_addresses = self._frozen_addresses.copy()
-        if confirmed_only is None:
-            confirmed_only = self.config.WALLET_SPEND_CONFIRMED_ONLY
-        utxos = self.get_utxos(
-            domain=domain,
-            excluded_addresses=frozen_addresses,
-            mature_only=True,
-            confirmed_funding_only=confirmed_only,
+        """Note: honours the user's coin-control selection by default.
+        Background/policy paths must pass ignore_coin_control=True.
+        """
+        return self.coinfilter.get_spendable_coins(
+            domain,
             nonlocal_only=nonlocal_only,
+            confirmed_only=confirmed_only,
+            ignore_coin_control=ignore_coin_control,
         )
-        utxos = [utxo for utxo in utxos if not self.is_frozen_coin(utxo)]
-        return utxos
 
     @abstractmethod
     def get_receiving_addresses(self, *, slice_start=None, slice_stop=None) -> Sequence[str]:
@@ -1189,20 +1186,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         return self.get_receiving_addresses(slice_start=0, slice_stop=1)[0]
 
     def get_frozen_balance(self) -> tuple[int, int, int]:
-        with self._freeze_lock:
-            frozen_addresses = self._frozen_addresses.copy()
-        # note: for coins, use is_frozen_coin instead of _frozen_coins,
-        #       as latter only contains *manually* frozen ones
-        frozen_coins = {utxo.prevout.to_str() for utxo in self.get_utxos()
-                        if self.is_frozen_coin(utxo)}
-        if not frozen_coins:  # shortcut
-            return self.adb.get_balance(frozen_addresses)
-        c1, u1, x1 = self.get_balance()
-        c2, u2, x2 = self.get_balance(
-            excluded_addresses=frozen_addresses,
-            excluded_coins=frozen_coins,
-        )
-        return c1-c2, u1-u2, x1-x2
+        return self.coinfilter.get_frozen_balance()
 
     def get_balances_for_piechart(self) -> PiechartBalance:
         """Note: intended for display-purposes.
@@ -1969,7 +1953,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if not is_reserve_needed:
             return False
 
-        coins_in_wallet = self.get_spendable_coins(nonlocal_only=False, confirmed_only=False)
+        coins_in_wallet = self.get_spendable_coins(
+            nonlocal_only=False, confirmed_only=False, ignore_coin_control=True)
         prevout_coins_in_wallet = set(c.prevout for c in coins_in_wallet)
         amount_in_wallet = sum(c.value_sats() for c in coins_in_wallet)
 
@@ -1993,7 +1978,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
             # tx has a reserve change output
             return reserve_output_amount
         if gui_spend_max:  # user tried to spend max amount
-            coins_in_wallet = self.get_spendable_coins(nonlocal_only=False, confirmed_only=False)
+            coins_in_wallet = self.get_spendable_coins(
+                nonlocal_only=False, confirmed_only=False, ignore_coin_control=True)
             amount_in_wallet = sum(c.value_sats() for c in coins_in_wallet)
             tx_spend_amount = tx.output_value() + tx.get_fee()
             if amount_in_wallet - tx_spend_amount == self.config.LN_UTXO_RESERVE:
@@ -2197,61 +2183,14 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         run_hook('make_unsigned_transaction', self, tx)
         return tx
 
+    # frozen state lives in CoinFilter. these are delegating shims kept so
+    # existing callers (gui, commands, bip329, plugins) work.
+
     def is_frozen_address(self, addr: str) -> bool:
-        return addr in self._frozen_addresses
+        return self.coinfilter.is_frozen_address(addr)
 
     def is_frozen_coin(self, utxo: PartialTxInput) -> bool:
-        prevout_str = utxo.prevout.to_str()
-        frozen = self._frozen_coins.get(prevout_str, None)
-        # note: there are three possible states for 'frozen':
-        #       True/False if the user explicitly set it,
-        #       None otherwise
-        if frozen is not None:  # user has explicitly set the state
-            return bool(frozen)
-        # State not set. We implicitly mark certain coins as frozen:
-        tx_mined_status = self.adb.get_tx_height(utxo.prevout.txid.hex())
-        if tx_mined_status.height() == TX_HEIGHT_FUTURE:
-            return True
-        if self._is_coin_small_and_unconfirmed(utxo):
-            return True
-        addr = utxo.address
-        assert addr is not None
-        if self.config.WALLET_FREEZE_REUSED_ADDRESS_UTXOS and self.adb.is_used_as_from_address(addr):
-            return True
-        return False
-
-    def _is_coin_small_and_unconfirmed(self, utxo: PartialTxInput) -> bool:
-        """If true, the coin should not be spent.
-        The idea here is that an attacker might send us a UTXO in a
-        large low-fee unconfirmed tx that will ~never confirm. If we
-        spend it as part of a tx ourselves, that too will not confirm
-        (unless we use a high fee, but that might not be worth it for
-        a small value UTXO).
-        In particular, this test triggers for large "dusting transactions"
-        that are used for advertising purposes by some entities.
-        see #6960
-        """
-        # confirmed UTXOs are fine; check this first for performance:
-        block_height = utxo.block_height
-        assert block_height is not None
-        if block_height > 0:
-            return False
-        # exempt large value UTXOs
-        value_sats = utxo.value_sats()
-        assert value_sats is not None
-        threshold = self.config.WALLET_UNCONF_UTXO_FREEZE_THRESHOLD_SAT
-        if value_sats >= threshold:
-            return False
-        # if funding tx has any is_mine input, then UTXO is fine
-        funding_tx = self.db.get_transaction(utxo.prevout.txid.hex())
-        if funding_tx is None:
-            # we should typically have the funding tx available;
-            # might not have it e.g. while not up_to_date
-            return True
-        if any(self.is_mine(self.adb.get_txin_address(txin))
-               for txin in funding_tx.inputs()):
-            return False
-        return True
+        return self.coinfilter.is_frozen_coin(utxo)
 
     def set_frozen_state_of_addresses(
         self,
@@ -2260,19 +2199,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         *,
         write_to_disk: bool = True,
     ) -> bool:
-        """Set frozen state of the addresses to FREEZE, True or False"""
-        if all(self.is_mine(addr) for addr in addrs):
-            with self._freeze_lock:
-                if freeze:
-                    self._frozen_addresses |= set(addrs)
-                else:
-                    self._frozen_addresses -= set(addrs)
-                self.db.put('frozen_addresses', list(self._frozen_addresses))
-            util.trigger_callback('status')
-            if write_to_disk:
-                self.save_db()
-            return True
-        return False
+        return self.coinfilter.set_frozen_state_of_addresses(
+            addrs, freeze, write_to_disk=write_to_disk)
 
     def set_frozen_state_of_coins(
         self,
@@ -2281,23 +2209,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         *,
         write_to_disk: bool = True,
     ) -> None:
-        """Set frozen state of the utxos to `freeze`, True or False (or None).
-        A value of True/False means the user explicitly set if the coin should be frozen.
-        In contrast, None is the default "unset" state. If unset, is_frozen_coin()
-        can decide whether a coin should be frozen.
-        """
-        # basic sanity check that input is not garbage: (see if raises)
-        [TxOutpoint.from_str(utxo) for utxo in utxos]
-        assert freeze in (None, False, True), f"{freeze=!r}"
-        with self._freeze_lock:
-            for utxo in utxos:
-                if freeze is None:
-                    self._frozen_coins.pop(utxo, None)
-                else:
-                    self._frozen_coins[utxo] = bool(freeze)
-        util.trigger_callback('status')
-        if write_to_disk:
-            self.save_db()
+        self.coinfilter.set_frozen_state_of_coins(
+            utxos, freeze, write_to_disk=write_to_disk)
 
     def is_address_reserved(self, addr: str) -> bool:
         # note: atm 'reserved' status is only taken into consideration for 'change addresses'
@@ -3710,8 +3623,18 @@ class Abstract_Wallet(ABC, Logger, EventListener):
     ) -> str:
         """Generate 'Not enough funds' text.
         Include mention of frozen coins (and append optional hint), iff unfreezing would satisfy for_amount
+        Also mention coin control, if an active selection is what is holding us back.
         """
         text = _('Not enough funds')
+        if (cc := self.coinfilter.get_coin_control_status()).is_active:
+            unrestricted = self.get_spendable_balance_sat(ignore_coin_control=True)
+            needed = for_amount if isinstance(for_amount, int) else cc.value_sat + 1
+            if unrestricted > needed:
+                text += " " + _('(coin control is active: only {} of {} coins, {} can be used)').format(
+                    cc.num_usable, cc.num_total, self.config.format_amount_and_units(cc.value_sat))
+                if hint:
+                    text += '. ' + hint
+                return text
         if for_amount is not None:
             if frozen_bal := sum(self.get_frozen_balance()):
                 frozen_str = None

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -3668,6 +3668,7 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         name = sweep_info.name
         # outputs = [] will send coins to a change address
         tx = self.make_unsigned_transaction(
+            coins=self.get_spendable_coins(ignore_coin_control=True),
             inputs=[txin],
             outputs=[],
             fee_policy=FixedFeePolicy(0),

--- a/tests/test_coinfilter.py
+++ b/tests/test_coinfilter.py
@@ -1,0 +1,459 @@
+import asyncio
+import gc
+import weakref
+
+from electrum import keystore, SimpleConfig, util
+from electrum.address_synchronizer import TX_HEIGHT_UNCONFIRMED
+from electrum.fee_policy import FixedFeePolicy
+from electrum.commands import Commands
+from electrum.transaction import Transaction, PartialTxOutput, tx_from_any
+from electrum.util import NotEnoughFunds, UserFacingException
+
+from . import ElectrumTestCase
+from .test_wallet_vertical import WalletIntegrityHelper
+
+
+async def fast_sleep():
+    # sleep a few event loop iterations, so queued callbacks get to run
+    for i in range(5):
+        await asyncio.sleep(0)
+
+
+# same fixtures as TestWalletSending.test_get_spendable_coins
+SEED = 'frost repair depend effort salon ring foam oak cancel receive save usage'
+FUNDING_TX1 = '01000000000102acd6459dec7c3c51048eb112630da756f5d4cb4752b8d39aa325407ae0885cba020000001716001455c7f5e0631d8e6f5f05dddb9f676cec48845532fdffffffd146691ef6a207b682b13da5f2388b1f0d2a2022c8cfb8dc27b65434ec9ec8f701000000171600147b3be8a7ceaf15f57d7df2a3d216bc3c259e3225fdffffff02a9875b000000000017a914ea5a99f83e71d1c1dfc5d0370e9755567fe4a141878096980000000000160014d4ca56fcbad98fb4dcafdc573a75d6a6fffb09b702483045022100dde1ba0c9a2862a65791b8d91295a6603207fb79635935a67890506c214dd96d022046c6616642ef5971103c1db07ac014e63fa3b0e15c5729eacdd3e77fcb7d2086012103a72410f185401bb5b10aaa30989c272b554dc6d53bda6da85a76f662723421af024730440220033d0be8f74e782fbcec2b396647c7715d2356076b442423f23552b617062312022063c95cafdc6d52ccf55c8ee0f9ceb0f57afb41ea9076eb74fe633f59c50c6377012103b96a4954d834fbcfb2bbf8cf7de7dc2b28bc3d661c1557d1fd1db1bfc123a94abb391400'
+FUNDING_TX2 = '01000000000101c0ec8b6cdcb6638fa117ead71a8edebc189b30e6e5415bdfb3c8260aa269e6520000000017160014ba9ca815474a674ff1efb3fc82cf0f3460de8c57fdffffff0230390f000000000017a9148b59abaca8215c0d4b18cbbf715550aa2b50c85b87404b4c000000000016001483c3bc7234f17a209cc5dcce14903b54ee4dab9002473044022038a05f7d38bcf810dfebb39f1feda5cc187da4cf5d6e56986957ddcccedc75d302203ab67ccf15431b4e2aeeab1582b9a5a7821e7ac4be8ebf512505dbfdc7e094fd0121032168234e0ba465b8cedc10173ea9391725c0f6d9fa517641af87926626a5144abd391400'
+
+UTXO1 = 'c36a6e1cd54df108e69574f70bc9b88dc13beddc70cfad9feb7f8f6593255d4a:1'  # 5_000_000 sat
+UTXO2 = '52e669a20a26c8b3df5b41e5e6309b18bcde8e1ad7ea17a18f63b6dc6c8becc0:1'  # 10_000_000 sat
+UTXO2_ADDR = 'tb1q6n99dl96mx8mfh90m3tn5awk5mllkzdh25dw7z'
+
+OTHER_ADDR = 'tb1q0ezagv55krljkz9973fryeyczhj3dnlsgr02g7'
+
+
+class TestCoinFilter(ElectrumTestCase):
+    TESTNET = True
+
+    def setUp(self):
+        super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+
+    def create_wallet(self):
+        ks = keystore.from_seed(SEED, passphrase='', for_multisig=False)
+        wallet = WalletIntegrityHelper.create_standard_wallet(ks, gap_limit=2, config=self.config)
+        for raw in (FUNDING_TX1, FUNDING_TX2):
+            wallet.adb.receive_tx_callback(Transaction(raw), tx_height=TX_HEIGHT_UNCONFIRMED)
+        return wallet
+
+    @staticmethod
+    def outpoints(coins):
+        return {txi.prevout.to_str() for txi in coins}
+
+    async def test_fixture_sanity(self):
+        wallet = self.create_wallet()
+        self.assertEqual((0, 15_000_000, 0), wallet.get_balance())
+        self.assertEqual({UTXO1, UTXO2}, self.outpoints(wallet.get_spendable_coins()))
+        self.assertFalse(wallet.coinfilter.is_coin_control_active())
+
+    # composition with the policy filters
+
+    async def test_selection_narrows_spendable_coins(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        self.assertEqual({UTXO1}, coinfilter.select_coins([UTXO1]))
+        self.assertTrue(coinfilter.is_coin_control_active())
+        self.assertEqual({UTXO1}, self.outpoints(wallet.get_spendable_coins()))
+        # ...but the raw utxo set is untouched
+        self.assertEqual({UTXO1, UTXO2}, self.outpoints(wallet.get_utxos()))
+
+    async def test_selection_composes_with_frozen_coin(self):
+        """Freezing a coin *after* selecting it must remove it from the spend set.
+        """
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1, UTXO2])
+        self.assertEqual({UTXO1, UTXO2}, self.outpoints(wallet.get_spendable_coins()))
+        wallet.set_frozen_state_of_coins([UTXO1], True)
+        self.assertEqual({UTXO2}, self.outpoints(wallet.get_spendable_coins()))
+        status = coinfilter.get_coin_control_status()
+        self.assertTrue(status.is_active)
+        self.assertEqual(2, status.num_selected)
+        self.assertEqual(1, status.num_usable)  # honest about the discrepancy
+        self.assertEqual(10_000_000, status.value_sat)
+
+    async def test_selection_composes_with_frozen_address(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1, UTXO2])
+        wallet.set_frozen_state_of_addresses([UTXO2_ADDR], True)
+        self.assertEqual({UTXO1}, self.outpoints(wallet.get_spendable_coins()))
+
+    async def test_selection_composes_with_confirmed_only(self):
+        """confirmed_only must still be honoured while coin control is active.
+        """
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1])
+        # both fixtures are unconfirmed
+        self.assertEqual(set(), self.outpoints(wallet.get_spendable_coins(confirmed_only=True)))
+        self.assertEqual({UTXO1}, self.outpoints(wallet.get_spendable_coins(confirmed_only=False)))
+
+    async def test_selection_composes_with_nonlocal_only(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        tx = self._spend_utxo(wallet, UTXO1)
+        change = [txo for txo in tx.outputs() if wallet.is_mine(txo.address)]
+        self.assertTrue(change, "expected a change output funded by a local tx")
+        local_op = f'{tx.txid()}:{tx.outputs().index(change[0])}'
+        coinfilter.select_coins([local_op])
+        self.assertEqual({local_op}, self.outpoints(wallet.get_spendable_coins()))
+        self.assertEqual(set(), self.outpoints(wallet.get_spendable_coins(nonlocal_only=True)))
+
+    async def test_selection_composes_with_domain(self):
+        wallet = self.create_wallet()
+        wallet.coinfilter.select_coins([UTXO1, UTXO2])
+        self.assertEqual({UTXO2}, self.outpoints(wallet.get_spendable_coins([UTXO2_ADDR])))
+
+    # pruning
+
+    def _spend_utxo(self, wallet, outpoint: str, *, height=None):
+        """Build+sign a tx spending `outpoint` and register it with the adb.
+
+        height=None adds it as a local (unbroadcast) tx, which is enough to mark
+        the input spent; pass a height to also give it a mined status.
+        """
+        coin = [c for c in wallet.get_utxos() if c.prevout.to_str() == outpoint]
+        assert coin, f"{outpoint} not in wallet"
+        tx = wallet.make_unsigned_transaction(
+            coins=coin,
+            outputs=[PartialTxOutput.from_address_and_value(OTHER_ADDR, 1_000_000)],
+            fee_policy=FixedFeePolicy(5000),
+        )
+        wallet.sign_transaction(tx, password=None)
+        if height is None:
+            wallet.adb.add_transaction(tx)
+        else:
+            wallet.adb.receive_tx_callback(tx, tx_height=height)
+        return tx
+
+    async def test_selection_pruned_on_spend_keeps_the_rest(self):
+        """Spending one selected coin must not silently disable coin control."""
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1, UTXO2])
+        self._spend_utxo(wallet, UTXO1)
+        await fast_sleep()
+        self.assertEqual({UTXO2}, coinfilter.get_selection())
+        self.assertTrue(coinfilter.is_coin_control_active())
+
+    async def test_selection_inactive_when_all_selected_coins_spent(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1])
+        self._spend_utxo(wallet, UTXO1)
+        await fast_sleep()
+        self.assertEqual(set(), coinfilter.get_selection())
+        self.assertFalse(coinfilter.is_coin_control_active())
+        # falls back to the whole wallet (UTXO2, plus the change of the spend)
+        spendable = self.outpoints(wallet.get_spendable_coins())
+        self.assertIn(UTXO2, spendable)
+        self.assertNotIn(UTXO1, spendable)
+        self.assertGreater(len(spendable), 1)
+
+    async def test_selection_pruned_when_funding_tx_removed(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1, UTXO2])
+        wallet.adb.remove_transaction(UTXO1.split(':')[0])
+        await fast_sleep()
+        self.assertEqual({UTXO2}, coinfilter.get_selection())
+
+    async def test_events_dont_leak_across_wallets(self):
+        wallet1 = self.create_wallet()
+        wallet2 = self.create_wallet()
+        wallet2.coinfilter.select_coins([UTXO1, UTXO2])
+        self._spend_utxo(wallet1, UTXO1)
+        await fast_sleep()
+        # wallet2 has its own adb; its selection must be untouched
+        self.assertEqual({UTXO1, UTXO2}, wallet2.coinfilter.get_selection())
+
+    # integration with tx building
+
+    async def test_make_unsigned_transaction_honours_selection(self):
+        wallet = self.create_wallet()
+        wallet.coinfilter.select_coins([UTXO2])
+        tx = wallet.make_unsigned_transaction(
+            outputs=[PartialTxOutput.from_address_and_value(OTHER_ADDR, 1_000_000)],
+            fee_policy=FixedFeePolicy(5000),
+        )
+        self.assertEqual({UTXO2}, {txin.prevout.to_str() for txin in tx.inputs()})
+
+    async def test_make_unsigned_transaction_raises_when_selection_too_small(self):
+        wallet = self.create_wallet()
+        wallet.coinfilter.select_coins([UTXO1])  # 5_000_000 sat
+        with self.assertRaises(NotEnoughFunds):
+            wallet.make_unsigned_transaction(
+                outputs=[PartialTxOutput.from_address_and_value(OTHER_ADDR, 12_000_000)],
+                fee_policy=FixedFeePolicy(5000),
+            )
+
+    async def test_background_paths_ignore_selection(self):
+        """The ignore_coin_control audit, locked in."""
+        wallet = self.create_wallet()
+        wallet.coinfilter.select_coins([UTXO1])
+        self.assertEqual(
+            {UTXO1, UTXO2},
+            self.outpoints(wallet.get_spendable_coins(ignore_coin_control=True)))
+        self.assertEqual(
+            15_000_000,
+            wallet.get_spendable_balance_sat(ignore_coin_control=True))
+        # ...while the user-facing balance does reflect the selection
+        self.assertEqual(5_000_000, wallet.get_spendable_balance_sat())
+
+    # write-time validation
+
+    async def test_get_coins_for_outpoints_deduplicates(self):
+        """Returning a coin twice would build a tx that spends it twice."""
+        wallet = self.create_wallet()
+        coins = wallet.coinfilter.get_coins_for_outpoints([UTXO1, UTXO2, UTXO1])
+        self.assertEqual([UTXO1, UTXO2], [c.prevout.to_str() for c in coins])
+
+    async def test_get_coins_for_outpoints_keeps_first_seen_order(self):
+        wallet = self.create_wallet()
+        coins = wallet.coinfilter.get_coins_for_outpoints([UTXO2, UTXO1, UTXO2])
+        self.assertEqual([UTXO2, UTXO1], [c.prevout.to_str() for c in coins])
+
+    async def test_get_coins_for_outpoints_still_validates_duplicates(self):
+        wallet = self.create_wallet()
+        bogus = '00' * 32 + ':7'
+        with self.assertRaises(UserFacingException):
+            wallet.coinfilter.get_coins_for_outpoints([bogus, bogus])
+
+    async def test_duplicate_from_coins_does_not_double_spend(self):
+        """End to end: a repeated outpoint must not appear twice in the tx."""
+        wallet = self.create_wallet()
+        coins = wallet.coinfilter.get_coins_for_outpoints([UTXO1, UTXO1])
+        tx = wallet.make_unsigned_transaction(
+            coins=coins,
+            outputs=[PartialTxOutput.from_address_and_value(OTHER_ADDR, 1_000_000)],
+            fee_policy=FixedFeePolicy(5000),
+        )
+        prevouts = [txin.prevout.to_str() for txin in tx.inputs()]
+        self.assertEqual(len(prevouts), len(set(prevouts)))
+        self.assertEqual([UTXO1], prevouts)
+
+    async def test_select_skips_unknown_outpoint(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        bogus = '00' * 32 + ':7'
+        self.assertEqual({UTXO1}, coinfilter.select_coins([UTXO1, bogus]))
+        self.assertEqual({UTXO1}, coinfilter.get_selection())
+
+    async def test_select_strict_raises_on_unknown_outpoint(self):
+        wallet = self.create_wallet()
+        with self.assertRaises(UserFacingException):
+            wallet.coinfilter.select_coins(['00' * 32 + ':7'], strict=True)
+
+    async def test_select_skips_frozen_coin(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        wallet.set_frozen_state_of_coins([UTXO1], True)
+        self.assertEqual({UTXO2}, coinfilter.select_coins([UTXO1, UTXO2]))
+
+    async def test_toggle_selection(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.toggle_selection([UTXO1])
+        self.assertEqual({UTXO1}, coinfilter.get_selection())
+        coinfilter.toggle_selection([UTXO2])  # active -> clears instead of adding
+        self.assertEqual(set(), coinfilter.get_selection())
+
+    async def test_select_and_deselect_addresses(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        self.assertEqual({UTXO2}, coinfilter.select_addresses([UTXO2_ADDR]))
+        self.assertEqual({UTXO2}, coinfilter.deselect_addresses([UTXO2_ADDR]))
+        self.assertFalse(coinfilter.is_coin_control_active())
+
+    async def test_status_when_inactive(self):
+        wallet = self.create_wallet()
+        status = wallet.coinfilter.get_coin_control_status()
+        self.assertFalse(status.is_active)
+        self.assertEqual(2, status.num_total)
+        self.assertEqual(0, status.value_sat)
+
+    # messaging
+
+    async def test_not_enough_funds_text_mentions_coin_control(self):
+        wallet = self.create_wallet()
+        wallet.coinfilter.select_coins([UTXO1])
+        text = wallet.get_text_not_enough_funds_mentioning_frozen(for_amount=12_000_000)
+        self.assertIn('coin control', text.lower())
+
+    async def test_not_enough_funds_text_silent_when_coin_control_inactive(self):
+        wallet = self.create_wallet()
+        text = wallet.get_text_not_enough_funds_mentioning_frozen(for_amount=99_000_000)
+        self.assertNotIn('coin control', text.lower())
+
+    # lifecycle
+
+    async def test_stop_unregisters_callbacks(self):
+        """A stopped wallet must stop reacting to adb events, which are process-global."""
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        coinfilter.select_coins([UTXO1, UTXO2])
+        before = util.callback_mgr.count_all_callbacks()
+        coinfilter.stop()
+        self.assertLess(util.callback_mgr.count_all_callbacks(), before)
+        coinfilter.stop()  # idempotent
+
+        # the selection is no longer pruned, because we are not listening anymore
+        self._spend_utxo(wallet, UTXO1)
+        await fast_sleep()
+        self.assertEqual({UTXO1, UTXO2}, coinfilter.get_selection())
+        # ...but reads stay correct, since filtering happens at read time
+        self.assertNotIn(UTXO1, self.outpoints(wallet.get_spendable_coins()))
+
+    async def test_wallet_backref_is_weak(self):
+        """The manager must not keep its wallet alive: wallet -> coinfilter -> wallet would
+        be a cycle that refcounting cannot break, which is also what stops __del__
+        from ever running."""
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        self.assertIs(coinfilter.wallet, wallet)  # still resolves normally
+        held = [id(o) for o in gc.get_referents(coinfilter.__dict__)]
+        self.assertNotIn(id(wallet), held)
+
+    async def test_dead_wallet_ref_is_handled(self):
+        """Once the wallet is gone, logging must still work and events must no-op."""
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+
+        class Gone:
+            pass
+        tmp = Gone()
+        dead = weakref.ref(tmp)
+        del tmp
+        coinfilter._wallet = dead
+
+        self.assertEqual('', coinfilter.diagnostic_name())  # must not raise
+        with self.assertRaises(RuntimeError):
+            coinfilter.wallet
+        coinfilter.on_event_adb_added_tx(object(), 'deadbeef', None)  # no-op, must not raise
+        coinfilter.on_event_adb_removed_tx(object(), 'deadbeef', None)
+        coinfilter.stop()  # teardown must not need the wallet
+
+    # events
+
+    async def test_coin_control_changed_event_fired(self):
+        wallet = self.create_wallet()
+        coinfilter = wallet.coinfilter
+        seen = []
+
+        def cb(w, added, removed, reason):
+            seen.append((set(added), set(removed), reason))
+
+        util.register_callback(cb, ['coin_control_changed'])
+        try:
+            coinfilter.select_coins([UTXO1])
+            await fast_sleep()
+            self.assertEqual([({UTXO1}, set(), 'user')], seen)
+            seen.clear()
+
+            coinfilter.clear_selection()
+            await fast_sleep()
+            self.assertEqual([(set(), {UTXO1}, 'cleared')], seen)
+            seen.clear()
+
+            coinfilter.select_coins([UTXO1])
+            await fast_sleep()
+            seen.clear()
+            self._spend_utxo(wallet, UTXO1)
+            await fast_sleep()
+            self.assertEqual([(set(), {UTXO1}, 'spent')], seen)
+        finally:
+            util.unregister_callback(cb)
+
+    async def test_frozen_state_changed_event_fired(self):
+        wallet = self.create_wallet()
+        seen = []
+
+        def cb(w, addresses, outpoints):
+            seen.append((set(addresses), set(outpoints)))
+
+        util.register_callback(cb, ['frozen_state_changed'])
+        try:
+            wallet.set_frozen_state_of_coins([UTXO1], True)
+            await fast_sleep()
+            self.assertEqual([(set(), {UTXO1})], seen)
+        finally:
+            util.unregister_callback(cb)
+
+
+class TestCoinControlCommands(ElectrumTestCase):
+    """The CLI/RPC surface. This is what coin control gains beyond the Qt client."""
+    TESTNET = True
+
+    def setUp(self):
+        super().setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+
+    def create_wallet(self):
+        ks = keystore.from_seed(SEED, passphrase='', for_multisig=False)
+        wallet = WalletIntegrityHelper.create_standard_wallet(ks, gap_limit=2, config=self.config)
+        for raw in (FUNDING_TX1, FUNDING_TX2):
+            wallet.adb.receive_tx_callback(Transaction(raw), tx_height=TX_HEIGHT_UNCONFIRMED)
+        return wallet
+
+    async def test_select_utxo_then_payto_restricts_inputs(self):
+        wallet = self.create_wallet()
+        cmds = Commands(config=self.config)
+        self.assertEqual([UTXO2], await cmds.select_utxo([UTXO2], wallet=wallet))
+        status = await cmds.list_selected_utxos(wallet=wallet)
+        self.assertTrue(status['active'])
+        self.assertEqual([UTXO2], status['selected'])
+
+        raw = await cmds.payto(
+            OTHER_ADDR, '0.001', feerate=1, unsigned=True, password=None, wallet=wallet)
+        tx = tx_from_any(raw)
+        self.assertEqual({UTXO2}, {txin.prevout.to_str() for txin in tx.inputs()})
+
+        await cmds.unselect_utxo(wallet=wallet)
+        self.assertFalse((await cmds.list_selected_utxos(wallet=wallet))['active'])
+
+    async def test_select_utxo_rejects_unknown_outpoint(self):
+        wallet = self.create_wallet()
+        cmds = Commands(config=self.config)
+        with self.assertRaises(UserFacingException):
+            await cmds.select_utxo(['00' * 32 + ':7'], wallet=wallet)
+
+    async def test_payto_from_coins_rejects_unknown_outpoint(self):
+        """Previously a typo'd outpoint just yielded a confusing NotEnoughFunds."""
+        wallet = self.create_wallet()
+        cmds = Commands(config=self.config)
+        with self.assertRaises(UserFacingException):
+            await cmds.payto(
+                OTHER_ADDR, '0.001', feerate=1, unsigned=True, password=None,
+                from_coins='00' * 32 + ':7', wallet=wallet)
+
+    async def test_payto_from_coins_overrides_stored_selection(self):
+        wallet = self.create_wallet()
+        cmds = Commands(config=self.config)
+        await cmds.select_utxo([UTXO1], wallet=wallet)
+        raw = await cmds.payto(
+            OTHER_ADDR, '0.001', feerate=1, unsigned=True, password=None,
+            from_coins=UTXO2, wallet=wallet)
+        tx = tx_from_any(raw)
+        self.assertEqual({UTXO2}, {txin.prevout.to_str() for txin in tx.inputs()})
+
+    async def test_listunspent_reports_frozen_and_selected(self):
+        wallet = self.create_wallet()
+        cmds = Commands(config=self.config)
+        await cmds.select_utxo([UTXO1], wallet=wallet)
+        await cmds.freeze_utxo(UTXO2, wallet=wallet)
+        by_outpoint = {c['prevout_hash'] + ':' + str(c['prevout_n']): c
+                       for c in await cmds.listunspent(wallet=wallet)}
+        self.assertTrue(by_outpoint[UTXO1]['selected'])
+        self.assertFalse(by_outpoint[UTXO1]['frozen'])
+        self.assertFalse(by_outpoint[UTXO2]['selected'])
+        self.assertTrue(by_outpoint[UTXO2]['frozen'])

--- a/tests/test_wallet_vertical.py
+++ b/tests/test_wallet_vertical.py
@@ -3315,22 +3315,22 @@ class TestWalletSending(ElectrumTestCase):
 
         # test freezing a utxo
         with self.subTest(msg="freeze_coin"):
-            self.assertTrue(utxo1 not in wallet._frozen_coins)
+            self.assertTrue(utxo1 not in wallet.coinfilter._frozen_coins)
 
             wallet.set_frozen_state_of_coins([utxo1], freeze=True)
-            self.assertEqual(wallet._frozen_coins.get(utxo1), True)
+            self.assertEqual(wallet.coinfilter._frozen_coins.get(utxo1), True)
             self.assertEqual(
                 {utxo2},
                 {txi.prevout.to_str() for txi in wallet.get_spendable_coins()})
 
             wallet.set_frozen_state_of_coins([utxo1], freeze=False)
-            self.assertEqual(wallet._frozen_coins.get(utxo1), False)
+            self.assertEqual(wallet.coinfilter._frozen_coins.get(utxo1), False)
             self.assertEqual(
                 {utxo1, utxo2},
                 {txi.prevout.to_str() for txi in wallet.get_spendable_coins()})
 
             wallet.set_frozen_state_of_coins([utxo1], freeze=None)
-            self.assertTrue(utxo1 not in wallet._frozen_coins)
+            self.assertTrue(utxo1 not in wallet.coinfilter._frozen_coins)
 
     async def test_export_psbt_with_xpubs__multisig(self):
         """When exporting a PSBT to be signed by a hw device, test that we populate


### PR DESCRIPTION
refactor coin filtering, combine frozen and coincontrol into new class `CoinFilter`.
    
Currently, the code for coin control is separate from frozen addresses/coins, and
an active coin control selection must be filtered against the frozen list by the caller
the moment the selection is used.
    
This commit is an attempt to unify the filtering, so filtering works in predictable
ways everywhere (and can e.g. be more easily be extended in the future, if needed)
    
a `CoinFilter` instance is owned by each wallet, and takes care of managing the list
of frozen coins/addresses and the coin control set. Upon query, additional filters like
`nonlocal_only`, `confirmed_only` are applied.

`CoinFilter` emits callbacks when the set of frozen coins/addresses is changed, or when 
coin control selection changes.
