### PR TITLE
contrib: build appimage: fetch ca-certificates from pinned sources

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile
+++ b/contrib/build-linux/appimage/Dockerfile
@@ -7,13 +7,20 @@ FROM debian:bullseye@sha256:cf48c31af360e1c0a0aedd33aae4d928b68c2cdf093f1612650e
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
-# need ca-certificates before using snapshot packages
-RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
-    ca-certificates
-
 # pin the distro packages
 COPY apt.sources.list /etc/apt/sources.list
 COPY apt.preferences /etc/apt/preferences.d/snapshot
+
+# fetch ca-certificates via http first so the snapshot packages below can be fetched via https
+# FIXME: could be simplified back to the below when bumping the base image:
+# https://github.com/spesmilo/electrum/blob/722f70238d8f719c0fa64940c5dd9c892782f8da/contrib/build-linux/appimage/Dockerfile#L10-L12
+RUN sed -e 's#https://#http://#' /etc/apt/sources.list > /tmp/sources.list.bootstrap && \
+    apt-get -o Dir::Etc::SourceList=/tmp/sources.list.bootstrap update -q && \
+    apt-get -o Dir::Etc::SourceList=/tmp/sources.list.bootstrap install -qy --allow-downgrades --no-install-recommends \
+        ca-certificates \
+        && \
+    rm -f /tmp/sources.list.bootstrap && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update -q && \
     apt-get install -qy --allow-downgrades \


### PR DESCRIPTION
Fetch ca-certificates from the pinned sources similar to the other packages.
This needs to be done because the default sources of debian 11 stopped working.
Because the pinned sources are https they need to be patched to http before using them to get ca-certificate, as https requires ca-certificates. This is safe as packages are signed by debian (the previous way of installing ca-certificates also used http).