### PR TITLE
qt: qr code reader: speed up camera

### DIFF
--- a/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
+++ b/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
@@ -192,12 +192,13 @@ class QrReaderCameraDialog(Logger, MessageBoxMixin, QDialog):
             self.logger.info("Warning: start_scan already called for this instance.")
 
         self.camera = QCamera(device_info)
-        self.camera.start()
         self.camera.errorOccurred.connect(self._on_camera_error)  # log the errors we get, if any, for debugging
 
         self.media_capture_session = QMediaCaptureSession()
         self.media_capture_session.setCamera(self.camera)
         self.media_capture_session.setVideoSink(self.video_surface)
+
+        self.camera.start()
 
         self.open()
 

--- a/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
+++ b/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
@@ -24,9 +24,9 @@
 # SOFTWARE.
 
 import time
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
-from PyQt6.QtMultimedia import QMediaDevices, QCamera, QMediaCaptureSession, QCameraDevice
+from PyQt6.QtMultimedia import QMediaDevices, QCamera, QMediaCaptureSession, QCameraDevice, QCameraFormat
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QCheckBox, QPushButton, QLabel, QWidget
 from PyQt6.QtGui import QImage, QPixmap
 from PyQt6.QtCore import QSize, QRect, Qt, pyqtSignal
@@ -159,6 +159,22 @@ class QrReaderCameraDialog(Logger, MessageBoxMixin, QDialog):
         scan_pos_y = (resolution.height() - scan_size) // 2
         return QRect(scan_pos_x, scan_pos_y, scan_size, scan_size)
 
+    @staticmethod
+    def _pick_camera_format(formats: Sequence[QCameraFormat], min_size: int) -> Optional[QCameraFormat]:
+        """
+        Picks the format with the lowest resolution that is at least min_size in both dimensions,
+        or the largest one if there is none.
+        Note: by default, Qt picks the largest resolution with ~30 fps, which is a bit overkill for QR scanning.
+        https://github.com/qt/qtmultimedia/blob/269bbd9904624b15f42efd5440374653abda065f/src/multimedia/platform/qplatformcamera.cpp#L22
+        """
+        def num_pixels(fmt: QCameraFormat) -> int:
+            return fmt.resolution().width() * fmt.resolution().height()
+        large_enough = [fmt for fmt in formats
+                        if fmt.resolution().width() >= min_size and fmt.resolution().height() >= min_size]
+        if large_enough:
+            return min(large_enough, key=num_pixels)
+        return max(formats, key=num_pixels) if formats else None
+
     def start_scan(self, device: str = ''):
         """
         Scans a QR code from the given camera device.
@@ -197,6 +213,12 @@ class QrReaderCameraDialog(Logger, MessageBoxMixin, QDialog):
         self.media_capture_session = QMediaCaptureSession()
         self.media_capture_session.setCamera(self.camera)
         self.media_capture_session.setVideoSink(self.video_surface)
+
+        camera_format = self._pick_camera_format(device_info.videoFormats(), self.SCAN_SIZE)
+        if camera_format is not None:
+            res = camera_format.resolution()
+            self.logger.info(f"chosen camera format: {res.width()}x{res.height()}")
+            self.camera.setCameraFormat(camera_format)
 
         self.camera.start()
 

--- a/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
+++ b/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
@@ -24,19 +24,16 @@
 # SOFTWARE.
 
 import time
-import math
-import sys
-import os
 from typing import List, Optional
 
 from PyQt6.QtMultimedia import QMediaDevices, QCamera, QMediaCaptureSession, QCameraDevice
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QCheckBox, QPushButton, QLabel, QWidget
 from PyQt6.QtGui import QImage, QPixmap
-from PyQt6.QtCore import QSize, QRect, Qt, pyqtSignal, PYQT_VERSION
+from PyQt6.QtCore import QSize, QRect, Qt, pyqtSignal
 
 from electrum.simple_config import SimpleConfig
 from electrum.i18n import _
-from electrum.qrreader import get_qr_reader, QrCodeResult, MissingQrDetectionLib
+from electrum.qrreader import get_qr_reader, QrCodeResult
 from electrum.logging import Logger
 
 from electrum.gui.qt.util import MessageBoxMixin, FixedAspectRatioLayout, ImageGraphicsEffect
@@ -89,7 +86,6 @@ class QrReaderCameraDialog(Logger, MessageBoxMixin, QDialog):
         self.media_capture_session: QMediaCaptureSession = None
         self._error_message: str | None = None
         self._ok_done: bool = False
-        self.camera_sc_conn = None
         self.resolution: QSize = None
 
         self.config = config

--- a/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
+++ b/electrum/gui/qt/qrreader/qtmultimedia/camera_dialog.py
@@ -255,7 +255,9 @@ class QrReaderCameraDialog(Logger, MessageBoxMixin, QDialog):
 
         self.frame_id += 1
 
-        self._set_resolution(frame.size())
+        if self.resolution is None or frame.size() != self.resolution:
+            self.logger.info(f"video frame size: {frame.width()}x{frame.height()}")
+            self._set_resolution(frame.size())
 
         flip_x = self.flip_x.isChecked()
 

--- a/electrum/gui/qt/qrreader/qtmultimedia/video_surface.py
+++ b/electrum/gui/qt/qrreader/qtmultimedia/video_surface.py
@@ -23,13 +23,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List
+from typing import Optional
 
-from PyQt6.QtMultimedia import (QVideoFrame, QVideoFrameFormat, QVideoSink)
+from PyQt6.QtMultimedia import QVideoFrame, QVideoSink
 from PyQt6.QtGui import QImage
-from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
-from electrum.i18n import _
 from electrum.logging import get_logger
 
 
@@ -38,44 +37,41 @@ _logger = get_logger(__name__)
 
 class QrReaderVideoSurface(QVideoSink):
     """
