### PR TITLE
descriptor: reject trailing characters after the closing parenthesis

### DIFF
--- a/electrum/descriptor.py
+++ b/electrum/descriptor.py
@@ -841,9 +841,11 @@ def _get_func_expr(s: str) -> Tuple[str, str]:
     try:
         start = s.index("(")
         end = s.rindex(")")
-        return s[0:start], s[start + 1:end]
     except ValueError:
         raise ValueError("A matching pair of parentheses cannot be found")
+    if end != len(s) - 1:
+        raise ValueError("Trailing characters '{}' after closing parenthesis".format(s[end + 1:]))
+    return s[0:start], s[start + 1:end]
 
 
 def _get_const(s: str, const: str) -> str:

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -182,6 +182,14 @@ class TestDescriptor(ElectrumTestCase):
         self.assertRaises(ValueError, parse_descriptor, "")
 
     @as_testnet
+    def test_parse_descriptor_rejects_trailing_characters(self):
+        key = "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B"
+        # trailing characters after the closing parenthesis must not be silently ignored
+        self.assertRaises(ValueError, parse_descriptor, "wpkh({}/0/0)abc".format(key))
+        # the same applies to the closing parenthesis of a nested descriptor
+        self.assertRaises(ValueError, parse_descriptor, "sh(wpkh({}/0/0))x".format(key))
+
+    @as_testnet
     def test_parse_descriptor_replace_h(self):
         d = "wpkh([00000001/84'/1'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)"
         desc = parse_descriptor(d)


### PR DESCRIPTION
`_get_func_expr` finds the closing parenthesis with `rindex`, but nothing checks that it is the final character, so trailing text after a descriptor's outer `)` is silently dropped: `pkh(<key>)garbage` parses as `pkh(<key>)`.

Bitcoin Core rejects trailing bytes — `Func` in `src/script/parsing.cpp` requires the closing parenthesis to be the span's last character. This makes `_get_func_expr` do the same, raising `ValueError` and naming the trailing text.

The checksum is stripped before parsing and `_get_func_expr` only ever receives a standalone `func(...)` expression, so no valid descriptor is affected; the existing tests pass unchanged, and a regression test covers a flat and a nested case.

The equivalent fix for Bitcoin Core's HWI, which shares this descriptor code, is bitcoin-core/HWI#858.
