### PR TITLE
lnchan: expiring recv htlcs: treat as unsafe if preimage public

### DIFF
--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -1089,7 +1089,7 @@ class Channel(AbstractChannel):
             htlc_proposer = LOCAL if htlc_direction is SENT else REMOTE
             if self.hm.was_htlc_failed(htlc_id=htlc.htlc_id, htlc_proposer=htlc_proposer):
                 _status = 'failed'
-            elif self.hm.was_htlc_preimage_released(htlc_id=htlc.htlc_id, htlc_proposer=htlc_proposer):
+            elif self.hm.was_htlc_settled(htlc_id=htlc.htlc_id, htlc_proposer=htlc_proposer):
                 _status = 'settled'
             else:
                 _status = 'inflight'
@@ -2019,7 +2019,7 @@ class Channel(AbstractChannel):
                               (REMOTE, SENT, self.get_oldest_unrevoked_ctn(REMOTE)),
                               (REMOTE, SENT, self.get_latest_ctn(REMOTE)),):
             for htlc_id, htlc in self.hm.htlcs_by_direction(subject=sub, direction=dir, ctn=ctn).items():
-                if not self.hm.was_htlc_preimage_released(htlc_id=htlc_id, htlc_proposer=REMOTE):
+                if not self.hm.was_htlc_settled(htlc_id=htlc_id, htlc_proposer=REMOTE):
                     continue
                 if htlc.cltv_abs - recv_htlc_deadline_delta > local_height:
                     continue

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -2013,6 +2013,7 @@ class Channel(AbstractChannel):
         # If there is a received HTLC for which we already released the preimage
         # but the remote did not revoke yet, and the CLTV of this HTLC is dangerously close
         # to the present, then unilaterally close channel
