### PR TITLE
qt: fix onchain invoice dialog exc for script outputs

### DIFF
--- a/electrum/gui/qt/main_window.py
+++ b/electrum/gui/qt/main_window.py
@@ -1667,9 +1667,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger, QtEventListener):
         grid.addWidget(QLabel(amount_str), 1, 1)
         if len(invoice.outputs) == 1:
             grid.addWidget(QLabel(_("Address") + ':'), 2, 0)
-            grid.addWidget(QLabel(invoice.get_address()), 2, 1)
+            grid.addWidget(QLabel(invoice.outputs[0].get_ui_address_str()), 2, 1)
         else:
-            outputs_str = '\n'.join(map(lambda x: x.address + ' : ' + self.format_amount(x.value)+ self.base_unit(), invoice.outputs))
+            outputs_str = '\n'.join(map(lambda x: x.get_ui_address_str() + ' : ' + self.format_amount(x.value) + self.base_unit(), invoice.outputs))
             grid.addWidget(QLabel(_("Outputs") + ':'), 2, 0)
             grid.addWidget(QLabel(outputs_str), 2, 1)
         grid.addWidget(QLabel(_("Description") + ':'), 3, 0)


### PR DESCRIPTION
Fixes exception when double clicking on saved invoice (`show_onchain_invoice()`) for an invoice containing a script output (invoice.address is None).

```
 17.57 | E | gui.qt.exception_window.Exception_Hook | exception caught by crash reporter
Traceback (most recent call last):
  File "/var/home/user/code/code_vm/electrum/electrum/gui/qt/my_treeview.py", line 341, in mouseDoubleClickEvent
    self.on_double_click(idx)
    ~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/var/home/user/code/code_vm/electrum/electrum/gui/qt/invoice_list.py", line 88, in on_double_click
    self.show_invoice(key)
    ~~~~~~~~~~~~~~~~~^^^^^
  File "/var/home/user/code/code_vm/electrum/electrum/gui/qt/invoice_list.py", line 150, in show_invoice
    self.main_window.show_onchain_invoice(invoice)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/var/home/user/code/code_vm/electrum/electrum/gui/qt/main_window.py", line 1672, in show_onchain_invoice
    outputs_str = '\n'.join(map(lambda x: x.address + ' : ' + self.format_amount(x.value)+ self.base_unit(), invoice.outputs))
  File "/var/home/user/code/code_vm/electrum/electrum/gui/qt/main_window.py", line 1672, in <lambda>
    outputs_str = '\n'.join(map(lambda x: x.address + ' : ' + self.format_amount(x.value)+ self.base_unit(), invoice.outputs))
                                          ~~~~~~~~~~^~~~~~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

<!--
Please read this before opening the PR:

Every line of this diff will be reviewed by hand by a human. A pull request
that its own author cannot explain costs the maintainers more time than it
saves, so:

  * You may use whatever tools you like to WRITE code, but you must
    UNDERSTAND the result, and be able to explain it in your own words.
  * The description below must be handwritten by you. Do not paste text
    produced by an LLM/AI assistant. Reviewing AI-written prose to find out
    what a patch is supposed to do is a burden we are not willing to carry.
  * If you cannot explain the change in your own words, please do NOT open a
    pull request. Open an issue instead (handwritten too) describing the
    problem you ran into. A clear bug report is genuinely useful to us; a
    patch nobody can explain is not.

Pull requests ignoring the above may be closed without further discussion.
-->