### PR TITLE
qt: keep send button enabled/disabled using same 'pi is usable' check.

### DIFF
--- a/electrum/gui/qt/send_tab.py
+++ b/electrum/gui/qt/send_tab.py
@@ -213,11 +213,10 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
         if not pi:
             self.send_button.setEnabled(False)
             return
-        pi_error = pi.is_error() if pi.is_valid() else False
         is_spk_script = pi.type == PaymentIdentifierType.SPK and not pi.spk_is_address
         valid_amount = is_spk_script or bool(self.amount_e.get_amount())
         ready_to_finalize = not pi.need_resolve()
-        self.send_button.setEnabled(pi.is_valid() and not pi_error and valid_amount and ready_to_finalize)
+        self.send_button.setEnabled(self._is_pi_usable(pi) and valid_amount and ready_to_finalize)
 
     def do_paste(self):
         self.logger.debug('do_paste')
@@ -468,16 +467,18 @@ class SendTab(QWidget, MessageBoxMixin, Logger):
         elif lock_max and self.amount_e.text() == '!':
             self.amount_e.clear()
 
-        pi_unusable = pi.is_error() or (not self.wallet.has_lightning() and not pi.is_onchain())
+        pi_usable = self._is_pi_usable(pi)
         is_spk_script = pi.type == PaymentIdentifierType.SPK and not pi.spk_is_address
-
         amount_valid = is_spk_script or bool(self.amount_e.get_amount())
 
-        self.send_button.setEnabled(not pi_unusable and amount_valid and not pi.has_expired())
-        self.save_button.setEnabled(not pi_unusable and not is_spk_script and not pi.has_expired() and \
+        self.send_button.setEnabled(pi_usable and amount_valid and not pi.has_expired())
+        self.save_button.setEnabled(pi_usable and not is_spk_script and not pi.has_expired() and \
                                     pi.type not in [PaymentIdentifierType.LNURLP, PaymentIdentifierType.LNADDR])
 
         self.invoice_error.setText(_('Expired') if pi.has_expired() else '')
+
+    def _is_pi_usable(self, pi: 'PaymentIdentifier') -> bool:
+        return pi.is_valid() and not pi.is_error() and (self.wallet.has_lightning() or pi.is_onchain())
 
     def _handle_payment_identifier(self):
         self.update_fields()

--- a/electrum/payment_identifier.py
+++ b/electrum/payment_identifier.py
@@ -182,6 +182,7 @@ class PaymentIdentifier(Logger):
             return bool(self.bolt11) and bool(self.bolt11.get_address())
         if self._type == PaymentIdentifierType.BIP21:
             return bool(self.bip21.get('address', None)) or (bool(self.bolt11) and bool(self.bolt11.get_address()))
+        return False
 
     def is_multiline(self):
         return bool(self.multiline_outputs)


### PR DESCRIPTION
before, a non-lightning wallet could inadvertently enable the Send button for lightning invoice via missing pi-is-usable check in `on_amount_changed`. (practical for LNURLp with amount-range, and amountless bolt11)

<!--
Please read this before opening the PR:

Every line of this diff will be reviewed by hand by a human. A pull request
that its own author cannot explain costs the maintainers more time than it
saves, so:

  * You may use whatever tools you like to WRITE code, but you must
    UNDERSTAND the result, and be able to explain it in your own words.
  * The description below must be handwritten by you. Do not paste text
    produced by an LLM/AI assistant. Reviewing AI-written prose to find out
    what a patch is supposed to do is a burden we are not willing to carry.
  * If you cannot explain the change in your own words, please do NOT open a
    pull request. Open an issue instead (handwritten too) describing the
    problem you ran into. A clear bug report is genuinely useful to us; a
    patch nobody can explain is not.

Pull requests ignoring the above may be closed without further discussion.
-->