-    Receives QVideoFrames from QCamera, converts them into a QImage, flips the X and Y axis if
-    necessary and sends them to listeners via the frame_available event.
+    Receives QVideoFrames from QCamera, converts the newest one into a QImage and
+    sends it to listeners via the frame_available signal.
     """
+
+    frame_available = pyqtSignal(QImage)
 
     def __init__(self, parent: QObject = None):
         super().__init__(parent)
+        self._pending_frame: Optional[QVideoFrame] = None
+        self._process_timer = QTimer(self)
+        self._process_timer.setSingleShot(True)
+        self._process_timer.setInterval(0)
+        self._process_timer.timeout.connect(self._process_pending_frame)
         self.videoFrameChanged.connect(self._on_new_frame)
 
     def _on_new_frame(self, frame: QVideoFrame) -> None:
         if not frame.isValid():
             return
+        # only keep the newest frame
+        self._pending_frame = QVideoFrame(frame)  # keep our own reference (the received frame is owned by Qt)
+        if not self._process_timer.isActive():
+            self._process_timer.start()
 
-        image_format = QVideoFrameFormat.imageFormatFromPixelFormat(frame.pixelFormat())
-        if image_format == QVideoFrameFormat.PixelFormat.Format_Invalid:
-            _logger.info(_('QR code scanner for video frame with invalid pixel format'))
+    def _process_pending_frame(self) -> None:
+        frame, self._pending_frame = self._pending_frame, None
+        if frame is None:
             return
-
         if not frame.map(QVideoFrame.MapMode.ReadOnly):
-            _logger.info(_('QR code scanner failed to map video frame'))
+            _logger.warning(f"failed to map video frame. pixel format: {frame.pixelFormat()}", only_once=True)
             return
-
         try:
             img = frame.toImage()
-
-            # Check whether we need to flip the image on any axis
-            surface_format = frame.surfaceFormat()
-            flip_x = surface_format.isMirrored()
-            flip_y = surface_format.scanLineDirection() == QVideoFrameFormat.Direction.BottomToTop
-
-            # Mirror the image if needed
-            if flip_x or flip_y:
-                img = img.mirrored(flip_x, flip_y)
-
-            # Create a copy of the image so the original frame data can be freed
-            img = img.copy()
         finally:
             frame.unmap()
-
+        if img.isNull():
+            _logger.warning(f"failed to convert video frame to image. pixel format: {frame.pixelFormat()}", only_once=True)
+            return
         self.frame_available.emit(img)
-
-    frame_available = pyqtSignal(QImage)


### PR DESCRIPTION
I tried the Qt QR camera on a slow windows VM. Electrum freezes and the scanner is unusable.
With these changes it is snappy again.

* Only keep the most recent camera frame in memory
* specify smaller camera format instead of giving choice to qt (qt picks high resolution) 
* some cleanup from the qt5->qt6 transition

Fixes https://github.com/spesmilo/electrum/issues/10380
Fixes https://github.com/spesmilo/electrum/issues/10928 