### PR TITLE
LNWallet: don't populate inflight_payments with incoming payments on restart

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1047,10 +1047,16 @@ class Channel(AbstractChannel):
     def get_next_feerate(self, subject: HTLCOwner) -> int:
         return self.hm.get_feerate_in_next_ctx(subject)
 
-    def get_payments(self, status=None) -> Mapping[bytes, List[HTLCWithStatus]]:
+    def get_payments(
+        self, *,
+        status: Optional[str] = None,
+        direction: Optional[lnutil.Direction] = None,
+    ) -> Mapping[bytes, List[HTLCWithStatus]]:
         out = defaultdict(list)
-        for direction, htlc in self.hm.all_htlcs_ever():
-            htlc_proposer = LOCAL if direction is SENT else REMOTE
+        for htlc_direction, htlc in self.hm.all_htlcs_ever():
+            if direction is not None and htlc_direction != direction:
+                continue
+            htlc_proposer = LOCAL if htlc_direction is SENT else REMOTE
             if self.hm.was_htlc_failed(htlc_id=htlc.htlc_id, htlc_proposer=htlc_proposer):
                 _status = 'failed'
             elif self.hm.was_htlc_preimage_released(htlc_id=htlc.htlc_id, htlc_proposer=htlc_proposer):
@@ -1060,7 +1066,7 @@ class Channel(AbstractChannel):
             if status and status != _status:
                 continue
             htlc_with_status = HTLCWithStatus(
-                channel_id=self.channel_id, htlc=htlc, direction=direction, status=_status)
+                channel_id=self.channel_id, htlc=htlc, direction=htlc_direction, status=_status)
             out[htlc.payment_hash].append(htlc_with_status)
         return out
 

--- a/electrum/lnworker.py
+++ b/electrum/lnworker.py
@@ -1067,7 +1067,7 @@ class LNWallet(Logger):
 
         # detect inflight payments
         self.inflight_payments = set()  # type: set[str]  # (not persisted) keys of invoices that are in PR_INFLIGHT state
-        for payment_hash in self.get_payments(status='inflight').keys():
+        for payment_hash in self.get_payments(status='inflight', direction=SENT).keys():
             self.set_invoice_status(payment_hash.hex(), PR_INFLIGHT)
 
         # payment forwarding
@@ -1264,10 +1264,14 @@ class LNWallet(Logger):
                 for peer in self.lnpeermgr.peers.values():
                     await group.spawn(peer.received_htlc_removed_event.wait())
 
-    def get_payments(self, *, status=None) -> Mapping[bytes, List[HTLCWithStatus]]:
+    def get_payments(
+        self, *,
+        status: Optional[str] = None,
+        direction: Optional[lnutil.Direction] = None,
+    ) -> Mapping[bytes, List[HTLCWithStatus]]:
         out = defaultdict(list)
         for chan in self.channels.values():
-            d = chan.get_payments(status=status)
+            d = chan.get_payments(status=status, direction=direction)
             for payment_hash, plist in d.items():
                 out[payment_hash] += plist
         return out

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -723,6 +723,13 @@ class TestChannel(ElectrumTestCase):
             )
         self.assertEqual({}, lnwatcher.get_pending_force_closes())
 
+    def test_get_payments(self):
+        phash = self.htlc.payment_hash
+        self.assertIn(phash, self.alice_channel.get_payments(status='inflight', direction=SENT))
+        self.assertEqual({}, self.alice_channel.get_payments(status='inflight', direction=RECEIVED))
+        self.assertIn(phash, self.bob_channel.get_payments(status='inflight', direction=RECEIVED))
+        self.assertEqual({}, self.bob_channel.get_payments(status='inflight', direction=SENT))
+
 
 class TestChannelNoAnchors(TestChannel):
     assert TestChannel.TEST_ANCHOR_CHANNELS is True


### PR DESCRIPTION
When restarting the app we would re-populate the `LNWallet.inflight_payments` set from htlcs pending on the channel. If there was a pending incoming htlc, e.g. from a submarine swap, they would get added to the set too, but then not removed anymore (until restart).
This makes the docstring from `invoices.py` true again:
https://github.com/spesmilo/electrum/blob/a1f74c147547b6dca6af15893246d0d26150ec2a/electrum/invoices.py#L27