### PR TITLE
qt: fix editing of multiline payment identifiers containing output scripts

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1662,9 +1662,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         grid.addWidget(QLabel(amount_str), 1, 1)
         if len(invoice.outputs) == 1:
             grid.addWidget(QLabel(_("Address") + ':'), 2, 0)
-            grid.addWidget(QLabel(invoice.get_address()), 2, 1)
+            grid.addWidget(QLabel(invoice.outputs[0].get_ui_address_str()), 2, 1)
         else:
-            outputs_str = '\n'.join(map(lambda x: x.address + ' : ' + self.format_amount(x.value)+ self.base_unit(), invoice.outputs))
+            outputs_str = '\n'.join(map(lambda x: x.get_ui_address_str() + ' : ' + self.format_amount(x.value) + self.base_unit(), invoice.outputs))
             grid.addWidget(QLabel(_("Outputs") + ':'), 2, 0)
             grid.addWidget(QLabel(outputs_str), 2, 1)
         grid.addWidget(QLabel(_("Description") + ':'), 3, 0)

--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -24,7 +24,7 @@ from electrum.transaction import Transaction, PartialTxInput, PartialTxOutput
 from electrum.network import TxBroadcastError, BestEffortRequestFailed
 from electrum.payment_identifier import (PaymentIdentifierType, PaymentIdentifier,
                                          invoice_from_payment_identifier,
-                                         PaymentIdentifierState)
+                                         PaymentIdentifierState, outputs_to_multiline_csv)
 from electrum.submarine_swaps import SwapServerError
 from electrum.fee_policy import FeePolicy, FixedFeePolicy
 from electrum.lnurl import LNURL3Data, request_lnurl_withdraw_callback, LNURLError
@@ -592,6 +592,11 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
     def do_edit_invoice(self, invoice: 'Invoice'):  # FIXME broken
         assert not bool(invoice.get_amount_sat())
         text = invoice.lightning_invoice if invoice.is_lightning() else invoice.get_address()
+        if len(invoice.get_outputs()) > 1 or text is None:
+            # invoice is not standard single-address-out, it's one of
+            # - multiple outputs (invoice.get_address() only returns output[0])
+            # - single output is script, not address
+            text = outputs_to_multiline_csv(invoice.get_outputs(), self.config)
         self.set_payment_identifier(text)
         self.amount_e.setFocus()
         # disable save button, because it would create a new invoice

--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -450,10 +450,12 @@ class PaymentIdentifier(Logger):
         for i, line in enumerate(lines):
             try:
                 output = self.parse_address_and_amount(line)
+                is_multiline = True  # we parsed a <script>/<address>,<amount> line
                 outputs.append(output)
                 if parse_max_spend(output.value):
                     self._is_max = True
                 else:
+                    assert output.value >= 0, 'no negative amounts allowed'
                     total += output.value
             except Exception as e:
                 errors = f'{errors}line #{i}: {str(e)}\n'

--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -11,9 +11,9 @@ from .contacts import AliasNotFoundException
 from .i18n import _
 from .invoices import Invoice
 from .logging import Logger
-from .util import parse_max_spend, InvoiceError
+from .util import parse_max_spend, InvoiceError, format_satoshis_plain
 from .util import get_asyncio_loop, log_exceptions
-from .transaction import PartialTxOutput
+from .transaction import PartialTxOutput, script_GetOp
 from .lnurl import (decode_lnurl, request_lnurl, callback_lnurl, LNURLError,
                     lightning_address_to_url, try_resolve_lnurlpay, LNURL6Data,
                     LNURL3Data, LNURLData, SUPPORTED_LNURL_SCHEMES)
@@ -26,6 +26,7 @@ from .segwit_addr import bech32_decode
 if TYPE_CHECKING:
     from .wallet import Abstract_Wallet
     from .transaction import Transaction
+    from .simple_config import SimpleConfig
 
 
 def maybe_extract_bech32_lightning_payment_identifier(data: str) -> Optional[str]:
