### PR TITLE
descriptor: reduce tr() keys to x-only for taproot expansion

### DIFF
--- a/electrum/descriptor.py
+++ b/electrum/descriptor.py
@@ -460,6 +460,19 @@ class Descriptor(object):
         return "unknown"
 
 
+def _pubkey_to_xonly(pubkey: bytes) -> bytes:
+    """Return the 32-byte x-only form of a public key, for use in a taproot context.
+
+    A 33-byte compressed key is reduced by dropping its parity byte. This is correct
+    even for an odd-parity key, as taproot keys are lifted to even-y before tweaking.
+    A 32-byte x-only key is returned unchanged.
+    """
+    if len(pubkey) == 33:
+        return pubkey[1:]
+    assert len(pubkey) == 32, len(pubkey)
+    return pubkey
+
+
 class PKDescriptor(Descriptor):
     """
     A descriptor for ``pk()`` descriptors
@@ -473,8 +486,10 @@ class PKDescriptor(Descriptor):
         """
         super().__init__([pubkey], [], "pk")
 
-    def expand(self, *, pos: Optional[int] = None) -> "ExpandedScripts":
+    def expand(self, *, pos: Optional[int] = None, taproot: bool = False) -> "ExpandedScripts":
         pubkey = self.pubkeys[0].get_pubkey_bytes(pos=pos)
+        if taproot:
+            pubkey = _pubkey_to_xonly(pubkey)
         script = construct_script([pubkey, opcodes.OP_CHECKSIG])
         return ExpandedScripts(output_script=script)
 
@@ -803,13 +818,15 @@ class TRDescriptor(Descriptor):
 
     # TODO add more test vectors from BIP-0386
     def expand(self, *, pos: Optional[int] = None) -> "ExpandedScripts":
-        internal_pubkey = self.pubkeys[0].get_pubkey_bytes(pos=pos)
+        # taproot keys are x-only: reduce a compressed internal key (e.g. from an xpub) to 32 bytes
+        internal_pubkey = _pubkey_to_xonly(self.pubkeys[0].get_pubkey_bytes(pos=pos))
         script_tree = None
         if self.desc_tree:
             def transform(tree_node):
                 if isinstance(tree_node, Descriptor):
                     leaf_version = 0xc0
-                    leaf_script = tree_node.expand(pos=pos).scriptcode_for_sighash  # FIXME maybe rename scriptcode_for_sighash
+                    # only pk() is a valid tapscript leaf; taproot=True reduces its key to x-only form
+                    leaf_script = tree_node.expand(pos=pos, taproot=True).scriptcode_for_sighash  # FIXME maybe rename scriptcode_for_sighash
                     return (leaf_version, leaf_script)
                 assert len(tree_node) == 2, len(tree_node)
                 return [transform(tree_node[0]), transform(tree_node[1])]

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -20,6 +20,8 @@ from electrum.descriptor import (
     WSHDescriptor,
     PubkeyProvider,
 )
+from electrum.bip32 import BIP32Node
+from electrum.bitcoin import taproot_output_script
 from electrum.util import bfh
 
 from . import ElectrumTestCase, as_testnet
@@ -257,6 +259,42 @@ class TestDescriptor(ElectrumTestCase):
         self.assertEqual(
             "512017cf18db381d836d8923b1bdb246cfcd818da1a9f0e6e7907f187f0b2f937754",
             parse_descriptor("tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0))").expand().output_script.hex())
+
+    @as_testnet
+    def test_tr_descriptor_expand_reduces_compressed_key_to_xonly(self):
+        # A tr() internal key, or a pk() tapscript leaf key, given as a 33-byte compressed
+        # point (raw, or derived from an extended key) is reduced to its 32-byte x-only form
+        # for the taproot output, as Bitcoin Core does by dropping the parity byte.
+        tpub = "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B"
+        compressed = "02669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0"
+
+        # internal key from an extended key: expansion uses the x-only form of the derived key.
+        derived = BIP32Node.from_xkey(tpub).subkey_at_public_derivation([0, 0]).eckey.get_public_key_bytes(compressed=True)
+        self.assertEqual(33, len(derived))
+        self.assertEqual(
+            taproot_output_script(derived[1:], script_tree=None).hex(),
+            parse_descriptor(f"tr([00000001/84h/1h/0h]{tpub}/0/0)").expand().output_script.hex())
+
+        # internal key given as a raw 33-byte compressed point.
+        self.assertEqual(
+            taproot_output_script(bytes.fromhex(compressed)[1:], script_tree=None).hex(),
+            parse_descriptor(f"tr({compressed})").expand().output_script.hex())
+
+        # tapscript leaf key given as a 33-byte compressed point: reducing it to x-only yields
+        # exactly the BIP-0386 vector for the same key written x-only.
+        self.assertEqual(
+            "512017cf18db381d836d8923b1bdb246cfcd818da1a9f0e6e7907f187f0b2f937754",
+            parse_descriptor(f"tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk({compressed}))").expand().output_script.hex())
+
+        # tapscript leaf key derived from an extended key also expands to a p2tr output.
+        leaf_from_xpub = parse_descriptor(f"tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk({tpub}))").expand().output_script
+        self.assertEqual(34, len(leaf_from_xpub))
+        self.assertTrue(leaf_from_xpub.hex().startswith("5120"))
+
+        # a 32-byte x-only internal key passes through unchanged.
+        self.assertEqual(
+            "512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11",
+            parse_descriptor("tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)").expand().output_script.hex())
 
     @as_testnet
     def test_parse_descriptor_with_range(self):


### PR DESCRIPTION
A `tr()` descriptor whose internal key — or a tapscript leaf key — resolves to a 33-byte compressed point cannot be expanded. `TRDescriptor.expand` passes the 33-byte value to `taproot_output_script`, whose `assert len(pubkey32) == 32` fails; a tapscript leaf key silently produces a non-standard 33-byte-push script.

So `tr(<xpub>/<path>)` — the natural single-signer taproot form — is unusable, and a raw compressed key in `tr()` expands to the wrong script.

Bitcoin Core derives the x-only key from a compressed key by dropping the parity byte at script construction (`XOnlyPubKey(CPubKey)`). This does the same: a small helper reduces a 33-byte compressed key to its 32-byte x-only form before it reaches the taproot output script — for both the internal key and tapscript leaf keys (`pk()`, the only function permitted as a leaf), covering both the extended-key and raw-compressed paths. A 32-byte key passes through unchanged, and the signing paths are untouched. The test checks the resulting output against the BIP-0386 x-only vector.
