### PR TITLE
qml: prevent deleting paid invoices

### DIFF
--- a/electrum/gui/qml/qeinvoicelistmodel.py
+++ b/electrum/gui/qml/qeinvoicelistmodel.py
@@ -119,6 +119,9 @@ class QEAbstractInvoiceListModel(QAbstractListModel):
         self._logger.debug(f'updating invoice for {key} to {status}')
         for i, item in enumerate(self._invoices):
             if item['key'] == key:
+                if status == PR_PAID:
+                    self.delete_invoice(key)
+                    return
                 invoice = self.get_invoice_for_key(key)
                 item['status'] = status
                 item['status_str'] = invoice.get_status_str(status)
@@ -228,7 +231,7 @@ class QERequestListModel(QEAbstractInvoiceListModel, QtEventListener):
     def on_event_request_status(self, wallet, key, status):
         if wallet == self.wallet:
             self._logger.debug(f'request status update for key {key} to {status}')
-            self.updateRequest(key, status)
+            self.updateInvoice(key, status)
 
     def invoice_to_model(self, invoice: BaseInvoice):
         item = super().invoice_to_model(invoice)
@@ -246,10 +249,3 @@ class QERequestListModel(QEAbstractInvoiceListModel, QtEventListener):
 
     def get_invoice_as_dict(self, invoice: Request):
         return self.wallet.export_request(invoice)
-
-    @pyqtSlot(str, int)
-    def updateRequest(self, key, status):
-        if status == PR_PAID:
-            self.delete_invoice(key)
-        else:
-            self.updateInvoice(key, status)

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -76,7 +76,7 @@ from .address_synchronizer import (
     AddressSynchronizer, TX_HEIGHT_LOCAL, TX_HEIGHT_UNCONF_PARENT, TX_HEIGHT_UNCONFIRMED, TX_HEIGHT_FUTURE,
     TX_TIMESTAMP_INF
 )
-from .invoices import BaseInvoice, Invoice, Request, PR_PAID, PR_UNPAID, PR_EXPIRED, PR_UNCONFIRMED
+from .invoices import BaseInvoice, Invoice, Request, PR_PAID, PR_UNPAID, PR_EXPIRED, PR_UNCONFIRMED, PR_INFLIGHT
 from .contacts import Contacts
 from .mnemonic import Mnemonic
 from .lnworker import LNWallet
@@ -3098,7 +3098,8 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         self._receive_requests.pop(request_id, None)
         if addr := req.get_address():
             self._requests_addr_to_key[addr].discard(request_id)
-        if req.is_lightning() and self.lnworker:
+        if req.is_lightning() and self.lnworker \
+                and self.lnworker.get_invoice_status(req) != PR_PAID:
             self.lnworker.delete_payment_info(req.rhash, direction=RECEIVED)
         if write_to_disk:
             self.save_db()
@@ -3109,7 +3110,10 @@ class Abstract_Wallet(ABC, Logger, EventListener):
         if inv is None:
             return
         self._paid_invoice_keys_cache.discard(invoice_id)
-        if inv.is_lightning() and self.lnworker:
+        if inv.is_lightning() and self.lnworker \
+                and self.lnworker.get_invoice_status(inv) not in (PR_PAID, PR_INFLIGHT):
+            # if an invoice was paid we need the PaymentInfo for the history and don't delete it.
+            # if it is still inflight and the payment fails later on we leak it and never delete it.
             self.lnworker.delete_payment_info(inv.rhash, direction=SENT)
         if write_to_disk:
             self.save_db()


### PR DESCRIPTION
It was possible to save an invoice, pay it, go back to the list
and then try to delete it, resulting in the following exception:

```
 45.00 | D | gui.qml.qewallet.[default_wallet] | delete inv bfc30618da8ac9a9690842a4c6ed7c68f8cf1014994c6907652cf51cf85b7220
 45.00 | E | gui.qml.qeapp.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
  File "/var/home/user/code/code_vm/electrum-2/electrum/gui/qml/qewallet.py", line 738, in deleteInvoice
    self.wallet.delete_invoice(key)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/var/home/user/code/code_vm/electrum-2/electrum/wallet.py", line 3113, in delete_invoice
    self.lnworker.delete_payment_info(inv.rhash, direction=SENT)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/user/code/code_vm/electrum-2/electrum/lnworker.py", line 3356, in delete_payment_info
    assert self.get_payment_status(bytes.fromhex(payment_hash_hex), direction=direction) != PR_PAID
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Now the invoice will get removed from the list automatically (similar to Qt), so the user cannot
even attempt to delete it. Also the wallet invoice and request deletion methods are adapted 
to just not delete the `PaymentInfo` if they are already paid, so that the CLI is robust against
this issue too (shouldn't really be reachable from the GUI). 