@@ -437,7 +438,7 @@ class PaymentIdentifier(Logger):
         else:
             raise Exception('not onchain')
 
-    def _parse_as_multiline(self, text: str):
+    def _parse_as_multiline(self, text: str) -> List[PartialTxOutput]:
         # filter out empty lines
         lines = text.split('\n')
         lines = [i for i in lines if i]
@@ -638,3 +639,27 @@ def invoice_from_payment_identifier(
             URI=pi.bip21,
         )
 
+
+def script_to_string(script: bytes) -> str:
+    """Convert script bytes to human-readable string for PI"""
+    words = []
+    for opcode, data, _pos in script_GetOp(script):
+        if data is None:  # not a push opcode
+            words.append(opcodes(opcode).name)
+        elif data:
+            words.append(data.hex())
+        else:  # empty push
+            words.append(opcodes.OP_0.name)
+    return ' '.join(words)
+
+
+def outputs_to_multiline_csv(outputs: List[PartialTxOutput], config: 'SimpleConfig') -> str:
+    lines = []
+    for output in outputs:
+        recipient = output.address or f'script({script_to_string(output.scriptpubkey)})'
+        if parse_max_spend(output.value):
+            amount = output.value
+        else:
+            amount = format_satoshis_plain(output.value, decimal_point=config.BTC_AMOUNTS_DECIMAL_POINT)
+        lines.append(f'{recipient},{amount}')
+    return '\n'.join(lines)

--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -491,7 +491,8 @@ class PaymentIdentifier(Logger):
 
         return None, False
 
-    def parse_script(self, x: str) -> bytes:
+    @staticmethod
+    def parse_script(x: str) -> bytes:
         script = bytearray()
         for word in x.split():
             if word[0:3] == 'OP_':
@@ -652,7 +653,9 @@ def script_to_string(script: bytes) -> str:
             words.append(data.hex())
         else:  # empty push
             words.append(opcodes.OP_0.name)
-    return ' '.join(words)
+    s = ' '.join(words)
+    assert PaymentIdentifier.parse_script(s) == script, f"{s} != {script.hex()}"
+    return s
 
 
 def outputs_to_multiline_csv(outputs: List[PartialTxOutput], config: 'SimpleConfig') -> str:

--- a/tests/test_payment_identifier.py
+++ b/tests/test_payment_identifier.py
@@ -6,7 +6,7 @@ from electrum import SimpleConfig
 from electrum.invoices import Invoice
 from electrum.payment_identifier import (
     maybe_extract_bech32_lightning_payment_identifier, PaymentIdentifier, PaymentIdentifierType,
-    PaymentIdentifierState, invoice_from_payment_identifier, remove_uri_prefix,
+    PaymentIdentifierState, invoice_from_payment_identifier, remove_uri_prefix, outputs_to_multiline_csv,
 )
 from electrum.lnurl import LNURL6Data, LNURL3Data, LNURLError
 from electrum.transaction import PartialTxOutput
@@ -299,6 +299,7 @@ class TestPaymentIdentifier(ElectrumTestCase):
         self.assertTrue(all(lambda x: isinstance(x, PartialTxOutput) for x in pi.multiline_outputs))
         self.assertEqual(1000, pi.multiline_outputs[0].value)
         self.assertEqual(1000, pi.multiline_outputs[1].value)
