### PR TITLE
build: bump pyinstaller to 6.14.0

### DIFF
--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 PYINSTALLER_REPO="https://github.com/pyinstaller/pyinstaller.git"
-PYINSTALLER_COMMIT="306d4d92580fea7be7ff2c89ba112cdc6f73fac1"
-# ^ tag "v6.13.0"
+PYINSTALLER_COMMIT="776a57a6b07cb2c71f02018953610bcbfcdaf0aa"
+# ^ tag "v6.14.0"
 
 PYTHON_VERSION=3.12.10
 

--- a/contrib/osx/make_osx.sh
+++ b/contrib/osx/make_osx.sh
@@ -89,8 +89,8 @@ brew install autoconf automake libtool gettext coreutils pkgconfig
 
 info "Building PyInstaller."
 PYINSTALLER_REPO="https://github.com/pyinstaller/pyinstaller.git"
-PYINSTALLER_COMMIT="306d4d92580fea7be7ff2c89ba112cdc6f73fac1"
-# ^ tag "v6.13.0"
+PYINSTALLER_COMMIT="776a57a6b07cb2c71f02018953610bcbfcdaf0aa"
+# ^ tag "v6.14.0"
 (
     if [ -f "$CACHEDIR/pyinstaller/PyInstaller/bootloader/Darwin-64bit/runw" ]; then
         info "pyinstaller already built, skipping"

--- a/contrib/requirements/requirements-build-mac.txt
+++ b/contrib/requirements/requirements-build-mac.txt
@@ -6,7 +6,7 @@ wheel
 # fixme: ugly to have to duplicate this here from upstream
 macholib>=1.8
 altgraph
-pyinstaller-hooks-contrib>=2025.2
+pyinstaller-hooks-contrib>=2025.4
 packaging>=22.0
 
 # Note: hidapi requires Cython at build-time (not needed at runtime).

--- a/contrib/requirements/requirements-build-wine.txt
+++ b/contrib/requirements/requirements-build-wine.txt
@@ -7,5 +7,5 @@ wheel
 pefile>=2022.5.30,!=2024.8.26
 altgraph
 pywin32-ctypes>=0.2.1
-pyinstaller-hooks-contrib>=2025.2
+pyinstaller-hooks-contrib>=2025.4
 packaging>=22.0


### PR DESCRIPTION
This minimal bump is necessary to suppress the warning reported in #10921 (I did explain more of this in the issue thread).  Also bumps the declared minimum for `pyinstaller-hooks-contrib` from `2025.2` to `2025.4` to match what pyinstaller `6.14.0` requires. The pinned version is already `2025.4`, so nothing actually changes at build time.

Ps: I've only tested this on macOS 26.5, python 3.12.14.