+        # BOLT-02: "fulfillment deadline"
         recv_htlc_deadline_delta = lnutil.NBLOCK_DEADLINE_DELTA_BEFORE_EXPIRY_FOR_RECEIVED_HTLCS
         for sub, dir, ctn in ((LOCAL, RECEIVED, self.get_latest_ctn(LOCAL)),
                               (REMOTE, SENT, self.get_oldest_unrevoked_ctn(REMOTE)),

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -841,7 +841,6 @@ class Channel(AbstractChannel):
         self.unconfirmed_closing_txid = None # not a state, only for GUI
         self.sent_channel_ready = False # no need to persist this, because channel_ready is re-sent in channel_reestablish
         self.sent_announcement_signatures = False
-        self.htlc_settle_time = {}
 
     def get_local_scid_alias(self, *, create_new_if_needed: bool = False) -> Optional[bytes]:
         """Get scid_alias to be used for *outgoing* HTLCs.
@@ -1785,7 +1784,6 @@ class Channel(AbstractChannel):
             raise Exception("incorrect preimage for HTLC")
         assert htlc_id not in self.hm.log[REMOTE]['settles']
         self.hm.send_settle(htlc_id)
-        self.htlc_settle_time[htlc_id] = now()
         self.lnworker.save_preimage(htlc.payment_hash, preimage, mark_as_public=True)
 
     def get_payment_hash(self, htlc_id: int) -> bytes:
@@ -2010,6 +2008,7 @@ class Channel(AbstractChannel):
         return not (next_htlcs == latest_htlcs and self.get_next_feerate(subject) == self.get_latest_feerate(subject))
 
     def should_be_closed_due_to_expiring_htlcs(self, local_height: int) -> bool:
+        time_since_startup = now() - self.lnworker.instantiation_timestamp
         htlcs_we_could_reclaim = {}  # type: Dict[Tuple[Direction, int], UpdateAddHtlc]
         # If there is a received HTLC for which we already released the preimage
         # but the remote did not revoke yet, and the CLTV of this HTLC is dangerously close
@@ -2025,21 +2024,21 @@ class Channel(AbstractChannel):
                     continue
                 if htlc.cltv_abs - recv_htlc_deadline_delta > local_height:
                     continue
-                # Do not force-close if we just sent fulfill_htlc and have not received revack yet
-                if htlc_id in self.htlc_settle_time and now() - self.htlc_settle_time[htlc_id] < 30:
+                if time_since_startup < lnutil.GRACE_TIME_FOR_REMOVING_HTLCS_OFFCHAIN_ON_RESTART:
+                    # Give us some time to send update_fulfill_htlc to peer, send commitsig,
+                    # and then receive revack.
                     continue
                 htlcs_we_could_reclaim[(RECEIVED, htlc_id)] = htlc
         # If there is an offered HTLC which has already expired (+ some grace period after), we
         # will unilaterally close the channel and time out the HTLC
         offered_htlc_deadline_delta = lnutil.NBLOCK_DEADLINE_DELTA_AFTER_EXPIRY_FOR_OFFERED_HTLCS
-        time_since_startup = now() - self.lnworker.instantiation_timestamp
         for sub, dir, ctn in ((LOCAL, SENT, self.get_latest_ctn(LOCAL)),
                               (REMOTE, RECEIVED, self.get_oldest_unrevoked_ctn(REMOTE)),
                               (REMOTE, RECEIVED, self.get_latest_ctn(REMOTE)),):
             for htlc_id, htlc in self.hm.htlcs_by_direction(subject=sub, direction=dir, ctn=ctn).items():
                 if htlc.cltv_abs + offered_htlc_deadline_delta > local_height:
                     continue
-                if time_since_startup < lnutil.TIME_FOR_OFFERED_HTLCS_TO_GET_FAILED_OFFCHAIN_ON_RESTART:
+                if time_since_startup < lnutil.GRACE_TIME_FOR_REMOVING_HTLCS_OFFCHAIN_ON_RESTART:
                     continue  # give the peer some time to fail the htlc offchain
                 htlcs_we_could_reclaim[(SENT, htlc_id)] = htlc
         # Note: previously we used a threshold concept, "min_value_worth_closing_channel_over_sat", and

--- a/electrum/lnchannel.py
+++ b/electrum/lnchannel.py
@@ -2019,7 +2019,9 @@ class Channel(AbstractChannel):
                               (REMOTE, SENT, self.get_oldest_unrevoked_ctn(REMOTE)),
                               (REMOTE, SENT, self.get_latest_ctn(REMOTE)),):
             for htlc_id, htlc in self.hm.htlcs_by_direction(subject=sub, direction=dir, ctn=ctn).items():
-                if not self.hm.was_htlc_settled(htlc_id=htlc_id, htlc_proposer=REMOTE):
+                if not self.lnworker.is_preimage_public(htlc.payment_hash):
+                    # If we haven't released this specific preimage for ANY htlc_id on ANY channel,
+                    # (via any means: ln/onchain/etc...), then it's still safe.
                     continue
                 if htlc.cltv_abs - recv_htlc_deadline_delta > local_height:
                     continue

--- a/electrum/lnhtlc.py
+++ b/electrum/lnhtlc.py
@@ -460,7 +460,8 @@ class HTLCManager:
         ctn = self.ctn_latest(subject) + 1
         return self.htlcs(subject, ctn)
 
-    def was_htlc_preimage_released(self, *, htlc_id: int, htlc_proposer: HTLCOwner) -> bool:
+    def was_htlc_settled(self, *, htlc_id: int, htlc_proposer: HTLCOwner) -> bool:
+        """Returns whether an HTLC has been (or will be if we already know) settled."""
         settles = self.log[htlc_proposer]['settles']
         if htlc_id not in settles:
             return False

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -2358,7 +2358,7 @@ class Peer(Logger, EventListener):
             if not chan.can_send_ctx_updates():
                 continue
             self.logger.info(f"fulfill htlc: {chan.short_channel_id}. {htlc_id=}. {payment_hash.hex()=}")
-            if chan.hm.was_htlc_preimage_released(htlc_id=htlc_id, htlc_proposer=REMOTE):
+            if chan.hm.was_htlc_settled(htlc_id=htlc_id, htlc_proposer=REMOTE):
                 # this check is intended to gracefully handle stale htlcs in the set, e.g. after a crash
                 self.logger.debug(f"{mpp_htlc=} was already settled before, dropping it.")
                 htlc_set = htlc_set._replace(htlcs=htlc_set.htlcs - {mpp_htlc})

--- a/electrum/lnpeer.py
+++ b/electrum/lnpeer.py
@@ -2988,6 +2988,10 @@ class Peer(Logger, EventListener):
             if preimage:
                 if self.lnworker.enable_htlc_settle:
                     self.lnworker.set_request_status(htlc_set.get_payment_hash(), PR_PAID)
+                    # FIXME maybe race here: if the peer *now* goes offline, and we are the ultimate receiver of this payment,
+                    #       and then they come back online *after* fulfillment deadline (even after cltv_expiry!),
+                    #       we might still send update_fulfill_htlc.
+                    #       Maybe we should only do that if `lnworker.is_preimage_public(payment_hash)`?
                     self._fulfill_htlc_set(payment_key, preimage)
             if callback:
                 task = asyncio.create_task(callback())

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -588,7 +588,7 @@ MIN_FUNDING_SAT = 200_000
 
 
 ##### CLTV-expiry-delta-related values
-# see https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection
+# see https://github.com/lightning/bolts/blob/152897261850d93c4f4597f39cf22d7d22d6ede6/02-peer-protocol.md#cltv_expiry_delta-selection
 
 # the minimum cltv_expiry accepted for newly received HTLCs
 # note: when changing, consider Blockchain.is_tip_stale()
@@ -598,12 +598,14 @@ MIN_FINAL_CLTV_DELTA_ACCEPTED = 144
 # of incoming payment htlcs reliable even if some blocks have been mined during forwarding
 MIN_FINAL_CLTV_DELTA_BUFFER_INVOICE = 3
 
-# the deadline for offered HTLCs:
-# the deadline after which the channel has to be failed and timed out on-chain
+# "the deadline for offered HTLCs": (BOLT-02)
+# "the deadline after which the channel has to be failed and timed out on-chain"
+# ("This is G blocks after the HTLC's cltv_expiry")
 NBLOCK_DEADLINE_DELTA_AFTER_EXPIRY_FOR_OFFERED_HTLCS = 1
 
-# the deadline for received HTLCs this node has fulfilled:
-# the deadline after which the channel has to be failed and the HTLC fulfilled on-chain before its cltv_expiry
+# "the deadline for received HTLCs this node has fulfilled": (BOLT-02)
+# "the deadline after which the channel has to be failed and the HTLC fulfilled on-chain before its cltv_expiry"
+# ("a deadline of 2R+G+S blocks before cltv_expiry")
 NBLOCK_DEADLINE_DELTA_BEFORE_EXPIRY_FOR_RECEIVED_HTLCS = 72
 
 NBLOCK_CLTV_DELTA_TOO_FAR_INTO_FUTURE = 28 * 144

--- a/electrum/lnutil.py
+++ b/electrum/lnutil.py
@@ -615,7 +615,13 @@ MAXIMUM_REMOTE_TO_SELF_DELAY_ACCEPTED = 2016
 # timeout after which we consider a zeroconf channel without funding tx to be failed
 ZEROCONF_TIMEOUT = 60 * 10
 
-TIME_FOR_OFFERED_HTLCS_TO_GET_FAILED_OFFCHAIN_ON_RESTART = 30
+# Just after startup, we give some time to remove HTLCs offchain, before force-closing channels.
+# - Time window cannot be too short: takes some time to reestablish channels,
+#   (disk reads, cpu, several network RTTs), and we might have many channels.
+# - but window cannot be long either: the logic is too naive, and we start the grace period
+#   on every startup. If we wait too long, a mobile user might likely close the app before
+#   we start force-closing chans on uncooperative peers.
+GRACE_TIME_FOR_REMOVING_HTLCS_OFFCHAIN_ON_RESTART = 30  # seconds
 
 
 class RevStoreStorage(TypedDict):

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -847,7 +847,7 @@ class TestChannel(ElectrumTestCase):
         self.assertFalse(alice_channel.should_be_closed_due_to_expiring_htlcs(expired_local_height))
 
         # expired offered htlc, past startup grace period
-        alice_lnwallet.instantiation_timestamp -= (lnutil.TIME_FOR_OFFERED_HTLCS_TO_GET_FAILED_OFFCHAIN_ON_RESTART + 10)
+        alice_lnwallet.instantiation_timestamp -= (lnutil.GRACE_TIME_FOR_REMOVING_HTLCS_OFFCHAIN_ON_RESTART + 10)
         self.assertTrue(alice_channel.should_be_closed_due_to_expiring_htlcs(expired_local_height))
 
     async def test_should_be_closed_due_to_expiring_htlcs_received_htlcs(self):
@@ -872,7 +872,7 @@ class TestChannel(ElectrumTestCase):
         self.assertFalse(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
 
         # now the settled htlc is past the grace period
-        bob_channel.htlc_settle_time[bob_htlc_id] = int(time.time()) - 60
+        bob_lnwallet.instantiation_timestamp -= (lnutil.GRACE_TIME_FOR_REMOVING_HTLCS_OFFCHAIN_ON_RESTART + 10)
         self.assertTrue(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
 
         # if bob force-closes, the sweep info for the received htlc must expose the correct cltv heights for both sides.

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -865,7 +865,7 @@ class TestChannel(ElectrumTestCase):
         # preimage wasn't released
         self.assertFalse(bob_channel.should_be_closed_due_to_expiring_htlcs(local_height=expired_height))
 
-        # now the preimage is released
+        # now the preimage is released (via any means, could be on different channel to different peer)
         bob_channel.settle_htlc(preimage, bob_htlc_id)
 
         # still in 30s grace period waiting for peers revack

--- a/tests/test_lnchannel.py
+++ b/tests/test_lnchannel.py
@@ -857,7 +857,7 @@ class TestChannel(ElectrumTestCase):
 
         preimage = os.urandom(32)
         htlc = UpdateAddHtlc(payment_hash=sha256(preimage), amount_msat=one_bitcoin_in_msat, cltv_abs=100)
-        expired_height = 100 + lnutil.NBLOCK_DEADLINE_DELTA_BEFORE_EXPIRY_FOR_RECEIVED_HTLCS + 5
+        expired_height = 100 - lnutil.NBLOCK_DEADLINE_DELTA_BEFORE_EXPIRY_FOR_RECEIVED_HTLCS + 5
         alice_channel.add_htlc(htlc)
         bob_htlc_id =  bob_channel.receive_htlc(htlc).htlc_id
         force_state_transition(alice_channel, bob_channel)


### PR DESCRIPTION
bugfix: consider a multi-channel MPP where we receive htlc A and htlc B, with the same RHASH, and we settle htlc A.

- If htlc B is still pending, and
- we can't settle it (e.g. remote peer is offline),
- if it gets close to expiry,

we should force-close and claim B onchain.

However seems like this is not the only issue here, there are several gotchas, so I still had to leave a fixme...