+        self.assertEqual(pi_str, outputs_to_multiline_csv(pi.multiline_outputs, self.config))
 
         pi_str = '\n'.join([
             'bc1qj3zx2zc4rpv3npzmznxhdxzn0wm7pzqp8p2293,0.01',
@@ -315,6 +316,7 @@ class TestPaymentIdentifier(ElectrumTestCase):
         self.assertEqual(1000, pi.multiline_outputs[0].value)
         self.assertEqual(1000, pi.multiline_outputs[1].value)
         self.assertEqual('!', pi.multiline_outputs[2].value)
+        self.assertEqual(pi_str, outputs_to_multiline_csv(pi.multiline_outputs, self.config))
 
         pi_str = '\n'.join([
             'bc1qj3zx2zc4rpv3npzmznxhdxzn0wm7pzqp8p2293,0.01',
@@ -334,16 +336,19 @@ class TestPaymentIdentifier(ElectrumTestCase):
 
         pi_str = '\n'.join([
             'bc1qj3zx2zc4rpv3npzmznxhdxzn0wm7pzqp8p2293,0.01',
-            'script(OP_RETURN baddc0ffee),0'
+            'script(OP_RETURN baddc0ffee),0',
+            'script(OP_0 OP_1NEGATE OP_16 ' + 'aa' * 80 + ' ' + 'bb' * 300 + '),0',  # every push encoding
         ])
         pi = PaymentIdentifier(self.wallet, pi_str)
         self.assertTrue(pi.is_valid())
         self.assertTrue(pi.is_multiline())
         self.assertIsNotNone(pi.multiline_outputs)
-        self.assertEqual(2, len(pi.multiline_outputs))
+        self.assertEqual(3, len(pi.multiline_outputs))
         self.assertTrue(all(lambda x: isinstance(x, PartialTxOutput) for x in pi.multiline_outputs))
         self.assertEqual(1000, pi.multiline_outputs[0].value)
         self.assertEqual(0, pi.multiline_outputs[1].value)
+        self.assertEqual(0, pi.multiline_outputs[2].value)
+        self.assertEqual(pi_str, outputs_to_multiline_csv(pi.multiline_outputs, self.config))
 
     def test_spk(self):
         address = 'bc1qj3zx2zc4rpv3npzmznxhdxzn0wm7pzqp8p2293'

--- a/tests/test_payment_identifier.py
+++ b/tests/test_payment_identifier.py
@@ -350,6 +350,15 @@ class TestPaymentIdentifier(ElectrumTestCase):
         self.assertEqual(0, pi.multiline_outputs[2].value)
         self.assertEqual(pi_str, outputs_to_multiline_csv(pi.multiline_outputs, self.config))
 
+        # disallow negative output values
+        pi_str = '\n'.join([
+            'bc1qj3zx2zc4rpv3npzmznxhdxzn0wm7pzqp8p2293,-0.01',
+        ])
+        pi = PaymentIdentifier(self.wallet, pi_str)
+        self.assertFalse(pi.is_valid())
+        self.assertTrue(pi.is_multiline())
+        self.assertIsNotNone(pi.error)
+
     def test_spk(self):
         address = 'bc1qj3zx2zc4rpv3npzmznxhdxzn0wm7pzqp8p2293'
         for pi_str in [


### PR DESCRIPTION
qt: fix editing of multiline payment identifiers containing output scripts

script outputs are 'reversed' into human-readable script statements by
`payment_identifier.script_to_string()`

fixes #10132

Note: this also fixes another pre-existing bug, where `do_edit_invoice` flow is entered for a multi-output invoice, but only the first output is put in the recipient field, ignoring the other outputs when subsequently saving/paying.

<!--
Please read this before opening the PR:

Every line of this diff will be reviewed by hand by a human. A pull request
that its own author cannot explain costs the maintainers more time than it
saves, so:

  * You may use whatever tools you like to WRITE code, but you must
    UNDERSTAND the result, and be able to explain it in your own words.
  * The description below must be handwritten by you. Do not paste text
    produced by an LLM/AI assistant. Reviewing AI-written prose to find out
    what a patch is supposed to do is a burden we are not willing to carry.
  * If you cannot explain the change in your own words, please do NOT open a
    pull request. Open an issue instead (handwritten too) describing the
    problem you ran into. A clear bug report is genuinely useful to us; a
    patch nobody can explain is not.

Pull requests ignoring the above may be closed without further discussion.
-->