### PR TITLE
qml: close keyboard when tapping on ElDialog background

### DIFF
--- a/electrum/gui/qml/components/controls/ElDialog.qml
+++ b/electrum/gui/qml/components/controls/ElDialog.qml
@@ -50,6 +50,15 @@ Dialog {
         ? Popup.CloseOnEscape | Popup.CloseOnPressOutside
         : Popup.NoAutoClose
 
+    TapHandler {  // close keyboard when tapping on the empty background
+        parent: abstractdialog.background
+        onTapped: {
+            // Release input focus so tapping the same field opens the keyboard again.
+            abstractdialog.contentItem.forceActiveFocus(Qt.MouseFocusReason)
+            Qt.inputMethod.hide()
+        }
+    }
+
     onOpenedChanged: {
         if (opened) {
             app.activeDialogs.push(abstractdialog)

--- a/electrum/gui/qml/components/wizard/Wizard.qml
+++ b/electrum/gui/qml/components/wizard/Wizard.qml
@@ -102,8 +102,8 @@ ElDialog {
         return page
     }
 
-    ColumnLayout {
-        anchors.fill: parent
+    // make layout contentItem so ElDialog TapHandler can focus on it and the Keys hook stays active
+    contentItem: ColumnLayout {
         spacing: 0
 
         // root Item in Wizard, capture back button here and delegate to main


### PR DESCRIPTION
When showing the keyboard over an ElDialog (e.g. when entering a comment into the lnurlpay dialog) it can only be closed using the android back button or the little "hide keyboard" button in the os system bar. 
Instead it is nicer if it is also possible to close the keyboard by clicking on some empty area of the dialog.
Tested on Pixel 9.